### PR TITLE
Check funding eligibility for Early Years

### DIFF
--- a/app/lib/forms/choose_your_npq.rb
+++ b/app/lib/forms/choose_your_npq.rb
@@ -28,7 +28,7 @@ module Forms
         :about_ehco
       elsif !wizard.query_store.inside_catchment?
         :funding_your_npq
-      elsif wizard.query_store.works_in_school? && eligible_for_funding?
+      elsif possible_school_funding? || possible_ey_funding?
         :possible_funding
       else
         :funding_your_npq
@@ -94,6 +94,14 @@ module Forms
       if course.blank?
         errors.add(:course_id, :invalid)
       end
+    end
+
+    def possible_school_funding?
+      wizard.query_store.works_in_school? && eligible_for_funding?
+    end
+
+    def possible_ey_funding?
+      Services::EarlyYearsFundingChecker.new(wizard.query_store, course_id).run
     end
   end
 end

--- a/app/lib/services/early_years_funding_checker.rb
+++ b/app/lib/services/early_years_funding_checker.rb
@@ -1,0 +1,15 @@
+module Services
+  class EarlyYearsFundingChecker
+    def initialize(query_store, course_id)
+      @query_store = query_store
+      @course = Course.find_by(id: course_id)
+    end
+
+    def run
+      @query_store.inside_catchment? &&
+        @query_store.works_in_private_childcare_provider? &&
+        @query_store.store["institution_identifier"].present? &&
+        @course.eyl?
+    end
+  end
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -16,4 +16,8 @@ class Course < ApplicationRecord
   def ehco?
     name == "The Early Headship Coaching Offer"
   end
+
+  def eyl?
+    name == "NPQ Early Years Leadership (NPQEYL)"
+  end
 end

--- a/app/views/registration_wizard/possible_funding.html.erb
+++ b/app/views/registration_wizard/possible_funding.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-  You may qualify for DfE scholarship funding
+  If your provider accepts your application, you’ll qualify for DfE funding
 <% end %>
 
 <% content_for :before_content do %>
@@ -11,15 +11,21 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">You may qualify for DfE scholarship funding</h1>
+    <h1 class="govuk-heading-xl">If your provider accepts your application, you’ll qualify for DfE funding</h1>
 
-    <p class="govuk-body">
-      DfE scholarship funding may be available for the <%= @form.course.name %> course you have selected.
-    </p>
+    <% if Services::EarlyYearsFundingChecker.new(@wizard.query_store, @wizard.store['course_id']).run %>
+      <p class="govuk-body">From the information you have provided, DfE scholarship funding should be available for the <strong>NPQ Early Years Leadership (NPQEYL)</strong>.</p>
 
-    <p class="govuk-body">
-      Your training provider will give you more details and confirm if you qualify for funding.
-    </p>
+      <p class="govuk-body">
+        You’ll only be eligible for DfE funding for this NPQ once. If you start this NPQ, and then withdraw or fail, you will not be funded again for the same course.
+      </p>
+    <% else %>
+      <p class="govuk-body"><strong>From the information you have provided, DfE scholarship funding should be available.</strong></p>
+
+      <p class="govuk-body">
+        You’ll only be eligible for DfE funding for each NPQ once. If you start an NPQ, and then withdraw or fail, you will not be funded again for the same course.
+      </p>
+    <% end %>
 
     <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
       <%= f.govuk_submit %>

--- a/spec/features/happy_journeys_non_js_spec.rb
+++ b/spec/features/happy_journeys_non_js_spec.rb
@@ -115,7 +115,8 @@ RSpec.feature "Happy journeys", type: :feature do
     page.choose("NPQ for Senior Leadership (NPQSL)")
     page.click_button("Continue")
 
-    expect(page).to have_text("You may qualify for DfE scholarship funding")
+    expect(page).to have_text("If your provider accepts your application, you’ll qualify for DfE funding")
+    expect(page).to have_text("From the information you have provided, DfE scholarship funding should be available.")
     page.click_button("Continue")
 
     expect(page).to have_text("Select your provider")

--- a/spec/lib/services/early_years_funding_checker_spec.rb
+++ b/spec/lib/services/early_years_funding_checker_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe Services::EarlyYearsFundingChecker do
+  let(:query_store) { Services::QueryStore.new(store: store) }
+
+  subject { described_class.new(query_store, course_id) }
+
+  describe "#run" do
+    context "when candidate is on Early Years register or CMA and wants to do EYL and is not abroad" do
+      let(:course_id) { 9 }
+      let(:store) do
+        {
+          "teacher_catchment" => "england",
+          "works_in_school" => "no",
+          "works_in_childcare" => "yes",
+          "works_in_nursery" => "yes",
+          "kind_of_nursery" => "private_nursery",
+          "has_ofsted_urn" => "no",
+          "institution_identifier" => "PrivateChildcareProvider-EY456789",
+        }
+      end
+
+      it "returns true" do
+        expect(subject.run).to be true
+      end
+    end
+
+    context "when does not meet all the criteria" do
+      let(:course_id) { 4 }
+      let(:store) do
+        {
+          "teacher_catchment" => "england",
+          "works_in_school" => "no",
+          "works_in_childcare" => "yes",
+          "works_in_nursery" => "yes",
+          "kind_of_nursery" => "private_nursery",
+          "has_ofsted_urn" => "yes",
+          "institution_identifier" => "PrivateChildcareProvider-EY456789",
+        }
+      end
+
+      it "returns false" do
+        expect(subject.run).to be false
+      end
+    end
+  end
+end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe Course do
+  describe "#eyl?" do
+    context "when the course name is NPQEYL" do
+      let(:course) { described_class.new(name: "NPQ Early Years Leadership (NPQEYL)") }
+
+      it "returns true" do
+        expect(course.eyl?).to be true
+      end
+    end
+
+    context "when the course name is not NPQEYL" do
+      let(:course) { described_class.new(name: "something") }
+
+      it "returns false" do
+        expect(course.eyl?).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

[Ticket](https://dfedigital.atlassian.net/browse/CN-98)

We want to add funding eligibility for Early Years when candidates:
1. are on the Early Years register or CMA
2. want to do EYL
3. are not abroad

### Changes proposed in this pull request

1. Update the copy for school funding
2. Add copy for Early Years funding
3. Create a service to check the funding eligibility for Early Years, based on the candidate's answers


### Guidance to review

