### PR TITLE
Fix back link on provider page

### DIFF
--- a/app/lib/forms/choose_your_provider.rb
+++ b/app/lib/forms/choose_your_provider.rb
@@ -18,7 +18,9 @@ module Forms
     end
 
     def previous_step
-      if course.npqh?
+      if course.npqh? && eligible_for_funding?
+        :possible_funding
+      elsif course.npqh?
         :headteacher_duration
       elsif course.aso? && wizard.store["aso_funding"] == "yes"
         :funding_your_aso

--- a/spec/lib/forms/choose_your_provider_spec.rb
+++ b/spec/lib/forms/choose_your_provider_spec.rb
@@ -14,4 +14,36 @@ RSpec.describe Forms::ChooseYourProvider, type: :model do
       expect(subject.errors[:lead_provider_id]).to be_blank
     end
   end
+
+  describe "#previous_step" do
+    let(:current_step) { "choose_your_provider" }
+    let(:request) { nil }
+    let(:course) { Course.find_by(name: "NPQ for Headship (NPQH)") }
+    let(:school) { create(:school) }
+    let(:store) do
+      {
+        "course_id" => course.id,
+        "institution_identifier" => "School-#{school.urn}",
+      }
+    end
+    let(:wizard) do
+      RegistrationWizard.new(
+        current_step: current_step,
+        store: store,
+        request: request,
+      )
+    end
+    let(:mock_funding_service) { instance_double(Services::FundingEligibility, call: true) }
+
+    context "when npqh and eligible for funding" do
+      before do
+        subject.wizard = wizard
+        allow(Services::FundingEligibility).to receive(:new).and_return(mock_funding_service)
+      end
+
+      it "returns :possible_funding" do
+        expect(subject.previous_step).to eql(:possible_funding)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

- When user has selected NPQH and is eligible for funding it should take user back to possible funding page and not the headteacher duration page

### Changes proposed in this pull request

- See above

### Guidance to review

- none