### PR TITLE
playback data after TRN auto validation failure

### DIFF
--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -62,7 +62,7 @@ class RegistrationWizard
 
     begin
       array << OpenStruct.new(key: "Date of birth",
-                              value: dob.to_s(:long),
+                              value: dob.to_s(:govuk),
                               change_step: :qualified_teacher_check)
     rescue ArgumentError => e
       Sentry.capture_exception(e, extra: { dob: dob })

--- a/app/views/registration_wizard/dqt_mismatch.html.erb
+++ b/app/views/registration_wizard/dqt_mismatch.html.erb
@@ -42,7 +42,7 @@
 
       <% summary_list.row do |row|
            row.key { "Date of birth" }
-           row.value { @wizard.store["date_of_birth"].to_s(:long) } %>
+           row.value { @wizard.store["date_of_birth"].to_s(:govuk) } %>
       <% end %>
 
       <% if @wizard.store["national_insurance_number"].present? %>

--- a/app/views/registration_wizard/dqt_mismatch.html.erb
+++ b/app/views/registration_wizard/dqt_mismatch.html.erb
@@ -14,7 +14,7 @@
     <h1 class="govuk-heading-xl">We cannot find your details</h1>
 
     <p class="govuk-body">
-      We cannot find a match with the details you have provided.
+      We cannot find a match with the details you’ve given.
     </p>
 
     <p class="govuk-body">
@@ -24,12 +24,41 @@
     <ul class="govuk-list govuk-list--bullet">
       <li>you have abbreviated your first name, for example Rob/Robert</li>
       <li>your surname is different to the name held on the Teaching Regulation Agency records</li>
-      <li>you’ve entered an incorrect TRN</li>
-      <li>you have entered an incorrect date of birth</li>
+      <li>mistyped or entered some incorrect information</li>
     </ul>
 
+    <h2 class="govuk-heading-m">Check your details and try again</h2>
+
+    <%= render GovukComponent::SummaryListComponent.new do |summary_list| %>
+      <% summary_list.row do |row|
+           row.key { "Teacher reference number (TRN)" }
+           row.value { @wizard.store["trn"] } %>
+      <% end %>
+
+      <% summary_list.row do |row|
+           row.key { "Full name" }
+           row.value { @wizard.store["full_name"] } %>
+      <% end %>
+
+      <% summary_list.row do |row|
+           row.key { "Date of birth" }
+           row.value { @wizard.store["date_of_birth"].to_s(:long) } %>
+      <% end %>
+
+      <% if @wizard.store["national_insurance_number"].present? %>
+        <% summary_list.row do |row|
+             row.key { "National Insurance number" }
+             row.value { @wizard.store["national_insurance_number"] } %>
+        <% end %>
+      <% end %>
+    <% end %>
+
     <p class="govuk-body">
-      Try again to enter your details - entering your National Insurance number will help us match your details.
+      <% if @wizard.store["national_insurance_number"].present? %>
+        Try again to enter your details.
+      <% else %>
+        Try again to enter your details – entering your National Insurance number will help us match your details.
+      <% end %>
     </p>
 
     <%= govuk_button_link_to "Try again", registration_wizard_show_path(@wizard.previous_step_path) %>

--- a/spec/features/happy_journeys_non_js_spec.rb
+++ b/spec/features/happy_journeys_non_js_spec.rb
@@ -138,7 +138,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(check_answers_page).to be_displayed
     expect(check_answers_page.summary_list["Full name"].value).to eql("John Doe")
     expect(check_answers_page.summary_list["TRN"].value).to eql("1234567")
-    expect(check_answers_page.summary_list["Date of birth"].value).to eql("December 13, 1980")
+    expect(check_answers_page.summary_list["Date of birth"].value).to eql("13 December 1980")
     expect(check_answers_page.summary_list.key?("National Insurance number")).to be_falsey
     expect(check_answers_page.summary_list["Email"].value).to eql("user@example.com")
     expect(check_answers_page.summary_list["Course"].value).to eql("NPQ for Senior Leadership (NPQSL)")
@@ -267,7 +267,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(check_answers_page).to be_displayed
     expect(check_answers_page.summary_list["Full name"].value).to eql("John Doe")
     expect(check_answers_page.summary_list["TRN"].value).to eql("1234567")
-    expect(check_answers_page.summary_list["Date of birth"].value).to eql("December 13, 1980")
+    expect(check_answers_page.summary_list["Date of birth"].value).to eql("13 December 1980")
     expect(check_answers_page.summary_list["National Insurance number"].value).to eql("AB123456C")
     expect(check_answers_page.summary_list["Email"].value).to eql("user@example.com")
     expect(check_answers_page.summary_list["Course"].value).to eql("NPQ for Headship (NPQH)")
@@ -442,7 +442,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(check_answers_page).to be_displayed
     expect(check_answers_page.summary_list["Full name"].value).to eql("John Doe")
     expect(check_answers_page.summary_list["TRN"].value).to eql("1234567")
-    expect(check_answers_page.summary_list["Date of birth"].value).to eql("December 13, 1980")
+    expect(check_answers_page.summary_list["Date of birth"].value).to eql("13 December 1980")
     expect(check_answers_page.summary_list["National Insurance number"].value).to eql("AB123456C")
     expect(check_answers_page.summary_list["Email"].value).to eql("user@example.com")
     expect(check_answers_page.summary_list["Course"].value).to eql("Additional Support Offer for new headteachers")
@@ -599,7 +599,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(check_answers_page).to be_displayed
     expect(check_answers_page.summary_list["Full name"].value).to eql("John Doe")
     expect(check_answers_page.summary_list["TRN"].value).to eql("1234567")
-    expect(check_answers_page.summary_list["Date of birth"].value).to eql("December 13, 1980")
+    expect(check_answers_page.summary_list["Date of birth"].value).to eql("13 December 1980")
     expect(check_answers_page.summary_list["National Insurance number"].value).to eql("AB123456C")
     expect(check_answers_page.summary_list["Email"].value).to eql("user@example.com")
     expect(check_answers_page.summary_list["Course"].value).to eql("Additional Support Offer for new headteachers")

--- a/spec/features/happy_journeys_spec.rb
+++ b/spec/features/happy_journeys_spec.rb
@@ -145,7 +145,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(check_answers_page).to be_displayed
     expect(check_answers_page.summary_list["Full name"].value).to eql("John Doe")
     expect(check_answers_page.summary_list["TRN"].value).to eql("1234567")
-    expect(check_answers_page.summary_list["Date of birth"].value).to eql("December 13, 1980")
+    expect(check_answers_page.summary_list["Date of birth"].value).to eql("13 December 1980")
     expect(check_answers_page.summary_list.key?("National Insurance number")).to be_falsey
     expect(check_answers_page.summary_list["Email"].value).to eql("user@example.com")
     expect(check_answers_page.summary_list["Course"].value).to eql("NPQ for Senior Leadership (NPQSL)")
@@ -270,7 +270,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(check_answers_page).to be_displayed
     expect(check_answers_page.summary_list["Full name"].value).to eql("John Doe")
     expect(check_answers_page.summary_list["TRN"].value).to eql("1234567")
-    expect(check_answers_page.summary_list["Date of birth"].value).to eql("December 13, 1980")
+    expect(check_answers_page.summary_list["Date of birth"].value).to eql("13 December 1980")
     expect(check_answers_page.summary_list["National Insurance number"].value).to eql("AB123456C")
     expect(check_answers_page.summary_list["Email"].value).to eql("user@example.com")
     expect(check_answers_page.summary_list["Course"].value).to eql("NPQ for Headship (NPQH)")

--- a/spec/features/sad_journeys_spec.rb
+++ b/spec/features/sad_journeys_spec.rb
@@ -117,7 +117,7 @@ RSpec.feature "Sad journeys", type: :feature do
     expect(check_answers_page).to be_displayed
     expect(check_answers_page.summary_list["Full name"].value).to eql("John Doeeeeee")
     expect(check_answers_page.summary_list["TRN"].value).to eql("1234567")
-    expect(check_answers_page.summary_list["Date of birth"].value).to eql("December 13, 1980")
+    expect(check_answers_page.summary_list["Date of birth"].value).to eql("13 December 1980")
     expect(check_answers_page.summary_list["National Insurance number"].value).to eql("AB123456C")
     expect(check_answers_page.summary_list["Email"].value).to eql("user@example.com")
     expect(check_answers_page.summary_list["Course"].value).to eql("NPQ for Senior Leadership (NPQSL)")

--- a/spec/views/registration_wizard/dqt_mismatch.html.erb_spec.rb
+++ b/spec/views/registration_wizard/dqt_mismatch.html.erb_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe "registration_wizard/dqt_mismatch.html.erb", type: :view do
+  let(:request) { {} }
+  let(:wizard) do
+    RegistrationWizard.new(
+      current_step: :dqt_mismatch,
+      store: store,
+      request: request,
+    )
+  end
+
+  context "when NI number is present" do
+    let(:store) do
+      {
+        "date_of_birth" => 30.years.ago,
+        "national_insurance_number" => "AB123456C",
+      }
+    end
+
+    it "playbacks NI number" do
+      assign(:wizard, wizard)
+
+      render
+      expect(rendered).to have_content("AB123456C")
+    end
+
+    it "does not have NI number suggestion text" do
+      assign(:wizard, wizard)
+
+      render
+      expect(rendered).not_to have_content("entering your National Insurance number")
+    end
+  end
+
+  context "when NI number is not present" do
+    let(:store) do
+      {
+        "date_of_birth" => 30.years.ago,
+      }
+    end
+
+    it "displays NI number suggestion text" do
+      assign(:wizard, wizard)
+
+      render
+      expect(rendered).to have_content("entering your National Insurance number")
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/3Qt9d1hQ/576-playback-details-on-validation-failed-page

### Changes proposed in this pull request

- After TRN auto validation failure playback entered data
- Slightly different content depending if optional NI number was entered or not
- Also fixed playing back of dates so they conform to govuk formatting

### Screenshots

![Screenshot 2021-10-07 at 11 47 49](https://user-images.githubusercontent.com/92580/136370053-e9ae058d-a14a-40e9-af9a-7840ff5358ec.png)

### Guidance to review

- none