### PR TITLE
display email confirmation code in sandbox

### DIFF
--- a/spec/lib/forms/contact_details_spec.rb
+++ b/spec/lib/forms/contact_details_spec.rb
@@ -67,5 +67,21 @@ RSpec.describe Forms::ContactDetails, type: :model do
 
       expect(email.to).to eql(["user@example.com"])
     end
+
+    it "sets flash message" do
+      subject.after_save
+      expect(subject.wizard.request.flash[:success]).to eql("We've emailed a confirmation code to user@example.com")
+    end
+
+    context "when whitelisted domain and in sandbox" do
+      before do
+        allow(ENV).to receive(:[]).with("SERVICE_ENV").and_return("sandbox")
+      end
+
+      it "displays code in flash message" do
+        subject.after_save
+        expect(subject.wizard.request.flash[:success]).to match(/Your code is \d{6}/)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

- In sandbox env we do not send out emails

### Changes proposed in this pull request

- So providers can enter data and complete the journey in sandbox we display the confirmation code on the screen instead of sending them an email

### Guidance to review

- Existing journey outside to sandbox should be identical