### PR TITLE
supply course name to email

### DIFF
--- a/app/jobs/application_submission_job.rb
+++ b/app/jobs/application_submission_job.rb
@@ -12,13 +12,14 @@ class ApplicationSubmissionJob < ApplicationJob
       end
     end
 
-    user.applications.where(ecf_id: nil).each do |application|
+    user.applications.includes(:lead_provider, :course).where(ecf_id: nil).each do |application|
       Services::NpqProfileCreator.new(application: application).call
 
       ApplicationSubmissionMailer.application_submitted_mail(
         to: user.email,
         full_name: user.full_name,
         provider_name: application.lead_provider.name,
+        course_name: application.course.name,
       ).deliver_now
     end
   end

--- a/app/mailers/application_submission_mailer.rb
+++ b/app/mailers/application_submission_mailer.rb
@@ -1,10 +1,11 @@
 class ApplicationSubmissionMailer < ApplicationMailer
-  def application_submitted_mail(to:, full_name:, provider_name:)
+  def application_submitted_mail(to:, full_name:, provider_name:, course_name:)
     template_mail("b8b53310-fa6f-4587-972a-f3f3c6e0892e",
                   to: to,
                   personalisation: {
                     full_name: full_name,
                     provider_name: provider_name,
+                    course_name: course_name,
                   })
   end
 end

--- a/spec/jobs/application_submission_job_spec.rb
+++ b/spec/jobs/application_submission_job_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe ApplicationSubmissionJob do
         to: user.email,
         full_name: user.full_name,
         provider_name: application.lead_provider.name,
+        course_name: application.course.name,
       )
 
       subject.perform_now


### PR DESCRIPTION
### Context

- https://trello.com/c/4cYAaYRK/405-confirmation-email-at-journey-end-should-include-course
- We do not at the moment playback the users selected course in the submission email

### Changes proposed in this pull request

- Supply course name to notify so we will be able to playback selected course to the user

### Guidance to review

- Notify template changes have not happened yet and need to happen after this change has been deployed