### PR TITLE
Add ability to close registrations

### DIFF
--- a/app/controllers/registration_wizard_controller.rb
+++ b/app/controllers/registration_wizard_controller.rb
@@ -46,6 +46,8 @@ private
   end
 
   def wizard_params
+    return {} if Services::Feature.registration_closed?
+
     params.fetch(:registration_wizard, {}).permit(RegistrationWizard.permitted_params_for_step(params[:step].underscore))
   end
 end

--- a/app/lib/forms/base.rb
+++ b/app/lib/forms/base.rb
@@ -9,11 +9,17 @@ module Forms
       []
     end
 
+    # Previous steps should lead to `closed` when registration is closed.
     def previous_step
+      return :closed if Services::Feature.registration_closed?
+
       raise NotImplementedError
     end
 
+    # Subsequent steps should lead to `closed` when registration is closed.
     def next_step
+      return :closed if Services::Feature.registration_closed?
+
       raise NotImplementedError
     end
 

--- a/app/lib/forms/closed.rb
+++ b/app/lib/forms/closed.rb
@@ -1,0 +1,7 @@
+module Forms
+  class Closed < Base
+    def requirements_met?
+      true
+    end
+  end
+end

--- a/app/lib/services/feature.rb
+++ b/app/lib/services/feature.rb
@@ -1,0 +1,11 @@
+module Services
+  class Feature
+    REGISTRATION_CLOSED = (Time.zone.parse("12 March 00:00")..).freeze
+
+    class << self
+      def registration_closed?
+        REGISTRATION_CLOSED.cover?(Time.zone.now)
+      end
+    end
+  end
+end

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -10,7 +10,9 @@ class RegistrationWizard
   attr_reader :current_step, :params, :store, :request
 
   def initialize(current_step:, store:, request:, params: {})
+    current_step = :closed if Services::Feature.registration_closed?
     set_current_step(current_step)
+
     @params = params
     @store = store
     @request = request
@@ -184,6 +186,7 @@ private
   def steps
     %i[
       start
+      closed
       chosen_start_date
       teacher_catchment
       work_in_school

--- a/app/views/interest_notification_sign_up/new.html.erb
+++ b/app/views/interest_notification_sign_up/new.html.erb
@@ -2,11 +2,11 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @notification_form, url: registration_interest_sign_up_path do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.govuk_text_field :email,
+      <%= f.govuk_email_field :email,
              label: { text: "What’s your email address?", tag: "h1", size: "xl" },
-             hint: { text: "We'll email you when registration reopens" },
-             width: 'three-quarters' %>
-      <%= f.govuk_submit %>
+             hint: { text: "We'll email you when registration reopens." },
+             width: "three-quarters" %>
+      <%= f.govuk_submit "Confirm" %>
     <% end %>
   </div>
 </div>

--- a/app/views/registration_wizard/closed.html.erb
+++ b/app/views/registration_wizard/closed.html.erb
@@ -1,0 +1,20 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Register for a National Professional Qualification (NPQ)</h1>
+
+    <h2 class="govuk-heading-m">Registration for NPQs has closed temporarily</h2>
+
+    <p class="govuk-body"><%= govuk_link_to "Sign up for an email", registration_interest_sign_up_path %> to be notified when registration reopens.</p>
+
+    <h2 class="govuk-heading-m">When registration reopens</h2>
+
+    <p class="govuk-body">You will be able to use this service to register:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>to study for an NPQ</li>
+      <li>for the Additional Support Offer for new headteachers</li>
+    </ul>
+
+    <p class="govuk-body">For more information you can read guidance on the <%= govuk_link_to "NPQ reforms.", "https://www.gov.uk/government/publications/national-professional-qualifications-npqs-reforms/national-professional-qualifications-npqs-reforms" %></p>
+  </div>
+</div>

--- a/spec/features/registration_interest_spec.rb
+++ b/spec/features/registration_interest_spec.rb
@@ -55,7 +55,7 @@ RSpec.feature "Register interest", type: :feature do
     expect(page).to be_axe_clean
     expect(page).to have_text("What’s your email address")
     page.fill_in "What’s your email address", with: "user@example.com"
-    page.click_button("Continue")
+    page.click_button("Confirm")
 
     expect(page).to be_axe_clean
     expect(page.current_path).to eq("/registration-interest/sign-up/confirm")

--- a/spec/features/service_closed_spec.rb
+++ b/spec/features/service_closed_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.feature "Service is hard closed", type: :feature do
+  before do
+    allow(Services::Feature).to receive(:registration_closed?).and_return(true)
+  end
+
+  scenario "Service close date has passed" do
+    visit "/"
+    expect(page).to have_content("Registration for NPQs has closed temporarily")
+    expect(page).to be_axe_clean
+
+    page.click_link("Sign up for an email")
+    expect(page).to have_content("What’s your email address?")
+    expect(page).to be_axe_clean
+  end
+end

--- a/spec/lib/services/feature_spec.rb
+++ b/spec/lib/services/feature_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe Services::Feature do
+  describe "#registration_closed?" do
+    let(:start_time) { Services::Feature::REGISTRATION_CLOSED.first }
+    let(:end_time)   { Services::Feature::REGISTRATION_CLOSED.last }
+
+    context "before the closure period" do
+      before { travel_to start_time - 1 }
+
+      it "returns false" do
+        expect(described_class.registration_closed?).to eql(false)
+      end
+    end
+
+    context "during the closure period" do
+      before { travel_to start_time }
+
+      it "returns true" do
+        expect(described_class.registration_closed?).to eql(true)
+      end
+    end
+
+    # Service doesn't have a re-open date currently.
+    #
+    # context "after the closure period" do
+    #   before { travel_to end_time + 1 }
+
+    #   it "returns false" do
+    #     expect(described_class.registration_closed?).to eql(false)
+    #   end
+    # end
+  end
+end

--- a/spec/models/registration_wizard_spec.rb
+++ b/spec/models/registration_wizard_spec.rb
@@ -22,6 +22,16 @@ RSpec.describe RegistrationWizard do
         }.to raise_error(RegistrationWizard::InvalidStep)
       end
     end
+
+    context "when registration is closed" do
+      before do
+        allow(Services::Feature).to receive(:registration_closed?).and_return(true)
+      end
+
+      it "always returns closed" do
+        expect(subject.current_step).to eql(:closed)
+      end
+    end
   end
 
   describe "#answers" do


### PR DESCRIPTION
### Context

We need to close NPQ registration journey in time for the ‘hard close’ deadline of 11th March 2022. Registration should close at March 12th 00:00:00. 

At this time the registration wizard will stop working and all pages within it will become the close page.

This PR allows some flexibility to add a time to reopen registrations later.

