### PR TITLE
add eligibility for school establishment type 43

### DIFF
--- a/app/lib/services/funding_eligibility.rb
+++ b/app/lib/services/funding_eligibility.rb
@@ -37,7 +37,7 @@ module Services
     end
 
     def eligible_establishment_type_codes_for_ltd_courses
-      %w[1 2 3 5 6 7 8 12 14 15 28 33 34 35 36 38 39 40 41 42 44 45].freeze
+      %w[1 2 3 5 6 7 8 12 14 15 28 33 34 35 36 38 39 40 41 42 43 44 45].freeze
     end
 
     def eligible_establishment_type_codes_for_headship_and_high_pupil_premiums
@@ -45,7 +45,7 @@ module Services
     end
 
     def eligible_establishment_type_codes_for_new_headship
-      %w[1 2 3 5 6 7 8 12 14 15 28 33 34 35 36 38 39 40 41 42 44 45].freeze
+      %w[1 2 3 5 6 7 8 12 14 15 28 33 34 35 36 38 39 40 41 42 43 44 45].freeze
     end
   end
 end

--- a/spec/lib/services/funding_eligibility_spec.rb
+++ b/spec/lib/services/funding_eligibility_spec.rb
@@ -63,46 +63,50 @@ RSpec.describe Services::FundingEligibility do
     context "studying for NPQLTD" do
       let(:course) { Course.all.select { |c| c.name.match?(/\(NPQLTD\)/) }.sample }
 
-      context "eligible establishment" do
-        let(:eligible_gias_code) { %w[1 2 3 5 6 7 8 12 14 15 28 33 34 35 36 38 39 40 41 42 44 45].sample }
-        let(:school) { build(:school, establishment_type_code: eligible_gias_code) }
-
-        it "returns true" do
-          expect(subject.call).to be_truthy
-        end
-      end
-
-      context "ineligible establishment" do
-        let(:ineligible_gias_code) { %w[10 11 18 24 25 26 27 29 30 31 32 37 43 46 56].sample }
-        let(:school) { build(:school, establishment_type_code: ineligible_gias_code) }
-
-        it "returns false" do
-          expect(subject.call).to be_falsey
-        end
-      end
-    end
-
-    context "studying for NPQLTD" do
-      let(:course) { Course.all.select { |c| c.name.match?(/\(NPQH\)/) }.sample }
-
-      context "in first 2 years of headship" do
-        let(:headteacher_status) { "yes_in_first_two_years" }
-
-        context "at eligible establishment" do
-          let(:eligible_gias_code) { %w[1 2 3 5 6 7 8 12 14 15 28 33 34 35 36 38 39 40 41 42 44 45].sample }
+      %w[1 2 3 5 6 7 8 12 14 15 28 33 34 35 36 38 39 40 41 42 43 44 45].each do |eligible_gias_code|
+        context "eligible establishment_type_code #{eligible_gias_code}" do
           let(:school) { build(:school, establishment_type_code: eligible_gias_code) }
 
           it "returns true" do
             expect(subject.call).to be_truthy
           end
         end
+      end
 
-        context "at ineligible establishment" do
-          let(:ineligible_gias_code) { %w[10 11 18 24 25 26 27 29 30 31 32 37 43 46 56].sample }
+      %w[10 11 18 24 25 26 27 29 30 31 32 37 46 56].each do |ineligible_gias_code|
+        context "ineligible establishment_type_code #{ineligible_gias_code}" do
           let(:school) { build(:school, establishment_type_code: ineligible_gias_code) }
 
           it "returns false" do
             expect(subject.call).to be_falsey
+          end
+        end
+      end
+    end
+
+    context "studying for NPQH" do
+      let(:course) { Course.all.select { |c| c.name.match?(/\(NPQH\)/) }.sample }
+
+      context "in first 2 years of headship" do
+        let(:headteacher_status) { "yes_in_first_two_years" }
+
+        %w[1 2 3 5 6 7 8 12 14 15 28 33 34 35 36 38 39 40 41 42 43 44 45].each do |eligible_gias_code|
+          context "at establishment_type_code #{eligible_gias_code}" do
+            let(:school) { build(:school, establishment_type_code: eligible_gias_code) }
+
+            it "returns true" do
+              expect(subject.call).to be_truthy
+            end
+          end
+        end
+
+        %w[10 11 18 24 25 26 27 29 30 31 32 37 46 56].each do |ineligible_gias_code|
+          context "at ineligible establishment #{ineligible_gias_code}" do
+            let(:school) { build(:school, establishment_type_code: ineligible_gias_code) }
+
+            it "returns false" do
+              expect(subject.call).to be_falsey
+            end
           end
         end
       end
@@ -110,21 +114,23 @@ RSpec.describe Services::FundingEligibility do
       context "headship when course starts" do
         let(:headteacher_status) { "yes_when_course_starts" }
 
-        context "at eligible establishment" do
-          let(:eligible_gias_code) { %w[1 2 3 5 6 7 8 12 14 15 28 33 34 35 36 38 39 40 41 42 44 45].sample }
-          let(:school) { build(:school, establishment_type_code: eligible_gias_code) }
+        %w[1 2 3 5 6 7 8 12 14 15 28 33 34 35 36 38 39 40 41 42 43 44 45].each do |eligible_gias_code|
+          context "at eligible establishment #{eligible_gias_code}" do
+            let(:school) { build(:school, establishment_type_code: eligible_gias_code) }
 
-          it "returns true" do
-            expect(subject.call).to be_truthy
+            it "returns true" do
+              expect(subject.call).to be_truthy
+            end
           end
         end
 
-        context "at ineligible establishment" do
-          let(:ineligible_gias_code) { %w[10 11 18 24 25 26 27 29 30 31 32 37 43 46 56].sample }
-          let(:school) { build(:school, establishment_type_code: ineligible_gias_code) }
+        %w[10 11 18 24 25 26 27 29 30 31 32 37 46 56].each do |ineligible_gias_code|
+          context "at ineligible establishment #{ineligible_gias_code}" do
+            let(:school) { build(:school, establishment_type_code: ineligible_gias_code) }
 
-          it "returns false" do
-            expect(subject.call).to be_falsey
+            it "returns false" do
+              expect(subject.call).to be_falsey
+            end
           end
         end
       end
@@ -132,43 +138,44 @@ RSpec.describe Services::FundingEligibility do
       context "not in first 2 years of headship" do
         let(:headteacher_status) { %w[yes_over_two_years no].sample }
 
-        context "at eligible establishment" do
-          let(:eligible_gias_code) { %w[1 2 3 5 6 7 8 12 14 28 33 34 35 36 38 40 41 42 43 44].sample }
+        %w[1 2 3 5 6 7 8 12 14 28 33 34 35 36 38 40 41 42 43 44].each do |eligible_gias_code|
+          context "at eligible establishment #{eligible_gias_code}" do
+            context "school has high_pupil_premium" do
+              let(:school) { build(:school, establishment_type_code: eligible_gias_code, high_pupil_premium: true) }
 
-          context "school has high_pupil_premium" do
-            let(:school) { build(:school, establishment_type_code: eligible_gias_code, high_pupil_premium: true) }
-
-            it "returns true" do
-              expect(subject.call).to be_truthy
+              it "returns true" do
+                expect(subject.call).to be_truthy
+              end
             end
-          end
 
-          context "school does not have high_pupil_premium" do
-            let(:school) { build(:school, establishment_type_code: eligible_gias_code, high_pupil_premium: false) }
+            context "school does not have high_pupil_premium" do
+              let(:school) { build(:school, establishment_type_code: eligible_gias_code, high_pupil_premium: false) }
 
-            it "returns false" do
-              expect(subject.call).to be_falsey
+              it "returns false" do
+                expect(subject.call).to be_falsey
+              end
             end
           end
         end
 
-        context "at ineligible establishment" do
-          let(:ineligible_gias_code) { %w[10 11 15 18 24 25 26 27 29 30 31 32 37 39 45 46 56].sample }
-          let(:school) { build(:school, establishment_type_code: ineligible_gias_code) }
+        %w[10 11 15 18 24 25 26 27 29 30 31 32 37 39 45 46 56].each do |ineligible_gias_code|
+          context "at ineligible establishment #{ineligible_gias_code}" do
+            let(:school) { build(:school, establishment_type_code: ineligible_gias_code) }
 
-          context "school has high_pupil_premium" do
-            let(:school) { build(:school, establishment_type_code: ineligible_gias_code, high_pupil_premium: true) }
+            context "school has high_pupil_premium" do
+              let(:school) { build(:school, establishment_type_code: ineligible_gias_code, high_pupil_premium: true) }
 
-            it "returns false" do
-              expect(subject.call).to be_falsey
+              it "returns false" do
+                expect(subject.call).to be_falsey
+              end
             end
-          end
 
-          context "school does not have high_pupil_premium" do
-            let(:school) { build(:school, establishment_type_code: ineligible_gias_code, high_pupil_premium: false) }
+            context "school does not have high_pupil_premium" do
+              let(:school) { build(:school, establishment_type_code: ineligible_gias_code, high_pupil_premium: false) }
 
-            it "returns false" do
-              expect(subject.call).to be_falsey
+              it "returns false" do
+                expect(subject.call).to be_falsey
+              end
             end
           end
         end


### PR DESCRIPTION
### Context

- `Academy alternative provision sponsor led` (coded as `43`) are now eligible for funding

### Changes proposed in this pull request

- Make schools with `establishment_type_code` `43` now eligible for funding
- Tweak tests so they run through every single scenario as opposed to sampling an example to test
- Any applications with this type will be retrospectively be given funding if there are any such applications

### Guidance to review

- none