### PR TITLE
[CN-111] Add remaining early years questions and hook up existing questions to flow

### DIFF
--- a/app/controllers/private_childcare_providers_controller.rb
+++ b/app/controllers/private_childcare_providers_controller.rb
@@ -1,7 +1,6 @@
 class PrivateChildcareProvidersController < ApplicationController
   def index
     @private_childcare_providers = PrivateChildcareProvider
-      .open
       .search_by_urn(params[:name])
       .limit(100)
   end

--- a/app/lib/forms/choose_private_childcare_provider.rb
+++ b/app/lib/forms/choose_private_childcare_provider.rb
@@ -4,8 +4,10 @@ module Forms
 
     attr_accessor :institution_name, :institution_identifier
 
-    validates :institution_identifier, format: { with: /\APrivateChildcareProvider-\d+\z/, unless: -> { institution_identifier.blank? || institution_identifier == "other" } }
+    validates :institution_identifier, format: { with: /\APrivateChildcareProvider-.+\z/, unless: -> { institution_identifier.blank? || institution_identifier == "other" } }
     validates :institution_name, length: { maximum: 64 }
+
+    validate :validate_institution_exists
 
     def self.permitted_params
       %i[
@@ -20,6 +22,14 @@ module Forms
 
     def previous_step
       :have_ofsted_urn
+    end
+
+  private
+
+    def validate_institution_exists
+      return if institution(source: institution_identifier).present?
+
+      errors.add(:institution_identifier, :invalid, urn: institution_identifier)
     end
   end
 end

--- a/app/lib/forms/dqt_mismatch.rb
+++ b/app/lib/forms/dqt_mismatch.rb
@@ -9,10 +9,8 @@ module Forms
         :check_answers
       elsif wizard.query_store.inside_catchment? && wizard.query_store.works_in_school?
         :find_school
-      elsif wizard.query_store.inside_catchment? && wizard.query_store.works_in_childcare?
-        :find_childcare_provider
       else
-        :choose_your_npq
+        :work_in_childcare
       end
     end
   end

--- a/app/lib/forms/find_childcare_provider.rb
+++ b/app/lib/forms/find_childcare_provider.rb
@@ -15,7 +15,7 @@ module Forms
     end
 
     def previous_step
-      :qualified_teacher_check
+      :kind_of_nursery
     end
   end
 end

--- a/app/lib/forms/have_ofsted_urn.rb
+++ b/app/lib/forms/have_ofsted_urn.rb
@@ -20,7 +20,7 @@ module Forms
     end
 
     def previous_step
-      if wizard.store["works_in_nursery"] == "yes"
+      if wizard.query_store.work_in_nursery?
         :kind_of_nursery
       else
         :work_in_nursery

--- a/app/lib/forms/have_ofsted_urn.rb
+++ b/app/lib/forms/have_ofsted_urn.rb
@@ -20,7 +20,11 @@ module Forms
     end
 
     def previous_step
-      :qualified_teacher_check
+      if wizard.store["works_in_nursery"] == "yes"
+        :kind_of_nursery
+      else
+        :work_in_nursery
+      end
     end
 
     def options

--- a/app/lib/forms/helpers/institution.rb
+++ b/app/lib/forms/helpers/institution.rb
@@ -11,7 +11,7 @@ module Forms
 
         @institution ||= case klass
                          when "PrivateChildcareProvider"
-                           PrivateChildcareProvider.find_by(urn: identifier)
+                           PrivateChildcareProvider.find_by(provider_urn: identifier)
                          when "School"
                            School.find_by(urn: identifier)
                          when "LocalAuthority"

--- a/app/lib/forms/kind_of_nursery.rb
+++ b/app/lib/forms/kind_of_nursery.rb
@@ -1,0 +1,36 @@
+module Forms
+  class KindOfNursery < Base
+    attr_accessor :kind_of_nursery
+
+    KIND_OF_NURSERY_PUBLIC_OPTIONS = %w[
+      local_authority_maintained_nursery
+      preschool_class_as_part_of_school
+    ].freeze
+    KIND_OF_NURSERY_PRIVATE_OPTIONS = %w[private_nursery].freeze
+    KIND_OF_NURSERY_OPTIONS = KIND_OF_NURSERY_PUBLIC_OPTIONS + KIND_OF_NURSERY_PRIVATE_OPTIONS
+
+    validates :kind_of_nursery, presence: true, inclusion: { in: KIND_OF_NURSERY_OPTIONS }
+
+    def self.permitted_params
+      %i[
+        kind_of_nursery
+      ]
+    end
+
+    def next_step
+      if private_nursery?
+        :have_ofsted_urn
+      else
+        :find_childcare_provider
+      end
+    end
+
+    def previous_step
+      :work_in_nursery
+    end
+
+    def private_nursery?
+      KIND_OF_NURSERY_PRIVATE_OPTIONS.include?(kind_of_nursery)
+    end
+  end
+end

--- a/app/lib/forms/qualified_teacher_check.rb
+++ b/app/lib/forms/qualified_teacher_check.rb
@@ -68,10 +68,8 @@ module Forms
           :check_answers
         elsif wizard.query_store.inside_catchment? && wizard.query_store.works_in_school?
           :find_school
-        elsif wizard.query_store.inside_catchment? && wizard.query_store.works_in_childcare?
-          :find_childcare_provider
         else
-          :choose_your_npq
+          :work_in_childcare
         end
       else
         mark_trn_as_unverified

--- a/app/lib/forms/work_in_childcare.rb
+++ b/app/lib/forms/work_in_childcare.rb
@@ -1,0 +1,33 @@
+module Forms
+  class WorkInChildcare < Base
+    VALID_WORK_IN_CHILDCARE_OPTIONS = %w[yes no].freeze
+
+    attr_accessor :works_in_childcare
+
+    validates :works_in_childcare, presence: true, inclusion: { in: VALID_WORK_IN_CHILDCARE_OPTIONS }
+
+    def self.permitted_params
+      %i[works_in_childcare]
+    end
+
+    def requirements_met?
+      true
+    end
+
+    def next_step
+      if wizard.query_store.inside_catchment? && works_in_childcare?
+        :work_in_nursery
+      else
+        :choose_your_npq
+      end
+    end
+
+    def works_in_childcare?
+      works_in_childcare == "yes"
+    end
+
+    def previous_step
+      :qualified_teacher_check
+    end
+  end
+end

--- a/app/lib/forms/work_in_childcare.rb
+++ b/app/lib/forms/work_in_childcare.rb
@@ -10,10 +10,6 @@ module Forms
       %i[works_in_childcare]
     end
 
-    def requirements_met?
-      true
-    end
-
     def next_step
       if wizard.query_store.inside_catchment? && works_in_childcare?
         :work_in_nursery

--- a/app/lib/forms/work_in_nursery.rb
+++ b/app/lib/forms/work_in_nursery.rb
@@ -1,0 +1,33 @@
+module Forms
+  class WorkInNursery < Base
+    VALID_WORK_IN_NURSERY_OPTIONS = %w[yes no].freeze
+
+    attr_accessor :works_in_nursery
+
+    validates :works_in_nursery, presence: true, inclusion: { in: VALID_WORK_IN_NURSERY_OPTIONS }
+
+    def self.permitted_params
+      %i[works_in_nursery]
+    end
+
+    def requirements_met?
+      true
+    end
+
+    def next_step
+      if works_in_nursery?
+        :kind_of_nursery
+      else
+        :have_ofsted_urn
+      end
+    end
+
+    def previous_step
+      :work_in_childcare
+    end
+
+    def works_in_nursery?
+      works_in_nursery == "yes"
+    end
+  end
+end

--- a/app/lib/services/eligibility/targeted_support_funding.rb
+++ b/app/lib/services/eligibility/targeted_support_funding.rb
@@ -11,6 +11,7 @@ module Services
         return false if institution.nil?
         return true  if eligible_fe_ukprns.include?(institution.ukprn)
         return false if institution.is_a?(LocalAuthority)
+        return false if institution.is_a?(PrivateChildcareProvider)
         return false if institution.number_of_pupils.nil?
         return false if institution.number_of_pupils.zero?
 

--- a/app/lib/services/query_store.rb
+++ b/app/lib/services/query_store.rb
@@ -22,7 +22,21 @@ class Services::QueryStore
   end
 
   def works_in_childcare?
-    store["works_in_childcare"] == "yes"
+    store["works_in_childcare?"] == "yes"
+  end
+
+  def work_in_nursery?
+    store["works_in_nursery"] == "yes"
+  end
+
+  def works_in_public_childcare_provider?
+    work_in_nursery? &&
+      Forms::KindOfNursery::KIND_OF_NURSERY_PUBLIC_OPTIONS.include?(store["kind_of_nursery"])
+  end
+
+  def works_in_private_childcare_provider?
+    work_in_nursery? &&
+      Forms::KindOfNursery::KIND_OF_NURSERY_PRIVATE_OPTIONS.include?(store["kind_of_nursery"])
   end
 
   def course

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -4,6 +4,12 @@ class Application < ApplicationRecord
   belongs_to :lead_provider
   belongs_to :school, foreign_key: "school_urn", primary_key: "urn", optional: true
 
+  enum kind_of_nursery: {
+    local_authority_maintained_nursery: "local_authority_maintained_nursery",
+    preschool_class_as_part_of_school: "preschool_class_as_part_of_school",
+    private_nursery: "private_nursery",
+  }
+
   def calculate_funding_eligbility
     Services::FundingEligibility.new(course: course, institution: school, new_headteacher: new_headteacher?).call
   end

--- a/app/models/private_childcare_provider.rb
+++ b/app/models/private_childcare_provider.rb
@@ -28,7 +28,7 @@ class PrivateChildcareProvider < ApplicationRecord
   end
 
   def ukprn
-    provider_urn
+    nil
   end
 
   def provider_name

--- a/app/models/private_childcare_provider.rb
+++ b/app/models/private_childcare_provider.rb
@@ -27,6 +27,10 @@ class PrivateChildcareProvider < ApplicationRecord
     provider_urn
   end
 
+  def ukprn
+    provider_urn
+  end
+
   def provider_name
     raw_name = self[:provider_name]
     raw_name unless raw_name == REDACTED_DATA_STRING
@@ -37,7 +41,7 @@ class PrivateChildcareProvider < ApplicationRecord
   end
 
   def address
-    [address_1, address_2, address_3, town, county, postcode].reject(&:blank?) - [REDACTED_DATA_STRING]
+    [address_1, address_2, address_3, town, region, postcode].reject(&:blank?) - [REDACTED_DATA_STRING]
   end
 
   def address_string

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -72,6 +72,26 @@ class RegistrationWizard
                             value: store["works_in_school"].capitalize,
                             change_step: :work_in_school)
 
+    unless query_store.works_in_school?
+      array << OpenStruct.new(key: "Do you work in early years or childcare?",
+                              value: store["works_in_childcare"].capitalize,
+                              change_step: :work_in_childcare)
+
+      if query_store.inside_catchment? && query_store.works_in_childcare?
+        array << OpenStruct.new(key: "Do you work in a nursery?",
+                                value: store["works_in_nursery"].capitalize,
+                                change_step: :work_in_nursery)
+
+        if query_store.work_in_nursery?
+          kind_of_nursery = store["kind_of_nursery"]
+
+          array << OpenStruct.new(key: "What kind of nursery do you work in?",
+                                  value: I18n.t("registration_wizard.kind_of_nursery.#{kind_of_nursery}"),
+                                  change_step: :kind_of_nursery)
+        end
+      end
+    end
+
     array << OpenStruct.new(key: "Full name",
                             value: store["full_name"],
                             change_step: :qualified_teacher_check)
@@ -105,10 +125,14 @@ class RegistrationWizard
         array << OpenStruct.new(key: "School or college",
                                 value: institution(source: store["institution_identifier"]).name,
                                 change_step: :find_school)
-      elsif query_store.works_in_childcare?
-        array << OpenStruct.new(key: "Childcare provider",
+      elsif query_store.works_in_public_childcare_provider?
+        array << OpenStruct.new(key: "Nursery",
                                 value: institution(source: store["institution_identifier"]).name,
                                 change_step: :find_childcare_provider)
+      elsif query_store.works_in_private_childcare_provider?
+        array << OpenStruct.new(key: "Nursery",
+                                value: institution(source: store["institution_identifier"]).provider_name,
+                                change_step: :have_ofsted_urn)
       end
     end
 
@@ -223,6 +247,9 @@ private
       choose_school
       find_childcare_provider
       choose_childcare_provider
+      work_in_childcare
+      work_in_nursery
+      kind_of_nursery
       have_ofsted_urn
       choose_private_childcare_provider
       your_work

--- a/app/views/admin/applications/show.html.erb
+++ b/app/views/admin/applications/show.html.erb
@@ -66,6 +66,11 @@
       end %>
 
       <%= summary_list.row do |row|
+        row.key { 'Private Childcare Provider URN' }
+        row.value { @application.private_childcare_provider_urn }
+      end %>
+
+      <%= summary_list.row do |row|
         row.key { 'Headteacher' }
         row.value { @application.headteacher_status }
       end %>

--- a/app/views/registration_wizard/choose_childcare_provider.html.erb
+++ b/app/views/registration_wizard/choose_childcare_provider.html.erb
@@ -24,7 +24,7 @@
 
           <%= f.govuk_text_field :institution_name,
                                  width: "full",
-                                 label: { text: "Enter name" } %>
+                                 label: { text: "Enter your nursery name" } %>
         <% else %>
           <%= f.govuk_radio_buttons_fieldset(:institution_identifier, legend: { size: 'm', text: "Please choose from nurseries located in #{@form.wizard.store["institution_location"]}" }) do %>
             <% @form.possible_institutions.each do |institution| %>
@@ -41,12 +41,12 @@
         <div class="npq-js-hidden">
           <%= f.govuk_text_field :institution_name,
                                  width: "full",
-                                 label: { text: "Enter name", class: "govuk-label govuk-label--s" } %>
+                                 label: { text: "Enter your nursery name", class: "govuk-label govuk-label--s" } %>
         </div>
 
         <div class="npq-js-reveal">
           <div class="govuk-form-group">
-            <%= f.label :institution_identifier, "Enter name", class: "govuk-label govuk-label--s", for: "nursery-picker" %>
+            <%= f.label :institution_identifier, "Enter your nursery name", class: "govuk-label govuk-label--s", for: "nursery-picker" %>
             <%= f.text_field :institution_identifier, data: { location: @form.wizard.store["institution_location"] }, id: "nursery-picker" %>
           </div>
         </div>

--- a/app/views/registration_wizard/choose_private_childcare_provider.html.erb
+++ b/app/views/registration_wizard/choose_private_childcare_provider.html.erb
@@ -14,18 +14,20 @@
     <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-xl">Enter your or your employer's URN</h1>
-
       <div class="npq-js-hidden">
         <%= f.govuk_text_field :institution_name,
                                width: "full",
                                label: { text: "Enter your nursery name", class: "govuk-label govuk-label--s" } %>
       </div>
 
+      <%= f.label :institution_identifier, class: "govuk-label govuk-label--s", for: "private-childcare-provider-picker" do %>
+        <h1 class="govuk-heading-xl">Enter your or your employer's URN</h1>
+      <% end %>
+
       <div class="npq-js-reveal">
         <div class="govuk-form-group">
-          <span class="govuk-hint" id="private-childcare-provider-picker-hint">For example EY456789</span>
-          <%= f.text_field :institution_identifier, id: "private-childcare-provider-picker" %>
+          <span class="govuk-hint" id="private-childcare-provider-picker__hint">For example EY456789</span>
+          <%= f.text_field(:institution_identifier, id: "private-childcare-provider-picker", "aria-label" => "Enter your or your employer's URN") %>
         </div>
       </div>
       <%= f.govuk_submit %>

--- a/app/views/registration_wizard/kind_of_nursery.html.erb
+++ b/app/views/registration_wizard/kind_of_nursery.html.erb
@@ -1,0 +1,39 @@
+<% content_for :title do %>
+  <%= @form.errors.present? ? "Error: " : nil %>What kind of nursery do you work in?
+<% end %>
+
+<% content_for :before_content do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: "Back",
+    href: registration_wizard_show_path(@wizard.previous_step_path)
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset(:kind_of_nursery,
+                                         legend: {
+                                           text: "What kind of nursery do you work in?",
+                                           tag: "h1",
+                                           size: "xl"
+                                         }
+                                        ) do %>
+        <% Forms::KindOfNursery::KIND_OF_NURSERY_OPTIONS.each_with_index do |nursery_kind, index| %>
+          <%=
+            f.govuk_radio_button(
+              :kind_of_nursery,
+              nursery_kind,
+              label: { text: t(".#{nursery_kind}") },
+              link_errors: index == 0
+            )
+          %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/registration_wizard/work_in_childcare.html.erb
+++ b/app/views/registration_wizard/work_in_childcare.html.erb
@@ -1,0 +1,31 @@
+<% content_for :title do %>
+  <%= @form.errors.present? ? "Error: " : nil %>Do you work in early years or childcare?
+<% end %>
+
+<% content_for :before_content do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: "Back",
+    href: registration_wizard_show_path(@wizard.previous_step_path)
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset(:works_in_childcare,
+                                         legend: {
+                                           text: "Do you work in early years or childcare?",
+                                           tag: "h1",
+                                           size: "xl"
+                                         }
+                                        ) do %>
+        <%= f.govuk_radio_button :works_in_childcare, "yes", label: { text: "Yes" }, link_errors: true %>
+        <%= f.govuk_radio_button :works_in_childcare, "no", label: { text: "No" } %>
+      <% end %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/registration_wizard/work_in_nursery.html.erb
+++ b/app/views/registration_wizard/work_in_nursery.html.erb
@@ -1,0 +1,31 @@
+<% content_for :title do %>
+  <%= @form.errors.present? ? "Error: " : nil %>Do you work in a nursery?
+<% end %>
+
+<% content_for :before_content do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: "Back",
+    href: registration_wizard_show_path(@wizard.previous_step_path)
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset(:works_in_nursery,
+                                         legend: {
+                                           text: "Do you work in a nursery?",
+                                           tag: "h1",
+                                           size: "xl"
+                                         }
+                                        ) do %>
+        <%= f.govuk_radio_button :works_in_nursery, "yes", label: { text: "Yes" }, link_errors: true %>
+        <%= f.govuk_radio_button :works_in_nursery, "no", label: { text: "No" } %>
+      <% end %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -108,6 +108,10 @@ en:
           attributes:
             institution_name:
               no_results: No nurseries in %{location} with the name %{name} were found, please try again
+        forms/choose_private_childcare_provider:
+          attributes:
+            institution_identifier:
+              invalid: No private childcare providers with the URN %{urn} were found, please try again
         forms/choose_school:
           attributes:
             institution_name:
@@ -161,3 +165,9 @@ en:
               blank: Enter an email address
               invalid: This email has already been registered for interest
               taken: You have already registered to be notified
+  registration_wizard:
+    kind_of_nursery:
+      local_authority_maintained_nursery: Local authority maintained nursery
+      preschool_class_as_part_of_school: Preschool class that's part of a school
+      private_nursery: Private nursery
+

--- a/db/migrate/20220505113441_add_early_years_columns_to_applications.rb
+++ b/db/migrate/20220505113441_add_early_years_columns_to_applications.rb
@@ -1,0 +1,8 @@
+class AddEarlyYearsColumnsToApplications < ActiveRecord::Migration[6.1]
+  def change
+    add_column :applications, :private_childcare_provider_urn, :text
+    add_column :applications, :works_in_nursery, :boolean
+    add_column :applications, :works_in_childcare, :boolean
+    add_column :applications, :kind_of_nursery, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_03_114606) do
+ActiveRecord::Schema.define(version: 2022_05_05_113441) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -35,6 +35,10 @@ ActiveRecord::Schema.define(version: 2022_05_03_114606) do
     t.string "employer_name"
     t.string "employment_role"
     t.boolean "targeted_support_funding_eligibility", default: false
+    t.text "private_childcare_provider_urn"
+    t.boolean "works_in_nursery"
+    t.boolean "works_in_childcare"
+    t.text "kind_of_nursery"
     t.index ["course_id"], name: "index_applications_on_course_id"
     t.index ["lead_provider_id"], name: "index_applications_on_lead_provider_id"
     t.index ["user_id"], name: "index_applications_on_user_id"

--- a/spec/features/happy_journeys_non_js_spec.rb
+++ b/spec/features/happy_journeys_non_js_spec.rb
@@ -736,6 +736,10 @@ RSpec.feature "Happy journeys", type: :feature do
     page.fill_in "National Insurance number (optional)", with: "AB123456C"
     page.click_button("Continue")
 
+    expect(page).to have_text("Do you work in early years or childcare?")
+    page.choose("No")
+    page.click_button("Continue")
+
     expect(page).to have_text("What are you applying for?")
     expect(page).not_to have_text("Additional Support Offer for new headteachers")
     page.choose("NPQ for Headship (NPQH)")

--- a/spec/features/happy_journeys_spec.rb
+++ b/spec/features/happy_journeys_spec.rb
@@ -411,6 +411,11 @@ RSpec.feature "Happy journeys", type: :feature do
     School.create!(urn: 100_000, name: "open manchester school", address_1: "street 1", town: "manchester", establishment_status_code: "1")
 
     expect(page).to be_axe_clean
+    expect(page).to have_text("Do you work in early years or childcare?")
+    page.choose("No", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
     expect(page).to have_text("What are you applying for?")
     page.choose("NPQ for Senior Leadership (NPQSL)", visible: :all)
     page.click_button("Continue")
@@ -523,8 +528,318 @@ RSpec.feature "Happy journeys", type: :feature do
     School.create!(urn: 100_000, name: "open manchester school", address_1: "street 1", town: "manchester", establishment_status_code: "1")
 
     expect(page).to be_axe_clean
+    expect(page).to have_text("Do you work in early years or childcare?")
+    page.choose("No", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
     expect(page).to have_text("What are you applying for?")
     page.choose("NPQ for Senior Leadership (NPQSL)", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("How is your course being paid for?")
+    page.choose "My employer is paying", visible: :all
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Choose your provider")
+    page.choose("Teach First", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Tell us about where you work")
+    page.fill_in "Name of employer", with: "Big company"
+    page.fill_in "Role", with: "Trainer"
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Sharing your NPQ information")
+    page.check("Yes, I agree my information can be shared", visible: :all)
+    page.click_button("Continue")
+
+    check_answers_page = CheckAnswersPage.new
+
+    expect(page).to be_axe_clean
+    expect(check_answers_page).to be_displayed
+    expect(check_answers_page.summary_list["Full name"].value).to eql("John Doe")
+    expect(check_answers_page.summary_list["TRN"].value).to eql("1234567")
+    expect(check_answers_page.summary_list["Date of birth"].value).to eql("13 December 1980")
+    expect(check_answers_page.summary_list.key?("National Insurance number")).to be_falsey
+    expect(check_answers_page.summary_list["Email"].value).to eql("user@example.com")
+    expect(check_answers_page.summary_list["Course"].value).to eql("NPQ for Senior Leadership (NPQSL)")
+    expect(check_answers_page.summary_list.key?("Have you been a headteacher for two years or more?")).to be_falsey
+    expect(check_answers_page.summary_list.key?("School or college")).to be_falsey
+    expect(check_answers_page.summary_list["How is your NPQ being paid for?"].value).to eql("My employer is paying")
+
+    allow(ApplicationSubmissionJob).to receive(:perform_later).with(anything)
+
+    page.click_button("Submit")
+
+    expect(page).to be_axe_clean
+  end
+
+  scenario "registration journey while working at public nursery" do
+    visit "/"
+    expect(page).to have_text("Before you start")
+    page.click_link("Start now")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Have you agreed a start date of")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Have you already chosen an NPQ and provider?")
+    page.choose("Yes, I have chosen my NPQ and provider", visible: :all)
+    page.click_button("Continue")
+
+    # expect(page).to be_axe_clean
+    # TODO: aria-expanded
+    expect(page.current_path).to eql("/registration/teacher-catchment")
+    page.choose("England", visible: :all)
+    page.click_button("Continue")
+
+    expect(page.current_path).to eql("/registration/work-in-school")
+    page.choose("No", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page.current_path).to eql("/registration/teacher-reference-number")
+    page.choose("Yes, I know my TRN", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page.current_path).to include("contact-details")
+    expect(page).to have_text("Email address")
+    page.fill_in "Email address", with: "user@example.com"
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Confirm your code")
+    expect(page).to have_text("user@example.com")
+    page.click_button("Continue")
+
+    code = ActionMailer::Base.deliveries.last[:personalisation].unparsed_value[:code]
+
+    expect(page).to be_axe_clean
+    page.fill_in "Enter your code", with: code
+    page.click_button("Continue")
+
+    stub_request(:post, "https://ecf-app.gov.uk/api/v1/participant-validation")
+      .with(
+        headers: {
+          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+        },
+        body: {
+          trn: "1234567",
+          date_of_birth: "1980-12-13",
+          full_name: "John Doe",
+          nino: "",
+        },
+      )
+      .to_return(status: 200, body: participant_validator_response, headers: {})
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Check your details")
+    page.fill_in "Teacher reference number (TRN)", with: "1234567"
+    page.fill_in "Full name", with: "John Doe"
+    page.fill_in "Day", with: "13"
+    page.fill_in "Month", with: "12"
+    page.fill_in "Year", with: "1980"
+    page.click_button("Continue")
+
+    School.create!(urn: 100_000, name: "open manchester school", address_1: "street 1", town: "manchester", establishment_status_code: "1")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Do you work in early years or childcare?")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Do you work in a nursery?")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("What kind of nursery do you work in?")
+    public_nursery_type = [
+      "Local authority maintained nursery",
+      "Preschool class that's part of a school",
+    ].sample
+    page.choose(public_nursery_type, visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Where is your nursery?")
+    page.fill_in "Nursery location", with: "manchester"
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Choose your nursery")
+    expect(page).to have_text("Choose from nurseries located in manchester")
+    within ".npq-js-reveal" do
+      page.fill_in "Enter your nursery name", with: "open"
+    end
+
+    expect(page).to have_content("open manchester school")
+    page.find("#nursery-picker__option--0").click
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("What are you applying for?")
+    page.choose("NPQ for Senior Leadership (NPQSL)", visible: :all) # Needs changing to an early years course once added
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("How is your course being paid for?")
+    page.choose "My employer is paying", visible: :all
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Choose your provider")
+    page.choose("Teach First", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Tell us about where you work")
+    page.fill_in "Name of employer", with: "Big company"
+    page.fill_in "Role", with: "Trainer"
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Sharing your NPQ information")
+    page.check("Yes, I agree my information can be shared", visible: :all)
+    page.click_button("Continue")
+
+    check_answers_page = CheckAnswersPage.new
+
+    expect(page).to be_axe_clean
+    expect(check_answers_page).to be_displayed
+    expect(check_answers_page.summary_list["Full name"].value).to eql("John Doe")
+    expect(check_answers_page.summary_list["TRN"].value).to eql("1234567")
+    expect(check_answers_page.summary_list["Date of birth"].value).to eql("13 December 1980")
+    expect(check_answers_page.summary_list.key?("National Insurance number")).to be_falsey
+    expect(check_answers_page.summary_list["Email"].value).to eql("user@example.com")
+    expect(check_answers_page.summary_list["Course"].value).to eql("NPQ for Senior Leadership (NPQSL)")
+    expect(check_answers_page.summary_list.key?("Have you been a headteacher for two years or more?")).to be_falsey
+    expect(check_answers_page.summary_list.key?("School or college")).to be_falsey
+    expect(check_answers_page.summary_list["How is your NPQ being paid for?"].value).to eql("My employer is paying")
+
+    allow(ApplicationSubmissionJob).to receive(:perform_later).with(anything)
+
+    page.click_button("Submit")
+
+    expect(page).to be_axe_clean
+  end
+
+  scenario "registration journey while working at private nursery" do
+    visit "/"
+    expect(page).to have_text("Before you start")
+    page.click_link("Start now")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Have you agreed a start date of")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Have you already chosen an NPQ and provider?")
+    page.choose("Yes, I have chosen my NPQ and provider", visible: :all)
+    page.click_button("Continue")
+
+    # expect(page).to be_axe_clean
+    # TODO: aria-expanded
+    expect(page.current_path).to eql("/registration/teacher-catchment")
+    page.choose("England", visible: :all)
+    page.click_button("Continue")
+
+    expect(page.current_path).to eql("/registration/work-in-school")
+    page.choose("No", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page.current_path).to eql("/registration/teacher-reference-number")
+    page.choose("Yes, I know my TRN", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page.current_path).to include("contact-details")
+    expect(page).to have_text("Email address")
+    page.fill_in "Email address", with: "user@example.com"
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Confirm your code")
+    expect(page).to have_text("user@example.com")
+    page.click_button("Continue")
+
+    code = ActionMailer::Base.deliveries.last[:personalisation].unparsed_value[:code]
+
+    expect(page).to be_axe_clean
+    page.fill_in "Enter your code", with: code
+    page.click_button("Continue")
+
+    stub_request(:post, "https://ecf-app.gov.uk/api/v1/participant-validation")
+      .with(
+        headers: {
+          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+        },
+        body: {
+          trn: "1234567",
+          date_of_birth: "1980-12-13",
+          full_name: "John Doe",
+          nino: "",
+        },
+      )
+      .to_return(status: 200, body: participant_validator_response, headers: {})
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Check your details")
+    page.fill_in "Teacher reference number (TRN)", with: "1234567"
+    page.fill_in "Full name", with: "John Doe"
+    page.fill_in "Day", with: "13"
+    page.fill_in "Month", with: "12"
+    page.fill_in "Year", with: "1980"
+    page.click_button("Continue")
+
+    School.create!(urn: 100_000, name: "open manchester school", address_1: "street 1", town: "manchester", establishment_status_code: "1")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Do you work in early years or childcare?")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Do you work in a nursery?")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("What kind of nursery do you work in?")
+    page.choose("Private nursery", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Do you have an Ofsted unique reference number (URN)?")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    PrivateChildcareProvider.create!(provider_urn: "EY123456", provider_name: "searchable childcare provider", address_1: "street 1", town: "manchester")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Enter your or your employer's URN")
+    within ".npq-js-reveal" do
+      page.fill_in "private-childcare-provider-picker", with: "EY123"
+    end
+
+    expect(page).to have_content("EY123456 - searchable childcare provider - street 1, manchester")
+    page.find("#private-childcare-provider-picker__option--0").click
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("What are you applying for?")
+    page.choose("NPQ for Senior Leadership (NPQSL)", visible: :all) # Needs changing to an early years course once added
     page.click_button("Continue")
 
     expect(page).to be_axe_clean

--- a/spec/features/sad_journeys_spec.rb
+++ b/spec/features/sad_journeys_spec.rb
@@ -273,4 +273,128 @@ RSpec.feature "Sad journeys", type: :feature do
     expect(page).to be_axe_clean
     expect(page).to have_text("Choosing an NPQ and Provider")
   end
+
+  scenario "works in childcare but not in england" do
+    visit "/"
+    expect(page).to have_text("Before you start")
+    page.click_link("Start now")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Have you agreed a start date of")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Have you already chosen an NPQ and provider?")
+    page.choose("Yes, I have chosen my NPQ and provider", visible: :all)
+    page.click_button("Continue")
+
+    # expect(page).to be_axe_clean
+    # TODO: aria-expanded
+    expect(page.current_path).to eql("/registration/teacher-catchment")
+    page.choose("Scotland", visible: :all)
+    page.click_button("Continue")
+
+    expect(page.current_path).to eql("/registration/work-in-school")
+    page.choose("No", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page.current_path).to eql("/registration/teacher-reference-number")
+    page.choose("Yes, I know my TRN", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page.current_path).to include("contact-details")
+    expect(page).to have_text("Email address")
+    page.fill_in "Email address", with: "user@example.com"
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Confirm your code")
+    expect(page).to have_text("user@example.com")
+    page.click_button("Continue")
+
+    code = ActionMailer::Base.deliveries.last[:personalisation].unparsed_value[:code]
+
+    expect(page).to be_axe_clean
+    page.fill_in "Enter your code", with: code
+    page.click_button("Continue")
+
+    stub_request(:post, "https://ecf-app.gov.uk/api/v1/participant-validation")
+      .with(
+        headers: {
+          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+        },
+        body: {
+          trn: "1234567",
+          date_of_birth: "1980-12-13",
+          full_name: "John Doe",
+          nino: "",
+        },
+      )
+      .to_return(status: 200, body: participant_validator_response, headers: {})
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Check your details")
+    page.fill_in "Teacher reference number (TRN)", with: "1234567"
+    page.fill_in "Full name", with: "John Doe"
+    page.fill_in "Day", with: "13"
+    page.fill_in "Month", with: "12"
+    page.fill_in "Year", with: "1980"
+    page.click_button("Continue")
+
+    School.create!(urn: 100_000, name: "open manchester school", address_1: "street 1", town: "manchester", establishment_status_code: "1")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Do you work in early years or childcare?")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("What are you applying for?")
+    page.choose("NPQ for Senior Leadership (NPQSL)", visible: :all) # Needs changing to an early years course once added
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("How is your course being paid for?")
+    page.choose "My employer is paying", visible: :all
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Choose your provider")
+    page.choose("Teach First", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Tell us about where you work")
+    page.fill_in "Name of employer", with: "Big company"
+    page.fill_in "Role", with: "Trainer"
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Sharing your NPQ information")
+    page.check("Yes, I agree my information can be shared", visible: :all)
+    page.click_button("Continue")
+
+    check_answers_page = CheckAnswersPage.new
+
+    expect(page).to be_axe_clean
+    expect(check_answers_page).to be_displayed
+    expect(check_answers_page.summary_list["Full name"].value).to eql("John Doe")
+    expect(check_answers_page.summary_list["TRN"].value).to eql("1234567")
+    expect(check_answers_page.summary_list["Date of birth"].value).to eql("13 December 1980")
+    expect(check_answers_page.summary_list.key?("National Insurance number")).to be_falsey
+    expect(check_answers_page.summary_list["Email"].value).to eql("user@example.com")
+    expect(check_answers_page.summary_list["Course"].value).to eql("NPQ for Senior Leadership (NPQSL)")
+    expect(check_answers_page.summary_list.key?("Have you been a headteacher for two years or more?")).to be_falsey
+    expect(check_answers_page.summary_list.key?("School or college")).to be_falsey
+    expect(check_answers_page.summary_list["How is your NPQ being paid for?"].value).to eql("My employer is paying")
+
+    allow(ApplicationSubmissionJob).to receive(:perform_later).with(anything)
+
+    page.click_button("Submit")
+
+    expect(page).to be_axe_clean
+  end
 end

--- a/spec/lib/forms/dqt_mismatch_spec.rb
+++ b/spec/lib/forms/dqt_mismatch_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Forms::DqtMismatch do
   let(:request) { nil }
-  let(:store) { { "teacher_catchment" => teacher_catchment, "works_in_school" => works_in_school, "works_in_childcare" => works_in_childcare } }
+  let(:store) { { "teacher_catchment" => teacher_catchment, "works_in_school" => works_in_school } }
   let(:wizard) { RegistrationWizard.new(store: store, request: request, current_step: :dqt_mismatch) }
 
   subject(:step) { described_class.new.tap { |s| s.wizard = wizard } }
@@ -13,33 +13,22 @@ RSpec.describe Forms::DqtMismatch do
     context "when both in catchment and works in school" do
       let(:teacher_catchment) { "england" }
       let(:works_in_school) { "yes" }
-      let(:works_in_childcare) { "no" }
 
       it { is_expected.to be :find_school }
-    end
-
-    context "when both in catchment and works in nursery" do
-      let(:teacher_catchment) { "england" }
-      let(:works_in_school) { "no" }
-      let(:works_in_childcare) { "yes" }
-
-      it { is_expected.to be :find_childcare_provider }
     end
 
     context "when international teacher" do
       let(:teacher_catchment) { "other" }
       let(:works_in_school) { "yes" }
-      let(:works_in_childcare) { "no" }
 
-      it { is_expected.to be :choose_your_npq }
+      it { is_expected.to be :work_in_childcare }
     end
 
     context "when not working in school or nursery" do
       let(:teacher_catchment) { "england" }
       let(:works_in_school) { "no" }
-      let(:works_in_childcare) { "no" }
 
-      it { is_expected.to be :choose_your_npq }
+      it { is_expected.to be :work_in_childcare }
     end
   end
 end

--- a/spec/lib/forms/kind_of_nursery_spec.rb
+++ b/spec/lib/forms/kind_of_nursery_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe Forms::KindOfNursery, type: :model do
+  it "defines valid kinds of nursery" do
+    expect(described_class::KIND_OF_NURSERY_OPTIONS).to eq(%w[
+      local_authority_maintained_nursery
+      preschool_class_as_part_of_school
+      private_nursery
+    ])
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:kind_of_nursery) }
+    it { is_expected.to validate_inclusion_of(:kind_of_nursery).in_array(described_class::KIND_OF_NURSERY_OPTIONS) }
+  end
+end

--- a/spec/lib/forms/qualified_teacher_check_spec.rb
+++ b/spec/lib/forms/qualified_teacher_check_spec.rb
@@ -184,16 +184,6 @@ RSpec.describe Forms::QualifiedTeacherCheck, type: :model do
         expect(subject.trn_verified?).to be_truthy
       end
 
-      context "when user selected they work in childcare" do
-        before do
-          store["works_in_childcare"] = "yes"
-        end
-
-        it "returns :find_childcare_provider" do
-          expect(subject.next_step).to eql(:find_childcare_provider)
-        end
-      end
-
       context "when user selected they work in a school" do
         before do
           store["works_in_school"] = "yes"
@@ -207,11 +197,10 @@ RSpec.describe Forms::QualifiedTeacherCheck, type: :model do
       context "when user selected they do not work in a school" do
         before do
           store["works_in_school"] = "no"
-          store["works_in_childcare"] = "no"
         end
 
         it "returns :choose_your_npq" do
-          expect(subject.next_step).to eql(:choose_your_npq)
+          expect(subject.next_step).to eql(:work_in_childcare)
         end
       end
     end

--- a/spec/lib/forms/work_in_childcare_spec.rb
+++ b/spec/lib/forms/work_in_childcare_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+RSpec.describe Forms::WorkInChildcare, type: :model do
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:works_in_childcare) }
+    it { is_expected.to validate_inclusion_of(:works_in_childcare).in_array(described_class::VALID_WORK_IN_CHILDCARE_OPTIONS) }
+  end
+end

--- a/spec/lib/forms/work_in_nursery_spec.rb
+++ b/spec/lib/forms/work_in_nursery_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+RSpec.describe Forms::WorkInNursery, type: :model do
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:works_in_nursery) }
+    it { is_expected.to validate_inclusion_of(:works_in_nursery).in_array(described_class::VALID_WORK_IN_NURSERY_OPTIONS) }
+  end
+end

--- a/spec/views/admin/applications/show.html.erb_spec.rb
+++ b/spec/views/admin/applications/show.html.erb_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "admin/applications/show.html.erb", type: :view do
   let(:application_page) { ApplicationPage.new }
-  let(:application) { create(:application, targeted_support_funding_eligibility: true) }
+  let(:application) { create(:application, targeted_support_funding_eligibility: true, private_childcare_provider_urn: "EY98753") }
 
   it "displays targeted_support_funding_eligibility" do
     assign(:application, application)
@@ -20,5 +20,13 @@ RSpec.describe "admin/applications/show.html.erb", type: :view do
     expected = application.created_at.strftime("%R on %d/%m/%Y")
 
     expect(application_page.summary_list["Created at"].value).to eql(expected)
+  end
+
+  it "displays application private_childcare_provider_urn" do
+    assign(:application, application)
+    render
+    application_page.load(rendered)
+
+    expect(application_page.summary_list["Private Childcare Provider URN"].value).to eql("EY98753")
   end
 end


### PR DESCRIPTION
[CNN-111](https://dfedigital.atlassian.net/browse/CN-111)

### Context

- Depends on https://github.com/DFE-Digital/npq-registration/pull/353
- Depends on https://github.com/DFE-Digital/npq-registration/pull/352

### Changes proposed in this pull request

- Adds Do you work in childcare?
- Adds Do you work in a nursery?
- Adds What kind of nursery do you work in?
- Hooks up existing early years questions to these new questions.
- Stores early years data on applications
- Adds early years data in registration wizard answers data

### Guidance to review

- Complete a journey through the public nursery flow in the app
- Complete a journey through the private nursery flow in the app

