### PR TITLE
Persist trn_auto_verified as boolean

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,9 @@ Style/HashLikeCase:
 Rails/Delegate:
   Enabled: false
 
+Style/DoubleNegation:
+  Enabled: false
+
 Rails/SaveBang:
   Exclude:
     - "app/lib/ecf_api/base.rb"

--- a/app/lib/forms/check_answers.rb
+++ b/app/lib/forms/check_answers.rb
@@ -16,7 +16,7 @@ module Forms
       user.update!(
         trn: wizard.store["verified_trn"].presence || wizard.store["trn"],
         trn_verified: wizard.store["trn_verified"],
-        trn_auto_verified: wizard.store["trn_auto_verified"],
+        trn_auto_verified: !!wizard.store["trn_auto_verified"],
         active_alert: wizard.store["active_alert"],
         full_name: wizard.store["full_name"],
         date_of_birth: wizard.store["date_of_birth"],

--- a/spec/lib/forms/check_answers_spec.rb
+++ b/spec/lib/forms/check_answers_spec.rb
@@ -32,5 +32,20 @@ RSpec.describe Forms::CheckAnswers do
         expect(user.trn).to eql(verified_trn)
       end
     end
+
+    context "when trn_auto_verified is nil" do
+      before do
+        store["trn_auto_verified"] = nil
+      end
+
+      it "persists as false" do
+        subject.wizard = wizard
+        subject.after_save
+
+        user.reload
+
+        expect(user.trn_auto_verified).to eql(false)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

- reporting is not capable of treating falsey (nil/false) as being the same
- so reporting is adding an extra slice when falsey should be grouped together

### Changes proposed in this pull request

- ensure truthy/falsey `trn_auto_verified` is persisted as a boolean value

### Guidance to review

- none