### PR TITLE
remove link to sign in

### DIFF
--- a/app/views/registration_wizard/contact_details.html.erb
+++ b/app/views/registration_wizard/contact_details.html.erb
@@ -18,8 +18,6 @@
 
       <p class="govuk-body">We’ll email you a code to confirm your email address.</p>
 
-      <p class="govuk-body">Already got an account? <%= govuk_link_to "Sign in", sign_in_path %> to continue.</p>
-
       <%= f.govuk_email_field :email,
                               width: 20,
                               label: { text: 'Email address' } %>


### PR DESCRIPTION
### Context

- this matches the prototype
- account area was never finished so is more of a dead end than of use
- some using are clicking this link to the dead end which is proving problematic

### Changes proposed in this pull request

- Remove link to sign in when asking for email address

### Guidance to review

- none