### PR TITLE
Storing employment details on applications

### DIFF
--- a/app/lib/services/handle_submission_for_store.rb
+++ b/app/lib/services/handle_submission_for_store.rb
@@ -30,6 +30,9 @@ module Services
           funding_choice: funding_choice,
           teacher_catchment: store["teacher_catchment"],
           teacher_catchment_country: store["teacher_catchment_country"].presence,
+          works_in_school: store["works_in_school"] == "yes",
+          employer_name: store["employer_name"].presence,
+          employment_role: store["employment_role"].presence,
         )
 
         enqueue_job

--- a/app/lib/services/npq_profile_creator.rb
+++ b/app/lib/services/npq_profile_creator.rb
@@ -18,6 +18,9 @@ module Services
         headteacher_status: application.headteacher_status,
         eligible_for_funding: application.eligible_for_funding,
         funding_choice: application.funding_choice,
+        works_in_school: application.works_in_school,
+        employer_name: application.employer_name,
+        employment_role: application.employment_role,
         relationships: {
           user: ecf_user,
           npq_course: ecf_npq_course,

--- a/db/migrate/20220224121536_add_work_information_to_applications.rb
+++ b/db/migrate/20220224121536_add_work_information_to_applications.rb
@@ -1,0 +1,7 @@
+class AddWorkInformationToApplications < ActiveRecord::Migration[6.1]
+  def change
+    add_column :applications, :works_in_school, :boolean
+    add_column :applications, :employer_name, :string
+    add_column :applications, :employment_role, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_25_143328) do
+ActiveRecord::Schema.define(version: 2022_02_24_121536) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -31,6 +31,9 @@ ActiveRecord::Schema.define(version: 2022_01_25_143328) do
     t.text "ukprn"
     t.text "teacher_catchment"
     t.text "teacher_catchment_country"
+    t.boolean "works_in_school"
+    t.string "employer_name"
+    t.string "employment_role"
     t.index ["course_id"], name: "index_applications_on_course_id"
     t.index ["lead_provider_id"], name: "index_applications_on_lead_provider_id"
     t.index ["user_id"], name: "index_applications_on_user_id"

--- a/spec/lib/services/npq_profile_creator_spec.rb
+++ b/spec/lib/services/npq_profile_creator_spec.rb
@@ -68,6 +68,9 @@ RSpec.describe Services::NpqProfileCreator do
             headteacher_status: "no",
             eligible_for_funding: true,
             funding_choice: "trust",
+            works_in_school: application.works_in_school,
+            employer_name: application.employer_name,
+            employment_role: application.employment_role,
           },
         },
       }.to_json


### PR DESCRIPTION
All the employment questions are currently only stored in session and the answers are lost on submission. This PR is to fix this.