### PR TITLE
funding radio labels no longer bold

### DIFF
--- a/app/views/registration_wizard/funding_your_npq.html.erb
+++ b/app/views/registration_wizard/funding_your_npq.html.erb
@@ -25,7 +25,9 @@
         :value,
         :text,
         :description,
-        legend: { text: "How is your #{@form.course.name} being paid for?" } %>
+        legend: { text: "How is your #{@form.course.name} being paid for?" },
+        bold_labels: false
+      %>
 
       <%= f.govuk_submit %>
     <% end %>


### PR DESCRIPTION
### Context

- Funding page radio labels were bold which does not match govuk component

### Changes proposed in this pull request

- Unbold to match govuk component

Before
![Screenshot 2021-09-13 at 10 26 12](https://user-images.githubusercontent.com/92580/133059583-f82ec0ea-d9ff-4f8a-8713-d4d919d79d7f.png)

After
![Screenshot 2021-09-13 at 10 26 02](https://user-images.githubusercontent.com/92580/133059605-5188f8a0-37df-4571-a739-a7d32160abb3.png)

### Guidance to review

- none