### PR TITLE
add application created at to admin area

### DIFF
--- a/app/views/admin/applications/show.html.erb
+++ b/app/views/admin/applications/show.html.erb
@@ -84,6 +84,11 @@
         row.key { 'Funding choice' }
         row.value { @application.funding_choice }
       end %>
+
+      <%= summary_list.row do |row|
+        row.key { "Created at" }
+        row.value { l @application.created_at, format: :admin }
+      end %>
     <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,7 @@
 en:
+  time:
+    formats:
+      admin: "%R on %d/%m/%Y"
   activemodel:
     attributes:
       forms/funding_your_npq:

--- a/spec/views/admin/applications/show.html.erb_spec.rb
+++ b/spec/views/admin/applications/show.html.erb_spec.rb
@@ -2,14 +2,23 @@ require "rails_helper"
 
 RSpec.describe "admin/applications/show.html.erb", type: :view do
   let(:application_page) { ApplicationPage.new }
+  let(:application) { create(:application, targeted_support_funding_eligibility: true) }
 
   it "displays targeted_support_funding_eligibility" do
-    assign(:application, build(:application, targeted_support_funding_eligibility: true))
-
+    assign(:application, application)
     render
-
     application_page.load(rendered)
 
     expect(application_page.summary_list["Targeted support funding eligibility"].value).to eql("YES")
+  end
+
+  it "displays application created_at" do
+    assign(:application, application)
+    render
+    application_page.load(rendered)
+
+    expected = application.created_at.strftime("%R on %d/%m/%Y")
+
+    expect(application_page.summary_list["Created at"].value).to eql(expected)
   end
 end


### PR DESCRIPTION
### Context

- https://dfedigital.atlassian.net/browse/CN-46
- Support are struggling to identify when applications were made to help with helping support queries

### Changes proposed in this pull request

- Expose `created_at` of an applications in admin area

### Guidance to review

- Login into admin area
- View an application
- Should see when application was created