### PR TITLE
confirmation panel playbacks course and provider

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,9 @@ Rails/BulkChangeTable:
 Style/HashLikeCase:
   Enabled: false
 
+Lint/MissingSuper:
+  Enabled: false
+
 Rails/Delegate:
   Enabled: false
 

--- a/app/components/npq_panel.html.erb
+++ b/app/components/npq_panel.html.erb
@@ -1,0 +1,8 @@
+<div class="govuk-panel govuk-panel--confirmation">
+  <h1 class="govuk-panel__title">
+    <%= title[:text] %>
+  </h1>
+  <div class="<%= body_classes.join(" ") %>">
+    <%= body[:text] %>
+  </div>
+</div>

--- a/app/components/npq_panel.rb
+++ b/app/components/npq_panel.rb
@@ -1,0 +1,18 @@
+class NpqPanel < ViewComponent::Base
+  attr_reader :title, :body
+
+  def initialize(title:, body:)
+    @title = title
+    @body = body
+  end
+
+  def body_classes
+    array = %w[govuk-panel__body]
+
+    if body[:classes]
+      array.concat(body[:classes])
+    end
+
+    array
+  end
+end

--- a/app/controllers/registration_wizard_controller.rb
+++ b/app/controllers/registration_wizard_controller.rb
@@ -7,6 +7,8 @@ class RegistrationWizardController < ApplicationController
     @form = @wizard.form
     @form.flag_as_changing_answer if params[:changing_answer] == "1"
 
+    @wizard.before_render
+
     return redirect_to root_path unless @form.requirements_met?
 
     render @wizard.current_step

--- a/app/controllers/registration_wizard_controller.rb
+++ b/app/controllers/registration_wizard_controller.rb
@@ -10,6 +10,8 @@ class RegistrationWizardController < ApplicationController
     return redirect_to root_path unless @form.requirements_met?
 
     render @wizard.current_step
+
+    @wizard.after_render
   end
 
   def update

--- a/app/lib/forms/base.rb
+++ b/app/lib/forms/base.rb
@@ -17,6 +17,10 @@ module Forms
       raise NotImplementedError
     end
 
+    def before_render
+      reset_store! if wizard.store["submitted"]
+    end
+
     def after_save; end
 
     def after_render; end
@@ -45,6 +49,10 @@ module Forms
 
     def requirements_met?
       wizard.store.present?
+    end
+
+    def reset_store!
+      wizard.store.clear
     end
   end
 end

--- a/app/lib/forms/base.rb
+++ b/app/lib/forms/base.rb
@@ -19,6 +19,8 @@ module Forms
 
     def after_save; end
 
+    def after_render; end
+
     def attributes
       self.class.permitted_params.index_with do |key|
         public_send(key)

--- a/app/lib/forms/check_answers.rb
+++ b/app/lib/forms/check_answers.rb
@@ -12,14 +12,6 @@ module Forms
 
     def after_save
       Services::HandleSubmissionForStore.new(store: wizard.store).call
-
-      clear_answers_in_store
-    end
-
-  private
-
-    def clear_answers_in_store
-      wizard.store.clear
     end
   end
 end

--- a/app/lib/forms/confirmation.rb
+++ b/app/lib/forms/confirmation.rb
@@ -13,7 +13,9 @@ module Forms
     end
 
     def after_render
-      wizard.store.clear
+      wizard.store["submitted"] = true
     end
+
+    def reset_store!; end
   end
 end

--- a/app/lib/forms/confirmation.rb
+++ b/app/lib/forms/confirmation.rb
@@ -3,5 +3,17 @@ module Forms
     def requirements_met?
       true
     end
+
+    def course
+      Course.find_by(id: wizard.store["course_id"])
+    end
+
+    def lead_provider
+      LeadProvider.find_by(id: wizard.store["lead_provider_id"])
+    end
+
+    def after_render
+      wizard.store.clear
+    end
   end
 end

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -19,6 +19,10 @@ class RegistrationWizard
     "Forms::#{step.to_s.camelcase}".constantize.permitted_params
   end
 
+  def after_render
+    form.after_render
+  end
+
   def session
     request.session
   end

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -19,6 +19,10 @@ class RegistrationWizard
     "Forms::#{step.to_s.camelcase}".constantize.permitted_params
   end
 
+  def before_render
+    form.before_render
+  end
+
   def after_render
     form.after_render
   end

--- a/app/views/registration_wizard/confirmation.html.erb
+++ b/app/views/registration_wizard/confirmation.html.erb
@@ -1,12 +1,18 @@
 <% content_for :title do %>
-  Initial registration complete
+  Your initial registration is complete
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render GovukComponent::PanelComponent.new(
-          title_text: 'Initial registration complete',
-          text: '') %>
+    <%= render NpqPanel.new(
+      title: {
+        text: "Your initial registration is complete"
+      },
+      body: {
+        text: "You’ve registered for an <strong>#{@form.course.name}</strong> with <strong>#{@form.lead_provider.name}</strong>".html_safe,
+        classes: ["govuk-!-font-size-19"]
+      }
+    ) %>
 
     <h2 class="govuk-heading-m">What happens next</h2>
 

--- a/spec/features/happy_journeys_non_js_spec.rb
+++ b/spec/features/happy_journeys_non_js_spec.rb
@@ -316,9 +316,9 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).to have_text("Teach First")
     expect(page).to have_text("NPQ for Headship (NPQH)")
 
-    visit "/registration/share-provider"
+    visit "/registration/check-answers"
 
-    expect(page).to have_content("Before you start")
+    expect(page.current_path).to eql("/")
   end
 
   scenario "self funded ASO registration journey" do
@@ -481,9 +481,9 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).to have_text("Teach First")
     expect(page).to have_text("Additional Support Offer for new headteachers")
 
-    visit "/registration/share-provider"
+    visit "/registration/check-answers"
 
-    expect(page).to have_content("Before you start")
+    expect(page.current_path).to eql("/")
   end
 
   scenario "funded ASO registration journey" do
@@ -638,8 +638,8 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).to have_text("Teach First")
     expect(page).to have_text("Additional Support Offer for new headteachers")
 
-    visit "/registration/share-provider"
+    visit "/registration/check-answers"
 
-    expect(page).to have_content("Before you start")
+    expect(page.current_path).to eql("/")
   end
 end

--- a/spec/features/happy_journeys_non_js_spec.rb
+++ b/spec/features/happy_journeys_non_js_spec.rb
@@ -288,7 +288,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
     page.click_button("Submit")
 
-    expect(page).to have_text("Initial registration complete")
+    expect(page).to have_text("Your initial registration is complete")
 
     expect(User.count).to eql(1)
 
@@ -453,7 +453,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
     page.click_button("Submit")
 
-    expect(page).to have_text("Initial registration complete")
+    expect(page).to have_text("Your initial registration is complete")
 
     expect(User.count).to eql(1)
 
@@ -610,7 +610,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
     page.click_button("Submit")
 
-    expect(page).to have_text("Initial registration complete")
+    expect(page).to have_text("Your initial registration is complete")
 
     expect(User.count).to eql(1)
 

--- a/spec/features/happy_journeys_spec.rb
+++ b/spec/features/happy_journeys_spec.rb
@@ -294,7 +294,7 @@ RSpec.feature "Happy journeys", type: :feature do
     page.click_button("Submit")
 
     expect(page).to be_axe_clean
-    expect(page).to have_text("Initial registration complete")
+    expect(page).to have_text("Your initial registration is complete")
 
     expect(User.count).to eql(1)
 


### PR DESCRIPTION
### Context

- https://trello.com/c/c2B9Qrlx/597-playback-what-was-registered-for-on-the-confirmation-page
- To improve the confirmation page after user has completed their transaction

### Changes proposed in this pull request

- Confirmation page panel playbacks chosen course and provider

### Screenshots

![Screenshot 2021-10-11 at 15 42 39](https://user-images.githubusercontent.com/92580/136812342-5675009d-f7b7-402f-aa02-d07caa8ea185.png)

### Guidance to review

- The component library does not support classes on the body of the panel component, so a custom component is used