### PR TITLE
add convenience method on Application

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -3,4 +3,8 @@ class Application < ApplicationRecord
   belongs_to :course
   belongs_to :lead_provider
   belongs_to :school, foreign_key: "school_urn", primary_key: "urn", optional: true
+
+  def calculate_funding_eligbility
+    Services::FundingEligibility.new(course: course, institution: school, headteacher_status: headteacher_status).call
+  end
 end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe Application do
+  describe "#calculate_funding_eligbility" do
+    let(:mock_funding_service) { instance_double(Services::FundingEligibility, call: nil) }
+
+    subject { build(:application) }
+
+    it "calls Services::FundingEligibility with correct params" do
+      allow(Services::FundingEligibility).to receive(:new).with(course: subject.course, institution: subject.school, headteacher_status: subject.headteacher_status).and_return(mock_funding_service)
+
+      subject.calculate_funding_eligbility
+
+      expect(mock_funding_service).to have_received(:call)
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Changes to policy may affecting funding eligibility
- Support queries to create new applications on users behalf, this allows for a quick mechanism to workout the funding eligibility for an application

### Changes proposed in this pull request

- Add convenience method that wraps a service to use on the command line as quick way to check funding eligibility for an application

### Guidance to review

- none