### PR TITLE
[CPDLP-1336] Send cohort to ECF on submission

### DIFF
--- a/app/lib/services/ecf/npq_profile_creator.rb
+++ b/app/lib/services/ecf/npq_profile_creator.rb
@@ -23,6 +23,7 @@ module Services
           employer_name: application.employer_name,
           employment_role: application.employment_role,
           targeted_support_funding_eligibility: application.targeted_support_funding_eligibility,
+          cohort: application.cohort,
           relationships: {
             user: ecf_user,
             npq_course: ecf_npq_course,

--- a/spec/lib/services/ecf/npq_profile_creator_spec.rb
+++ b/spec/lib/services/ecf/npq_profile_creator_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Services::Ecf::NpqProfileCreator do
       eligible_for_funding: true,
       funding_choice: "trust",
       targeted_support_funding_eligibility: true,
+      cohort: 2022,
     )
   end
 
@@ -73,6 +74,7 @@ RSpec.describe Services::Ecf::NpqProfileCreator do
             employer_name: application.employer_name,
             employment_role: application.employment_role,
             targeted_support_funding_eligibility: true,
+            cohort: 2022,
           },
         },
       }.to_json


### PR DESCRIPTION
### Context

- https://dfedigital.atlassian.net/browse/CPDLP-1336
- Depends on https://github.com/DFE-Digital/early-careers-framework/pull/2082
- When sending over application to ECF the cohort is not currently included
- Therefore ECF is not able to determine which cohort the application is associated with

### Changes proposed in this pull request

- On submission of application send over the cohort to ECF

### Guidance to review

- Locally you can run this branch with mainline of ECF
- Point NPQ app to ECF app
- Submit an application
- Should see new application with specified cohort, defaults to `2022`