### PR TITLE
fix headteacher_status when over five years

### DIFF
--- a/app/lib/services/handle_submission_for_store.rb
+++ b/app/lib/services/handle_submission_for_store.rb
@@ -105,7 +105,7 @@ module Services
           when "yes"
             "yes_in_first_five_years"
           when "no"
-            "no"
+            "yes_over_five_years"
           end
         when "no"
           "no"

--- a/spec/lib/services/handle_submission_for_store_spec.rb
+++ b/spec/lib/services/handle_submission_for_store_spec.rb
@@ -55,5 +55,27 @@ RSpec.describe Services::HandleSubmissionForStore do
         end
       end
     end
+
+    context "when applying for EHCO" do
+      context "a headteacher for over five years" do
+        let(:store) do
+          {
+            "confirmed_email" => user.email,
+            "trn_verified" => false,
+            "trn" => "12345",
+            "course_id" => Course.ehco.first.id,
+            "institution_identifier" => "School-#{school.urn}",
+            "lead_provider_id" => LeadProvider.all.sample.id,
+            "aso_headteacher" => "yes",
+            "aso_new_headteacher" => "no",
+          }
+        end
+
+        it "returns headteacher_status as yes_over_five_years" do
+          subject.call
+          expect(user.applications.first.reload.headteacher_status).to eq "yes_over_five_years"
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

- Bug when a headteacher of over five years applies, headteacher status would be incorrect

### Changes proposed in this pull request

- When headteacher of over five year applies headteacher status is now correctly set to `yes_over_five_years`

### Guidance to review

- Apply for ECHO as headteacher with over 5 years as headteacher
- Application should result in headteacher status of `yes_over_five_years`