### PR TITLE
Enable features only in production

### DIFF
--- a/app/lib/services/feature.rb
+++ b/app/lib/services/feature.rb
@@ -4,7 +4,12 @@ module Services
 
     class << self
       def registration_closed?
-        REGISTRATION_CLOSED.cover?(Time.zone.now)
+        features_enabled? && REGISTRATION_CLOSED.cover?(Time.zone.now)
+      end
+
+      # We only enable these feature in prod.
+      def features_enabled?
+        ENV["SERVICE_ENV"] == "production"
       end
     end
   end

--- a/spec/features/service_closed_spec.rb
+++ b/spec/features/service_closed_spec.rb
@@ -38,10 +38,12 @@ RSpec.feature "Service is hard closed", type: :feature do
 private
 
   def close_registration!
+    allow(Services::Feature).to receive(:features_enabled?).and_return(true)
     allow(Services::Feature).to receive(:registration_closed?).and_return(true)
   end
 
   def open_registration!
+    allow(Services::Feature).to receive(:features_enabled?).and_return(true)
     allow(Services::Feature).to receive(:registration_closed?).and_return(false)
   end
 end

--- a/spec/lib/services/feature_spec.rb
+++ b/spec/lib/services/feature_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe Services::Feature do
     let(:start_time) { Services::Feature::REGISTRATION_CLOSED.first }
     let(:end_time)   { Services::Feature::REGISTRATION_CLOSED.last }
 
+    before do
+      allow(Services::Feature).to receive(:features_enabled?).and_return(true)
+    end
+
     context "before the closure period" do
       before { travel_to start_time - 1 }
 

--- a/spec/models/registration_wizard_spec.rb
+++ b/spec/models/registration_wizard_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe RegistrationWizard do
 
     context "when registration is closed" do
       before do
+        allow(Services::Feature).to receive(:features_enabled?).and_return(true)
         allow(Services::Feature).to receive(:registration_closed?).and_return(true)
       end
 


### PR DESCRIPTION
### Context

We recently closed the NPQ reg service after a certain date had passed. This date has passed and the service is closed. However, we would still like to test on other environments as if the service is still open.

This PR closes the service _only_ in the actual prod environment. 

