### PR TITLE
Persist padded TRN on submit

### DIFF
--- a/app/lib/services/handle_submission_for_store.rb
+++ b/app/lib/services/handle_submission_for_store.rb
@@ -11,7 +11,7 @@ module Services
     def call
       ActiveRecord::Base.transaction do
         user.update!(
-          trn: store["verified_trn"].presence || store["trn"],
+          trn: store["verified_trn"].presence || padded_entered_trn,
           trn_verified: store["trn_verified"],
           trn_auto_verified: !!store["trn_auto_verified"],
           active_alert: store["active_alert"],
@@ -35,6 +35,10 @@ module Services
     end
 
   private
+
+    def padded_entered_trn
+      store["trn"].rjust(7, "0")
+    end
 
     def funding_choice
       if course.aso?

--- a/spec/lib/services/handle_submission_for_store_spec.rb
+++ b/spec/lib/services/handle_submission_for_store_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe Services::HandleSubmissionForStore do
+  let(:user) { create(:user, trn: nil) }
+  let(:school) { create(:school) }
+
+  let(:store) do
+    {
+      "confirmed_email" => user.email,
+      "trn_verified" => false,
+      "trn" => "12345",
+      "course_id" => Course.all.sample.id,
+      "institution_identifier" => "School-#{school.urn}",
+      "lead_provider_id" => LeadProvider.all.sample.id,
+    }
+  end
+
+  subject { described_class.new(store: store) }
+
+  describe "#call" do
+    context "when entered trn is shorter than 7 characters" do
+      it "pads by prefixing zeros to 7 characters" do
+        subject.call
+
+        expect(user.reload.trn).to eql("0012345")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/bkubjWxF/379-ensure-retrospectively-fix-trns-so-they-are-padded
- If TRN could not be verified we pad the TRN the user entered
- DQT API already only supports TRNs with length of 7 characters, we just failed to persist the user entered value if auto validation fails
- This is to ensure consistency when dealing with TRNs so they are always 7 characters long
- There will be some work after once deployed to retrospectively fix data where TRNs are not 7 characters long
- Some providers are also expecting TRNs to be 7 characters long and this PR plus above action should resolve this matter

### Changes proposed in this pull request

- When storing the users entered TRN because it could not be verified we pad the entered value with leading zeros till it is 7 characters long

### Guidance to review

- none