### PR TITLE
[CPDLP-838] Add ecf_user_id to report

### DIFF
--- a/app/lib/services/report.rb
+++ b/app/lib/services/report.rb
@@ -9,6 +9,7 @@ module Services
         applications.each do |a|
           csv << [
             a.user.id,
+            a.user.ecf_id,
             a.user.created_at,
             a.user.trn_verified,
             a.user.trn_auto_verified,
@@ -36,6 +37,7 @@ module Services
     def headers
       %w[
         user_id
+        ecf_user_id
         user_created_at
         trn_verified
         trn_auto_verified


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-858

We need a way of linking participant declarations and the applications in this report in bigquery. The participant declarations table already has the user id for ecf.

The join table proposed in the ticket isn't simple as the existing user id and participant ids are in different serviced. I spoke to Will and this approach is sufficient.

### Changes proposed in this pull request

### Guidance to review

