### PR TITLE
Lower Sentry sample rate 0.1 to 0.01

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -23,7 +23,7 @@ Sentry.init do |config|
       when /healthcheck/
         0.0 # ignore healthcheck requests
       else
-        0.1
+        0.01
       end
     else
       0.0 # We don't care about performance of other things


### PR DESCRIPTION
### Context

We are reaching our transaction limits so we can safely reduce the sampler rate.
