### PR TITLE
use FakeParticipantValidator in sandbox

### DIFF
--- a/app/lib/forms/qualified_teacher_check.rb
+++ b/app/lib/forms/qualified_teacher_check.rb
@@ -30,7 +30,7 @@ module Forms
     end
 
     def next_step
-      record = Services::ParticipantValidator.new(
+      record = participant_validator_class.new(
         trn: trn_digits_only,
         full_name: full_name,
         date_of_birth: date_of_birth,
@@ -111,6 +111,14 @@ module Forms
     def validate_date_of_birth_valid?
       if @date_of_birth_invalid
         errors.add(:date_of_birth, :invalid)
+      end
+    end
+
+    def participant_validator_class
+      if ENV["SERVICE_ENV"] == "sandbox"
+        Services::FakeParticipantValidator
+      else
+        Services::ParticipantValidator
       end
     end
   end

--- a/app/lib/services/fake_participant_validator.rb
+++ b/app/lib/services/fake_participant_validator.rb
@@ -1,0 +1,24 @@
+module Services
+  class FakeParticipantValidator
+    attr_reader :trn, :full_name, :date_of_birth, :national_insurance_number
+
+    def initialize(trn:, full_name:, date_of_birth:, national_insurance_number: nil)
+      @trn = trn
+      @full_name = full_name
+      @date_of_birth = date_of_birth
+      @national_insurance_number = national_insurance_number
+    end
+
+    def call
+      if first_name.match?(/John|Jane/)
+        OpenStruct.new(trn: trn, qts: true, active_alert: false)
+      end
+    end
+
+  private
+
+    def first_name
+      full_name.split(" ").first
+    end
+  end
+end

--- a/spec/lib/forms/qualified_teacher_check_spec.rb
+++ b/spec/lib/forms/qualified_teacher_check_spec.rb
@@ -114,6 +114,20 @@ RSpec.describe Forms::QualifiedTeacherCheck, type: :model do
         expect(Sentry).to have_received(:capture_exception)
       end
     end
+
+    context "when in sandbox" do
+      before do
+        allow(ENV).to receive(:[]).with("SERVICE_ENV").and_return("sandbox")
+      end
+
+      it "uses FakeParticipantValidator" do
+        allow(Services::FakeParticipantValidator).to receive(:new)
+
+        subject.next_step
+
+        expect(Services::FakeParticipantValidator).to have_received(:new)
+      end
+    end
   end
 
   describe "#after_save" do

--- a/spec/lib/services/fake_participant_validator_spec.rb
+++ b/spec/lib/services/fake_participant_validator_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe Services::FakeParticipantValidator do
+  let(:trn) { rand(1_000_000..9_999_999).to_s }
+  let(:date_of_birth) { rand(60.years.ago..20.years.ago).to_date }
+  let(:national_insurance_number) { "AB123456C" }
+
+  subject do
+    described_class.new(
+      trn: trn,
+      full_name: full_name,
+      date_of_birth: date_of_birth,
+      national_insurance_number: national_insurance_number,
+    )
+  end
+
+  describe "#call" do
+    context "when user called John" do
+      let(:full_name) { "John Doe" }
+
+      it "returns record with matching trn" do
+        expect(subject.call.trn).to eql(trn)
+        expect(subject.call.active_alert).to be_falsey
+      end
+    end
+
+    context "when user called Jane" do
+      let(:full_name) { "Jane Doe" }
+
+      it "returns record with matching trn" do
+        expect(subject.call.trn).to eql(trn)
+        expect(subject.call.active_alert).to be_falsey
+      end
+    end
+
+    context "when user not called John or Jane" do
+      let(:full_name) { "Jack Doe" }
+
+      it "returns nil" do
+        expect(subject.call).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Sandbox users want to be able to add TRN verified users to their test datasets
- We do not want to depend on test data that is outside of our control to be able to control this

### Changes proposed in this pull request

- any user called John or Jane will be TRN verified in sandbox

### Guidance to review

- none