### PR TITLE
Add rake task for syncing applications to ecf

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,6 +37,7 @@ Rails/SaveBang:
     - "app/lib/ecf_api/base.rb"
     - "app/lib/services/ecf_user_creator.rb"
     - "app/lib/services/npq_profile_creator.rb"
+    - "app/lib/services/npq_profile_updater.rb"
 
 Rails/Output:
   Exclude:

--- a/app/lib/services/npq_profile_updater.rb
+++ b/app/lib/services/npq_profile_updater.rb
@@ -1,0 +1,15 @@
+module Services
+  class NpqProfileUpdater
+    attr_reader :application
+
+    def initialize(application:)
+      @application = application
+    end
+
+    def call
+      profile = EcfApi::NpqProfile.find(application.ecf_id).first
+      profile.eligible_for_funding = application.eligible_for_funding
+      profile.save
+    end
+  end
+end

--- a/lib/tasks/sync_applications.rb
+++ b/lib/tasks/sync_applications.rb
@@ -1,0 +1,20 @@
+namespace :sync do
+  desc "Sync applications attributes with ecf service"
+  task applications: :environment do
+    Rails.logger.info "syncing applications"
+
+    count = Application.count
+    errored_ids = []
+    Application.each_with_index do |application, i|
+      Rails.logger.info "syncing application #{application.id}, (#{i + 1},/#{count})"
+      Services::NpqProfileUpdater.new(application: application).call
+    rescue StandardError
+      Rails.logger.info "error with application #{application.id}"
+      errored_ids << application.id
+    end
+
+    Rails.logger.info "done"
+
+    Rails.logger.info "errored applications: #{errored_ids}"
+  end
+end

--- a/spec/lib/services/npq_profile_updater_spec.rb
+++ b/spec/lib/services/npq_profile_updater_spec.rb
@@ -1,0 +1,112 @@
+require "rails_helper"
+
+RSpec.describe Services::NpqProfileUpdater do
+  let(:user) do
+    User.create!(
+      email: "john.doe@example.com",
+      full_name: "John Doe",
+      ecf_id: "123",
+      trn: "1234567",
+      trn_verified: true,
+      active_alert: true,
+      date_of_birth: Date.new(1980, 12, 13),
+      national_insurance_number: "AB123456C",
+    )
+  end
+  let(:course) { Course.create!(name: "Some course", ecf_id: "234") }
+  let(:lead_provider) { LeadProvider.create!(name: "Some lead provider", ecf_id: "345") }
+  let(:school) { create(:school) }
+
+  let(:application) do
+    Application.create!(
+      user: user,
+      course: course,
+      lead_provider: lead_provider,
+      school_urn: school.urn,
+      ukprn: school.ukprn,
+      headteacher_status: "no",
+      eligible_for_funding: true,
+      funding_choice: "trust",
+      ecf_id: "1234",
+    )
+  end
+
+  let(:find_response_body) do
+    {
+      data: {
+        type: "npq_profiles",
+        id: "1234",
+        attributes: {
+          teacher_reference_number: "1234567",
+          teacher_reference_number_verified: true,
+          active_alert: true,
+          date_of_birth: user.date_of_birth.iso8601,
+          national_insurance_number: user.national_insurance_number,
+          school_urn: application.school_urn,
+          school_ukprn: application.ukprn,
+          headteacher_status: "no",
+          eligible_for_funding: false,
+          funding_choice: "trust",
+        },
+      },
+    }.to_json
+  end
+
+  let(:request_body) do
+    {
+      data: {
+        id: "1234",
+        type: "npq_profiles",
+        attributes: {
+          eligible_for_funding: true,
+        },
+      },
+    }.to_json
+  end
+
+  let(:response_body) do
+    {
+      data: {
+        type: "npq_profiles",
+        id: "1234",
+      },
+    }.to_json
+  end
+
+  subject { described_class.new(application: application) }
+
+  before do
+    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-profiles/#{application.ecf_id}")
+      .to_return(
+        status: 200,
+        body: find_response_body,
+        headers: {
+          "Content-Type" => "application/vnd.api+json",
+        },
+      )
+  end
+
+  let!(:update_ecf_stub) do
+    stub_request(:patch, "https://ecf-app.gov.uk/api/v1/npq-profiles/#{application.ecf_id}")
+      .with(
+        body: request_body,
+        headers: {
+          "Accept" => "application/vnd.api+json",
+          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+          "Content-Type" => "application/vnd.api+json",
+        },
+      )
+        .to_return(
+          status: 200,
+          body: response_body,
+          headers: {
+            "Content-Type" => "application/vnd.api+json",
+          },
+        )
+  end
+
+  it "calls ecf to update the eligible_for_funding attribute" do
+    subject.call
+    expect(update_ecf_stub).to have_been_requested
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-852

Corresponding PR: https://github.com/DFE-Digital/early-careers-framework/pull/1622

Adds a rake task to sync all the `eligible_for_funding` statuses with ecf

### Changes proposed in this pull request

### Guidance to review

