### PR TITLE
Persist and send NINO

### DIFF
--- a/app/lib/forms/check_answers.rb
+++ b/app/lib/forms/check_answers.rb
@@ -15,6 +15,7 @@ module Forms
         active_alert: wizard.store["active_alert"],
         full_name: wizard.store["full_name"],
         date_of_birth: wizard.store["date_of_birth"],
+        national_insurance_number: ni_number_to_store,
       )
 
       user.applications.create!(
@@ -36,6 +37,10 @@ module Forms
     end
 
   private
+
+    def ni_number_to_store
+      wizard.store["national_insurance_number"] unless wizard.store["trn_verified"]
+    end
 
     def course
       @course ||= Course.find(wizard.store["course_id"])

--- a/app/lib/services/npq_profile_creator.rb
+++ b/app/lib/services/npq_profile_creator.rb
@@ -12,6 +12,7 @@ module Services
         teacher_reference_number_verified: user.trn_verified,
         active_alert: user.active_alert,
         date_of_birth: user.date_of_birth,
+        national_insurance_number: user.national_insurance_number,
         school_urn: application.school_urn,
         headteacher_status: application.headteacher_status,
         eligible_for_funding: application.eligible_for_funding,

--- a/db/migrate/20210715092732_add_ni_number_to_users.rb
+++ b/db/migrate/20210715092732_add_ni_number_to_users.rb
@@ -1,0 +1,5 @@
+class AddNiNumberToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :national_insurance_number, :text, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_01_145259) do
+ActiveRecord::Schema.define(version: 2021_07_15_092732) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -103,6 +103,7 @@ ActiveRecord::Schema.define(version: 2021_07_01_145259) do
     t.date "date_of_birth"
     t.boolean "trn_verified", default: false, null: false
     t.boolean "active_alert", default: false
+    t.text "national_insurance_number"
     t.index ["ecf_id"], name: "index_users_on_ecf_id", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
   end

--- a/spec/features/happy_journeys_spec.rb
+++ b/spec/features/happy_journeys_spec.rb
@@ -305,6 +305,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(user.trn).to eql("1234567")
     expect(user.trn_verified).to be_truthy
     expect(user.date_of_birth).to eql(Date.new(1980, 12, 13))
+    expect(user.national_insurance_number).to be_blank
 
     expect(user.applications.count).to eql(1)
 

--- a/spec/lib/services/npq_profile_creator_spec.rb
+++ b/spec/lib/services/npq_profile_creator_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Services::NpqProfileCreator do
       trn_verified: true,
       active_alert: true,
       date_of_birth: Date.new(1980, 12, 13),
+      national_insurance_number: "AB123456C",
     )
   end
   let(:course) { Course.create!(name: "Some course", ecf_id: "234") }
@@ -60,6 +61,7 @@ RSpec.describe Services::NpqProfileCreator do
             teacher_reference_number_verified: true,
             active_alert: true,
             date_of_birth: user.date_of_birth.iso8601,
+            national_insurance_number: user.national_insurance_number,
             school_urn: application.school_urn,
             headteacher_status: "no",
             eligible_for_funding: true,


### PR DESCRIPTION
### Context

- We need to persist NI number for validation if users cannot be validated automatically. It will be used for manual validation

### Changes proposed in this pull request

- Persist NI number if TRN cannot be automatically be validated
- Send NI Number to ECF if record could not be automatically be validated assuming user has entered it

### Guidance to review

- Depends on https://github.com/DFE-Digital/early-careers-framework/pull/699 being deployed to production