### PR TITLE
convert names with smart quotes to apostrophes

### DIFF
--- a/app/lib/forms/qualified_teacher_check.rb
+++ b/app/lib/forms/qualified_teacher_check.rb
@@ -14,6 +14,7 @@ module Forms
     end
 
     before_validation :strip_full_name_whitespace
+    before_validation :convert_full_name_smart_quotes
     before_validation :strip_trn_whitespace
     before_validation :strip_ni_number_whitespace
     before_validation :strip_title_prefixes
@@ -103,6 +104,10 @@ module Forms
 
     def strip_full_name_whitespace
       full_name&.squish!
+    end
+
+    def convert_full_name_smart_quotes
+      full_name&.tr!("’", "'")
     end
 
     def strip_trn_whitespace

--- a/spec/lib/forms/qualified_teacher_check_spec.rb
+++ b/spec/lib/forms/qualified_teacher_check_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Forms::QualifiedTeacherCheck, type: :model do
     subject do
       described_class.new(
         trn: "  1234  567  ",
-        full_name: "  John     Doe   ",
+        full_name: "  John     O’Doe   ",
         national_insurance_number: "  AB 12 34 56 C ",
       )
     end
@@ -15,9 +15,9 @@ RSpec.describe Forms::QualifiedTeacherCheck, type: :model do
       expect(subject.trn).to eql("1234567")
     end
 
-    it "strips superflous whitespace from full_name" do
+    it "strips superflous whitespace from full_name + converts smart quotes" do
       subject.valid?
-      expect(subject.full_name).to eql("John Doe")
+      expect(subject.full_name).to eql("John O'Doe")
     end
 
     it "strips superflous whitespace from NI number" do


### PR DESCRIPTION
### Context

- Users are entering their names with smart quotes and not "normal" apostrophes
- This causes an error on encoding when sending off to the API
- This is also how they appear to DQT so want to send "correct" name

### Changes proposed in this pull request

- Convert smart apostrophes into "normal" apostrophes

### Guidance to review

- none