### PR TITLE
fix back link for international journey

### DIFF
--- a/app/lib/forms/choose_your_npq.rb
+++ b/app/lib/forms/choose_your_npq.rb
@@ -36,7 +36,11 @@ module Forms
     end
 
     def previous_step
-      :choose_school
+      if query_store.inside_catchment?
+        :choose_school
+      else
+        :qualified_teacher_check
+      end
     end
 
     def options

--- a/spec/lib/forms/choose_your_npq_spec.rb
+++ b/spec/lib/forms/choose_your_npq_spec.rb
@@ -64,4 +64,32 @@ RSpec.describe Forms::ChooseYourNpq, type: :model do
       end
     end
   end
+
+  describe "#previous_step" do
+    let(:request) { nil }
+
+    before do
+      subject.wizard = RegistrationWizard.new(
+        current_step: :choose_your_npq,
+        store: store,
+        request: request,
+      )
+    end
+
+    context "when inside catchment" do
+      let(:store) { { teacher_catchment: "england" }.stringify_keys }
+
+      it "returns choose_school" do
+        expect(subject.previous_step).to eql(:choose_school)
+      end
+    end
+
+    context "when outside catchment" do
+      let(:store) { { teacher_catchment: "another" }.stringify_keys }
+
+      it "return qualified_teacher_check" do
+        expect(subject.previous_step).to eql(:qualified_teacher_check)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

- Fixes a back link on the international journey so user is not sent to school pages as they do not need to enter a school

### Changes proposed in this pull request

- see above

### Guidance to review

- none