### PR TITLE
Use database sessions instead of cookie sessions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby File.read(".ruby-version").chomp
 
+gem "activerecord-session_store"
 gem "bootsnap", ">= 1.1.0", require: false
 gem "canonical-rails"
 gem "delayed_job_active_record"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,12 @@ GEM
     activerecord (6.1.4.1)
       activemodel (= 6.1.4.1)
       activesupport (= 6.1.4.1)
+    activerecord-session_store (2.0.0)
+      actionpack (>= 5.2.4.1)
+      activerecord (>= 5.2.4.1)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 2.0.8, < 3)
+      railties (>= 5.2.4.1)
     activestorage (6.1.4.1)
       actionpack (= 6.1.4.1)
       activejob (= 6.1.4.1)
@@ -187,6 +193,7 @@ GEM
     mini_portile2 (2.6.1)
     minitest (5.14.4)
     msgpack (1.4.2)
+    multi_json (1.15.0)
     multipart-post (2.1.1)
     nio4r (2.5.8)
     nokogiri (1.12.3)
@@ -394,6 +401,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activerecord-session_store
   axe-core-capybara
   axe-core-rspec
   bootsnap (>= 1.1.0)

--- a/app/lib/forms/base.rb
+++ b/app/lib/forms/base.rb
@@ -42,7 +42,7 @@ module Forms
     end
 
     def requirements_met?
-      true
+      wizard.store.present?
     end
   end
 end

--- a/app/lib/forms/check_answers.rb
+++ b/app/lib/forms/check_answers.rb
@@ -1,9 +1,5 @@
 module Forms
   class CheckAnswers < Base
-    def requirements_met?
-      wizard.store["date_of_birth"].present?
-    end
-
     def previous_step
       :choose_school
     end

--- a/app/lib/forms/confirmation.rb
+++ b/app/lib/forms/confirmation.rb
@@ -1,4 +1,7 @@
 module Forms
   class Confirmation < Base
+    def requirements_met?
+      true
+    end
   end
 end

--- a/app/lib/forms/provider_check.rb
+++ b/app/lib/forms/provider_check.rb
@@ -24,5 +24,9 @@ module Forms
     def previous_step
       :start
     end
+
+    def requirements_met?
+      true
+    end
   end
 end

--- a/app/lib/forms/start.rb
+++ b/app/lib/forms/start.rb
@@ -1,4 +1,7 @@
 module Forms
   class Start < Base
+    def requirements_met?
+      true
+    end
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -52,5 +52,5 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  config.session_store :cookie_store, key: "_npq_registration_session", secure: false, expire_after: 2.weeks
+  config.session_store :active_record_store, key: "_npq_registration_session", secure: false, expire_after: 2.weeks
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -120,5 +120,5 @@ Rails.application.configure do
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 
-  config.session_store :cookie_store, key: "_npq_registration_session", secure: true, expire_after: 2.weeks
+  config.session_store :active_record_store, key: "_npq_registration_session", secure: true, expire_after: 2.weeks
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -48,5 +48,5 @@ Rails.application.configure do
 
   config.active_job.queue_adapter = :test
 
-  config.session_store :cookie_store, key: "_npq_registration_session", secure: false, expire_after: 2.weeks
+  config.session_store :active_record_store, key: "_npq_registration_session", secure: false, expire_after: 2.weeks
 end

--- a/db/migrate/20210831105602_add_sessions_table.rb
+++ b/db/migrate/20210831105602_add_sessions_table.rb
@@ -1,0 +1,12 @@
+class AddSessionsTable < ActiveRecord::Migration[6.1]
+  def change
+    create_table :sessions do |t|
+      t.string :session_id, null: false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id, unique: true
+    add_index :sessions, :updated_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_02_094543) do
+ActiveRecord::Schema.define(version: 2021_08_31_105602) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -97,6 +97,15 @@ ActiveRecord::Schema.define(version: 2021_08_02_094543) do
     t.text "postcode_without_spaces"
     t.index "to_tsvector('english'::regconfig, COALESCE(name, ''::text))", name: "school_name_search_idx", using: :gin
     t.index ["urn"], name: "index_schools_on_urn"
+  end
+
+  create_table "sessions", force: :cascade do |t|
+    t.string "session_id", null: false
+    t.text "data"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
+    t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/features/happy_journeys_spec.rb
+++ b/spec/features/happy_journeys_spec.rb
@@ -322,6 +322,6 @@ RSpec.feature "Happy journeys", type: :feature do
 
     visit "/registration/share-provider"
 
-    expect(page).to have_unchecked_field("Yes, I agree my information can be shared", visible: :all)
+    expect(page).to have_content("Before you start")
   end
 end


### PR DESCRIPTION
### Context

- This is needed as there will be a breaking change over form data stored in the session in the future
- This would render existing data to be incompatible, causing errors
- Using a server side store we are able to reset sessions when we want
- This is not easy with a cookie based store

### Changes proposed in this pull request

- Switch over from cookie store to databased backed store
- If the form data is missing for registration bounce users to the root path

### Guidance to review

- We can deploy this out of hours so direct effect so someone mid journey is minimised
- However those who come back to their journey will have to start again
- Those who hit submit `Continue` mid journey will get invalid authenticity csrf token. theres not much i can do about that