### PR TITLE
Revert "Temporarily use ECF test environment"

### DIFF
--- a/config/manifests/staging-manifest.yml
+++ b/config/manifests/staging-manifest.yml
@@ -27,6 +27,6 @@ applications:
     GOVUK_NOTIFY_API_KEY: ((GOVUK_NOTIFY_API_KEY))
     GOOGLE_TAG_MANAGER_ID: "GTM-N58Z5PG"
     GOOGLE_ANALYTICS_ID: "G-G3823VRN6N"
-    ECF_APP_BASE_URL: "https://ecf-review-pr-594.london.cloudapps.digital"
+    ECF_APP_BASE_URL: "https://ecf-staging.london.cloudapps.digital"
     ECF_APP_BEARER_TOKEN: ((ECF_APP_BEARER_TOKEN))
     SENTRY_DSN: ((SENTRY_DSN))


### PR DESCRIPTION
Reverts DFE-Digital/npq-registration#44

Pentest has now finished so we can revert this.