### PR TITLE
CST-364 Clear funding choice on submission for funding eligible applications

### DIFF
--- a/spec/lib/services/handle_submission_for_store_spec.rb
+++ b/spec/lib/services/handle_submission_for_store_spec.rb
@@ -25,5 +25,35 @@ RSpec.describe Services::HandleSubmissionForStore do
         expect(user.reload.trn).to eql("0012345")
       end
     end
+
+    context "when there is a funding choice selected" do
+      let(:store) do
+        super().merge(
+          "funding" => "school",
+        )
+      end
+
+      context "when there is a funding choice selected and eligible for funding is true" do
+        before do
+          allow_any_instance_of(Services::FundingEligibility).to receive(:call) { true }
+        end
+
+        it "clears the funding choice to nil on the application" do
+          subject.call
+          expect(user.applications.first.reload.funding_choice).to eq nil
+        end
+      end
+
+      context "when there is a funding choice selected and eligible for funding is false" do
+        before do
+          allow_any_instance_of(Services::FundingEligibility).to receive(:call) { false }
+        end
+
+        it "saves the funding choice to nil on the application" do
+          subject.call
+          expect(user.applications.first.reload.funding_choice).to eq "school"
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/CST-364

### Context

The only way a non-nil value can be here is if the user originally originally selected an ineligible route, selected a funding choice and then backtracked to an eligible one, so the value should be discarded.

### Changes proposed in this pull request

### Guidance to review

