### PR TITLE
add csv importer for manual validation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,3 +31,7 @@ Rails/SaveBang:
     - "app/lib/ecf_api/base.rb"
     - "app/lib/services/ecf_user_creator.rb"
     - "app/lib/services/npq_profile_creator.rb"
+
+Rails/Output:
+  Exclude:
+    - "app/lib/services/importers/*"

--- a/app/lib/services/importers/manual_validation.rb
+++ b/app/lib/services/importers/manual_validation.rb
@@ -1,0 +1,36 @@
+require "csv"
+
+class Services::Importers::ManualValidation
+  attr_reader :path_to_csv
+
+  def initialize(path_to_csv:)
+    @path_to_csv = path_to_csv
+  end
+
+  def call
+    check_headers
+
+    rows.each do |row|
+      application = Application.includes(:user).find_by(ecf_id: row["application_ecf_id"])
+
+      puts "no application found for #{row['application_ecf_id']}" if application.nil?
+      next if application.nil?
+
+      puts "updating trn for application: #{row['application_ecf_id']} with trn: #{row['validated_trn']}"
+
+      application.user.update!(trn: row["validated_trn"], trn_verified: true)
+    end
+  end
+
+private
+
+  def check_headers
+    unless rows.headers == %w[application_ecf_id validated_trn]
+      raise NameError, "Invalid headers"
+    end
+  end
+
+  def rows
+    @rows ||= CSV.read(path_to_csv, headers: true)
+  end
+end

--- a/spec/factories/applications.rb
+++ b/spec/factories/applications.rb
@@ -1,3 +1,5 @@
+require "securerandom"
+
 FactoryBot.define do
   factory :application do
     user
@@ -5,5 +7,9 @@ FactoryBot.define do
     lead_provider { LeadProvider.all.sample }
     school_urn { rand(100_000..999_999).to_s }
     headteacher_status { "no" }
+
+    trait :with_ecf_id do
+      ecf_id { SecureRandom.uuid }
+    end
   end
 end

--- a/spec/lib/services/importers/manual_validation_spec.rb
+++ b/spec/lib/services/importers/manual_validation_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+require "tempfile"
+
+RSpec.describe Services::Importers::ManualValidation do
+  let(:school) { create(:school) }
+  let(:user) { create(:user) }
+  let(:application) { create(:application, :with_ecf_id, user: user, school: school) }
+
+  let(:file) { Tempfile.new("test.csv") }
+
+  describe "#call" do
+    subject do
+      described_class.new(path_to_csv: file.path)
+    end
+
+    context "with well formed csv" do
+      before do
+        file.write("application_ecf_id,validated_trn")
+        file.write("\n")
+        file.write("123,7654321")
+        file.write("\n")
+        file.write("#{application.ecf_id},7654321")
+        file.rewind
+      end
+
+      it "updates trn" do
+        expect {
+          subject.call
+        }.to change { user.reload.trn }.to("7654321")
+      end
+
+      it "updates trn_verified to true" do
+        expect {
+          subject.call
+        }.to change { user.reload.trn_verified }.to(true)
+      end
+    end
+
+    context "with malformed csv" do
+      before do
+        file.write("application_id,trn")
+        file.write("\n")
+        file.rewind
+      end
+
+      it "raises error" do
+        expect {
+          subject.call
+        }.to raise_error(NameError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Import manual validation CSV
- Double entry required. Meaning this data also needs to be applied to ECF
- As there is no mechanism at the moment to sync

### Changes proposed in this pull request

### Guidance to review

