### PR TITLE
add exporter for user with a TRN

### DIFF
--- a/app/lib/services/exporters/users_with_trn.rb
+++ b/app/lib/services/exporters/users_with_trn.rb
@@ -1,0 +1,15 @@
+class Services::Exporters::UsersWithTrn
+  def call
+    puts "participant_id,user_id,trn"
+    users.each do |user|
+      puts "#{user.ecf_id},#{user.id},#{user.trn}"
+    end
+    nil
+  end
+
+private
+
+  def users
+    @users ||= User.joins(:applications).where("trn IS NOT NULL").distinct
+  end
+end

--- a/spec/lib/services/exporters/users_with_trn_spec.rb
+++ b/spec/lib/services/exporters/users_with_trn_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe Services::Exporters::UsersWithTrn do
+  around do |example|
+    original_stdout = $stdout
+    $stdout = StringIO.new
+    example.run
+    $stdout = original_stdout
+  end
+
+  describe "#call" do
+    let(:user) { create(:user, ecf_id: "12345") }
+    let(:application) { create(:application, user: user) }
+
+    before do
+      application
+      create(:user)
+    end
+
+    it "outputs headers" do
+      subject.call
+
+      expect($stdout.string).to include("participant_id,user_id,trn")
+    end
+
+    it "outputs correct number of rows" do
+      subject.call
+
+      expect($stdout.string.lines.size).to eql(2)
+    end
+
+    it "outputs correct data" do
+      subject.call
+
+      expect($stdout.string).to include("#{user.ecf_id},#{user.id},#{user.trn}")
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Internal users have requested data for users with trns for their `ecf_id`, `id` and `trn` 

### Changes proposed in this pull request

- Add exporter to output required data to stdout

### Guidance to review

- none