### PR TITLE
Add ECF foreign key to reporting

### DIFF
--- a/.github/workflows/export_dashboard_report.yml
+++ b/.github/workflows/export_dashboard_report.yml
@@ -1,7 +1,8 @@
 name: Export dashboard report to BigQuery
 
 on:
-  schedule:
+  - workflow_dispatch
+  - schedule:
     - cron:  '10 * * * *'
 
 jobs:

--- a/.github/workflows/generate_dashboard_report.yml
+++ b/.github/workflows/generate_dashboard_report.yml
@@ -1,7 +1,8 @@
 name: Generate dashboard report
 
 on:
-  schedule:
+  - workflow_dispatch
+  - schedule:
     - cron:  '0 * * * *'
 
 jobs:

--- a/app/lib/services/report.rb
+++ b/app/lib/services/report.rb
@@ -13,6 +13,7 @@ module Services
             a.user.trn_verified,
             a.user.trn_auto_verified,
             a.id,
+            a.ecf_id,
             a.created_at,
             a.headteacher_status,
             a.eligible_for_funding,
@@ -39,6 +40,7 @@ module Services
         trn_verified
         trn_auto_verified
         application_id
+        application_ecf_id
         application_created_at
         headteacher_status
         eligible_for_funding


### PR DESCRIPTION
### Context

- At the moment reporting is from NPQ only
- We want to join this up with ECF reporting
- We now export the id used in ECF for applications
- This allows joins in big query to made across datasets

### Changes proposed in this pull request

- Able to run reporting on ad-hoc basis via workflow dispatch
- Exporting application_ecf_id in reporting

### Guidance to review

- none