### PR TITLE
add possible funding page

### DIFF
--- a/app/lib/forms/check_answers.rb
+++ b/app/lib/forms/check_answers.rb
@@ -3,7 +3,11 @@ module Forms
     include Helpers::Institution
 
     def previous_step
-      :choose_school
+      if funding_eligbility
+        :possible_funding
+      else
+        :funding_your_npq
+      end
     end
 
     def next_step
@@ -27,11 +31,7 @@ module Forms
         school_urn: institution.urn,
         ukprn: institution.ukprn,
         headteacher_status: wizard.store["headteacher_status"],
-        eligible_for_funding: Services::FundingEligibility.new(
-          course: course,
-          institution: institution,
-          headteacher_status: wizard.store["headteacher_status"],
-        ).call,
+        eligible_for_funding: funding_eligbility,
         funding_choice: wizard.store["funding"],
       )
 
@@ -41,6 +41,14 @@ module Forms
     end
 
   private
+
+    def funding_eligbility
+      @funding_eligbility ||= Services::FundingEligibility.new(
+        course: course,
+        institution: institution,
+        headteacher_status: wizard.store["headteacher_status"],
+      ).call
+    end
 
     def ni_number_to_store
       wizard.store["national_insurance_number"] unless wizard.store["trn_verified"]

--- a/app/lib/forms/choose_school.rb
+++ b/app/lib/forms/choose_school.rb
@@ -22,7 +22,7 @@ module Forms
       elsif !institution(source: institution_identifier).in_england?
         :school_not_in_england
       elsif eligible_for_funding?
-        :check_answers
+        :possible_funding
       else
         :funding_your_npq
       end

--- a/app/lib/forms/possible_funding.rb
+++ b/app/lib/forms/possible_funding.rb
@@ -1,0 +1,15 @@
+module Forms
+  class PossibleFunding < Base
+    def next_step
+      :check_answers
+    end
+
+    def previous_step
+      :choose_school
+    end
+
+    def course
+      @course ||= Course.find(wizard.store["course_id"])
+    end
+  end
+end

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -153,6 +153,7 @@ private
       find_school
       choose_school
       school_not_in_england
+      possible_funding
       funding_your_npq
       check_answers
       confirmation

--- a/app/views/registration_wizard/possible_funding.html.erb
+++ b/app/views/registration_wizard/possible_funding.html.erb
@@ -1,0 +1,28 @@
+<% content_for :title do %>
+  You may qualify for DfE scholarship funding
+<% end %>
+
+<% content_for :before_content do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: "Back",
+    href: registration_wizard_show_path(@wizard.previous_step_path)
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">You may qualify for DfE scholarship funding</h1>
+
+    <p class="govuk-body">
+      DfE scholarship funding may be available for the <%= @form.course.name %> course you have selected.
+    </p>
+
+    <p class="govuk-body">
+      Your training provider will give you more details and confirm if you qualify for funding.
+    </p>
+
+    <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/spec/features/happy_journeys_non_js_spec.rb
+++ b/spec/features/happy_journeys_non_js_spec.rb
@@ -104,7 +104,15 @@ RSpec.feature "Happy journeys", type: :feature do
     page.choose("Teach First", visible: :all)
     page.click_button("Continue")
 
-    School.create!(urn: 100_000, name: "open manchester school", address_1: "street 1", town: "manchester", establishment_status_code: "1")
+    School.create!(
+      urn: 100_000,
+      name: "open manchester school",
+      address_1: "street 1",
+      town: "manchester",
+      establishment_status_code: "1",
+      establishment_type_code: "1",
+      high_pupil_premium: true,
+    )
 
     expect(page).to have_text("Where is your school or college?")
     page.fill_in "School or college location", with: "manchester"
@@ -122,8 +130,7 @@ RSpec.feature "Happy journeys", type: :feature do
     page.choose "open manchester school", visible: :all
     page.click_button("Continue")
 
-    expect(page).to have_text("Funding")
-    page.choose "My school or college is covering the cost", visible: :all
+    expect(page).to have_text("You may qualify for DfE scholarship funding")
     page.click_button("Continue")
 
     check_answers_page = CheckAnswersPage.new
@@ -137,7 +144,6 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(check_answers_page.summary_list["NPQ"].value).to eql("NPQ for Senior Leadership (NPQSL)")
     expect(check_answers_page.summary_list.key?("Have you been a headteacher for two years or more?")).to be_falsey
     expect(check_answers_page.summary_list["School or college"].value).to eql("open manchester school")
-    expect(check_answers_page.summary_list["How is your NPQ being paid for?"].value).to eql("My school or college is covering the cost")
 
     allow(ApplicationSubmissionJob).to receive(:perform_later).with(anything)
 

--- a/spec/lib/forms/check_answers_spec.rb
+++ b/spec/lib/forms/check_answers_spec.rb
@@ -48,4 +48,37 @@ RSpec.describe Forms::CheckAnswers do
       end
     end
   end
+
+  describe "#previous_step" do
+    let(:course) { Course.all.sample }
+    let(:store) do
+      {
+        "course_id" => course.id.to_s,
+        "institution_identifier" => "School-#{school.urn}",
+      }
+    end
+    let(:school) { build(:school) }
+
+    subject { described_class.new(wizard: wizard) }
+
+    context "eligible_for_funding" do
+      let(:funding_double) { instance_double(Services::FundingEligibility, call: true) }
+
+      it "goes to possible_funding" do
+        allow(Services::FundingEligibility).to receive(:new).and_return(funding_double)
+
+        expect(subject.previous_step).to eql(:possible_funding)
+      end
+    end
+
+    context "ineligible_for_funding" do
+      let(:funding_double) { instance_double(Services::FundingEligibility, call: false) }
+
+      it "goes to funding_your_npq" do
+        allow(Services::FundingEligibility).to receive(:new).and_return(funding_double)
+
+        expect(subject.previous_step).to eql(:funding_your_npq)
+      end
+    end
+  end
 end

--- a/spec/lib/forms/choose_school_spec.rb
+++ b/spec/lib/forms/choose_school_spec.rb
@@ -66,10 +66,10 @@ RSpec.describe Forms::ChooseSchool, type: :model do
     context "eligible_for_funding" do
       let(:funding_double) { instance_double(Services::FundingEligibility, call: true) }
 
-      it "goes to check_answers" do
+      it "goes to possible_funding" do
         allow(Services::FundingEligibility).to receive(:new).and_return(funding_double)
 
-        expect(subject.next_step).to eql(:check_answers)
+        expect(subject.next_step).to eql(:possible_funding)
       end
     end
 

--- a/spec/lib/forms/possible_funding_spec.rb
+++ b/spec/lib/forms/possible_funding_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe Forms::PossibleFunding do
+  describe "#next_step" do
+    it "returns check_answers" do
+      expect(subject.next_step).to eql(:check_answers)
+    end
+  end
+
+  describe "#previous_step" do
+    it "returns choose_school" do
+      expect(subject.previous_step).to eql(:choose_school)
+    end
+  end
+
+  describe "#course" do
+    let(:course) { Course.all.sample }
+    let(:store) { { "course_id" => course.id } }
+    let(:request) { nil }
+    let(:wizard) do
+      RegistrationWizard.new(
+        current_step: :possible_funding,
+        store: store,
+        request: request,
+      )
+    end
+
+    before do
+      subject.wizard = wizard
+    end
+
+    it "reutrns the course undertaken" do
+      expect(subject.course).to eql(course)
+    end
+  end
+end


### PR DESCRIPTION
### Context

- If we think user is eligible for funding we now show possible funding screen before the user checks their answers
- If they are not eligible for funding they would get the "Choose your funding" page instead

### Changes proposed in this pull request

- Add extra page to journey
- Fixed back button on check answers page, now goes to where it should

#### Screenshots

![Screenshot 2021-09-23 at 16 45 32](https://user-images.githubusercontent.com/92580/134540159-19a4929f-cbfd-4d50-aef5-5a5b625017a9.png)

### Guidance to review

- none