### PR TITLE
extra cases for removing titles from names

### DIFF
--- a/app/lib/forms/qualified_teacher_check.rb
+++ b/app/lib/forms/qualified_teacher_check.rb
@@ -142,7 +142,7 @@ module Forms
     end
 
     def strip_title_prefixes
-      full_name&.sub!(/^Mr |^Mrs |^Miss |^Ms /, "")
+      full_name&.sub!(/^Mr\.* |^Mrs\.* |^Miss\.* |^Ms\.* /i, "")
     end
   end
 end

--- a/spec/lib/forms/qualified_teacher_check_spec.rb
+++ b/spec/lib/forms/qualified_teacher_check_spec.rb
@@ -31,7 +31,19 @@ RSpec.describe Forms::QualifiedTeacherCheck, type: :model do
         subject.valid?
         expect(subject.full_name).to eql("John Doe")
 
+        subject.full_name = "MR JOHN DOE"
+        subject.valid?
+        expect(subject.full_name).to eql("JOHN DOE")
+
+        subject.full_name = "Mr. John Doe"
+        subject.valid?
+        expect(subject.full_name).to eql("John Doe")
+
         subject.full_name = "Ms Jane Doe"
+        subject.valid?
+        expect(subject.full_name).to eql("Jane Doe")
+
+        subject.full_name = "Ms. Jane Doe"
         subject.valid?
         expect(subject.full_name).to eql("Jane Doe")
 
@@ -39,7 +51,15 @@ RSpec.describe Forms::QualifiedTeacherCheck, type: :model do
         subject.valid?
         expect(subject.full_name).to eql("Jane Doe")
 
+        subject.full_name = "Mrs. Jane Doe"
+        subject.valid?
+        expect(subject.full_name).to eql("Jane Doe")
+
         subject.full_name = "Miss Jane Doe"
+        subject.valid?
+        expect(subject.full_name).to eql("Jane Doe")
+
+        subject.full_name = "Miss. Jane Doe"
         subject.valid?
         expect(subject.full_name).to eql("Jane Doe")
       end


### PR DESCRIPTION
### Context

- There are still cases of users entering titles into their full name and slipping through

### Changes proposed in this pull request

- Adds additional case where we strip the title from the name

### Guidance to review

- none