### PR TITLE
Spaceless postcodes

### DIFF
--- a/app/lib/services/import_gias_schools.rb
+++ b/app/lib/services/import_gias_schools.rb
@@ -56,6 +56,7 @@ module Services
         town: row["Town"],
         county: row["County (name)"],
         postcode: row["Postcode"],
+        postcode_without_spaces: row["Postcode"]&.gsub(" ", ""),
         easting: row["Easting"],
         northing: row["Northing"],
         region: row["RSCRegion (name)"],

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -11,7 +11,7 @@ class School < ApplicationRecord
                   }
 
   pg_search_scope :search_by_location,
-                  against: %i[la_name address_1 address_2 address_3 town county postcode region]
+                  against: %i[la_name address_1 address_2 address_3 town county postcode postcode_without_spaces region]
 
   scope :open, -> { where(establishment_status_code: %w[1 3 4]) }
 

--- a/db/migrate/20210730094220_add_postcode_without_spaces.rb
+++ b/db/migrate/20210730094220_add_postcode_without_spaces.rb
@@ -1,0 +1,5 @@
+class AddPostcodeWithoutSpaces < ActiveRecord::Migration[6.1]
+  def change
+    add_column :schools, :postcode_without_spaces, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_19_104504) do
+ActiveRecord::Schema.define(version: 2021_07_30_094220) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -94,6 +94,7 @@ ActiveRecord::Schema.define(version: 2021_07_19_104504) do
     t.text "establishment_type_code"
     t.text "establishment_type_name"
     t.boolean "high_pupil_premium", default: false, null: false
+    t.text "postcode_without_spaces"
     t.index "to_tsvector('english'::regconfig, COALESCE(name, ''::text))", name: "school_name_search_idx", using: :gin
     t.index ["urn"], name: "index_schools_on_urn"
   end

--- a/spec/lib/services/import_gias_schools_spec.rb
+++ b/spec/lib/services/import_gias_schools_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe Services::ImportGiasSchools do
         expect(school.town).to eql(row["Town"])
         expect(school.county).to eql(row["County (name)"])
         expect(school.postcode).to eql(row["Postcode"])
+        expect(school.postcode_without_spaces).to eql(row["Postcode"]&.gsub(" ", ""))
         expect(school.easting.to_s).to eql(row["Easting"].to_s)
         expect(school.northing.to_s).to eql(row["Northing"].to_s)
         expect(school.region).to eql(row["RSCRegion (name)"])

--- a/spec/requests/schools_spec.rb
+++ b/spec/requests/schools_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SchoolsController do
       create(:school, name: "heart", town: "London")
       create(:school, name: "health", town: "London")
       create(:school, :closed, name: "heat", town: "London")
-      create(:school, name: "heal", town: "Manchester")
+      create(:school, name: "heal", town: "Manchester", postcode: "EC1N 2TD", postcode_without_spaces: "EC1N2TD")
     end
 
     it "returns all possible matches" do
@@ -19,6 +19,15 @@ RSpec.describe SchoolsController do
 
     it "returns only needed data" do
       get "/schools.json?location=london&name=hea"
+
+      parsed_response = JSON.parse(response.body)
+
+      expect(parsed_response.sample.keys).to eql(%w[urn name address])
+      expect(parsed_response.sample["address"]).to be_a(String)
+    end
+
+    it "returns postcode when whitespace is removed" do
+      get "/schools.json?location=ec1n2td&name=hea"
 
       parsed_response = JSON.parse(response.body)
 


### PR DESCRIPTION
### Context

- My first attempt was using a `GENERATED` postgres column introduced in postgres 12. However Rails don't seem to support this out the box and caused more pain than not
- So this is the basic fix of simply duping the postcode and we have to maintain this application side

### Changes proposed in this pull request

- After deployment I will hotfix data on all environments to ensure this feature is available 

### Guidance to review

