### PR TITLE
Allow IE10 user to use JS school picker

### DIFF
--- a/app/webpacker/packs/school-picker.js
+++ b/app/webpacker/packs/school-picker.js
@@ -47,7 +47,7 @@ schoolPicker.enhanceSelectElement = (configurationOptions) => {
     }
   }
 
-  const location = configurationOptions.selectElement.dataset.location
+  const location = configurationOptions.selectElement.getAttribute("data-location")
 
   configurationOptions.source = debounce( async ( query, populateResults ) => {
     const res = await fetchSource(query, location);


### PR DESCRIPTION
### Context

- This allows IE10 user to complete a journey successfully with JS

### Changes proposed in this pull request

- IE10 does not support `dataset` and use `getAttribute` instead

### Guidance to review

- none