### PR TITLE
strip of title prefixes from full_name

### DIFF
--- a/app/lib/forms/qualified_teacher_check.rb
+++ b/app/lib/forms/qualified_teacher_check.rb
@@ -16,6 +16,7 @@ module Forms
     before_validation :strip_full_name_whitespace
     before_validation :strip_trn_whitespace
     before_validation :strip_ni_number_whitespace
+    before_validation :strip_title_prefixes
 
     validates :trn, presence: true, length: { in: 5..7 }, format: { with: /\A\d+\z/ }
     validates :full_name, presence: true, length: { maximum: 128 }
@@ -128,6 +129,10 @@ module Forms
       if @date_of_birth_invalid
         errors.add(:date_of_birth, :invalid)
       end
+    end
+
+    def strip_title_prefixes
+      full_name&.sub!(/^Mr |^Mrs |^Miss |^Ms /, "")
     end
   end
 end

--- a/spec/lib/forms/qualified_teacher_check_spec.rb
+++ b/spec/lib/forms/qualified_teacher_check_spec.rb
@@ -24,6 +24,26 @@ RSpec.describe Forms::QualifiedTeacherCheck, type: :model do
       subject.valid?
       expect(subject.national_insurance_number).to eql("AB123456C")
     end
+
+    context "full_name with titles" do
+      it "removes leading titles from full_name" do
+        subject.full_name = "Mr John Doe"
+        subject.valid?
+        expect(subject.full_name).to eql("John Doe")
+
+        subject.full_name = "Ms Jane Doe"
+        subject.valid?
+        expect(subject.full_name).to eql("Jane Doe")
+
+        subject.full_name = "Mrs Jane Doe"
+        subject.valid?
+        expect(subject.full_name).to eql("Jane Doe")
+
+        subject.full_name = "Miss Jane Doe"
+        subject.valid?
+        expect(subject.full_name).to eql("Jane Doe")
+      end
+    end
   end
 
   describe "validations" do


### PR DESCRIPTION
### Context

- users are entering their titles in full names
- we remove this as it negatively impacts auto validation

### Changes proposed in this pull request

### Guidance to review

