### PR TITLE
[CN-110] Add "Choose Nursery" pathway for public nurseries

### DIFF
--- a/app/lib/forms/childcare_provider_not_in_england.rb
+++ b/app/lib/forms/childcare_provider_not_in_england.rb
@@ -1,0 +1,7 @@
+module Forms
+  class ChildcareProviderNotInEngland < Base
+    def previous_step
+      :choose_childcare_provider
+    end
+  end
+end

--- a/app/lib/forms/choose_childcare_provider.rb
+++ b/app/lib/forms/choose_childcare_provider.rb
@@ -1,0 +1,68 @@
+module Forms
+  # This is for choosing *public* childcare providers, these are stored alongside schools in the educationl_institutions
+  # table as type School, therefore, we search and display identically to as we do for schools
+  class ChooseChildcareProvider < Base
+    include Helpers::Institution
+
+    attr_accessor :institution_name, :institution_identifier
+
+    validates :institution_identifier, format: { with: /\ASchool-\d{6,7}\z|\ALocalAuthority-\d+\z/, unless: -> { institution_identifier.blank? || institution_identifier == "other" } }
+    validates :institution_name, length: { maximum: 64 }
+
+    validate :validate_childcare_provider_name_returns_results
+
+    def self.permitted_params
+      %i[
+        institution_name
+        institution_identifier
+      ]
+    end
+
+    def next_step
+      if institution_identifier == "other" || institution_identifier.blank?
+        :choose_childcare_provider
+      elsif !institution(source: institution_identifier).in_england? # Right now this is always true when it shouldn't be
+        :childcare_provider_not_in_england
+      else
+        :choose_your_npq
+      end
+    end
+
+    def previous_step
+      :find_childcare_provider
+    end
+
+    def display_childcare_providers?
+      wizard.store["institution_location"].present? && wizard.store["institution_name"].present?
+    end
+
+    def possible_institutions
+      return @possible_institutions if @possible_institutions
+
+      schools = School
+                  .open
+                  .search_by_location(institution_location)
+                  .search_by_name(institution_name)
+                  .limit(10)
+
+      local_authorities = LocalAuthority
+                            .search_by_location(institution_location)
+                            .search_by_name(institution_name)
+                            .limit(10)
+
+      @possible_institutions = schools + local_authorities
+    end
+
+  private
+
+    def institution_location
+      wizard.store["institution_location"]
+    end
+
+    def validate_childcare_provider_name_returns_results
+      if display_childcare_providers? && possible_institutions.blank?
+        errors.add(:institution_name, :no_results, location: institution_location, name: institution_name)
+      end
+    end
+  end
+end

--- a/app/lib/forms/dqt_mismatch.rb
+++ b/app/lib/forms/dqt_mismatch.rb
@@ -9,6 +9,8 @@ module Forms
         :check_answers
       elsif wizard.query_store.inside_catchment? && wizard.query_store.works_in_school?
         :find_school
+      elsif wizard.query_store.inside_catchment? && wizard.query_store.works_in_childcare?
+        :find_childcare_provider
       else
         :choose_your_npq
       end

--- a/app/lib/forms/find_childcare_provider.rb
+++ b/app/lib/forms/find_childcare_provider.rb
@@ -1,0 +1,21 @@
+module Forms
+  class FindChildcareProvider < Base
+    attr_accessor :institution_location
+
+    validates :institution_location, presence: true, length: { maximum: 64 }
+
+    def self.permitted_params
+      %i[
+        institution_location
+      ]
+    end
+
+    def next_step
+      :choose_childcare_provider
+    end
+
+    def previous_step
+      :qualified_teacher_check
+    end
+  end
+end

--- a/app/lib/forms/helpers/institution.rb
+++ b/app/lib/forms/helpers/institution.rb
@@ -10,8 +10,6 @@ module Forms
         klass, identifier = source.split("-")
 
         @institution ||= case klass
-                         when "PrivateChildcareProvider"
-                           PrivateChildcareProvider.find_by(urn: identifier)
                          when "School"
                            School.find_by(urn: identifier)
                          when "LocalAuthority"

--- a/app/lib/forms/helpers/institution.rb
+++ b/app/lib/forms/helpers/institution.rb
@@ -10,6 +10,8 @@ module Forms
         klass, identifier = source.split("-")
 
         @institution ||= case klass
+                         when "PrivateChildcareProvider"
+                           PrivateChildcareProvider.find_by(urn: identifier)
                          when "School"
                            School.find_by(urn: identifier)
                          when "LocalAuthority"

--- a/app/lib/forms/qualified_teacher_check.rb
+++ b/app/lib/forms/qualified_teacher_check.rb
@@ -68,6 +68,8 @@ module Forms
           :check_answers
         elsif wizard.query_store.inside_catchment? && wizard.query_store.works_in_school?
           :find_school
+        elsif wizard.query_store.inside_catchment? && wizard.query_store.works_in_childcare?
+          :find_childcare_provider
         else
           :choose_your_npq
         end

--- a/app/lib/services/query_store.rb
+++ b/app/lib/services/query_store.rb
@@ -21,6 +21,10 @@ class Services::QueryStore
     store["works_in_school"] == "yes"
   end
 
+  def works_in_childcare?
+    store["works_in_childcare"] == "yes"
+  end
+
   def course
     @course ||= Course.find(store["course_id"])
   end

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -106,7 +106,7 @@ class RegistrationWizard
                                 value: institution(source: store["institution_identifier"]).name,
                                 change_step: :find_school)
       elsif query_store.works_in_childcare?
-        array << OpenStruct.new(key: "Childcare Provider",
+        array << OpenStruct.new(key: "Childcare provider",
                                 value: institution(source: store["institution_identifier"]).name,
                                 change_step: :find_childcare_provider)
       end

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -100,10 +100,16 @@ class RegistrationWizard
                             value: store["confirmed_email"],
                             change_step: :contact_details)
 
-    if query_store.inside_catchment? && query_store.works_in_school?
-      array << OpenStruct.new(key: "School or college",
-                              value: institution(source: store["institution_identifier"]).name,
-                              change_step: :find_school)
+    if query_store.inside_catchment?
+      if query_store.works_in_school?
+        array << OpenStruct.new(key: "School or college",
+                                value: institution(source: store["institution_identifier"]).name,
+                                change_step: :find_school)
+      elsif query_store.works_in_childcare?
+        array << OpenStruct.new(key: "Childcare Provider",
+                                value: institution(source: store["institution_identifier"]).name,
+                                change_step: :find_childcare_provider)
+      end
     end
 
     array << OpenStruct.new(key: "Course",
@@ -215,6 +221,8 @@ private
       choose_your_provider
       find_school
       choose_school
+      find_childcare_provider
+      choose_childcare_provider
       your_work
       school_not_in_england
       possible_funding

--- a/app/views/registration_wizard/childcare_provider_not_in_england.html.erb
+++ b/app/views/registration_wizard/childcare_provider_not_in_england.html.erb
@@ -1,0 +1,22 @@
+<% content_for :title do %>
+  Nursery must be in England, Guernsey, Jersey or the Isle of Man
+<% end %>
+
+<% content_for :before_content do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: "Back",
+    href: registration_wizard_show_path(@wizard.previous_step_path)
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Nursery must be in England, Guernsey, Jersey or the Isle of Man</h1>
+
+    <p class="govuk-body">The nursery you have selected is not in England, Guernsey, Jersey or the Isle of Man.</p>
+
+    <p class="govuk-body">This NPQ application can only be completed by people working in these locations.</p>
+
+    <p class="govuk-body">If you work in a nursery outside these locations and you want to study for an NPQ, check with your training provider or nursery’s training contact.</p>
+  </div>
+</div>

--- a/app/views/registration_wizard/choose_childcare_provider.html.erb
+++ b/app/views/registration_wizard/choose_childcare_provider.html.erb
@@ -1,0 +1,58 @@
+<% content_for :title do %>
+  <%= @form.errors.present? ? "Error: " : nil %>Choose your nursery
+<% end %>
+
+<% content_for :before_content do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: "Back",
+    href: registration_wizard_show_path(@wizard.previous_step_path)
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl">Choose your nursery</h1>
+
+      <% if @form.display_childcare_providers? %>
+        <% if @form.possible_institutions.blank? %>
+          <p class="govuk-body">Choose from nurseries located in <strong><%= @form.wizard.store["institution_location"] %></strong></p>
+
+          <p class="govuk-body">No nurseries were found with that name, please try again</p>
+
+          <%= f.govuk_text_field :institution_name,
+                                 width: "full",
+                                 label: { text: "Enter name" } %>
+        <% else %>
+          <%= f.govuk_radio_buttons_fieldset(:institution_identifier, legend: { size: 'm', text: "Please choose from nurseries located in #{@form.wizard.store["institution_location"]}" }) do %>
+            <% @form.possible_institutions.each do |institution| %>
+              <%= f.govuk_radio_button :institution_identifier, institution.identifier, label: { text: institution.name }, hint: { text: institution.address_string }, link_errors: true %>
+            <% end %>
+            <%= f.govuk_radio_divider %>
+            <%= f.govuk_radio_button :institution_identifier, 'other', label: { text: "Nursery not shown above" } do %>
+              <%= f.govuk_text_field :institution_name, label: { text: "Search for another nursery name" } %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% else %>
+        <p class="govuk-body">Choose from nurseries located in <%= @form.wizard.store["institution_location"] %></p>
+        <div class="npq-js-hidden">
+          <%= f.govuk_text_field :institution_name,
+                                 width: "full",
+                                 label: { text: "Enter name", class: "govuk-label govuk-label--s" } %>
+        </div>
+
+        <div class="npq-js-reveal">
+          <div class="govuk-form-group">
+            <%= f.label :institution_identifier, "Enter name", class: "govuk-label govuk-label--s", for: "nursery-picker" %>
+            <%= f.text_field :institution_identifier, data: { location: @form.wizard.store["institution_location"] }, id: "nursery-picker" %>
+          </div>
+        </div>
+      <% end %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/registration_wizard/find_childcare_provider.html.erb
+++ b/app/views/registration_wizard/find_childcare_provider.html.erb
@@ -1,0 +1,31 @@
+<% content_for :title do %>
+  <%= @form.errors.present? ? "Error: " : nil %>Where is your nursery?
+<% end %>
+
+<% content_for :before_content do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: "Back",
+    href: registration_wizard_show_path(@wizard.previous_step_path)
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl">Where is your nursery?</h1>
+
+      <p class="govuk-body">We need this information to check if you can access Department for Education funding.</p>
+
+      <%= render GovukComponent::InsetTextComponent.new(text: "You can only select nurseries in England, Guernsey, Jersey or the Isle of Man. If your workplace is outside these locations, check with your training provider.") %>
+
+      <%= f.govuk_text_field :institution_location,
+                             width: "three-quarters",
+                             hint: { text: "Enter town, city or postcode" },
+                             label: { text: "Nursery location", class: "govuk-label--s" } %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -20,3 +20,11 @@ if (document.querySelector('#school-picker')) {
     placeholder: "Start typing to search schools and colleges",
   })
 }
+
+if (document.querySelector('#nursery-picker')) {
+  institutionPicker.enhanceSelectElement({
+    selectElement: document.querySelector('#nursery-picker'),
+    lookupPath: 'institutions',
+    placeholder: "Start typing to search nurseries",
+  })
+}

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -16,6 +16,7 @@ require('isomorphic-fetch')
 if (document.querySelector('#school-picker')) {
   institutionPicker.enhanceSelectElement({
     selectElement: document.querySelector('#school-picker'),
+    lookupPath: 'institutions',
     placeholder: "Start typing to search schools and colleges",
   })
 }

--- a/app/webpacker/packs/institution-picker.js
+++ b/app/webpacker/packs/institution-picker.js
@@ -9,8 +9,8 @@ function institutionPicker (options) {
   render(<Autocomplete {...options} />, options.element)
 }
 
-async function fetchSource(query, location) {
-  const res  = await fetch( `/institutions.json?location=${encodeURIComponent(location)}&name=${encodeURIComponent(query)}` );
+async function fetchSource(lookupPath, query, location) {
+  const res  = await fetch( `/${lookupPath}.json?location=${encodeURIComponent(location)}&name=${encodeURIComponent(query)}` );
   const data = await res.json();
   return data;
 }
@@ -48,7 +48,7 @@ institutionPicker.enhanceSelectElement = (configurationOptions) => {
   const location = configurationOptions.selectElement.getAttribute("data-location")
 
   configurationOptions.source = debounce( async ( query, populateResults ) => {
-    const res = await fetchSource(query, location);
+    const res = await fetchSource(configurationOptions.lookupPath, query, location);
     populateResults(res);
   }, 300 )
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -101,6 +101,10 @@ en:
             code:
               blank: Code can’t be blank
               incorrect: Code is not correct. Please try again
+        forms/choose_childcare_provider:
+          attributes:
+            institution_name:
+              no_results: No nurseries in %{location} with the name %{name} were found, please try again
         forms/choose_school:
           attributes:
             institution_name:
@@ -109,6 +113,10 @@ en:
           attributes:
             institution_location:
               blank: School location can’t be blank
+        forms/find_childcare_provider:
+          attributes:
+            institution_location:
+              blank: Nursery location can’t be blank
         forms/funding_your_npq:
           attributes:
             funding:

--- a/spec/lib/forms/dqt_mismatch_spec.rb
+++ b/spec/lib/forms/dqt_mismatch_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Forms::DqtMismatch do
   let(:request) { nil }
-  let(:store) { { "teacher_catchment" => "england", "works_in_school" => "yes" } }
+  let(:store) { { "teacher_catchment" => teacher_catchment, "works_in_school" => works_in_school, "works_in_childcare" => works_in_childcare } }
   let(:wizard) { RegistrationWizard.new(store: store, request: request, current_step: :dqt_mismatch) }
 
   subject(:step) { described_class.new.tap { |s| s.wizard = wizard } }
@@ -11,17 +11,33 @@ RSpec.describe Forms::DqtMismatch do
     subject(:next_step) { step.next_step }
 
     context "when both in catchment and works in school" do
+      let(:teacher_catchment) { "england" }
+      let(:works_in_school) { "yes" }
+      let(:works_in_childcare) { "no" }
+
       it { is_expected.to be :find_school }
     end
 
+    context "when both in catchment and works in nursery" do
+      let(:teacher_catchment) { "england" }
+      let(:works_in_school) { "no" }
+      let(:works_in_childcare) { "yes" }
+
+      it { is_expected.to be :find_childcare_provider }
+    end
+
     context "when international teacher" do
-      let(:store) { super().merge("teacher_catchment" => "other") }
+      let(:teacher_catchment) { "other" }
+      let(:works_in_school) { "yes" }
+      let(:works_in_childcare) { "no" }
 
       it { is_expected.to be :choose_your_npq }
     end
 
-    context "when not working in school" do
-      let(:store) { super().merge("works_in_school" => "no") }
+    context "when not working in school or nursery" do
+      let(:teacher_catchment) { "england" }
+      let(:works_in_school) { "no" }
+      let(:works_in_childcare) { "no" }
 
       it { is_expected.to be :choose_your_npq }
     end

--- a/spec/lib/forms/qualified_teacher_check_spec.rb
+++ b/spec/lib/forms/qualified_teacher_check_spec.rb
@@ -184,6 +184,16 @@ RSpec.describe Forms::QualifiedTeacherCheck, type: :model do
         expect(subject.trn_verified?).to be_truthy
       end
 
+      context "when user selected they work in childcare" do
+        before do
+          store["works_in_childcare"] = "yes"
+        end
+
+        it "returns :find_childcare_provider" do
+          expect(subject.next_step).to eql(:find_childcare_provider)
+        end
+      end
+
       context "when user selected they work in a school" do
         before do
           store["works_in_school"] = "yes"
@@ -197,9 +207,10 @@ RSpec.describe Forms::QualifiedTeacherCheck, type: :model do
       context "when user selected they do not work in a school" do
         before do
           store["works_in_school"] = "no"
+          store["works_in_childcare"] = "no"
         end
 
-        it "returns :find_school" do
+        it "returns :choose_your_npq" do
           expect(subject.next_step).to eql(:choose_your_npq)
         end
       end


### PR DESCRIPTION
### Context

https://dfedigital.atlassian.net/browse/CN-110

Users who mark themselves as working in a public nursery rather than a school should be directed to a find/choose your nursery path. We want to use the same data for both rather than showing just schools in the school path and just nurseries in the nursery path. This is because which path you end up going down depends in some cases on your perception of whether you’re a part of a school or a nursery. Where these are the same entity it can be unclear which path someone will pick. To resolve that we let people pick either regardless of the path they take.

### Changes proposed in this pull request

- Add `/registration/find-childcare-provider` page for selecting nursery location
- Add `/registration/choose-childcare-provider` page for searching nursery within location from find page

