### PR TITLE
[CST-252] EOI for autumn 2022 

### DIFF
--- a/app/controllers/interest_notification_sign_up_controller.rb
+++ b/app/controllers/interest_notification_sign_up_controller.rb
@@ -1,0 +1,31 @@
+class InterestNotificationSignUpController < ApplicationController
+  before_action :set_notification_form, only: %i[new]
+
+  def new; end
+
+  def create
+    @notification_form = Forms::RegistrationInterestNotification.new(notification_params)
+    @notification_form.notification_option = "yes"
+
+    if @notification_form.valid?
+      @notification_form.save!
+      redirect_to registration_interest_sign_up_confirm_path(email: @notification_form.email)
+    else
+      render :new
+    end
+  end
+
+  def confirm
+    @email = params[:email]
+  end
+
+private
+
+  def notification_params
+    params.require(:forms_registration_interest_notification).permit(:email)
+  end
+
+  def set_notification_form
+    @notification_form = Forms::RegistrationInterestNotification.new
+  end
+end

--- a/app/controllers/registration_interest_controller.rb
+++ b/app/controllers/registration_interest_controller.rb
@@ -1,0 +1,39 @@
+class RegistrationInterestController < ApplicationController
+  def new
+    @notification_form = Forms::RegistrationInterestNotification.new
+  end
+
+  def create
+    @notification_form = Forms::RegistrationInterestNotification.new(notification_params)
+
+    if @notification_form.selected_no?
+      redirect_to registration_interest_no_notification_path and return
+    end
+
+    if @notification_form.valid?
+      ActiveRecord::Base.transaction do
+        RegistrationInterest.create!(
+          email: @notification_form.email,
+          term: @notification_form.current_term,
+        )
+      rescue ActiveRecord::RecordInvalid
+        render :new
+      end
+      redirect_to registration_interest_confirm_path(email: @notification_form.email)
+    else
+      render :new
+    end
+  end
+
+  def confirm
+    @email = params[:email]
+  end
+
+  def no_notification; end
+
+private
+
+  def notification_params
+    params.require(:forms_registration_interest_notification).permit(:notification_option, :email)
+  end
+end

--- a/app/controllers/registration_interest_controller.rb
+++ b/app/controllers/registration_interest_controller.rb
@@ -1,7 +1,7 @@
 class RegistrationInterestController < ApplicationController
-  def new
-    @notification_form = Forms::RegistrationInterestNotification.new
-  end
+  before_action :set_notification_form, only: %i[new]
+
+  def new; end
 
   def create
     @notification_form = Forms::RegistrationInterestNotification.new(notification_params)
@@ -11,14 +11,7 @@ class RegistrationInterestController < ApplicationController
     end
 
     if @notification_form.valid?
-      ActiveRecord::Base.transaction do
-        RegistrationInterest.create!(
-          email: @notification_form.email,
-          term: @notification_form.current_term,
-        )
-      rescue ActiveRecord::RecordInvalid
-        render :new
-      end
+      @notification_form.save!
       redirect_to registration_interest_confirm_path(email: @notification_form.email)
     else
       render :new
@@ -35,5 +28,9 @@ private
 
   def notification_params
     params.require(:forms_registration_interest_notification).permit(:notification_option, :email)
+  end
+
+  def set_notification_form
+    @notification_form = Forms::RegistrationInterestNotification.new
   end
 end

--- a/app/controllers/registration_wizard_controller.rb
+++ b/app/controllers/registration_wizard_controller.rb
@@ -27,6 +27,8 @@ class RegistrationWizardController < ApplicationController
     if @form.valid?
       if @form.changing_answer? && @form.next_step != :check_answers
         redirect_to registration_wizard_show_change_path(@wizard.next_step_path)
+      elsif @form.next_step == :notification_option
+        redirect_to registration_interest_path
       else
         redirect_to registration_wizard_show_path(@wizard.next_step_path)
       end

--- a/app/lib/forms/chosen_start_date.rb
+++ b/app/lib/forms/chosen_start_date.rb
@@ -1,0 +1,32 @@
+module Forms
+  class ChosenStartDate < Base
+    VALID_CHOSEN_START_DATE_OPTIONS = %w[yes no].freeze
+
+    attr_accessor :chosen_start_date
+
+    validates :chosen_start_date, presence: true, inclusion: { in: VALID_CHOSEN_START_DATE_OPTIONS }
+
+    def self.permitted_params
+      %i[
+        chosen_start_date
+      ]
+    end
+
+    def requirements_met?
+      true
+    end
+
+    def next_step
+      case chosen_start_date
+      when "yes"
+        :provider_check
+      when "no"
+        :notification_option
+      end
+    end
+
+    def previous_step
+      :start
+    end
+  end
+end

--- a/app/lib/forms/provider_check.rb
+++ b/app/lib/forms/provider_check.rb
@@ -26,7 +26,7 @@ module Forms
     end
 
     def previous_step
-      :start
+      :chosen_start_date
     end
   end
 end

--- a/app/lib/forms/registration_interest_notification.rb
+++ b/app/lib/forms/registration_interest_notification.rb
@@ -11,7 +11,7 @@ module Forms
               presence: true,
               length: { maximum: 128 },
               unless: :selected_no?
-    validate :can_register_interest?
+    validate :can_register_interest
 
     def current_term(term = "Autumn 2022")
       term
@@ -21,10 +21,14 @@ module Forms
       notification_option == "no"
     end
 
-    def can_register_interest?
+    def can_register_interest
       if RegistrationInterest.find_by(email: email).present?
         errors.add(:email, :taken)
       end
+    end
+
+    def save!
+      RegistrationInterest.create!(email: email, term: current_term)
     end
   end
 end

--- a/app/lib/forms/registration_interest_notification.rb
+++ b/app/lib/forms/registration_interest_notification.rb
@@ -4,7 +4,7 @@ module Forms
 
     VALID_NOTIFICATION_OPTIONS = %w[yes no].freeze
 
-    attr_accessor :email, :notification_option, :term_interest_registered
+    attr_accessor :email, :notification_option
 
     validates :notification_option, inclusion: { in: VALID_NOTIFICATION_OPTIONS }
     validates :email,
@@ -13,9 +13,6 @@ module Forms
               unless: :selected_no?
     validate :can_register_interest
 
-    def term
-      term_interest_registered || "Autumn 2022"
-    end
 
     def selected_no?
       notification_option == "no"
@@ -28,7 +25,7 @@ module Forms
     end
 
     def save!
-      RegistrationInterest.create!(email: email, term: term)
+      RegistrationInterest.create!(email: email)
     end
   end
 end

--- a/app/lib/forms/registration_interest_notification.rb
+++ b/app/lib/forms/registration_interest_notification.rb
@@ -1,0 +1,30 @@
+module Forms
+  class RegistrationInterestNotification
+    include ActiveModel::Model
+
+    VALID_NOTIFICATION_OPTIONS = %w[yes no].freeze
+
+    attr_accessor :email, :notification_option
+
+    validates :notification_option, inclusion: { in: VALID_NOTIFICATION_OPTIONS }
+    validates :email,
+              presence: true,
+              length: { maximum: 128 },
+              unless: :selected_no?
+    validate :can_register_interest?
+
+    def current_term(term = "Autumn 2022")
+      term
+    end
+
+    def selected_no?
+      notification_option == "no"
+    end
+
+    def can_register_interest?
+      if RegistrationInterest.find_by(email: email).present?
+        errors.add(:email, :taken)
+      end
+    end
+  end
+end

--- a/app/lib/forms/registration_interest_notification.rb
+++ b/app/lib/forms/registration_interest_notification.rb
@@ -13,7 +13,6 @@ module Forms
               unless: :selected_no?
     validate :can_register_interest
 
-
     def selected_no?
       notification_option == "no"
     end

--- a/app/lib/forms/registration_interest_notification.rb
+++ b/app/lib/forms/registration_interest_notification.rb
@@ -4,7 +4,7 @@ module Forms
 
     VALID_NOTIFICATION_OPTIONS = %w[yes no].freeze
 
-    attr_accessor :email, :notification_option
+    attr_accessor :email, :notification_option, :term_interest_registered
 
     validates :notification_option, inclusion: { in: VALID_NOTIFICATION_OPTIONS }
     validates :email,
@@ -13,8 +13,8 @@ module Forms
               unless: :selected_no?
     validate :can_register_interest
 
-    def current_term(term = "Autumn 2022")
-      term
+    def term
+      term_interest_registered || "Autumn 2022"
     end
 
     def selected_no?
@@ -28,7 +28,7 @@ module Forms
     end
 
     def save!
-      RegistrationInterest.create!(email: email, term: current_term)
+      RegistrationInterest.create!(email: email, term: term)
     end
   end
 end

--- a/app/models/registration_interest.rb
+++ b/app/models/registration_interest.rb
@@ -1,0 +1,6 @@
+class RegistrationInterest < ApplicationRecord
+  validates :email,
+            presence: true,
+            length: { maximum: 128 },
+            uniqueness: { case_sensitive: false }
+end

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -184,6 +184,7 @@ private
   def steps
     %i[
       start
+      chosen_start_date
       teacher_catchment
       work_in_school
       provider_check

--- a/app/views/interest_notification_sign_up/confirm.html.erb
+++ b/app/views/interest_notification_sign_up/confirm.html.erb
@@ -6,12 +6,9 @@
         Your email alert has been set up.
       </h1>
 
-      <div class="govuk-panel__body">
-        <div class="govuk-!-font-size-24">
+      <p>
           We’ll send an email to <%= @email %> when registration reopens.
-        </div>
-
-      </div>
+      </p>
     </div>
   </div>
 </div>

--- a/app/views/interest_notification_sign_up/confirm.html.erb
+++ b/app/views/interest_notification_sign_up/confirm.html.erb
@@ -1,0 +1,17 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <div class="govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-6">
+      <h1 class="govuk-panel__title">
+        Your email alert has been set up.
+      </h1>
+
+      <div class="govuk-panel__body">
+        <div class="govuk-!-font-size-24">
+          We’ll send an email to <%= @email %> when registration reopens.
+        </div>
+
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/interest_notification_sign_up/new.html.erb
+++ b/app/views/interest_notification_sign_up/new.html.erb
@@ -2,8 +2,10 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @notification_form, url: registration_interest_sign_up_path do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.hidden_field :notification_option, value: "yes" %>
-        <%= f.govuk_text_field :email, label: { text: "What's your email address", size: 'xl' }, hint: { text: "We'll email you when registration reopens" }, width: 'three-quarters' %>
+      <%= f.govuk_text_field :email,
+             label: { text: "What’s your email address?", tag: "h1", size: "xl" },
+             hint: { text: "We'll email you when registration reopens" },
+             width: 'three-quarters' %>
       <%= f.govuk_submit %>
     <% end %>
   </div>

--- a/app/views/interest_notification_sign_up/new.html.erb
+++ b/app/views/interest_notification_sign_up/new.html.erb
@@ -1,0 +1,10 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @notification_form, url: registration_interest_sign_up_path do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.hidden_field :notification_option, value: "yes" %>
+        <%= f.govuk_text_field :email, label: { text: "What's your email address", size: 'xl' }, hint: { text: "We'll email you when registration reopens" }, width: 'three-quarters' %>
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/registration_interest/confirm.html.erb
+++ b/app/views/registration_interest/confirm.html.erb
@@ -1,0 +1,14 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <div class="govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-6">
+      <h1 class="govuk-panel__title">
+        Your email alert has been set up.
+      </h1>
+      <p>
+       We’ll send an email to <%= @email %> when registration reopens.
+      <p>
+    </div>
+
+  </div>
+</div>

--- a/app/views/registration_interest/new.html.erb
+++ b/app/views/registration_interest/new.html.erb
@@ -1,0 +1,38 @@
+<% content_for :title, "Registration for NPQs has closed temporarily" %>
+
+<% content_for :before_content do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: "Back",
+    href: :back
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+  <h1 class="govuk-heading-xl">Registration for NPQs has closed temporarily</h1>
+
+  <p class="govuk-body">Registration for NPQs starting in autumn will reopen soon. For more information you can read guidance on the
+    <%= govuk_link_to "NPQ reforms", "https://www.gov.uk/government/publications/national-professional-qualifications-npqs-reforms/national-professional-qualifications-npqs-reforms" %>.</p>
+
+    <%= form_with model: @notification_form, url: registration_interest_path do |f| %>
+      <%= f.govuk_error_summary %>
+      <%= f.govuk_radio_buttons_fieldset(:notification_option,
+                                         legend: {
+                                           text: "Would you like to receive an email when registration reopens?",
+                                           tag: "h2",
+                                           size: "m"
+                                         },
+                                        ) do %>
+        <%= f.govuk_radio_button :notification_option, "yes", label: { text: "Yes" }, link_errors: true do %>
+             <%= f.govuk_text_field :email,
+                                          label: { text: 'Email address', size: 's' },
+                                          width: 'three-quarters' %>
+        <% end %>
+        <%= f.govuk_radio_button :notification_option, "no", label: { text: "No" } %>
+      <% end %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/registration_interest/no_notification.html.erb
+++ b/app/views/registration_interest/no_notification.html.erb
@@ -1,0 +1,6 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">You will not get an email alert</h1>
+    <p class="govuk-body">If you change your mind, you can revisit <%= govuk_link_to "Register for a National Professional Qualification", registration_wizard_show_path(step: "start") %>.</p>
+  </div>
+</div>

--- a/app/views/registration_wizard/chosen_start_date.html.erb
+++ b/app/views/registration_wizard/chosen_start_date.html.erb
@@ -1,0 +1,31 @@
+<% content_for :title do %>
+  <%= @form.errors.present? ? "Error: " : nil %>Have you agreed a start date of February 2022 with an NPQ provider?
+<% end %>
+
+<% content_for :before_content do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: "Back",
+    href: registration_wizard_show_path(@wizard.previous_step_path)
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset(:chosen_start_date,
+                                         legend: {
+                                           text: "Have you agreed a start date of February 2022 with an NPQ provider?",
+                                           tag: "h1",
+                                           size: "xl"
+                                         }
+                                        ) do %>
+        <%= f.govuk_radio_button :chosen_start_date, "yes", label: { text: "Yes" }, link_errors: true %>
+        <%= f.govuk_radio_button :chosen_start_date, "no", label: { text: "No" } %>
+      <% end %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/registration_wizard/start.html.erb
+++ b/app/views/registration_wizard/start.html.erb
@@ -37,6 +37,6 @@
 
     <%= render GovukComponent::StartButtonComponent.new(
           text: "Start now",
-          href: registration_wizard_show_path(step: "provider-check")) %>
+          href: registration_wizard_show_path(step: "chosen-start-date")) %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,10 @@ en:
           another: Another country
     errors:
       models:
+        forms/chosen_start_date:
+          attributes:
+            chosen_start_date:
+              blank: Select whether you have agreed a start date
         forms/provider_check:
           attributes:
             chosen_provider:
@@ -137,3 +141,11 @@ en:
             teacher_catchment_country:
               blank: Select which country you work in
               inclusion: Select one of the listed countries
+        forms/registration_interest_notification:
+          attributes:
+            notification_option:
+              inclusion: Select an option
+            email:
+              blank: Enter an email address
+              invalid: This email has already been registered for interest
+              taken: You have already registered to be notified

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,11 @@ Rails.application.routes.draw do
   patch "/registration/:step", to: "registration_wizard#update", as: "registration_wizard_update"
   patch "/registration/:step/change", to: "registration_wizard#update", as: "registration_wizard_update_change", changing_answer: "1"
 
+  get "/registration-interest", to: "registration_interest#new"
+  post "/registration-interest", to: "registration_interest#create"
+  get "/registration-interest/confirm", to: "registration_interest#confirm"
+  get "/registration-interest/no-notification", to: "registration_interest#no_notification"
+
   get "/sign-in", to: "session_wizard#show", step: "sign_in"
 
   get "/session/:step", to: "session_wizard#show", as: "session_wizard_show"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,9 @@ Rails.application.routes.draw do
   post "/registration-interest", to: "registration_interest#create"
   get "/registration-interest/confirm", to: "registration_interest#confirm"
   get "/registration-interest/no-notification", to: "registration_interest#no_notification"
+  get "/registration-interest/sign-up", to: "interest_notification_sign_up#new"
+  post "/registration-interest/sign-up", to: "interest_notification_sign_up#create"
+  get "/registration-interest/sign-up/confirm", to: "interest_notification_sign_up#confirm"
 
   get "/sign-in", to: "session_wizard#show", step: "sign_in"
 

--- a/db/migrate/20220125143328_create_registration_interests.rb
+++ b/db/migrate/20220125143328_create_registration_interests.rb
@@ -1,0 +1,13 @@
+class CreateRegistrationInterests < ActiveRecord::Migration[6.1]
+  def change
+    enable_extension("citext")
+
+    create_table :registration_interests do |t|
+      t.citext :email, null: false, index: { unique: true }
+      t.string :term
+      t.boolean :notified, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220125143328_create_registration_interests.rb
+++ b/db/migrate/20220125143328_create_registration_interests.rb
@@ -4,7 +4,6 @@ class CreateRegistrationInterests < ActiveRecord::Migration[6.1]
 
     create_table :registration_interests do |t|
       t.citext :email, null: false, index: { unique: true }
-      t.string :term
       t.boolean :notified, default: false
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -84,7 +84,6 @@ ActiveRecord::Schema.define(version: 2022_01_25_143328) do
 
   create_table "registration_interests", force: :cascade do |t|
     t.citext "email", null: false
-    t.string "term"
     t.boolean "notified", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_25_103506) do
+ActiveRecord::Schema.define(version: 2022_01_25_143328) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
+  enable_extension "citext"
   enable_extension "plpgsql"
 
   create_table "applications", force: :cascade do |t|
@@ -79,6 +80,15 @@ ActiveRecord::Schema.define(version: 2021_10_25_103506) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["ukprn"], name: "index_local_authorities_on_ukprn"
+  end
+
+  create_table "registration_interests", force: :cascade do |t|
+    t.citext "email", null: false
+    t.string "term"
+    t.boolean "notified", default: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["email"], name: "index_registration_interests_on_email", unique: true
   end
 
   create_table "reports", force: :cascade do |t|

--- a/spec/factories/registration_interest.rb
+++ b/spec/factories/registration_interest.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :registration_interest do
     email { "johndoe@example.com" }
-    term { "autumn_2022" }
   end
 end

--- a/spec/factories/registration_interest.rb
+++ b/spec/factories/registration_interest.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :registration_interest do
+    email { "johndoe@example.com" }
+    term { "autumn_2022" }
+  end
+end

--- a/spec/features/back_links_spec.rb
+++ b/spec/features/back_links_spec.rb
@@ -6,13 +6,13 @@ RSpec.feature "Back links", type: :feature do
     page.click_link("Start now")
 
     expect(page).to be_axe_clean
-    expect(page).to have_text("Have you already chosen an NPQ and provider?")
-    page.choose("Yes, I have chosen my NPQ and provider", visible: :all)
+    expect(page).to have_text("Have you agreed a start date of")
+    page.choose("Yes", visible: :all)
     page.click_button("Continue")
 
     page.click_link("Back")
 
     expect(page).to be_axe_clean
-    expect(page).to have_checked_field("Yes, I have chosen my NPQ and provider", visible: :all)
+    expect(page).to have_checked_field("Yes", visible: :all)
   end
 end

--- a/spec/features/email_confirmation_spec.rb
+++ b/spec/features/email_confirmation_spec.rb
@@ -4,6 +4,8 @@ RSpec.feature "Email confirmation", type: :feature do
   scenario "going back and changing their email address requires confirmation" do
     visit "/"
     page.click_link("Start now")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
     page.choose("Yes, I have chosen my NPQ and provider", visible: :all)
     page.click_button("Continue")
     page.choose("England", visible: :all)

--- a/spec/features/happy_journeys_non_js_spec.rb
+++ b/spec/features/happy_journeys_non_js_spec.rb
@@ -14,6 +14,10 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).to have_text("Before you start")
     page.click_link("Start now")
 
+    expect(page).to have_text("Have you agreed a start date of")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
     expect(page).to have_text("Have you already chosen an NPQ and provider?")
     page.choose("Yes, I have chosen my NPQ and provider")
     page.click_button("Continue")
@@ -171,6 +175,10 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).to have_text("Before you start")
     page.click_link("Start now")
 
+    expect(page).to have_text("Have you agreed a start date of")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
     expect(page).to have_text("Have you already chosen an NPQ and provider?")
     page.choose("Yes, I have chosen my NPQ and provider")
     page.click_button("Continue")
@@ -319,6 +327,10 @@ RSpec.feature "Happy journeys", type: :feature do
     visit "/"
     expect(page).to have_text("Before you start")
     page.click_link("Start now")
+
+    expect(page).to have_text("Have you agreed a start date of")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
 
     expect(page).to have_text("Have you already chosen an NPQ and provider?")
     page.choose("Yes, I have chosen my NPQ and provider")
@@ -497,6 +509,10 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).to have_text("Before you start")
     page.click_link("Start now")
 
+    expect(page).to have_text("Have you agreed a start date of")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
     expect(page).to have_text("Have you already chosen an NPQ and provider?")
     page.choose("Yes, I have chosen my NPQ and provider")
     page.click_button("Continue")
@@ -667,6 +683,10 @@ RSpec.feature "Happy journeys", type: :feature do
     visit "/"
     expect(page).to have_text("Before you start")
     page.click_link("Start now")
+
+    expect(page).to have_text("Have you agreed a start date of")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
 
     expect(page).to have_text("Have you already chosen an NPQ and provider?")
     page.choose("Yes, I have chosen my NPQ and provider")

--- a/spec/features/happy_journeys_spec.rb
+++ b/spec/features/happy_journeys_spec.rb
@@ -7,6 +7,11 @@ RSpec.feature "Happy journeys", type: :feature do
     page.click_link("Start now")
 
     expect(page).to be_axe_clean
+    expect(page).to have_text("Have you agreed a start date of")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
     expect(page).to have_text("Have you already chosen an NPQ and provider?")
     page.choose("Yes, I have chosen my NPQ and provider", visible: :all)
     page.click_button("Continue")
@@ -147,6 +152,11 @@ RSpec.feature "Happy journeys", type: :feature do
     visit "/"
     expect(page).to have_text("Before you start")
     page.click_link("Start now")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Have you agreed a start date of")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
 
     expect(page).to be_axe_clean
     expect(page).to have_text("Have you already chosen an NPQ and provider?")
@@ -309,6 +319,11 @@ RSpec.feature "Happy journeys", type: :feature do
     page.click_link("Start now")
 
     expect(page).to be_axe_clean
+    expect(page).to have_text("Have you agreed a start date of")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
     expect(page).to have_text("Have you already chosen an NPQ and provider?")
     page.choose("Yes, I have chosen my NPQ and provider", visible: :all)
     page.click_button("Continue")
@@ -439,6 +454,11 @@ RSpec.feature "Happy journeys", type: :feature do
     visit "/"
     expect(page).to have_text("Before you start")
     page.click_link("Start now")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Have you agreed a start date of")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
 
     expect(page).to be_axe_clean
     expect(page).to have_text("Have you already chosen an NPQ and provider?")

--- a/spec/features/registration_interest_spec.rb
+++ b/spec/features/registration_interest_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.feature "Register interest", type: :feature do
+  scenario "Sign up to notification via NPQ registration path" do
+    visit "/"
+
+    expect(page).to have_text("Before you start")
+    page.click_link("Start now")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Have you agreed a start date of")
+    page.choose("No", visible: :all)
+    page.click_button("Continue")
+
+    # expect(page).to be_axe_clean
+    # TODO: aria-expanded
+    expect(page.current_path).to eq("/registration-interest")
+    page.choose("Yes", visible: :all)
+    page.fill_in "Email address", with: "user@example.com"
+    page.click_button("Continue")
+
+    expect(page.current_path).to eq("/registration-interest/confirm")
+    expect(page).to have_text("We’ll send an email to user@example.com when registration reopens.")
+
+    expect(RegistrationInterest.count).to eql(1)
+  end
+
+  scenario "Chooses not to sign up for notifications via NPQ registration path" do
+    visit "/"
+
+    expect(page).to have_text("Before you start")
+    page.click_link("Start now")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Have you agreed a start date of")
+    page.choose("No", visible: :all)
+    page.click_button("Continue")
+
+    # expect(page).to be_axe_clean
+    # TODO: aria-expanded
+    expect(page.current_path).to eq("/registration-interest")
+    page.choose("No", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page.current_path).to eq("/registration-interest/no-notification")
+    expect(page).to have_text("You will not get an email alert")
+
+    expect(RegistrationInterest.count).to eql(0)
+  end
+
+  scenario "Sign up to notification with direct link" do
+    visit "/registration-interest/sign-up"
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("What’s your email address")
+    page.fill_in "What’s your email address", with: "user@example.com"
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page.current_path).to eq("/registration-interest/sign-up/confirm")
+    expect(page).to have_text("We’ll send an email to user@example.com when registration reopens.")
+
+    expect(RegistrationInterest.count).to eql(1)
+  end
+end

--- a/spec/features/sad_journeys_spec.rb
+++ b/spec/features/sad_journeys_spec.rb
@@ -7,6 +7,11 @@ RSpec.feature "Sad journeys", type: :feature do
     page.click_link("Start now")
 
     expect(page).to be_axe_clean
+    expect(page).to have_text("Have you agreed a start date of")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
     expect(page).to have_text("Have you already chosen an NPQ and provider?")
     page.choose("Yes, I have chosen my NPQ and provider", visible: :all)
     page.click_button("Continue")
@@ -157,6 +162,11 @@ RSpec.feature "Sad journeys", type: :feature do
     page.click_link("Start now")
 
     expect(page).to be_axe_clean
+    expect(page).to have_text("Have you agreed a start date of")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
     expect(page).to have_text("Have you already chosen an NPQ and provider?")
     page.choose("Yes, I have chosen my NPQ and provider", visible: :all)
     page.click_button("Continue")
@@ -249,6 +259,11 @@ RSpec.feature "Sad journeys", type: :feature do
     visit "/"
     expect(page).to have_text("Before you start")
     page.click_link("Start now")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Have you agreed a start date of")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
 
     expect(page).to be_axe_clean
     expect(page).to have_text("Have you already chosen an NPQ and provider?")

--- a/spec/lib/forms/provider_check_spec.rb
+++ b/spec/lib/forms/provider_check_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Forms::ProviderCheck, type: :model do
 
   describe "#previous_step" do
     it "returns start" do
-      expect(subject.previous_step).to eql(:start)
+      expect(subject.previous_step).to eql(:chosen_start_date)
     end
   end
 end

--- a/spec/lib/forms/registration_interest_notification_spec.rb
+++ b/spec/lib/forms/registration_interest_notification_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe Forms::RegistrationInterestNotification, type: :model do
+  let(:existing_registration) { FactoryBot.create(:registration_interest) }
+  before do
+    subject { described_class.new }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_inclusion_of(:notification_option).in_array(Forms::RegistrationInterestNotification::VALID_NOTIFICATION_OPTIONS) }
+    it { is_expected.to validate_presence_of(:email) }
+    it { is_expected.to validate_length_of(:email).is_at_most(128) }
+
+    describe "#can_register_interest" do
+      context "trying to register the same email" do
+        it "shows the form is invalid when trying to register again" do
+          subject.email = existing_registration.email
+          subject.valid?
+          expect(subject.errors[:email]).to include("You have already registered to be notified")
+        end
+      end
+    end
+
+    describe "#selected_no?" do
+      context "opting not to register" do
+        it "does not provide an email error when selecting not to register interest" do
+          subject.notification_option = "no"
+          expect(subject.valid?).to be_truthy
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/forms/registration_interest_notification_spec.rb
+++ b/spec/lib/forms/registration_interest_notification_spec.rb
@@ -30,4 +30,17 @@ RSpec.describe Forms::RegistrationInterestNotification, type: :model do
       end
     end
   end
+
+  describe "#term" do
+    context "when term isn't explicitly set" do
+      it "shows the default term set" do
+        expect(subject.term).to eq("Autumn 2022")
+      end
+
+      it "shows the term has been set" do
+        subject.term_interest_registered = "Spring 2022"
+        expect(subject.term).to eq("Spring 2022")
+      end
+    end
+  end
 end

--- a/spec/lib/forms/registration_interest_notification_spec.rb
+++ b/spec/lib/forms/registration_interest_notification_spec.rb
@@ -30,17 +30,4 @@ RSpec.describe Forms::RegistrationInterestNotification, type: :model do
       end
     end
   end
-
-  describe "#term" do
-    context "when term isn't explicitly set" do
-      it "shows the default term set" do
-        expect(subject.term).to eq("Autumn 2022")
-      end
-
-      it "shows the term has been set" do
-        subject.term_interest_registered = "Spring 2022"
-        expect(subject.term).to eq("Spring 2022")
-      end
-    end
-  end
 end

--- a/spec/models/registration_interest_spec.rb
+++ b/spec/models/registration_interest_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe RegistrationInterest do
+  describe "validations" do
+    subject { RegistrationInterest.new(email: "email@example.com") }
+
+    it { is_expected.to validate_uniqueness_of(:email).case_insensitive }
+    it { is_expected.to validate_presence_of(:email) }
+    it { is_expected.to validate_length_of(:email).is_at_most(128) }
+  end
+end


### PR DESCRIPTION
### Context

We want to create an EOI for those who haven't agreed a February start date with an NPQ provider. 

This will be done in 2 stages, soft close and hard close. 

Soft close - Go to NPQ registration site and start journey, they don't have an agreed start date and so submit an EOI to be notified when registrations reopen.
Hard close - Users go straight to `registration-interest/sign-up`. 

Both routes are being shown at the same time for a brief period. One linking via registration path, another from the gov uk page. 

### Changes proposed in this pull request

- Updated routes for soft and hard close path
- New registration interests table to capture email addresses
- New first page after starting registration journey
- Notification sign up via the registration journey route(soft-close)
- Notification sign up via direct route, which will come from a link placed on the GOVUK website (hard-close)
- Both routes use the same `register_interest_notification` form
- Updated specs because of the change in the first page of the journey

### Guidance to review

#### Soft close
New first page
<img width="759" alt="Screenshot 2022-01-26 at 11 26 17" src="https://user-images.githubusercontent.com/69353998/151377637-a2a0abd6-2e8e-4e8a-af4b-223cc69ad668.png">
No date agreed so can select whether to submit email to be notified when registrations will open.
<img width="662" alt="Screenshot 2022-01-27 at 14 20 31" src="https://user-images.githubusercontent.com/69353998/151377764-b24c4154-2b99-4273-a9c5-619850a42b3a.png">
Confirmation of registering to be notified
<img width="673" alt="Screenshot 2022-01-27 at 14 20 42" src="https://user-images.githubusercontent.com/69353998/151378089-4b500642-4e1a-4dec-83c4-80f58f913536.png">


#### Hard close
Taken directly to a registration page
<img width="627" alt="Screenshot 2022-01-27 at 14 20 54" src="https://user-images.githubusercontent.com/69353998/151378134-271754f2-f0c7-4a71-9402-6d9caa4b9b82.png">
Confirmation of registering to be notified
<img width="671" alt="Screenshot 2022-01-27 at 14 21 08" src="https://user-images.githubusercontent.com/69353998/151379031-9a4f6221-af57-4116-a460-06bbf67a35ad.png">

