### PR TITLE
Application sync task improvements

### DIFF
--- a/lib/tasks/sync_applications.rake
+++ b/lib/tasks/sync_applications.rake
@@ -3,9 +3,10 @@ namespace :sync do
   task applications: :environment do
     Rails.logger.info "syncing applications"
 
-    count = Application.count
+    count = Application.where("ecf_id is not null").count
     errored_ids = []
-    Application.each_with_index do |application, i|
+    Application.where("ecf_id is not null").order(created_at: :asc).each_with_index do |application, i|
+      sleep(0.1)
       Rails.logger.info "syncing application #{application.id}, (#{i + 1},/#{count})"
       Services::NpqProfileUpdater.new(application: application).call
     rescue StandardError


### PR DESCRIPTION
- Rename file to .rake extension so it actually gets picked up by rake
- only select applications where the ecf_id is not null, there isn't a constraint on this and there is no point making a request without an id, it won't work
- Add a 100ms sleep between each iteration to reduce the chance of overloading ecf
- Add an order by so the task can be resumed from that point if it needs to be terminated for any reason

### Context

Previous PR: https://github.com/DFE-Digital/npq-registration/pull/285

### Changes proposed in this pull request

### Guidance to review

