### PR TITLE
grant admins ability to search by GUIDS

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,3 +42,6 @@ Rails/Output:
   Exclude:
     - "app/lib/services/importers/*"
     - "app/lib/services/exporters/*"
+
+Naming/MethodParameterName:
+  Enabled: false

--- a/app/controllers/admin/applications_controller.rb
+++ b/app/controllers/admin/applications_controller.rb
@@ -2,17 +2,16 @@ class Admin::ApplicationsController < AdminController
   include Pagy::Backend
 
   def index
-    scope = Application.includes(:user, :course, :lead_provider)
-
-    if params[:q]
-      scope = scope.joins(:user)
-      scope = scope.where("users.email ilike ?", "%#{params[:q]}%")
-    end
-
     @pagy, @applications = pagy(scope)
   end
 
   def show
     @application = Application.includes(:user).find(params[:id])
+  end
+
+private
+
+  def scope
+    Services::Admin::ApplicationsSearch.new(q: params[:q]).call
   end
 end

--- a/app/lib/services/admin/applications_search.rb
+++ b/app/lib/services/admin/applications_search.rb
@@ -1,0 +1,25 @@
+class Services::Admin::ApplicationsSearch
+  attr_reader :q
+
+  def initialize(q:)
+    @q = q
+  end
+
+  def call
+    chain = default_scope
+
+    if q.present?
+      chain = chain.where("users.email ilike ?", "%#{q}%")
+      chain = chain.or(default_scope.where(ecf_id: q))
+      chain = chain.or(default_scope.where(users: { ecf_id: q }))
+    end
+
+    chain
+  end
+
+private
+
+  def default_scope
+    Application.joins(:user).includes(:user, :course, :lead_provider)
+  end
+end

--- a/app/views/admin/applications/index.html.erb
+++ b/app/views/admin/applications/index.html.erb
@@ -14,7 +14,7 @@
         <%= f.govuk_text_field(
             :q,
             value: params[:q],
-            label: { text: "Search by email", size: "s" },
+            label: { text: "Search by email, user GUID or application GUID", size: "s" },
           )
         %>
 

--- a/spec/lib/services/admin/applications_search_spec.rb
+++ b/spec/lib/services/admin/applications_search_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe Services::Admin::ApplicationsSearch do
+  let!(:application) { create(:application) }
+  let!(:user) { application.user }
+
+  subject { described_class.new(q: q) }
+
+  describe "#call" do
+    context "when partial email match" do
+      let(:q) { user.email.split("@").first }
+
+      it "returns the hit" do
+        expect(subject.call).to include(application)
+      end
+    end
+
+    context "when application#ecf_id match" do
+      let(:q) { application.ecf_id }
+
+      it "returns the hit" do
+        expect(subject.call).to include(application)
+      end
+    end
+
+    context "when user#ecf_id match" do
+      let(:q) { user.ecf_id }
+
+      it "returns the hit" do
+        expect(subject.call).to include(application)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Admins want to the ability to locate applications more easily when users provider guids

### Changes proposed in this pull request

- Admins can search for application via user guid or application guid

### Guidance to review

- none