### PR TITLE
support legacy style trns

### DIFF
--- a/app/lib/forms/qualified_teacher_check.rb
+++ b/app/lib/forms/qualified_teacher_check.rb
@@ -19,8 +19,9 @@ module Forms
     before_validation :strip_ni_number_whitespace
     before_validation :strip_title_prefixes
 
-    validates :trn, presence: true, length: { in: 5..7 }, format: { with: /\A\d+\z/ }
+    validates :trn, presence: true
     validates :full_name, presence: true, length: { maximum: 128 }
+    validate :validate_processed_trn
     validate :validate_date_of_birth_valid?
     validates :date_of_birth, presence: true
     validate :validate_date_of_birth_in_the_past?
@@ -33,6 +34,20 @@ module Forms
         date_of_birth
         national_insurance_number
       ]
+    end
+
+    def validate_processed_trn
+      if processed_trn !~ /\A\d+\z/
+        errors.add(:trn, :invalid)
+      elsif processed_trn.length < 5
+        errors.add(:trn, :too_short, count: 5)
+      elsif processed_trn.length > 7
+        errors.add(:trn, :too_long, count: 7)
+      end
+    end
+
+    def processed_trn
+      @processed_trn ||= (trn || "").gsub("RP", "").gsub("/", "")
     end
 
     def next_step

--- a/app/lib/services/handle_submission_for_store.rb
+++ b/app/lib/services/handle_submission_for_store.rb
@@ -11,7 +11,7 @@ module Services
     def call
       ActiveRecord::Base.transaction do
         user.update!(
-          trn: store["verified_trn"].presence || padded_entered_trn,
+          trn: padded_verified_trn || padded_entered_trn,
           trn_verified: store["trn_verified"],
           trn_auto_verified: !!store["trn_auto_verified"],
           active_alert: store["active_alert"],
@@ -38,6 +38,12 @@ module Services
 
     def padded_entered_trn
       store["trn"].rjust(7, "0")
+    end
+
+    def padded_verified_trn
+      if store["verified_trn"].present?
+        store["verified_trn"].rjust(7, "0")
+      end
     end
 
     def funding_choice

--- a/spec/features/happy_journeys_non_js_spec.rb
+++ b/spec/features/happy_journeys_non_js_spec.rb
@@ -86,16 +86,16 @@ RSpec.feature "Happy journeys", type: :feature do
           "Authorization" => "Bearer ECFAPPBEARERTOKEN",
         },
         body: {
-          trn: "1234567",
+          trn: "12345",
           date_of_birth: "1980-12-13",
           full_name: "John Doe",
           nino: "",
         },
       )
-      .to_return(status: 200, body: participant_validator_response, headers: {})
+      .to_return(status: 200, body: participant_validator_response(trn: "12345"), headers: {})
 
     expect(page).to have_text("Check your details")
-    page.fill_in "Teacher reference number (TRN)", with: "1234567"
+    page.fill_in "Teacher reference number (TRN)", with: "RP12/345"
     page.fill_in "Full name", with: "John Doe"
     page.fill_in "Day", with: "13"
     page.fill_in "Month", with: "12"
@@ -143,7 +143,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
     expect(check_answers_page).to be_displayed
     expect(check_answers_page.summary_list["Full name"].value).to eql("John Doe")
-    expect(check_answers_page.summary_list["TRN"].value).to eql("1234567")
+    expect(check_answers_page.summary_list["TRN"].value).to eql("RP12/345")
     expect(check_answers_page.summary_list["Date of birth"].value).to eql("13 December 1980")
     expect(check_answers_page.summary_list.key?("National Insurance number")).to be_falsey
     expect(check_answers_page.summary_list["Email"].value).to eql("user@example.com")
@@ -161,7 +161,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
     expect(user.email).to eql("user@example.com")
     expect(user.full_name).to eql("John Doe")
-    expect(user.trn).to eql("1234567")
+    expect(user.trn).to eql("0012345")
     expect(user.trn_verified).to be_truthy
     expect(user.trn_auto_verified).to be_truthy
     expect(user.date_of_birth).to eql(Date.new(1980, 12, 13))

--- a/spec/lib/forms/qualified_teacher_check_spec.rb
+++ b/spec/lib/forms/qualified_teacher_check_spec.rb
@@ -85,7 +85,6 @@ RSpec.describe Forms::QualifiedTeacherCheck, type: :model do
 
   describe "validations" do
     it { is_expected.to validate_presence_of(:trn) }
-    it { is_expected.to validate_length_of(:trn).is_at_least(5).is_at_most(7) }
     it { is_expected.to validate_presence_of(:full_name) }
     it { is_expected.to validate_length_of(:full_name).is_at_most(128) }
     it { is_expected.to validate_presence_of(:date_of_birth) }
@@ -94,6 +93,33 @@ RSpec.describe Forms::QualifiedTeacherCheck, type: :model do
     describe "#trn" do
       it "can only contain numbers" do
         subject.trn = "123456a"
+        subject.valid?
+        expect(subject.errors[:trn]).to be_present
+      end
+    end
+
+    describe "#processed_trn" do
+      it "permits legacy style trns" do
+        subject.trn = "RP99/12345"
+        subject.valid?
+        expect(subject.errors[:trn]).to be_blank
+        expect(subject.processed_trn).to eql("9912345")
+      end
+
+      it "denies trns over 7 characters" do
+        subject.trn = "RP99/123456"
+        subject.valid?
+        expect(subject.errors[:trn]).to be_present
+      end
+
+      it "denies trns under 5 characters" do
+        subject.trn = "RP/1234"
+        subject.valid?
+        expect(subject.errors[:trn]).to be_present
+      end
+
+      it "denies trns with other letters" do
+        subject.trn = "AA99/12345"
         subject.valid?
         expect(subject.errors[:trn]).to be_present
       end


### PR DESCRIPTION
### Context

- Allow legacy style TRNs to be entered for improved user experience eg `RP99/12345`
- Consistency with https://github.com/DFE-Digital/early-careers-framework/pull/1163/files#diff-5ef053c925940ee24b9c81c45bf18b21b6e5bcabb446621a61816738d9ed0b32R105 for more consistent CPD experience

### Changes proposed in this pull request

- Permit legacy style TRNs
- Also always pad TRN from api to ensure 7 characters

### Guidance to review

- There should be some copy changes in the near future to better explain this feature and improve user experience