### PR TITLE
Pin GitHub action setup-gcloud

### DIFF
--- a/.github/workflows/export_dashboard_report.yml
+++ b/.github/workflows/export_dashboard_report.yml
@@ -11,7 +11,7 @@ jobs:
     container: google/cloud-sdk:latest
     steps:
       - name: Auth with gcloud
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           service_account_key: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_BASE64 }}
 


### PR DESCRIPTION
### Context

[This](https://github.com/DFE-Digital/npq-registration/runs/5638135417?check_suite_focus=true) action was failing jobs with:

```
Warning: google-github-actions/setup-gcloud is pinned at "master". We strongly advise against pinning to "@master" as it may be unstable. Please update your GitHub Action YAML from:

    uses: 'google-github-actions/setup-gcloud@master'

to:

    uses: 'google-github-actions/setup-gcloud@v0'

Alternatively, you can pin to any git tag or git SHA in the repository.
```

I have followed the advice and pinned to v0.