### PR TITLE
Fix visiting check answers page directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@
 - fire up a rails console and run the following
 - `Services::ImportGiasSchools.new.call`
 
+## Importing premium pupils data
+
+- fire up a rails console and run the following
+- `Services::SetHighPupilPremiums.new(path_to_csv: Rails.root.join("config/data/high_pupil_premiums_2021_2022.csv")).call`
+
 ## Running specs, linter(without auto correct) and annotate models and serializers
 ```
 bundle exec rake

--- a/app/controllers/registration_wizard_controller.rb
+++ b/app/controllers/registration_wizard_controller.rb
@@ -7,6 +7,8 @@ class RegistrationWizardController < ApplicationController
     @form = @wizard.form
     @form.flag_as_changing_answer if params[:changing_answer] == "1"
 
+    return redirect_to root_path unless @form.requirements_met?
+
     render @wizard.current_step
   end
 

--- a/app/lib/forms/base.rb
+++ b/app/lib/forms/base.rb
@@ -39,5 +39,9 @@ module Forms
     def no_answers_will_change?
       wizard.store.slice(*self.class.permitted_params.map(&:to_s)) == attributes.stringify_keys
     end
+
+    def requirements_met?
+      true
+    end
   end
 end

--- a/app/lib/forms/check_answers.rb
+++ b/app/lib/forms/check_answers.rb
@@ -1,5 +1,9 @@
 module Forms
   class CheckAnswers < Base
+    def requirements_met?
+      wizard.store["date_of_birth"].present?
+    end
+
     def previous_step
       :choose_school
     end

--- a/spec/features/short_circuiting_pages_spec.rb
+++ b/spec/features/short_circuiting_pages_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+RSpec.feature "Short circuiting pages", type: :feature do
+  scenario "visit /registration/check-answers directly" do
+    visit "/registration/check-answers"
+    expect(page.current_path).to eql("/")
+  end
+end


### PR DESCRIPTION
### Context

- users are submitting their application the hitting the browser back button back to the check answers page
- to prevent them visiting this page again which causes an error we do a basic check which then redirects them back to the root_path

### Changes proposed in this pull request

### Guidance to review