### PR TITLE
add Targeted support funding eligibility to admin

### DIFF
--- a/app/views/admin/applications/show.html.erb
+++ b/app/views/admin/applications/show.html.erb
@@ -76,6 +76,11 @@
       end %>
 
       <%= summary_list.row do |row|
+        row.key { "Targeted support funding eligibility" }
+        row.value { admin_funding_tag(@application.targeted_support_funding_eligibility) }
+      end %>
+
+      <%= summary_list.row do |row|
         row.key { 'Funding choice' }
         row.value { @application.funding_choice }
       end %>

--- a/spec/page_objects/admin/application_page.rb
+++ b/spec/page_objects/admin/application_page.rb
@@ -1,0 +1,5 @@
+class ApplicationPage < SitePrism::Page
+  set_url "/admin/applications/{id}"
+
+  section :summary_list, SummaryListSection, ".govuk-summary-list"
+end

--- a/spec/views/admin/applications/show.html.erb_spec.rb
+++ b/spec/views/admin/applications/show.html.erb_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe "admin/applications/show.html.erb", type: :view do
+  let(:application_page) { ApplicationPage.new }
+
+  it "displays targeted_support_funding_eligibility" do
+    assign(:application, build(:application, targeted_support_funding_eligibility: true))
+
+    render
+
+    application_page.load(rendered)
+
+    expect(application_page.summary_list["Targeted support funding eligibility"].value).to eql("YES")
+  end
+end


### PR DESCRIPTION
### Context

- Admins are not able to see `Targeted support funding eligibility` flag
- Adding this will enable this and also help with PO review to ensure everything is working as expected

### Changes proposed in this pull request

- In admin area surface `Targeted support funding eligibility` when viewing an application

### Guidance to review

- Login as an admin
- View applications
- Should be a field labelled `Targeted support funding eligibility` which correctly mirrors that of the viewed application