### PR TITLE
Add Additional Support Offer Journey

### DIFF
--- a/app/lib/forms/about_aso.rb
+++ b/app/lib/forms/about_aso.rb
@@ -1,11 +1,11 @@
 module Forms
-  class DqtMismatch < Base
+  class AboutAso < Base
     def previous_step
-      :qualified_teacher_check
+      :choose_your_npq
     end
 
     def next_step
-      :find_school
+      :npqh_status
     end
   end
 end

--- a/app/lib/forms/aso_funding_contact.rb
+++ b/app/lib/forms/aso_funding_contact.rb
@@ -1,0 +1,7 @@
+module Forms
+  class AsoFundingContact < Base
+    def previous_step
+      :aso_funding_not_available
+    end
+  end
+end

--- a/app/lib/forms/aso_funding_not_available.rb
+++ b/app/lib/forms/aso_funding_not_available.rb
@@ -1,0 +1,40 @@
+module Forms
+  class AsoFundingNotAvailable < Base
+    attr_accessor :aso_funding
+
+    validates :aso_funding, presence: true
+
+    def self.permitted_params
+      %i[
+        aso_funding
+      ]
+    end
+
+    def previous_step
+      if wizard.store["aso_headteacher"] == "yes"
+        :aso_new_headteacher
+      else
+        :aso_headteacher
+      end
+    end
+
+    def next_step
+      if aso_funding == "no"
+        :aso_funding_contact
+      else
+        :funding_your_aso
+      end
+    end
+
+    def options
+      [
+        OpenStruct.new(value: "yes",
+                       text: "Yes, I will pay another way",
+                       link_errors: true),
+        OpenStruct.new(value: "no",
+                       text: "No",
+                       link_errors: false),
+      ]
+    end
+  end
+end

--- a/app/lib/forms/aso_funding_not_available.rb
+++ b/app/lib/forms/aso_funding_not_available.rb
@@ -1,8 +1,10 @@
 module Forms
   class AsoFundingNotAvailable < Base
+    VALID_ASO_FUNDING_OPTIONS = %w[yes no].freeze
+
     attr_accessor :aso_funding
 
-    validates :aso_funding, presence: true
+    validates :aso_funding, presence: true, inclusion: { in: VALID_ASO_FUNDING_OPTIONS }
 
     def self.permitted_params
       %i[

--- a/app/lib/forms/aso_headteacher.rb
+++ b/app/lib/forms/aso_headteacher.rb
@@ -1,0 +1,50 @@
+module Forms
+  class AsoHeadteacher < Base
+    include Helpers::Institution
+
+    attr_accessor :aso_headteacher
+
+    validates :aso_headteacher, presence: true
+
+    def self.permitted_params
+      %i[
+        aso_headteacher
+      ]
+    end
+
+    def next_step
+      if aso_headteacher == "no"
+        :aso_funding_not_available
+      else
+        :aso_new_headteacher
+      end
+    end
+
+    def previous_step
+      :npqh_status
+    end
+
+    def options
+      options_array.each_with_index.map do |option, index|
+        OpenStruct.new(value: option[:value],
+                       text: option[:text],
+                       link_errors: index.zero?)
+      end
+    end
+
+  private
+
+    def options_array
+      [
+        {
+          text: "Yes, I am a headteacher",
+          value: "yes",
+        },
+        {
+          text: "No",
+          value: "no",
+        },
+      ]
+    end
+  end
+end

--- a/app/lib/forms/aso_headteacher.rb
+++ b/app/lib/forms/aso_headteacher.rb
@@ -1,10 +1,12 @@
 module Forms
   class AsoHeadteacher < Base
+    VALID_ASO_HEADTEACHER_OPTIONS = %w[yes no].freeze
+
     include Helpers::Institution
 
     attr_accessor :aso_headteacher
 
-    validates :aso_headteacher, presence: true
+    validates :aso_headteacher, presence: true, inclusion: { in: VALID_ASO_HEADTEACHER_OPTIONS }
 
     def self.permitted_params
       %i[

--- a/app/lib/forms/aso_new_headteacher.rb
+++ b/app/lib/forms/aso_new_headteacher.rb
@@ -1,10 +1,12 @@
 module Forms
   class AsoNewHeadteacher < Base
+    VALID_ASO_NEW_HEADTEACHER_OPTIONS = %w[yes no].freeze
+
     include Helpers::Institution
 
     attr_accessor :aso_new_headteacher
 
-    validates :aso_new_headteacher, presence: true
+    validates :aso_new_headteacher, presence: true, inclusion: { in: VALID_ASO_NEW_HEADTEACHER_OPTIONS }
 
     def self.permitted_params
       %i[

--- a/app/lib/forms/aso_new_headteacher.rb
+++ b/app/lib/forms/aso_new_headteacher.rb
@@ -1,0 +1,50 @@
+module Forms
+  class AsoNewHeadteacher < Base
+    include Helpers::Institution
+
+    attr_accessor :aso_new_headteacher
+
+    validates :aso_new_headteacher, presence: true
+
+    def self.permitted_params
+      %i[
+        aso_new_headteacher
+      ]
+    end
+
+    def next_step
+      if aso_new_headteacher == "no"
+        :aso_funding_not_available
+      else
+        :aso_possible_funding
+      end
+    end
+
+    def previous_step
+      :aso_headteacher
+    end
+
+    def options
+      options_array.each_with_index.map do |option, index|
+        OpenStruct.new(value: option[:value],
+                       text: option[:text],
+                       link_errors: index.zero?)
+      end
+    end
+
+  private
+
+    def options_array
+      [
+        {
+          text: "Yes, I am in my first 2 years of a headship",
+          value: "yes",
+        },
+        {
+          text: "No",
+          value: "no",
+        },
+      ]
+    end
+  end
+end

--- a/app/lib/forms/aso_possible_funding.rb
+++ b/app/lib/forms/aso_possible_funding.rb
@@ -1,12 +1,11 @@
 module Forms
-  class PossibleFunding < Base
+  class AsoPossibleFunding < Base
     def next_step
       :choose_your_provider
     end
 
     def previous_step
-      # TODO: WRONG
-      :choose_school
+      :aso_new_headteacher
     end
 
     def course

--- a/app/lib/forms/aso_unavailable.rb
+++ b/app/lib/forms/aso_unavailable.rb
@@ -1,0 +1,7 @@
+module Forms
+  class AsoUnavailable < Base
+    def previous_step
+      :npqh_status
+    end
+  end
+end

--- a/app/lib/forms/change_dqt.rb
+++ b/app/lib/forms/change_dqt.rb
@@ -3,9 +3,5 @@ module Forms
     def previous_step
       :not_updated_name
     end
-
-    def next_step
-      :not_updated_name
-    end
   end
 end

--- a/app/lib/forms/check_answers.rb
+++ b/app/lib/forms/check_answers.rb
@@ -3,15 +3,7 @@ module Forms
     include Helpers::Institution
 
     def previous_step
-      if course.name == "Additional Support Offer for new headteachers"
-        :choose_your_provider
-      else
-        if funding_eligbility
-          :possible_funding
-        else
-          :funding_your_npq
-        end
-      end
+      :choose_your_provider
     end
 
     def next_step

--- a/app/lib/forms/check_answers.rb
+++ b/app/lib/forms/check_answers.rb
@@ -3,10 +3,14 @@ module Forms
     include Helpers::Institution
 
     def previous_step
-      if funding_eligbility
-        :possible_funding
+      if course.name == "Additional Support Offer for new headteachers"
+        :choose_your_provider
       else
-        :funding_your_npq
+        if funding_eligbility
+          :possible_funding
+        else
+          :funding_your_npq
+        end
       end
     end
 

--- a/app/lib/forms/check_answers.rb
+++ b/app/lib/forms/check_answers.rb
@@ -11,56 +11,12 @@ module Forms
     end
 
     def after_save
-      user.update!(
-        trn: wizard.store["verified_trn"].presence || wizard.store["trn"],
-        trn_verified: wizard.store["trn_verified"],
-        trn_auto_verified: !!wizard.store["trn_auto_verified"],
-        active_alert: wizard.store["active_alert"],
-        full_name: wizard.store["full_name"],
-        date_of_birth: wizard.store["date_of_birth"],
-        national_insurance_number: ni_number_to_store,
-      )
-
-      user.applications.create!(
-        course_id: course.id,
-        lead_provider_id: wizard.store["lead_provider_id"],
-        school_urn: institution.urn,
-        ukprn: institution.ukprn,
-        headteacher_status: wizard.store["headteacher_status"],
-        eligible_for_funding: funding_eligbility,
-        funding_choice: wizard.store["funding"],
-      )
-
-      ApplicationSubmissionJob.perform_later(user: user)
+      Services::HandleSubmissionForStore.new(store: wizard.store).call
 
       clear_answers_in_store
     end
 
   private
-
-    def funding_eligbility
-      @funding_eligbility ||= Services::FundingEligibility.new(
-        course: course,
-        institution: institution,
-        headteacher_status: wizard.store["headteacher_status"],
-      ).call
-    end
-
-    def ni_number_to_store
-      wizard.store["national_insurance_number"] unless wizard.store["trn_verified"]
-    end
-
-    def course
-      @course ||= Course.find(wizard.store["course_id"])
-    end
-
-    def school
-      @school ||= School.find_by(urn: wizard.store["school_urn"])
-    end
-
-    def user
-      @user ||= User.find_by(email: wizard.store["confirmed_email"])
-    end
 
     def clear_answers_in_store
       wizard.store.clear

--- a/app/lib/forms/choose_school.rb
+++ b/app/lib/forms/choose_school.rb
@@ -21,10 +21,8 @@ module Forms
         :choose_school
       elsif !institution(source: institution_identifier).in_england?
         :school_not_in_england
-      elsif eligible_for_funding?
-        :possible_funding
       else
-        :funding_your_npq
+        :choose_your_npq
       end
     end
 

--- a/app/lib/forms/choose_your_npq.rb
+++ b/app/lib/forms/choose_your_npq.rb
@@ -19,8 +19,9 @@ module Forms
           :check_answers
         elsif studying_for_headship?
           :headteacher_duration
-        elsif wizard.form_for_step(:choose_school).eligible_for_funding? &&
-            !Services::FundingEligibility.new(course: course, institution: institution, headteacher_status: headteacher_status).call
+        elsif studying_for_aso?
+          :about_aso
+        elsif previously_eligible_for_funding? && now_no_longer_eligible_for_funding?
           :funding_your_npq
         else
           :check_answers
@@ -62,6 +63,14 @@ module Forms
     end
 
   private
+
+    def previously_eligible_for_funding?
+      wizard.form_for_step(:choose_school).eligible_for_funding?
+    end
+
+    def now_no_longer_eligible_for_funding?
+      !Services::FundingEligibility.new(course: course, institution: institution, headteacher_status: headteacher_status).call
+    end
 
     def headteacher_status
       wizard.store["headteacher_status"]

--- a/app/lib/forms/choose_your_npq.rb
+++ b/app/lib/forms/choose_your_npq.rb
@@ -17,18 +17,18 @@ module Forms
       if changing_answer?
         if no_answers_will_change?
           :check_answers
-        elsif studying_for_headship?
+        elsif course.npqh?
           :headteacher_duration
-        elsif studying_for_aso?
+        elsif course.aso?
           :about_aso
         elsif previously_eligible_for_funding? && now_no_longer_eligible_for_funding?
           :funding_your_npq
         else
           :check_answers
         end
-      elsif studying_for_headship?
+      elsif course.npqh?
         :headteacher_duration
-      elsif studying_for_aso?
+      elsif course.aso?
         :about_aso
       elsif Services::FundingEligibility.new(course: course, institution: institution, headteacher_status: headteacher_status).call
         :possible_funding
@@ -39,14 +39,6 @@ module Forms
 
     def previous_step
       :choose_school
-    end
-
-    def studying_for_headship?
-      course.studying_for_headship?
-    end
-
-    def studying_for_aso?
-      course.studying_for_aso?
     end
 
     def options

--- a/app/lib/forms/choose_your_npq.rb
+++ b/app/lib/forms/choose_your_npq.rb
@@ -27,24 +27,33 @@ module Forms
         end
       elsif studying_for_headship?
         :headteacher_duration
+      elsif studying_for_aso?
+        :about_aso
+      elsif Services::FundingEligibility.new(course: course, institution: institution, headteacher_status: headteacher_status).call
+        :possible_funding
       else
-        :choose_your_provider
+        :funding_your_npq
       end
     end
 
     def previous_step
-      :qualified_teacher_check
+      :choose_school
     end
 
     def studying_for_headship?
       course.studying_for_headship?
     end
 
+    def studying_for_aso?
+      course.studying_for_aso?
+    end
+
     def options
       Course.all.each_with_index.map do |course, index|
         OpenStruct.new(value: course.id,
                        text: course.name,
-                       link_errors: index.zero?)
+                       link_errors: index.zero?,
+                       hint: course.description)
       end
     end
 

--- a/app/lib/forms/choose_your_provider.rb
+++ b/app/lib/forms/choose_your_provider.rb
@@ -1,5 +1,7 @@
 module Forms
   class ChooseYourProvider < Base
+    include Helpers::Institution
+
     attr_accessor :lead_provider_id
 
     validates :lead_provider_id, presence: true
@@ -15,13 +17,17 @@ module Forms
       if changing_answer?
         :check_answers
       else
-        :find_school
+        :check_answers
       end
     end
 
     def previous_step
       if wizard.form_for_step(:choose_your_npq).studying_for_headship?
         :headteacher_duration
+      elsif course.name == "Additional Support Offer for new headteachers" && wizard.store["aso_funding"] == "yes"
+        :funding_your_aso
+      elsif wizard.store["aso_new_headteacher"] == "yes"
+        :aso_possible_funding
       else
         :choose_your_npq
       end
@@ -44,6 +50,18 @@ module Forms
     end
 
   private
+
+    def eligible_for_funding?
+      Services::FundingEligibility.new(course: course, institution: institution(source: institution_identifier), headteacher_status: headteacher_status).call
+    end
+
+    def institution_identifier
+      wizard.store["institution_identifier"]
+    end
+
+    def headteacher_status
+      wizard.store["headteacher_status"]
+    end
 
     def validate_lead_provider_exists
       if lead_provider.blank?

--- a/app/lib/forms/choose_your_provider.rb
+++ b/app/lib/forms/choose_your_provider.rb
@@ -18,7 +18,7 @@ module Forms
     end
 
     def previous_step
-      if course.nph?
+      if course.npqh?
         :headteacher_duration
       elsif course.aso? && wizard.store["aso_funding"] == "yes"
         :funding_your_aso

--- a/app/lib/forms/choose_your_provider.rb
+++ b/app/lib/forms/choose_your_provider.rb
@@ -18,9 +18,9 @@ module Forms
     end
 
     def previous_step
-      if wizard.form_for_step(:choose_your_npq).studying_for_headship?
+      if course.nph?
         :headteacher_duration
-      elsif course.name == "Additional Support Offer for new headteachers" && wizard.store["aso_funding"] == "yes"
+      elsif course.aso? && wizard.store["aso_funding"] == "yes"
         :funding_your_aso
       elsif wizard.store["aso_new_headteacher"] == "yes"
         :aso_possible_funding

--- a/app/lib/forms/choose_your_provider.rb
+++ b/app/lib/forms/choose_your_provider.rb
@@ -14,11 +14,7 @@ module Forms
     end
 
     def next_step
-      if changing_answer?
-        :check_answers
-      else
-        :check_answers
-      end
+      :check_answers
     end
 
     def previous_step

--- a/app/lib/forms/dqt_mismatch.rb
+++ b/app/lib/forms/dqt_mismatch.rb
@@ -5,7 +5,11 @@ module Forms
     end
 
     def next_step
-      :find_school
+      if changing_answer?
+        :check_answers
+      else
+        :find_school
+      end
     end
   end
 end

--- a/app/lib/forms/find_school.rb
+++ b/app/lib/forms/find_school.rb
@@ -15,7 +15,7 @@ module Forms
     end
 
     def previous_step
-      :choose_your_provider
+      :qualified_teacher_check
     end
   end
 end

--- a/app/lib/forms/funding_your_aso.rb
+++ b/app/lib/forms/funding_your_aso.rb
@@ -1,14 +1,14 @@
 module Forms
-  class FundingYourNpq < Base
+  class FundingYourAso < Base
     VALID_FUNDING_OPTIONS = %w[school trust self another].freeze
 
-    attr_accessor :funding
+    attr_accessor :aso_funding_choice
 
-    validates :funding, presence: true, inclusion: { in: VALID_FUNDING_OPTIONS }
+    validates :aso_funding_choice, presence: true, inclusion: { in: VALID_FUNDING_OPTIONS }
 
     def self.permitted_params
       %i[
-        funding
+        aso_funding_choice
       ]
     end
 
@@ -17,11 +17,7 @@ module Forms
     end
 
     def previous_step
-      :choose_school
-    end
-
-    def course
-      @course ||= Course.find(wizard.store["course_id"])
+      :aso_funding_not_available
     end
 
     def options
@@ -36,8 +32,8 @@ module Forms
                        text: "I am paying",
                        link_errors: false),
         OpenStruct.new(value: "another",
-                       text: "My NPQ is being paid in another way",
-                       description: "For example, I am sharing the costs with my school or college",
+                       text: "The Additional Support Offer is being paid in another way",
+                       hint: "For example, I am sharing the costs with my school or college",
                        link_errors: false),
       ].freeze
     end

--- a/app/lib/forms/headteacher_duration.rb
+++ b/app/lib/forms/headteacher_duration.rb
@@ -1,5 +1,7 @@
 module Forms
   class HeadteacherDuration < Base
+    include Helpers::Institution
+
     VALID_HEADTEACHER_STATUS_OPTIONS = %w[yes_in_first_two_years yes_over_two_years yes_when_course_starts no].freeze
 
     attr_accessor :headteacher_status
@@ -15,8 +17,10 @@ module Forms
     def next_step
       if changing_answer?
         :check_answers
+      elsif Services::FundingEligibility.new(course: course, institution: institution, headteacher_status: headteacher_status).call
+        :possible_funding
       else
-        :choose_your_provider
+        :funding_your_npq
       end
     end
 
@@ -39,6 +43,12 @@ module Forms
                        text: "No, I am not a headteacher",
                        link_errors: false),
       ]
+    end
+
+  private
+
+    def course
+      Course.find(wizard.store["course_id"])
     end
   end
 end

--- a/app/lib/forms/npqh_status.rb
+++ b/app/lib/forms/npqh_status.rb
@@ -1,0 +1,58 @@
+module Forms
+  class NpqhStatus < Base
+    include Helpers::Institution
+
+    attr_accessor :npqh_status
+
+    validates :npqh_status, presence: true
+
+    def self.permitted_params
+      %i[
+        npqh_status
+      ]
+    end
+
+    def next_step
+      if npqh_status == "none"
+        :aso_unavailable
+      else
+        :aso_headteacher
+      end
+    end
+
+    def previous_step
+      :about_aso
+    end
+
+    def options
+      options_array.each_with_index.map do |option, index|
+        OpenStruct.new(value: option[:value],
+                       text: option[:text],
+                       link_errors: index.zero?)
+      end
+    end
+
+  private
+
+    def options_array
+      [
+        {
+          text: "I have completed an NPQH",
+          value: "completed_npqh",
+        },
+        {
+          text: "I am still studying for an NPQH",
+          value: "studying_npqh",
+        },
+        {
+          text: "I am about to start an NPQH",
+          value: "will_start_npqh",
+        },
+        {
+          text: "None of the above",
+          value: "none",
+        },
+      ]
+    end
+  end
+end

--- a/app/lib/forms/npqh_status.rb
+++ b/app/lib/forms/npqh_status.rb
@@ -1,10 +1,12 @@
 module Forms
   class NpqhStatus < Base
+    VALID_NPQH_STATUS_OPTIONS = %w[completed_npqh studying_npqh will_start_npqh none].freeze
+
     include Helpers::Institution
 
     attr_accessor :npqh_status
 
-    validates :npqh_status, presence: true
+    validates :npqh_status, presence: true, inclusion: { in: VALID_NPQH_STATUS_OPTIONS }
 
     def self.permitted_params
       %i[

--- a/app/lib/forms/possible_funding.rb
+++ b/app/lib/forms/possible_funding.rb
@@ -5,8 +5,11 @@ module Forms
     end
 
     def previous_step
-      # TODO: WRONG
-      :choose_school
+      if course.name == "NPQ for Headship (NPQH)"
+        :headteacher_duration
+      else
+        :choose_your_npq
+      end
     end
 
     def course

--- a/app/lib/forms/possible_funding.rb
+++ b/app/lib/forms/possible_funding.rb
@@ -5,7 +5,7 @@ module Forms
     end
 
     def previous_step
-      if course.name == "NPQ for Headship (NPQH)"
+      if course.npqh?
         :headteacher_duration
       else
         :choose_your_npq

--- a/app/lib/forms/qualified_teacher_check.rb
+++ b/app/lib/forms/qualified_teacher_check.rb
@@ -52,7 +52,7 @@ module Forms
         if changing_answer?
           :check_answers
         else
-          :choose_your_npq
+          :find_school
         end
       else
         mark_trn_as_unverified

--- a/app/lib/services/handle_submission_for_store.rb
+++ b/app/lib/services/handle_submission_for_store.rb
@@ -59,11 +59,15 @@ module Services
     end
 
     def funding_eligbility
-      @funding_eligbility ||= Services::FundingEligibility.new(
-        course: course,
-        institution: institution(source: store["institution_identifier"]),
-        headteacher_status: store["headteacher_status"],
-      ).call
+      if course.aso?
+        (store["aso_headteacher"] == "yes") && (store["aso_new_headteacher"] == "yes")
+      else
+        Services::FundingEligibility.new(
+          course: course,
+          institution: institution(source: store["institution_identifier"]),
+          headteacher_status: store["headteacher_status"],
+        ).call
+      end
     end
 
     def ni_number_to_store

--- a/app/lib/services/handle_submission_for_store.rb
+++ b/app/lib/services/handle_submission_for_store.rb
@@ -27,7 +27,7 @@ module Services
           ukprn: institution(source: store["institution_identifier"]).ukprn,
           headteacher_status: headteacher_status,
           eligible_for_funding: funding_eligbility,
-          funding_choice: store["funding"],
+          funding_choice: funding_choice,
         )
 
         enqueue_job
@@ -35,6 +35,14 @@ module Services
     end
 
   private
+
+    def funding_choice
+      if course.aso?
+        store["aso_funding_choice"]
+      else
+        store["funding"]
+      end
+    end
 
     def headteacher_status
       if course.aso?

--- a/app/lib/services/handle_submission_for_store.rb
+++ b/app/lib/services/handle_submission_for_store.rb
@@ -1,0 +1,85 @@
+module Services
+  class HandleSubmissionForStore
+    include Forms::Helpers::Institution
+
+    attr_reader :store
+
+    def initialize(store:)
+      @store = store
+    end
+
+    def call
+      ActiveRecord::Base.transaction do
+        user.update!(
+          trn: store["verified_trn"].presence || store["trn"],
+          trn_verified: store["trn_verified"],
+          trn_auto_verified: !!store["trn_auto_verified"],
+          active_alert: store["active_alert"],
+          full_name: store["full_name"],
+          date_of_birth: store["date_of_birth"],
+          national_insurance_number: ni_number_to_store,
+        )
+
+        user.applications.create!(
+          course_id: course.id,
+          lead_provider_id: store["lead_provider_id"],
+          school_urn: institution(source: store["institution_identifier"]).urn,
+          ukprn: institution(source: store["institution_identifier"]).ukprn,
+          headteacher_status: headteacher_status,
+          eligible_for_funding: funding_eligbility,
+          funding_choice: store["funding"],
+        )
+
+        enqueue_job
+      end
+    end
+
+  private
+
+    def headteacher_status
+      if course.aso?
+        case store["aso_headteacher"]
+        when "yes"
+          case store["aso_new_headteacher"]
+          when "yes"
+            "yes_in_first_two_years"
+          when "no"
+            "yes_over_two_years"
+          end
+        when "no"
+          "no"
+        end
+      else
+        store["headteacher_status"]
+      end
+    end
+
+    def enqueue_job
+      ApplicationSubmissionJob.perform_later(user: user)
+    end
+
+    def funding_eligbility
+      @funding_eligbility ||= Services::FundingEligibility.new(
+        course: course,
+        institution: institution(source: store["institution_identifier"]),
+        headteacher_status: store["headteacher_status"],
+      ).call
+    end
+
+    def ni_number_to_store
+      store["national_insurance_number"] unless store["trn_verified"]
+    end
+
+    def course
+      @course ||= Course.find(store["course_id"])
+    end
+
+    def school
+      @school ||= School.find_by(urn: store["school_urn"])
+    end
+
+    def user
+      @user ||= User.find_by(email: store["confirmed_email"])
+    end
+  end
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,14 +1,6 @@
 class Course < ApplicationRecord
-  def studying_for_headship?
-    name == "NPQ for Headship (NPQH)"
-  end
-
   def npqh?
     name == "NPQ for Headship (NPQH)"
-  end
-
-  def studying_for_aso?
-    name == "Additional Support Offer for new headteachers"
   end
 
   def aso?

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -14,4 +14,8 @@ class Course < ApplicationRecord
   def aso?
     name == "Additional Support Offer for new headteachers"
   end
+
+  def npqsl?
+    name == "NPQ for Senior Leadership (NPQSL)"
+  end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -3,7 +3,15 @@ class Course < ApplicationRecord
     name == "NPQ for Headship (NPQH)"
   end
 
+  def npqh?
+    name == "NPQ for Headship (NPQH)"
+  end
+
   def studying_for_aso?
+    name == "Additional Support Offer for new headteachers"
+  end
+
+  def aso?
     name == "Additional Support Offer for new headteachers"
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -2,4 +2,8 @@ class Course < ApplicationRecord
   def studying_for_headship?
     name == "NPQ for Headship (NPQH)"
   end
+
+  def studying_for_aso?
+    name == "Additional Support Offer for new headteachers"
+  end
 end

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -79,12 +79,12 @@ class RegistrationWizard
     array << OpenStruct.new(key: "Email",
                             value: store["confirmed_email"],
                             change_step: :contact_details)
-    array << OpenStruct.new(key: "NPQ",
+    array << OpenStruct.new(key: "Course",
                             value: form_for_step(:choose_your_npq).course.name,
                             change_step: :choose_your_npq)
 
     if form_for_step(:choose_your_npq).studying_for_headship?
-      array << OpenStruct.new(key: "How long have you been a headteacher?",
+      array << OpenStruct.new(key: "Have you been a headteacher for less than 24 months?",
                               value: store["headteacher_status"].humanize,
                               change_step: :headteacher_duration)
     end
@@ -147,6 +147,15 @@ private
       resend_code
       qualified_teacher_check
       dqt_mismatch
+      about_aso
+      npqh_status
+      aso_unavailable
+      aso_headteacher
+      aso_new_headteacher
+      aso_funding_not_available
+      aso_possible_funding
+      aso_funding_contact
+      funding_your_aso
       choose_your_npq
       headteacher_duration
       choose_your_provider

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -88,13 +88,13 @@ class RegistrationWizard
                             value: form_for_step(:choose_your_npq).course.name,
                             change_step: :choose_your_npq)
 
-    if form_for_step(:choose_your_npq).studying_for_headship?
+    if course.npqh?
       array << OpenStruct.new(key: "Have you been a headteacher for less than 24 months?",
                               value: store["headteacher_status"].humanize,
                               change_step: :headteacher_duration)
     end
 
-    if studying_aso?
+    if course.aso?
       if aso_needs_funding?
         array << OpenStruct.new(key: "How is the Additional Support Offer being paid for?",
                                 value: I18n.t(store["aso_funding_choice"], scope: "activemodel.attributes.forms/funding_your_aso.funding_options"),
@@ -126,10 +126,6 @@ private
 
   def aso_needs_funding?
     store["aso_funding"] == "yes"
-  end
-
-  def studying_aso?
-    course.name == "Additional Support Offer for new headteachers"
   end
 
   def course

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -95,6 +95,11 @@ class RegistrationWizard
     end
 
     if studying_aso?
+      if aso_needs_funding?
+        array << OpenStruct.new(key: "How is the Additional Support Offer being paid for?",
+                                value: I18n.t(store["aso_funding_choice"], scope: "activemodel.attributes.forms/funding_your_aso.funding_options"),
+                                change_step: :funding_your_aso)
+      end
     else
       unless form_for_step(:choose_school).eligible_for_funding?
         array << OpenStruct.new(key: "How is your NPQ being paid for?",
@@ -118,6 +123,10 @@ class RegistrationWizard
   end
 
 private
+
+  def aso_needs_funding?
+    store["aso_funding"] == "yes"
+  end
 
   def studying_aso?
     course.name == "Additional Support Offer for new headteachers"

--- a/app/views/registration_wizard/about_aso.html.erb
+++ b/app/views/registration_wizard/about_aso.html.erb
@@ -1,0 +1,38 @@
+<% content_for :title do %>
+  Additional Support Offer for new headteachers
+<% end %>
+
+<% content_for :before_content do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: "Back",
+    href: registration_wizard_show_path(@wizard.previous_step_path)
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl" >Additional Support Offer for new headteachers</h1>
+
+    <p class="govuk-body">The Additional Support Offer is a targeted support package for new headteachers.</p>
+
+    <h2 class="govuk-heading-m">Who is this for?</h2>
+
+    <p class="govuk-body">You can register for the Additonal Support Offer if you:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>have completed an NPQH</li>
+      <li>are studying for an NPQH</li>
+      <li>are about to start an NPQH</li>
+    </ul>
+
+    <h2 class="govuk-heading-m">How is this paid for?</h2>
+
+    <p class="govuk-body">You may be eligible for DfE scholarship funding if you are a headteacher in your first 2 years of headship.</p>
+
+    <p class="govuk-body">Or you can pay the £800 cost of your Additional Support Offer another way.</p>
+
+    <p class="govuk-body"><%= govuk_link_to "Read more about the Additional Support Offer for new headteachers", "https://www.gov.uk/government/publications/national-professional-qualifications-npqs-reforms/national-professional-qualifications-npqs-reforms#additional-support-offer-for-the-npq-in-headship" %></p>
+
+    <%= govuk_button_link_to "Continue", registration_wizard_show_path(@wizard.next_step_path) %>
+  </div>
+</div>

--- a/app/views/registration_wizard/about_npq.html.erb
+++ b/app/views/registration_wizard/about_npq.html.erb
@@ -30,6 +30,7 @@
     </ul>
 
     <p class="govuk-body">These will be known as:</p>
+
     <ul class="govuk-list govuk-list--bullet">
       <li>NPQ Leading Teaching</li>
       <li>NPQ Leading Behaviour and Culture</li>
@@ -39,7 +40,14 @@
       <li>NPQ Executive Leadership</li>
     </ul>
 
+    <h2 class="govuk-heading-m">Additional Support Offer for new headteachers</h2>
+
+    <p class="govuk-body">From autumn 2021 the additional support offer is a new targeted support package for teachers new to the role of headship.</p>
+
+    <p class="govuk-body">It is for new headteachers in their first 2 years of a headship role who have either completed an NPQH or are currently taking an NPQH.</p>
+
     <h2 class="govuk-heading-m">Providers</h2>
+
     <p class="govuk-body">There are nine training providers across England which run NPQ training courses.</p>
     <p class="govuk-body">They are:</p>
     <ul class="govuk-list govuk-list--bullet">
@@ -55,6 +63,7 @@
     </ul>
 
     <p class="govuk-body">Some providers may have specific criteria depending on your school or college’s circumstances. </p>
-    <p class="govuk-body">If you are interested in a particular NPQ programme, your first step will be to sign up with a provider. The easiest way to do this is to contact your local teaching school hub. To find your local Teaching School Hub, please search ‘teaching school hubs’ on GOV.UK. You can also contact lead providers or other delivery partners directly.</p>
+
+    <p class="govuk-body">Check with your current school or college to see if they recommended accredited partners for NPQ training.</p>
   </div>
 </div>

--- a/app/views/registration_wizard/about_npq.html.erb
+++ b/app/views/registration_wizard/about_npq.html.erb
@@ -32,8 +32,8 @@
     <p class="govuk-body">These will be known as:</p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>NPQ Leading Teaching</li>
       <li>NPQ Leading Behaviour and Culture</li>
+      <li>NPQ Leading Teaching</li>
       <li>NPQ Leading Teaching Development</li>
       <li>NPQ Senior Leadership</li>
       <li>NPQ Headship</li>

--- a/app/views/registration_wizard/aso_funding_contact.html.erb
+++ b/app/views/registration_wizard/aso_funding_contact.html.erb
@@ -1,0 +1,20 @@
+<% content_for :title do %>
+  Contact your provider
+<% end %>
+
+<% content_for :before_content do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: "Back",
+    href: registration_wizard_show_path(@wizard.previous_step_path)
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Contact your provider</h1>
+
+    <p class="govuk-body">Get in touch with your provider for other funding options for the Additional Support Offer.</p>
+
+    <p class="govuk-body"><%= govuk_link_to "Read more about the Additional Support Offer for new headteachers", "https://www.gov.uk/government/publications/national-professional-qualifications-npqs-reforms/national-professional-qualifications-npqs-reforms#additional-support-offer-for-the-npq-in-headship" %></p>
+  </div>
+</div>

--- a/app/views/registration_wizard/aso_funding_not_available.html.erb
+++ b/app/views/registration_wizard/aso_funding_not_available.html.erb
@@ -1,0 +1,35 @@
+<% content_for :title do %>
+  DfE scholarship funding not available
+<% end %>
+
+<% content_for :before_content do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: "Back",
+    href: registration_wizard_show_path(@wizard.previous_step_path)
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl" >DfE scholarship funding not available</h1>
+
+      <p class="govuk-body">You can still register for the Additional Support Offer, but you need to pay for it another way.</p>
+
+      <p class="govuk-body">The Additional Support Offer costs £800.</p>
+
+      <%= f.govuk_collection_radio_buttons :aso_funding,
+        @form.options,
+        :value,
+        :text,
+        :description,
+        legend: { text: "Do you want to pay for the Additional Support Offer in another way?" },
+        bold_labels: false
+      %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/registration_wizard/aso_headteacher.html.erb
+++ b/app/views/registration_wizard/aso_headteacher.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-  <%= @form.errors.present? ? "Error: " : nil %> What are you applying for?
+  <%= @form.errors.present? ? "Error: " : nil %> Are you a headteacher?
 <% end %>
 
 <% content_for :before_content do %>
@@ -14,15 +14,15 @@
     <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset(:course_id,
+      <%= f.govuk_radio_buttons_fieldset(:aso_headteacher,
             legend: {
-              text: "What are you applying for?",
+              text: "Are you a headteacher?",
               size: "xl",
               tag: "h1"
             }
           ) do %>
         <% @form.options.each do |struct| %>
-          <%= f.govuk_radio_button :course_id, struct.value, label: { text: struct.text }, hint: { text: struct.hint }, link_errors: struct.link_errors %>
+          <%= f.govuk_radio_button :aso_headteacher, struct.value, label: { text: struct.text }, hint: { text: struct.hint }, link_errors: struct.link_errors %>
         <% end %>
       <% end %>
 

--- a/app/views/registration_wizard/aso_new_headteacher.html.erb
+++ b/app/views/registration_wizard/aso_new_headteacher.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-  <%= @form.errors.present? ? "Error: " : nil %> What are you applying for?
+  <%= @form.errors.present? ? "Error: " : nil %> Are you a headteacher?
 <% end %>
 
 <% content_for :before_content do %>
@@ -14,15 +14,15 @@
     <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset(:course_id,
+      <%= f.govuk_radio_buttons_fieldset(:aso_new_headteacher,
             legend: {
-              text: "What are you applying for?",
+              text: "Are you in your first 2 years of a headship?",
               size: "xl",
               tag: "h1"
             }
           ) do %>
         <% @form.options.each do |struct| %>
-          <%= f.govuk_radio_button :course_id, struct.value, label: { text: struct.text }, hint: { text: struct.hint }, link_errors: struct.link_errors %>
+          <%= f.govuk_radio_button :aso_new_headteacher, struct.value, label: { text: struct.text }, hint: { text: struct.hint }, link_errors: struct.link_errors %>
         <% end %>
       <% end %>
 

--- a/app/views/registration_wizard/aso_possible_funding.html.erb
+++ b/app/views/registration_wizard/aso_possible_funding.html.erb
@@ -1,0 +1,28 @@
+<% content_for :title do %>
+  You may qualify for DfE scholarship funding
+<% end %>
+
+<% content_for :before_content do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: "Back",
+    href: registration_wizard_show_path(@wizard.previous_step_path)
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">You may qualify for DfE scholarship funding</h1>
+
+    <p class="govuk-body">
+      DfE scholarship funding may be available for the Additional Support Offer.
+    </p>
+
+    <p class="govuk-body">
+      Your training provider will give you more details and confirm if you qualify for funding.
+    </p>
+
+    <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/registration_wizard/aso_unavailable.html.erb
+++ b/app/views/registration_wizard/aso_unavailable.html.erb
@@ -1,0 +1,26 @@
+<% content_for :title do %>
+  You cannot register for the Additional Support Offer
+<% end %>
+
+<% content_for :before_content do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: "Back",
+    href: registration_wizard_show_path(@wizard.previous_step_path)
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">You cannot register for the Additional Support Offer</h1>
+
+    <p class="govuk-body">You do not meet the eligibility criteria for taking the Additional Support Offer.</p>
+
+    <p class="govuk-body">You can only register if you:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>have completed an NPQH</li>
+      <li>are studying for an NPQH</li>
+      <li>are about to start an NPQH</li>
+    </ul>
+  </div>
+</div>

--- a/app/views/registration_wizard/funding_your_aso.html.erb
+++ b/app/views/registration_wizard/funding_your_aso.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-  <%= @form.errors.present? ? "Error: " : nil %> What are you applying for?
+  <%= @form.errors.present? ? "Error: " : nil %>Funding
 <% end %>
 
 <% content_for :before_content do %>
@@ -14,15 +14,19 @@
     <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset(:course_id,
+      <%= f.govuk_radio_buttons_fieldset(:aso_funding_choice,
             legend: {
-              text: "What are you applying for?",
+              text: "How is the Additional Support Offer being paid for?",
               size: "xl",
               tag: "h1"
             }
           ) do %>
         <% @form.options.each do |struct| %>
-          <%= f.govuk_radio_button :course_id, struct.value, label: { text: struct.text }, hint: { text: struct.hint }, link_errors: struct.link_errors %>
+          <%= f.govuk_radio_button :aso_funding_choice,
+            struct.value,
+            label: { text: struct.text },
+            hint: { text: struct.hint },
+            link_errors: struct.link_errors %>
         <% end %>
       <% end %>
 

--- a/app/views/registration_wizard/npqh_status.html.erb
+++ b/app/views/registration_wizard/npqh_status.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-  <%= @form.errors.present? ? "Error: " : nil %> What are you applying for?
+  <%= @form.errors.present? ? "Error: " : nil %> Are you studying for, or have you completed an NPQ for Headship (NPQH)?
 <% end %>
 
 <% content_for :before_content do %>
@@ -14,15 +14,22 @@
     <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset(:course_id,
+      <%= f.govuk_radio_buttons_fieldset(:npqh_status,
             legend: {
-              text: "What are you applying for?",
-              size: "xl",
+              text: "Are you studying for, or have you completed an NPQ for Headship (NPQH)?",
+              size: "l",
               tag: "h1"
             }
           ) do %>
         <% @form.options.each do |struct| %>
-          <%= f.govuk_radio_button :course_id, struct.value, label: { text: struct.text }, hint: { text: struct.hint }, link_errors: struct.link_errors %>
+          <% if @form.options.last == struct %>
+            <%= f.govuk_radio_divider %>
+          <% end %>
+
+          <%= f.govuk_radio_button :npqh_status, struct.value,
+            label: { text: struct.text },
+            hint: { text: struct.hint },
+            link_errors: struct.link_errors %>
         <% end %>
       <% end %>
 

--- a/app/views/registration_wizard/start.html.erb
+++ b/app/views/registration_wizard/start.html.erb
@@ -2,38 +2,22 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Register for a National Professional Qualification (NPQ)</h1>
 
-    <p class="govuk-body-l">This service is for teachers who want to register to study for an NPQ.</p>
-
-    <p class="govuk-body">Use this service to:</p>
+    <p class="govuk-body">This service is for teachers who want to register:</p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>start your NPQ registration</li>
+      <li>to study for an NPQ</li>
+      <li>for the Additional Support Offer for new headteachers</li>
     </ul>
 
     <h2 class="govuk-heading-m">Before you start</h2>
 
     <p class="govuk-body">You must:</p>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <li>only use this service if you are a teacher working in England, Guernsey, Jersey or the Isle of Man - if you are a teacher working outside these locations contact your provider directly to register</li>
-      <li>
-        have your teacher reference number (TRN)
-        <details class="govuk-details" data-module="govuk-details">
-          <summary class="govuk-details__summary">
-            <span class="govuk-details__summary-text">
-              What is a teacher reference number?
-            </span>
-          </summary>
-          <div class="govuk-details__text">
-            <p class="govuk-body">A teacher reference number (TRN) is a unique ID that allows us to check you are a teacher.</p>
-            <p class="govuk-body">If you don’t know what your teacher reference number (TRN) is, this can usually be found on your payslip, teachers’ pension documentation or teacher training records.</p>
-            <p class="govuk-body">The TRN has previously been known as a QTS, GTC, DfE, DfES or DCSF number.</p>
-            <p class="govuk-body">You may not have a TRN if you qualified outside England or overseas.</p>
-          </div>
-        </details>
-      </li>
-      <li>have your funding source confirmed - either a scholarship, school, college or personal funding</li>
-      <li>know which NPQ you want to study</li>
+    <ul class="govuk-list govuk-list--bullet govuk-!-padding-bottom-3">
+      <li>only use this service if you are a teacher working in England, Guernsey, Jersey or the Isle of Man – if you are a teacher working outside these locations contact your provider directly to register</li>
+      <li>have your teacher reference number (TRN)</li>
+      <li>have your funding source confirmed – either a scholarship, school, college or personal funding</li>
+      <li>know which NPQ course you want to study</li>
       <li>have chosen a provider</li>
     </ul>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,3 +100,19 @@ en:
             funding:
               blank: Choose how your NPQ will be funded
               invalid: Choose a valid funding option
+        forms/npqh_status:
+          attributes:
+            npqh_status:
+              blank: Information about NPQH can’t be blank
+        forms/aso_headteacher:
+          attributes:
+            aso_headteacher:
+              blank: Choose whether or not you are a headteacher
+        forms/aso_funding_not_available:
+          attributes:
+            aso_funding:
+              blank: Choose whether or not you want to pay for the Additional Support Offer in another way?
+        forms/funding_your_aso:
+          attributes:
+            aso_funding:
+              inclusion: Choose one of the following funding options for your Additional Support Offer

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,12 @@ en:
           trust: My trust is paying
           self: I am paying
           another: My NPQ is being paid in another way
+      forms/funding_your_aso:
+        funding_options:
+          school: My school or college is covering the cost
+          trust: My trust is paying
+          self: I am paying
+          another: The Additional Support Offer is being paid in another way
     errors:
       models:
         forms/provider_check:

--- a/db/migrate/20210928142225_add_description_to_courses.rb
+++ b/db/migrate/20210928142225_add_description_to_courses.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToCourses < ActiveRecord::Migration[6.1]
+  def change
+    add_column :courses, :description, :text, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_21_092011) do
+ActiveRecord::Schema.define(version: 2021_09_28_142225) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -38,6 +38,7 @@ ActiveRecord::Schema.define(version: 2021_09_21_092011) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "ecf_id"
+    t.text "description"
   end
 
   create_table "delayed_jobs", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,8 +6,9 @@ def seed_courses!
     { name: "NPQ for Senior Leadership (NPQSL)", ecf_id: "a42736ad-3d0b-401d-aebe-354ef4c193ec" },
     { name: "NPQ for Headship (NPQH)", ecf_id: "0f7d6578-a12c-4498-92a0-2ee0f18e0768" },
     { name: "NPQ for Executive Leadership (NPQEL)", ecf_id: "aef853f2-9b48-4b6a-9d2a-91b295f5ca9a" },
+    { name: "Additional Support Offer for new headteachers", ecf_id: "7fbefdd4-dd2d-4a4f-8995-d59e525124b7", description: "The Additional Support Offer is a targeted support package for new headteachers." },
   ].each do |hash|
-    Course.find_or_create_by!(name: hash[:name], ecf_id: hash[:ecf_id])
+    Course.find_or_create_by!(name: hash[:name], ecf_id: hash[:ecf_id], description: hash[:description])
   end
 end
 

--- a/spec/features/happy_journeys_non_js_spec.rb
+++ b/spec/features/happy_journeys_non_js_spec.rb
@@ -448,7 +448,10 @@ RSpec.feature "Happy journeys", type: :feature do
 
     application = user.applications.first
 
+    expect(application.course).to be_aso
+    expect(application.headteacher_status).to eql("no")
     expect(application.eligible_for_funding).to be_falsey
+    expect(application.funding_choice).to eql("self")
 
     visit "/account"
 

--- a/spec/features/happy_journeys_non_js_spec.rb
+++ b/spec/features/happy_journeys_non_js_spec.rb
@@ -460,7 +460,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).to have_content("Before you start")
   end
 
-  scenario "funded ASO registration journey" do
+  fscenario "funded ASO registration journey" do
     visit "/"
     expect(page).to have_text("Before you start")
     page.click_link("Start now")
@@ -602,7 +602,10 @@ RSpec.feature "Happy journeys", type: :feature do
 
     application = user.applications.first
 
+    expect(application.course).to be_aso
+    expect(application.headteacher_status).to eql("yes_in_first_two_years")
     expect(application.eligible_for_funding).to be_falsey
+    expect(application.funding_choice).to be_nil
 
     visit "/account"
 

--- a/spec/features/happy_journeys_non_js_spec.rb
+++ b/spec/features/happy_journeys_non_js_spec.rb
@@ -460,7 +460,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).to have_content("Before you start")
   end
 
-  fscenario "funded ASO registration journey" do
+  scenario "funded ASO registration journey" do
     visit "/"
     expect(page).to have_text("Before you start")
     page.click_link("Start now")
@@ -604,7 +604,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
     expect(application.course).to be_aso
     expect(application.headteacher_status).to eql("yes_in_first_two_years")
-    expect(application.eligible_for_funding).to be_falsey
+    expect(application.eligible_for_funding).to be_truthy
     expect(application.funding_choice).to be_nil
 
     visit "/account"

--- a/spec/features/happy_journeys_non_js_spec.rb
+++ b/spec/features/happy_journeys_non_js_spec.rb
@@ -148,6 +148,27 @@ RSpec.feature "Happy journeys", type: :feature do
     allow(ApplicationSubmissionJob).to receive(:perform_later).with(anything)
 
     page.click_button("Submit")
+
+    expect(User.count).to eql(1)
+
+    user = User.last
+
+    expect(user.email).to eql("user@example.com")
+    expect(user.full_name).to eql("John Doe")
+    expect(user.trn).to eql("1234567")
+    expect(user.trn_verified).to be_truthy
+    expect(user.trn_auto_verified).to be_truthy
+    expect(user.date_of_birth).to eql(Date.new(1980, 12, 13))
+    expect(user.national_insurance_number).to be_blank
+
+    expect(user.applications.count).to eql(1)
+
+    application = user.applications.first
+
+    expect(application.eligible_for_funding).to be_truthy
+    expect(application.funding_choice).to be_nil
+    expect(application.course).to be_npqsl
+    expect(application.headteacher_status).to be_nil
   end
 
   scenario "registration journey via using same name" do
@@ -287,6 +308,8 @@ RSpec.feature "Happy journeys", type: :feature do
 
     expect(application.eligible_for_funding).to be_falsey
     expect(application.funding_choice).to eql("trust")
+    expect(application.course).to be_npqh
+    expect(application.headteacher_status).to eql("no")
 
     visit "/account"
 

--- a/spec/features/happy_journeys_non_js_spec.rb
+++ b/spec/features/happy_journeys_non_js_spec.rb
@@ -96,14 +96,6 @@ RSpec.feature "Happy journeys", type: :feature do
     page.fill_in "Year", with: "1980"
     page.click_button("Continue")
 
-    expect(page).to have_text("Choose your NPQ")
-    page.choose("NPQ for Senior Leadership (NPQSL)", visible: :all)
-    page.click_button("Continue")
-
-    expect(page).to have_text("Choose your provider")
-    page.choose("Teach First", visible: :all)
-    page.click_button("Continue")
-
     School.create!(
       urn: 100_000,
       name: "open manchester school",
@@ -130,7 +122,15 @@ RSpec.feature "Happy journeys", type: :feature do
     page.choose "open manchester school", visible: :all
     page.click_button("Continue")
 
+    expect(page).to have_text("What are you applying for?")
+    page.choose("NPQ for Senior Leadership (NPQSL)", visible: :all)
+    page.click_button("Continue")
+
     expect(page).to have_text("You may qualify for DfE scholarship funding")
+    page.click_button("Continue")
+
+    expect(page).to have_text("Choose your provider")
+    page.choose("Teach First", visible: :all)
     page.click_button("Continue")
 
     check_answers_page = CheckAnswersPage.new
@@ -141,7 +141,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(check_answers_page.summary_list["Date of birth"].value).to eql("December 13, 1980")
     expect(check_answers_page.summary_list.key?("National Insurance number")).to be_falsey
     expect(check_answers_page.summary_list["Email"].value).to eql("user@example.com")
-    expect(check_answers_page.summary_list["NPQ"].value).to eql("NPQ for Senior Leadership (NPQSL)")
+    expect(check_answers_page.summary_list["Course"].value).to eql("NPQ for Senior Leadership (NPQSL)")
     expect(check_answers_page.summary_list.key?("Have you been a headteacher for two years or more?")).to be_falsey
     expect(check_answers_page.summary_list["School or college"].value).to eql("open manchester school")
 
@@ -206,18 +206,6 @@ RSpec.feature "Happy journeys", type: :feature do
     page.fill_in "National Insurance number (optional)", with: "AB123456C"
     page.click_button("Continue")
 
-    expect(page).to have_text("Choose your NPQ")
-    page.choose("NPQ for Headship (NPQH)", visible: :all)
-    page.click_button("Continue")
-
-    expect(page).to have_text("How long have you been a headteacher?")
-    page.choose("No, I have been a headteacher for more than 24 months", visible: :all)
-    page.click_button("Continue")
-
-    expect(page).to have_text("Choose your provider")
-    page.choose("Teach First", visible: :all)
-    page.click_button("Continue")
-
     School.create!(urn: 100_000, name: "open manchester school", address_1: "street 1", town: "manchester", establishment_status_code: "1")
     School.create!(urn: 100_001, name: "closed manchester school", address_1: "street 2", town: "manchester", establishment_status_code: "2")
     School.create!(urn: 100_002, name: "open newcastle school", address_1: "street 3", town: "newcastle", establishment_status_code: "1")
@@ -237,8 +225,20 @@ RSpec.feature "Happy journeys", type: :feature do
     page.choose "open manchester school", visible: :all
     page.click_button("Continue")
 
+    expect(page).to have_text("What are you applying for?")
+    page.choose("NPQ for Headship (NPQH)", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to have_text("How long have you been a headteacher?")
+    page.choose("No, I have been a headteacher for more than 24 months", visible: :all)
+    page.click_button("Continue")
+
     expect(page).to have_text("Funding")
     page.choose "My trust is paying", visible: :all
+    page.click_button("Continue")
+
+    expect(page).to have_text("Choose your provider")
+    page.choose("Teach First", visible: :all)
     page.click_button("Continue")
 
     check_answers_page = CheckAnswersPage.new
@@ -249,19 +249,19 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(check_answers_page.summary_list["Date of birth"].value).to eql("December 13, 1980")
     expect(check_answers_page.summary_list["National Insurance number"].value).to eql("AB123456C")
     expect(check_answers_page.summary_list["Email"].value).to eql("user@example.com")
-    expect(check_answers_page.summary_list["NPQ"].value).to eql("NPQ for Headship (NPQH)")
-    expect(check_answers_page.summary_list["How long have you been a headteacher?"].value).to eql("Yes over two years")
+    expect(check_answers_page.summary_list["Course"].value).to eql("NPQ for Headship (NPQH)")
+    expect(check_answers_page.summary_list["Have you been a headteacher for less than 24 months?"].value).to eql("Yes over two years")
     expect(check_answers_page.summary_list["Lead provider"].value).to eql("Teach First")
     expect(check_answers_page.summary_list["School or college"].value).to eql("open manchester school")
     expect(check_answers_page.summary_list["How is your NPQ being paid for?"].value).to eql("My trust is paying")
-    page.click_link("Change How long have you been a headteacher?")
+    page.click_link("Change Have you been a headteacher for less than 24 months?")
 
     expect(page).to have_text("How long have you been a headteacher?")
     page.choose("No, I am not a headteacher", visible: :all)
     page.click_button("Continue")
 
     expect(check_answers_page).to be_displayed
-    expect(check_answers_page.summary_list["How long have you been a headteacher?"].value).to eql("No")
+    expect(check_answers_page.summary_list["Have you been a headteacher for less than 24 months?"].value).to eql("No")
 
     allow(ApplicationSubmissionJob).to receive(:perform_later).with(anything)
 
@@ -292,6 +292,322 @@ RSpec.feature "Happy journeys", type: :feature do
 
     expect(page).to have_text("Teach First")
     expect(page).to have_text("NPQ for Headship (NPQH)")
+
+    visit "/registration/share-provider"
+
+    expect(page).to have_content("Before you start")
+  end
+
+  scenario "self funded ASO registration journey" do
+    visit "/"
+    expect(page).to have_text("Before you start")
+    page.click_link("Start now")
+
+    expect(page).to have_text("Have you already chosen an NPQ and provider?")
+    page.choose("Yes, I have chosen my NPQ and provider", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to have_text("Sharing your NPQ information")
+    page.check("Yes, I agree my information can be shared", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to have_text("Teacher reference number")
+    page.choose("Yes, I know my TRN", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to have_text("Name changes")
+    page.choose("No, I have the same name", visible: :all)
+    page.click_button("Continue")
+
+    expect(page.current_path).to include("contact-details")
+    expect(page).to have_text("Email details")
+    page.fill_in "Email address", with: "user@example.com"
+    page.click_button("Continue")
+
+    expect(page).to have_text("Confirm your code")
+    expect(page).to have_text("user@example.com")
+    page.fill_in "Enter your code", with: "000000"
+    page.click_button("Continue")
+
+    expect(page).to have_text("Confirm your code")
+    expect(page).to have_text("Code is not correct")
+
+    code = ActionMailer::Base.deliveries.last[:personalisation].unparsed_value[:code]
+
+    page.fill_in "Enter your code", with: code
+    page.click_button("Continue")
+
+    stub_request(:get, "https://ecf-app.gov.uk/api/v1/participant-validation/1234567?date_of_birth=1980-12-13&full_name=John%20Doe&nino=AB123456C")
+      .with(
+        headers: {
+          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+        },
+      )
+      .to_return(status: 200, body: participant_validator_response, headers: {})
+
+    expect(page).to have_text("Check your details")
+    page.fill_in "Teacher reference number (TRN)", with: "1234567"
+    page.fill_in "Full name", with: "John Doe"
+    page.fill_in "Day", with: "13"
+    page.fill_in "Month", with: "12"
+    page.fill_in "Year", with: "1980"
+    page.fill_in "National Insurance number (optional)", with: "AB123456C"
+    page.click_button("Continue")
+
+    School.create!(urn: 100_000, name: "open manchester school", address_1: "street 1", town: "manchester", establishment_status_code: "1")
+    School.create!(urn: 100_001, name: "closed manchester school", address_1: "street 2", town: "manchester", establishment_status_code: "2")
+    School.create!(urn: 100_002, name: "open newcastle school", address_1: "street 3", town: "newcastle", establishment_status_code: "1")
+
+    expect(page).to have_text("Where is your school or college?")
+    page.fill_in "School or college location", with: "manchester"
+    page.click_button("Continue")
+
+    expect(page).to have_text("Choose your school or college")
+    expect(page).to have_text("Please choose from schools and colleges located in manchester")
+    within ".npq-js-hidden" do
+      page.fill_in "Enter your school or college name", with: "open"
+    end
+    page.click_button("Continue")
+
+    expect(page).to have_text("Choose your school or college")
+    page.choose "open manchester school", visible: :all
+    page.click_button("Continue")
+
+    expect(page).to have_text("What are you applying for?")
+    page.choose("Additional Support Offer for new headteachers", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to have_selector "h1", text: "Additional Support Offer for new headteachers"
+    page.click_link("Continue")
+
+    expect(page).to have_selector "h1", text: "Are you studying for, or have you completed an NPQ for Headship (NPQH)?"
+    page.choose "None of the above"
+    page.click_button("Continue")
+
+    expect(page).to have_selector "h1", text: "You cannot register for the Additional Support Offer"
+    page.click_link("Back")
+
+    expect(page).to have_selector "h1", text: "Are you studying for, or have you completed an NPQ for Headship (NPQH)?"
+    page.choose "I have completed an NPQH"
+    page.click_button("Continue")
+
+    expect(page).to have_selector "h1", text: "Are you a headteacher?"
+    page.choose "No"
+    page.click_button("Continue")
+
+    expect(page).to have_selector "h1", text: "DfE scholarship funding not available"
+    page.choose "No"
+    page.click_button("Continue")
+
+    expect(page).to have_selector "h1", text: "Contact your provider"
+    page.click_link("Back")
+
+    expect(page).to have_selector "h1", text: "DfE scholarship funding not available"
+    page.choose "Yes, I will pay another way"
+    page.click_button("Continue")
+
+    expect(page).to have_selector "h1", text: "How is the Additional Support Offer being paid for?"
+    page.choose "I am paying"
+    page.click_button("Continue")
+
+    expect(page).to have_text("Choose your provider")
+    page.choose("Teach First")
+    page.click_button("Continue")
+
+    check_answers_page = CheckAnswersPage.new
+
+    expect(check_answers_page).to be_displayed
+    expect(check_answers_page.summary_list["Full name"].value).to eql("John Doe")
+    expect(check_answers_page.summary_list["TRN"].value).to eql("1234567")
+    expect(check_answers_page.summary_list["Date of birth"].value).to eql("December 13, 1980")
+    expect(check_answers_page.summary_list["National Insurance number"].value).to eql("AB123456C")
+    expect(check_answers_page.summary_list["Email"].value).to eql("user@example.com")
+    expect(check_answers_page.summary_list["Course"].value).to eql("Additional Support Offer for new headteachers")
+    expect(check_answers_page.summary_list["Lead provider"].value).to eql("Teach First")
+    expect(check_answers_page.summary_list["School or college"].value).to eql("open manchester school")
+
+    allow(ApplicationSubmissionJob).to receive(:perform_later).with(anything)
+
+    page.click_button("Submit")
+
+    expect(page).to have_text("Initial registration complete")
+
+    expect(User.count).to eql(1)
+
+    user = User.last
+
+    expect(user.email).to eql("user@example.com")
+    expect(user.full_name).to eql("John Doe")
+    expect(user.trn).to eql("1234567")
+    expect(user.trn_verified).to be_truthy
+    expect(user.trn_auto_verified).to be_truthy
+    expect(user.date_of_birth).to eql(Date.new(1980, 12, 13))
+    expect(user.national_insurance_number).to be_blank
+
+    expect(user.applications.count).to eql(1)
+
+    application = user.applications.first
+
+    expect(application.eligible_for_funding).to be_falsey
+
+    visit "/account"
+
+    expect(page).to have_text("Teach First")
+    expect(page).to have_text("Additional Support Offer for new headteachers")
+
+    visit "/registration/share-provider"
+
+    expect(page).to have_content("Before you start")
+  end
+
+  scenario "funded ASO registration journey" do
+    visit "/"
+    expect(page).to have_text("Before you start")
+    page.click_link("Start now")
+
+    expect(page).to have_text("Have you already chosen an NPQ and provider?")
+    page.choose("Yes, I have chosen my NPQ and provider", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to have_text("Sharing your NPQ information")
+    page.check("Yes, I agree my information can be shared", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to have_text("Teacher reference number")
+    page.choose("Yes, I know my TRN", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to have_text("Name changes")
+    page.choose("No, I have the same name", visible: :all)
+    page.click_button("Continue")
+
+    expect(page.current_path).to include("contact-details")
+    expect(page).to have_text("Email details")
+    page.fill_in "Email address", with: "user@example.com"
+    page.click_button("Continue")
+
+    expect(page).to have_text("Confirm your code")
+    expect(page).to have_text("user@example.com")
+    page.fill_in "Enter your code", with: "000000"
+    page.click_button("Continue")
+
+    expect(page).to have_text("Confirm your code")
+    expect(page).to have_text("Code is not correct")
+
+    code = ActionMailer::Base.deliveries.last[:personalisation].unparsed_value[:code]
+
+    page.fill_in "Enter your code", with: code
+    page.click_button("Continue")
+
+    stub_request(:get, "https://ecf-app.gov.uk/api/v1/participant-validation/1234567?date_of_birth=1980-12-13&full_name=John%20Doe&nino=AB123456C")
+      .with(
+        headers: {
+          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+        },
+      )
+      .to_return(status: 200, body: participant_validator_response, headers: {})
+
+    expect(page).to have_text("Check your details")
+    page.fill_in "Teacher reference number (TRN)", with: "1234567"
+    page.fill_in "Full name", with: "John Doe"
+    page.fill_in "Day", with: "13"
+    page.fill_in "Month", with: "12"
+    page.fill_in "Year", with: "1980"
+    page.fill_in "National Insurance number (optional)", with: "AB123456C"
+    page.click_button("Continue")
+
+    School.create!(urn: 100_000, name: "open manchester school", address_1: "street 1", town: "manchester", establishment_status_code: "1")
+    School.create!(urn: 100_001, name: "closed manchester school", address_1: "street 2", town: "manchester", establishment_status_code: "2")
+    School.create!(urn: 100_002, name: "open newcastle school", address_1: "street 3", town: "newcastle", establishment_status_code: "1")
+
+    expect(page).to have_text("Where is your school or college?")
+    page.fill_in "School or college location", with: "manchester"
+    page.click_button("Continue")
+
+    expect(page).to have_text("Choose your school or college")
+    expect(page).to have_text("Please choose from schools and colleges located in manchester")
+    within ".npq-js-hidden" do
+      page.fill_in "Enter your school or college name", with: "open"
+    end
+    page.click_button("Continue")
+
+    expect(page).to have_text("Choose your school or college")
+    page.choose "open manchester school", visible: :all
+    page.click_button("Continue")
+
+    expect(page).to have_text("What are you applying for?")
+    page.choose("Additional Support Offer for new headteachers", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to have_selector "h1", text: "Additional Support Offer for new headteachers"
+    page.click_link("Continue")
+
+    expect(page).to have_selector "h1", text: "Are you studying for, or have you completed an NPQ for Headship (NPQH)?"
+    page.choose "None of the above"
+    page.click_button("Continue")
+
+    expect(page).to have_selector "h1", text: "You cannot register for the Additional Support Offer"
+    page.click_link("Back")
+
+    expect(page).to have_selector "h1", text: "Are you studying for, or have you completed an NPQ for Headship (NPQH)?"
+    page.choose "I have completed an NPQH"
+    page.click_button("Continue")
+
+    expect(page).to have_selector "h1", text: "Are you a headteacher?"
+    page.choose "Yes, I am a headteacher"
+    page.click_button("Continue")
+
+    expect(page).to have_selector "h1", text: "Are you in your first 2 years of a headship?"
+    page.choose "Yes, I am in my first 2 years of a headship"
+    page.click_button("Continue")
+
+    expect(page).to have_selector "h1", text: "You may qualify for DfE scholarship funding"
+    page.click_button("Continue")
+
+    expect(page).to have_text("Choose your provider")
+    page.choose("Teach First")
+    page.click_button("Continue")
+
+    check_answers_page = CheckAnswersPage.new
+
+    expect(check_answers_page).to be_displayed
+    expect(check_answers_page.summary_list["Full name"].value).to eql("John Doe")
+    expect(check_answers_page.summary_list["TRN"].value).to eql("1234567")
+    expect(check_answers_page.summary_list["Date of birth"].value).to eql("December 13, 1980")
+    expect(check_answers_page.summary_list["National Insurance number"].value).to eql("AB123456C")
+    expect(check_answers_page.summary_list["Email"].value).to eql("user@example.com")
+    expect(check_answers_page.summary_list["Course"].value).to eql("Additional Support Offer for new headteachers")
+    expect(check_answers_page.summary_list["Lead provider"].value).to eql("Teach First")
+    expect(check_answers_page.summary_list["School or college"].value).to eql("open manchester school")
+
+    allow(ApplicationSubmissionJob).to receive(:perform_later).with(anything)
+
+    page.click_button("Submit")
+
+    expect(page).to have_text("Initial registration complete")
+
+    expect(User.count).to eql(1)
+
+    user = User.last
+
+    expect(user.email).to eql("user@example.com")
+    expect(user.full_name).to eql("John Doe")
+    expect(user.trn).to eql("1234567")
+    expect(user.trn_verified).to be_truthy
+    expect(user.trn_auto_verified).to be_truthy
+    expect(user.date_of_birth).to eql(Date.new(1980, 12, 13))
+    expect(user.national_insurance_number).to be_blank
+
+    expect(user.applications.count).to eql(1)
+
+    application = user.applications.first
+
+    expect(application.eligible_for_funding).to be_falsey
+
+    visit "/account"
+
+    expect(page).to have_text("Teach First")
+    expect(page).to have_text("Additional Support Offer for new headteachers")
 
     visit "/registration/share-provider"
 

--- a/spec/features/happy_journeys_spec.rb
+++ b/spec/features/happy_journeys_spec.rb
@@ -106,16 +106,6 @@ RSpec.feature "Happy journeys", type: :feature do
     page.fill_in "Year", with: "1980"
     page.click_button("Continue")
 
-    expect(page).to be_axe_clean
-    expect(page).to have_text("Choose your NPQ")
-    page.choose("NPQ for Senior Leadership (NPQSL)", visible: :all)
-    page.click_button("Continue")
-
-    expect(page).to be_axe_clean
-    expect(page).to have_text("Choose your provider")
-    page.choose("Teach First", visible: :all)
-    page.click_button("Continue")
-
     School.create!(urn: 100_000, name: "open manchester school", address_1: "street 1", town: "manchester", establishment_status_code: "1")
 
     expect(page).to be_axe_clean
@@ -135,8 +125,18 @@ RSpec.feature "Happy journeys", type: :feature do
     page.click_button("Continue")
 
     expect(page).to be_axe_clean
+    expect(page).to have_text("What are you applying for?")
+    page.choose("NPQ for Senior Leadership (NPQSL)", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
     expect(page).to have_text("Funding")
     page.choose "My school or college is covering the cost", visible: :all
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Choose your provider")
+    page.choose("Teach First", visible: :all)
     page.click_button("Continue")
 
     check_answers_page = CheckAnswersPage.new
@@ -148,7 +148,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(check_answers_page.summary_list["Date of birth"].value).to eql("December 13, 1980")
     expect(check_answers_page.summary_list.key?("National Insurance number")).to be_falsey
     expect(check_answers_page.summary_list["Email"].value).to eql("user@example.com")
-    expect(check_answers_page.summary_list["NPQ"].value).to eql("NPQ for Senior Leadership (NPQSL)")
+    expect(check_answers_page.summary_list["Course"].value).to eql("NPQ for Senior Leadership (NPQSL)")
     expect(check_answers_page.summary_list.key?("Have you been a headteacher for two years or more?")).to be_falsey
     expect(check_answers_page.summary_list["School or college"].value).to eql("open manchester school")
     expect(check_answers_page.summary_list["How is your NPQ being paid for?"].value).to eql("My school or college is covering the cost")
@@ -224,21 +224,6 @@ RSpec.feature "Happy journeys", type: :feature do
     page.fill_in "National Insurance number (optional)", with: "AB123456C"
     page.click_button("Continue")
 
-    expect(page).to be_axe_clean
-    expect(page).to have_text("Choose your NPQ")
-    page.choose("NPQ for Headship (NPQH)", visible: :all)
-    page.click_button("Continue")
-
-    expect(page).to be_axe_clean
-    expect(page).to have_text("How long have you been a headteacher?")
-    page.choose("No, I have been a headteacher for more than 24 months", visible: :all)
-    page.click_button("Continue")
-
-    expect(page).to be_axe_clean
-    expect(page).to have_text("Choose your provider")
-    page.choose("Teach First", visible: :all)
-    page.click_button("Continue")
-
     School.create!(urn: 100_000, name: "open manchester school", address_1: "street 1", town: "manchester", establishment_status_code: "1")
     School.create!(urn: 100_001, name: "closed manchester school", address_1: "street 2", town: "manchester", establishment_status_code: "2")
     School.create!(urn: 100_002, name: "open newcastle school", address_1: "street 3", town: "newcastle", establishment_status_code: "1")
@@ -260,8 +245,23 @@ RSpec.feature "Happy journeys", type: :feature do
     page.click_button("Continue")
 
     expect(page).to be_axe_clean
+    expect(page).to have_text("What are you applying for?")
+    page.choose("NPQ for Headship (NPQH)", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("How long have you been a headteacher?")
+    page.choose("No, I have been a headteacher for more than 24 months", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
     expect(page).to have_text("Funding")
     page.choose "My trust is paying", visible: :all
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Choose your provider")
+    page.choose("Teach First", visible: :all)
     page.click_button("Continue")
 
     check_answers_page = CheckAnswersPage.new
@@ -273,21 +273,21 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(check_answers_page.summary_list["Date of birth"].value).to eql("December 13, 1980")
     expect(check_answers_page.summary_list["National Insurance number"].value).to eql("AB123456C")
     expect(check_answers_page.summary_list["Email"].value).to eql("user@example.com")
-    expect(check_answers_page.summary_list["NPQ"].value).to eql("NPQ for Headship (NPQH)")
-    expect(check_answers_page.summary_list["How long have you been a headteacher?"].value).to eql("Yes over two years")
+    expect(check_answers_page.summary_list["Course"].value).to eql("NPQ for Headship (NPQH)")
+    expect(check_answers_page.summary_list["Have you been a headteacher for less than 24 months?"].value).to eql("Yes over two years")
     expect(check_answers_page.summary_list["Lead provider"].value).to eql("Teach First")
     expect(check_answers_page.summary_list["School or college"].value).to eql("open manchester school")
     expect(check_answers_page.summary_list["How is your NPQ being paid for?"].value).to eql("My trust is paying")
-    page.click_link("Change How long have you been a headteacher?")
+    page.click_link("Change Have you been a headteacher for less than 24 months?")
 
     expect(page).to be_axe_clean
-    expect(page).to have_text("How long have you been a headteacher?")
+    expect(page).to have_text("Have you been a headteacher for less than 24 months?")
     page.choose("No, I am not a headteacher", visible: :all)
     page.click_button("Continue")
 
     expect(page).to be_axe_clean
     expect(check_answers_page).to be_displayed
-    expect(check_answers_page.summary_list["How long have you been a headteacher?"].value).to eql("No")
+    expect(check_answers_page.summary_list["Have you been a headteacher for less than 24 months?"].value).to eql("No")
 
     allow(ApplicationSubmissionJob).to receive(:perform_later).with(anything)
 

--- a/spec/features/sad_journeys_spec.rb
+++ b/spec/features/sad_journeys_spec.rb
@@ -76,16 +76,6 @@ RSpec.feature "Sad journeys", type: :feature do
     expect(page).to have_text("We cannot find your details")
     page.click_link("Continue registration")
 
-    expect(page).to be_axe_clean
-    expect(page).to have_text("Choose your NPQ")
-    page.choose("NPQ for Senior Leadership (NPQSL)", visible: :all)
-    page.click_button("Continue")
-
-    expect(page).to be_axe_clean
-    expect(page).to have_text("Choose your provider")
-    page.choose("Teach First", visible: :all)
-    page.click_button("Continue")
-
     School.create!(urn: 100_000, name: "open manchester school", address_1: "street 1", town: "manchester", establishment_status_code: "1")
     School.create!(urn: 100_001, name: "closed manchester school", address_1: "street 2", town: "manchester", establishment_status_code: "2")
     School.create!(urn: 100_002, name: "open newcastle school", address_1: "street 3", town: "newcastle", establishment_status_code: "1")
@@ -107,8 +97,18 @@ RSpec.feature "Sad journeys", type: :feature do
     page.click_button("Continue")
 
     expect(page).to be_axe_clean
+    expect(page).to have_text("What are you applying for?")
+    page.choose("NPQ for Senior Leadership (NPQSL)", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
     expect(page).to have_text("Funding")
     page.choose "My trust is paying", visible: :all
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Choose your provider")
+    page.choose("Teach First", visible: :all)
     page.click_button("Continue")
 
     check_answers_page = CheckAnswersPage.new
@@ -120,7 +120,7 @@ RSpec.feature "Sad journeys", type: :feature do
     expect(check_answers_page.summary_list["Date of birth"].value).to eql("December 13, 1980")
     expect(check_answers_page.summary_list["National Insurance number"].value).to eql("AB123456C")
     expect(check_answers_page.summary_list["Email"].value).to eql("user@example.com")
-    expect(check_answers_page.summary_list["NPQ"].value).to eql("NPQ for Senior Leadership (NPQSL)")
+    expect(check_answers_page.summary_list["Course"].value).to eql("NPQ for Senior Leadership (NPQSL)")
     expect(check_answers_page.summary_list["Lead provider"].value).to eql("Teach First")
     expect(check_answers_page.summary_list["School or college"].value).to eql("open manchester school")
     expect(check_answers_page.summary_list["How is your NPQ being paid for?"].value).to eql("My trust is paying")
@@ -201,16 +201,6 @@ RSpec.feature "Sad journeys", type: :feature do
     page.fill_in "Day", with: "13"
     page.fill_in "Month", with: "12"
     page.fill_in "Year", with: "1980"
-    page.click_button("Continue")
-
-    expect(page).to be_axe_clean
-    expect(page).to have_text("Choose your NPQ")
-    page.choose("NPQ for Senior Leadership (NPQSL)", visible: :all)
-    page.click_button("Continue")
-
-    expect(page).to be_axe_clean
-    expect(page).to have_text("Choose your provider")
-    page.choose("Teach First", visible: :all)
     page.click_button("Continue")
 
     School.create!(urn: 100_000, name: "open welsh school", county: "Wrexham", establishment_status_code: "1", establishment_type_code: "30")

--- a/spec/lib/forms/aso_funding_not_available_spec.rb
+++ b/spec/lib/forms/aso_funding_not_available_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe Forms::AsoFundingNotAvailable, type: :model do
+  it { is_expected.to validate_inclusion_of(:aso_funding).in_array(Forms::AsoFundingNotAvailable::VALID_ASO_FUNDING_OPTIONS) }
+end

--- a/spec/lib/forms/aso_headteacher_spec.rb
+++ b/spec/lib/forms/aso_headteacher_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe Forms::AsoHeadteacher, type: :model do
+  it { is_expected.to validate_inclusion_of(:aso_headteacher).in_array(Forms::AsoHeadteacher::VALID_ASO_HEADTEACHER_OPTIONS) }
+end

--- a/spec/lib/forms/aso_new_headteacher_spec.rb
+++ b/spec/lib/forms/aso_new_headteacher_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe Forms::AsoNewHeadteacher, type: :model do
+  it { is_expected.to validate_inclusion_of(:aso_new_headteacher).in_array(Forms::AsoNewHeadteacher::VALID_ASO_NEW_HEADTEACHER_OPTIONS) }
+end

--- a/spec/lib/forms/check_answers_spec.rb
+++ b/spec/lib/forms/check_answers_spec.rb
@@ -50,35 +50,8 @@ RSpec.describe Forms::CheckAnswers do
   end
 
   describe "#previous_step" do
-    let(:course) { Course.all.sample }
-    let(:store) do
-      {
-        "course_id" => course.id.to_s,
-        "institution_identifier" => "School-#{school.urn}",
-      }
-    end
-    let(:school) { build(:school) }
-
-    subject { described_class.new(wizard: wizard) }
-
-    context "eligible_for_funding" do
-      let(:funding_double) { instance_double(Services::FundingEligibility, call: true) }
-
-      it "goes to possible_funding" do
-        allow(Services::FundingEligibility).to receive(:new).and_return(funding_double)
-
-        expect(subject.previous_step).to eql(:possible_funding)
-      end
-    end
-
-    context "ineligible_for_funding" do
-      let(:funding_double) { instance_double(Services::FundingEligibility, call: false) }
-
-      it "goes to funding_your_npq" do
-        allow(Services::FundingEligibility).to receive(:new).and_return(funding_double)
-
-        expect(subject.previous_step).to eql(:funding_your_npq)
-      end
+    it "goes to choose_your_provider" do
+      expect(subject.previous_step).to eql(:choose_your_provider)
     end
   end
 end

--- a/spec/lib/forms/choose_school_spec.rb
+++ b/spec/lib/forms/choose_school_spec.rb
@@ -63,24 +63,8 @@ RSpec.describe Forms::ChooseSchool, type: :model do
 
     subject { described_class.new(institution_identifier: "School-#{school.urn}", wizard: wizard) }
 
-    context "eligible_for_funding" do
-      let(:funding_double) { instance_double(Services::FundingEligibility, call: true) }
-
-      it "goes to possible_funding" do
-        allow(Services::FundingEligibility).to receive(:new).and_return(funding_double)
-
-        expect(subject.next_step).to eql(:possible_funding)
-      end
-    end
-
-    context "ineligible_for_funding" do
-      let(:funding_double) { instance_double(Services::FundingEligibility, call: false) }
-
-      it "goes to funding_your_npq" do
-        allow(Services::FundingEligibility).to receive(:new).and_return(funding_double)
-
-        expect(subject.next_step).to eql(:funding_your_npq)
-      end
+    it "goes to choose_your_npq" do
+      expect(subject.next_step).to eql(:choose_your_npq)
     end
   end
 end

--- a/spec/lib/forms/choose_your_npq_spec.rb
+++ b/spec/lib/forms/choose_your_npq_spec.rb
@@ -29,10 +29,10 @@ RSpec.describe Forms::ChooseYourNpq, type: :model do
     end
 
     context "when studying for headship" do
-      let(:course) { Course.first }
+      let(:course) { Course.find_by(name: "NPQ for Headship (NPQH)") }
 
-      it "returns choose_your_provider" do
-        expect(subject.next_step).to eql(:choose_your_provider)
+      it "returns headteacher_duration" do
+        expect(subject.next_step).to eql(:headteacher_duration)
       end
     end
 

--- a/spec/lib/forms/funding_your_aso_spec.rb
+++ b/spec/lib/forms/funding_your_aso_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe Forms::FundingYourAso, type: :model do
+  it { is_expected.to validate_inclusion_of(:aso_funding_choice).in_array(Forms::FundingYourAso::VALID_FUNDING_OPTIONS) }
+end

--- a/spec/lib/forms/npqh_status_spec.rb
+++ b/spec/lib/forms/npqh_status_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe Forms::NpqhStatus, type: :model do
+  it { is_expected.to validate_inclusion_of(:npqh_status).in_array(Forms::NpqhStatus::VALID_NPQH_STATUS_OPTIONS) }
+end

--- a/spec/lib/forms/possible_funding_spec.rb
+++ b/spec/lib/forms/possible_funding_spec.rb
@@ -2,14 +2,41 @@ require "rails_helper"
 
 RSpec.describe Forms::PossibleFunding do
   describe "#next_step" do
-    it "returns check_answers" do
-      expect(subject.next_step).to eql(:check_answers)
+    it "returns choose_your_provider" do
+      expect(subject.next_step).to eql(:choose_your_provider)
     end
   end
 
   describe "#previous_step" do
-    it "returns choose_school" do
-      expect(subject.previous_step).to eql(:choose_school)
+    let(:course) { Course.all.sample }
+    let(:store) { { "course_id" => course.id } }
+    let(:request) { nil }
+    let(:wizard) do
+      RegistrationWizard.new(
+        current_step: :possible_funding,
+        store: store,
+        request: request,
+      )
+    end
+
+    before do
+      subject.wizard = wizard
+    end
+
+    context "studying for NPQH" do
+      let(:course) { Course.find_by(name: "NPQ for Headship (NPQH)") }
+
+      it "returns headteacher_duration" do
+        expect(subject.previous_step).to eql(:headteacher_duration)
+      end
+    end
+
+    context "studying for NPQ this is not NPQH or ASO" do
+      let(:course) { Course.find_by(name: "NPQ for Senior Leadership (NPQSL)") }
+
+      it "returns choose_your_npq" do
+        expect(subject.previous_step).to eql(:choose_your_npq)
+      end
     end
   end
 

--- a/spec/lib/forms/qualified_teacher_check_spec.rb
+++ b/spec/lib/forms/qualified_teacher_check_spec.rb
@@ -126,8 +126,8 @@ RSpec.describe Forms::QualifiedTeacherCheck, type: :model do
           .to_return(status: 200, body: participant_validator_response, headers: {})
       end
 
-      it "returns :choose_your_npq" do
-        expect(subject.next_step).to eql(:choose_your_npq)
+      it "returns :find_school" do
+        expect(subject.next_step).to eql(:find_school)
       end
 
       it "marks trn_verified as truthy" do

--- a/spec/models/registration_wizard_spec.rb
+++ b/spec/models/registration_wizard_spec.rb
@@ -26,19 +26,37 @@ RSpec.describe RegistrationWizard do
 
   describe "#answers" do
     let(:school) { create(:school) }
-    let(:store) do
-      {
-        "date_of_birth" => 30.years.ago,
-        "institution_identifier" => "School-#{school.urn}",
-        "course_id" => Course.find_by(name: "Additional Support Offer for new headteachers").id,
-        "lead_provider_id" => LeadProvider.all.sample.id,
-        "funding_choice" => "school",
-      }
-    end
 
     context "when ASO is selected course" do
+      let(:store) do
+        {
+          "date_of_birth" => 30.years.ago,
+          "institution_identifier" => "School-#{school.urn}",
+          "course_id" => Course.find_by(name: "Additional Support Offer for new headteachers").id,
+          "lead_provider_id" => LeadProvider.all.sample.id,
+          "funding_choice" => "school",
+        }
+      end
+
       it "does not show How is your NPQ being paid for?" do
         expect(subject.answers.map(&:key)).not_to include("How is your NPQ being paid for?")
+      end
+    end
+
+    context "when ASO and not eligible for funding" do
+      let(:store) do
+        {
+          "date_of_birth" => 30.years.ago,
+          "institution_identifier" => "School-#{school.urn}",
+          "course_id" => Course.find_by(name: "Additional Support Offer for new headteachers").id,
+          "lead_provider_id" => LeadProvider.all.sample.id,
+          "aso_funding" => "yes",
+          "aso_funding_choice" => "another",
+        }
+      end
+
+      it "shows ASO funding option" do
+        expect(subject.answers.find { |el| el.key == "How is the Additional Support Offer being paid for?" }.value).to eql("The Additional Support Offer is being paid in another way")
       end
     end
   end

--- a/spec/models/registration_wizard_spec.rb
+++ b/spec/models/registration_wizard_spec.rb
@@ -1,13 +1,14 @@
 require "rails_helper"
 
 RSpec.describe RegistrationWizard do
+  let(:store) { {} }
+  let(:session) { {} }
+  let(:request) { ActionController::TestRequest.new({}, session, ApplicationController) }
+  let(:current_step) { "share_provider" }
+
+  subject { described_class.new(current_step: current_step, store: store, request: request) }
+
   describe "#current_step" do
-    let(:store) { {} }
-    let(:session) { {} }
-    let(:request) { ActionController::TestRequest.new({}, session, ApplicationController) }
-
-    subject { described_class.new(current_step: "share_provider", store: store, request: request) }
-
     it "returns current step" do
       expect(subject.current_step).to eql(:share_provider)
     end
@@ -19,6 +20,25 @@ RSpec.describe RegistrationWizard do
         expect {
           subject.current_step
         }.to raise_error(RegistrationWizard::InvalidStep)
+      end
+    end
+  end
+
+  describe "#answers" do
+    let(:school) { create(:school) }
+    let(:store) do
+      {
+        "date_of_birth" => 30.years.ago,
+        "institution_identifier" => "School-#{school.urn}",
+        "course_id" => Course.find_by(name: "Additional Support Offer for new headteachers").id,
+        "lead_provider_id" => LeadProvider.all.sample.id,
+        "funding_choice" => "school",
+      }
+    end
+
+    context "when ASO is selected course" do
+      it "does not show How is your NPQ being paid for?" do
+        expect(subject.answers.map(&:key)).not_to include("How is your NPQ being paid for?")
       end
     end
   end

--- a/spec/page_objects/summary_list_section.rb
+++ b/spec/page_objects/summary_list_section.rb
@@ -4,7 +4,7 @@ class SummaryListSection < SitePrism::Section
   def [](key)
     result = rows.find { |row| row.key == key }
 
-    raise "No row with key '#{key}' could be found" unless result
+    raise "No row with key '#{key}' could be found. The following row keys were present: #{rows.map(&:key)}" unless result
 
     result
   end


### PR DESCRIPTION
### Context

- Adds `Additional Support Offer` aka `ASO` to the service
- This is treated as a course
- New user journey to be able to register for this course

### Changes proposed in this pull request

- Adds a new course - This will be added to the database at deployment time by hand
- This course is a lookup inside ECF and the change has already been deployed
- Adds new journey for ASO
- Ordering of pages have been tinkered with to slot in the new journey
- Reused the same columns for `headteacher_status` and the `course` so no change needed inside ECF

### Guidance to review

- We don't have review apps
- Since this is the next thing to release, we'll merge, do manual integration testing, apply any patches then release