### PR TITLE
Fix removal of historic countries

### DIFF
--- a/public/location-autocomplete-graph.json
+++ b/public/location-autocomplete-graph.json
@@ -6756,23 +6756,6 @@
       "en-GB": "Czech Republic"
     }
   },
-  "nym:DD": {
-    "edges": {
-      "from": [
-        "country:DD"
-      ]
-    },
-    "meta": {
-      "canonical": false,
-      "canonical-mask": 0,
-      "display-name": false,
-      "stable-name": false
-    },
-    "names": {
-      "cy": false,
-      "en-GB": "DD"
-    }
-  },
   "nym:DE": {
     "edges": {
       "from": [
@@ -8864,23 +8847,6 @@
       "en-GB": "Georgia"
     }
   },
-  "nym:Germany Democratic Republic": {
-    "edges": {
-      "from": [
-        "country:DD"
-      ]
-    },
-    "meta": {
-      "canonical": false,
-      "canonical-mask": 0,
-      "display-name": true,
-      "stable-name": true
-    },
-    "names": {
-      "cy": false,
-      "en-GB": "Germany Democratic Republic"
-    }
-  },
   "nym:Gibraltar": {
     "edges": {
       "from": [
@@ -10324,23 +10290,6 @@
     "names": {
       "cy": false,
       "en-GB": "Johnston Atoll"
-    }
-  },
-  "nym:Jugoslavija": {
-    "edges": {
-      "from": [
-        "country:YU"
-      ]
-    },
-    "meta": {
-      "canonical": false,
-      "canonical-mask": 0,
-      "display-name": false,
-      "stable-name": false
-    },
-    "names": {
-      "cy": false,
-      "en-GB": "Jugoslavija"
     }
   },
   "nym:Juzur al-Qamar": {
@@ -16956,23 +16905,6 @@
       "en-GB": "ST"
     }
   },
-  "nym:SU": {
-    "edges": {
-      "from": [
-        "country:SU"
-      ]
-    },
-    "meta": {
-      "canonical": false,
-      "canonical-mask": 0,
-      "display-name": false,
-      "stable-name": false
-    },
-    "names": {
-      "cy": false,
-      "en-GB": "SU"
-    }
-  },
   "nym:SV": {
     "edges": {
       "from": [
@@ -17566,23 +17498,6 @@
     "names": {
       "cy": false,
       "en-GB": "Slovenská"
-    }
-  },
-  "nym:Socialist Federal Republic of Yugoslavia": {
-    "edges": {
-      "from": [
-        "country:YU"
-      ]
-    },
-    "meta": {
-      "canonical": false,
-      "canonical-mask": 0,
-      "display-name": true,
-      "stable-name": true
-    },
-    "names": {
-      "cy": false,
-      "en-GB": "Socialist Federal Republic of Yugoslavia"
     }
   },
   "nym:Socialist People's Libyan Arab": {
@@ -22464,23 +22379,6 @@
       "en-GB": "Umbuso weSwatini"
     }
   },
-  "nym:Union of Soviet Socialist Republics": {
-    "edges": {
-      "from": [
-        "country:SU"
-      ]
-    },
-    "meta": {
-      "canonical": false,
-      "canonical-mask": 0,
-      "display-name": true,
-      "stable-name": true
-    },
-    "names": {
-      "cy": false,
-      "en-GB": "Union of Soviet Socialist Republics"
-    }
-  },
   "nym:Union of the Comoros": {
     "edges": {
       "from": [
@@ -23416,23 +23314,6 @@
       "en-GB": "YT"
     }
   },
-  "nym:YU": {
-    "edges": {
-      "from": [
-        "country:YU"
-      ]
-    },
-    "meta": {
-      "canonical": false,
-      "canonical-mask": 0,
-      "display-name": false,
-      "stable-name": false
-    },
-    "names": {
-      "cy": false,
-      "en-GB": "YU"
-    }
-  },
   "nym:Yaltopya": {
     "edges": {
       "from": [
@@ -23482,23 +23363,6 @@
     "names": {
       "cy": false,
       "en-GB": "Yisrael"
-    }
-  },
-  "nym:Yugosav": {
-    "edges": {
-      "from": [
-        "country:YU"
-      ]
-    },
-    "meta": {
-      "canonical": false,
-      "canonical-mask": 0,
-      "display-name": false,
-      "stable-name": false
-    },
-    "names": {
-      "cy": false,
-      "en-GB": "Yugosav"
     }
   },
   "nym:ZA": {
@@ -25267,23 +25131,6 @@
     "names": {
       "cy": false,
       "en-GB": "Россия1"
-    }
-  },
-  "nym:Союз Советских Социалистических Республик": {
-    "edges": {
-      "from": [
-        "country:SU"
-      ]
-    },
-    "meta": {
-      "canonical": false,
-      "canonical-mask": 0,
-      "display-name": false,
-      "stable-name": false
-    },
-    "names": {
-      "cy": false,
-      "en-GB": "Союз Советских Социалистических Республик"
     }
   },
   "nym:Србија": {


### PR DESCRIPTION
6e2dbde attempted to remove some historic countries from the autocomplete graph but it was only partially done. You need to delete the sub-alias countries when a top-level country code is removed.