### PR TITLE
Only show confirmation page if data is present

### DIFF
--- a/app/lib/forms/confirmation.rb
+++ b/app/lib/forms/confirmation.rb
@@ -1,7 +1,7 @@
 module Forms
   class Confirmation < Base
     def requirements_met?
-      true
+      wizard.store["course_id"].present? && wizard.store["lead_provider_id"].present?
     end
 
     def course

--- a/spec/features/happy_journeys_non_js_spec.rb
+++ b/spec/features/happy_journeys_non_js_spec.rb
@@ -169,6 +169,11 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(application.funding_choice).to be_nil
     expect(application.course).to be_npqsl
     expect(application.headteacher_status).to be_nil
+
+    visit "/"
+    visit "/registration/confirmation"
+
+    expect(page.current_path).to eql("/")
   end
 
   scenario "registration journey via using same name" do


### PR DESCRIPTION
### Context

- Users are hitting the browser back button to the confirmation page
- This causes an error as their session data has been cleared
- So we first check session data is available otherwise send to start page
- This bug was introduced recently when we added course and provider name to the confirmation page

### Changes proposed in this pull request

- Check needed session data is present for confirmation page, otherwise send them to start page

### Guidance to review

- none