### PR TITLE
Only show ASO funding choice if it needs funding

### DIFF
--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -125,7 +125,7 @@ class RegistrationWizard
 private
 
   def aso_needs_funding?
-    store["aso_funding"] == "yes"
+    (store["aso_headteacher"] != "yes" || store["aso_new_headteacher"] != "yes") && store["aso_funding"] == "yes"
   end
 
   def course

--- a/spec/models/registration_wizard_spec.rb
+++ b/spec/models/registration_wizard_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe RegistrationWizard do
   describe "#answers" do
     let(:school) { create(:school) }
 
-    context "when ASO is selected course" do
+    context "when ASO is selected course and not eligible for funding" do
       let(:store) do
         {
           "date_of_birth" => 30.years.ago,
@@ -35,11 +35,19 @@ RSpec.describe RegistrationWizard do
           "course_id" => Course.find_by(name: "Additional Support Offer for new headteachers").id,
           "lead_provider_id" => LeadProvider.all.sample.id,
           "funding_choice" => "school",
+          "aso_headteacher" => "yes",
+          "aso_new_headteacher" => "yes",
+          "aso_funding" => "yes",
+          "aso_funding_choice" => "another",
         }
       end
 
       it "does not show How is your NPQ being paid for?" do
         expect(subject.answers.map(&:key)).not_to include("How is your NPQ being paid for?")
+      end
+
+      it "does not show ASO funding option" do
+        expect(subject.answers.find { |el| el.key == "How is the Additional Support Offer being paid for?" }).to be_nil
       end
     end
 


### PR DESCRIPTION
### Context

- On ASO journey when user selects non DfE funding then backtracks to changes answers so DfE funding kicks in. The incorrect answers were shown on the check answers page

### Changes proposed in this pull request

- Correctly identify when ASO needs funding and only then show funding choice on the check answers page 

### Guidance to review

- none