### PR TITLE
Revert copy to exactly 7 digit TRN

### DIFF
--- a/app/views/registration_wizard/qualified_teacher_check.html.erb
+++ b/app/views/registration_wizard/qualified_teacher_check.html.erb
@@ -23,7 +23,7 @@
       <%= f.govuk_text_field :trn,
         width: 10,
         label: { text: "Teacher reference number (TRN)", size: "s" },
-        hint: { text: "Your TRN is between 5 and 7 digits long" } %>
+        hint: { text: "Your TRN is exactly 7 digits long" } %>
 
       <%= f.govuk_text_field :full_name,
         width: "three-quarters",


### PR DESCRIPTION
### Context

- Users seem to be chopping the first 2 numbers of TRNs
- hoping a copy change should rectify this problem
- however under the hood it allows 5 to 7

### Changes proposed in this pull request

- Copy change

### Guidance to review

- none