### PR TITLE
[CN-99] Add funding ineligibility flow

### DIFF
--- a/app/controllers/registration_wizard_controller.rb
+++ b/app/controllers/registration_wizard_controller.rb
@@ -2,7 +2,8 @@ class RegistrationWizardController < ApplicationController
   def show
     @wizard = RegistrationWizard.new(current_step: params[:step].underscore,
                                      store: store,
-                                     request: request)
+                                     request: request,
+                                     params: wizard_params)
 
     @form = @wizard.form
     @form.flag_as_changing_answer if params[:changing_answer] == "1"

--- a/app/lib/forms/aso_new_headteacher.rb
+++ b/app/lib/forms/aso_new_headteacher.rb
@@ -44,6 +44,7 @@ module Forms
       Services::FundingEligibility.new(
         course: course,
         institution: institution,
+        inside_catchment: wizard.query_store.inside_catchment?,
         new_headteacher: new_headteacher?,
       ).funded?
     end

--- a/app/lib/forms/choose_your_npq.rb
+++ b/app/lib/forms/choose_your_npq.rb
@@ -26,8 +26,6 @@ module Forms
         end
       elsif course.ehco?
         :about_ehco
-      elsif !wizard.query_store.inside_catchment?
-        :funding_your_npq
       elsif wizard.query_store.works_in_school? && eligible_for_funding?
         :possible_funding
       else
@@ -74,6 +72,7 @@ module Forms
       Services::FundingEligibility.new(
         course: previous_course,
         institution: institution,
+        inside_catchment: inside_catchment?,
         new_headteacher: new_headteacher?,
       ).funded?
     end
@@ -82,6 +81,7 @@ module Forms
       Services::FundingEligibility.new(
         course: course,
         institution: institution,
+        inside_catchment: inside_catchment?,
         new_headteacher: new_headteacher?,
       ).funded?
     end
@@ -89,6 +89,8 @@ module Forms
     def new_headteacher?
       wizard.store["aso_headteacher"] == "yes" && wizard.store["aso_new_headteacher"] == "yes"
     end
+
+    delegate :inside_catchment?, to: :query_store
 
     def validate_course_exists
       if course.blank?

--- a/app/lib/forms/choose_your_npq.rb
+++ b/app/lib/forms/choose_your_npq.rb
@@ -86,11 +86,7 @@ module Forms
       ).funded?
     end
 
-    def new_headteacher?
-      wizard.store["aso_headteacher"] == "yes" && wizard.store["aso_new_headteacher"] == "yes"
-    end
-
-    delegate :inside_catchment?, to: :query_store
+    delegate :new_headteacher?, :inside_catchment?, to: :query_store
 
     def validate_course_exists
       if course.blank?

--- a/app/lib/forms/choose_your_npq.rb
+++ b/app/lib/forms/choose_your_npq.rb
@@ -20,24 +20,42 @@ module Forms
         elsif course.aso?
           :about_aso
         elsif previously_eligible_for_funding? && !eligible_for_funding?
-          :funding_your_npq
+          if ineligible_institution_type?
+            :your_work
+          else
+            :ineligible_for_funding
+          end
         else
           :check_answers
         end
       elsif course.ehco?
         :about_ehco
-      elsif wizard.query_store.works_in_school? && eligible_for_funding?
-        :possible_funding
+      elsif wizard.query_store.works_in_childcare? || wizard.query_store.works_in_school?
+        if eligible_for_funding?
+          :possible_funding
+        else
+          :ineligible_for_funding
+        end
+      elsif ineligible_institution_type?
+        :your_work
       else
-        :funding_your_npq
+        :ineligible_for_funding
       end
     end
 
     def previous_step
       if query_store.inside_catchment? && query_store.works_in_school?
         :choose_school
+      elsif query_store.inside_catchment? && query_store.works_in_childcare?
+        if query_store.works_in_nursery? && query_store.works_in_public_childcare_provider?
+          :choose_childcare_provider
+        elsif query_store.has_ofsted_urn?
+          :choose_private_childcare_provider
+        else
+          :have_ofsted_urn
+        end
       else
-        :qualified_teacher_check
+        :work_in_childcare
       end
     end
 
@@ -77,15 +95,20 @@ module Forms
       ).funded?
     end
 
-    def eligible_for_funding?
-      Services::FundingEligibility.new(
+    def funding_eligibility_calculator
+      @funding_eligibility_calculator ||= Services::FundingEligibility.new(
         course: course,
         institution: institution,
         inside_catchment: inside_catchment?,
         new_headteacher: new_headteacher?,
-      ).funded?
+      )
     end
 
+    def eligible_for_funding?
+      funding_eligibility_calculator.funded?
+    end
+
+    delegate :ineligible_institution_type?, to: :funding_eligibility_calculator
     delegate :new_headteacher?, :inside_catchment?, to: :query_store
 
     def validate_course_exists

--- a/app/lib/forms/choose_your_provider.rb
+++ b/app/lib/forms/choose_your_provider.rb
@@ -66,10 +66,7 @@ module Forms
       wizard.store["institution_identifier"]
     end
 
-    def new_headteacher?
-      wizard.store["aso_headteacher"] == "yes" && wizard.store["aso_new_headteacher"] == "yes"
-    end
-    delegate :inside_catchment?, to: :query_store
+    delegate :new_headteacher?, :inside_catchment?, to: :query_store
 
     def validate_lead_provider_exists
       if lead_provider.blank?

--- a/app/lib/forms/choose_your_provider.rb
+++ b/app/lib/forms/choose_your_provider.rb
@@ -57,6 +57,7 @@ module Forms
       Services::FundingEligibility.new(
         course: course,
         institution: institution(source: institution_identifier),
+        inside_catchment: inside_catchment?,
         new_headteacher: new_headteacher?,
       ).funded?
     end
@@ -68,6 +69,7 @@ module Forms
     def new_headteacher?
       wizard.store["aso_headteacher"] == "yes" && wizard.store["aso_new_headteacher"] == "yes"
     end
+    delegate :inside_catchment?, to: :query_store
 
     def validate_lead_provider_exists
       if lead_provider.blank?

--- a/app/lib/forms/choose_your_provider.rb
+++ b/app/lib/forms/choose_your_provider.rb
@@ -14,11 +14,7 @@ module Forms
     end
 
     def next_step
-      if wizard.query_store.works_in_school?
-        :share_provider
-      else
-        :your_work
-      end
+      :share_provider
     end
 
     def previous_step

--- a/app/lib/forms/funding_your_npq.rb
+++ b/app/lib/forms/funding_your_npq.rb
@@ -17,7 +17,7 @@ module Forms
     end
 
     def previous_step
-      :choose_your_npq
+      :ineligible_for_funding
     end
 
     def course

--- a/app/lib/forms/have_ofsted_urn.rb
+++ b/app/lib/forms/have_ofsted_urn.rb
@@ -20,7 +20,7 @@ module Forms
     end
 
     def previous_step
-      if wizard.query_store.work_in_nursery?
+      if wizard.query_store.works_in_nursery?
         :kind_of_nursery
       else
         :work_in_nursery

--- a/app/lib/forms/ineligible_for_funding.rb
+++ b/app/lib/forms/ineligible_for_funding.rb
@@ -1,0 +1,55 @@
+module Forms
+  class IneligibleForFunding < Base
+    include Helpers::Institution
+
+    attr_accessor :version
+
+    def self.permitted_params
+      [:version]
+    end
+
+    def next_step
+      :funding_your_npq
+    end
+
+    def previous_step
+      :choose_your_npq
+    end
+
+    def ineligible_template
+      @ineligible_template ||= begin
+        return version if version.present?
+
+        case funding_eligiblity_status_code
+        when Services::FundingEligibility::SCHOOL_OUTSIDE_ENGLAND_OR_CROWN_DEPENDENCIES, Services::FundingEligibility::INELIGIBLE_ESTABLISHMENT_TYPE
+          return 'school/outside_catchment_or_ineligible_establishment'
+        when Services::FundingEligibility::PREVIOUSLY_FUNDED
+          return 'school/has_already_been_funded'
+        when Services::FundingEligibility::EARLY_YEARS_OUTSIDE_ENGLAND_OR_CROWN_DEPENDENCIES, Services::FundingEligibility::NOT_ON_EARLY_YEARS_REGISTER
+          return 'early_years/outside_catchment_or_not_on_early_years_register'
+        when Services::FundingEligibility::EARLY_YEARS_INVALID_NPQ
+          return 'early_years/not_applying_for_NPQEY'
+        when Services::FundingEligibility::NO_INSTITUTION
+          if query_store.works_in_school?
+            return 'school/outside_catchment_or_ineligible_establishment'
+          else
+            return 'early_years/outside_catchment_or_not_on_early_years_register'
+          end
+        end
+      end
+
+      raise RuntimeError, "Missing status code handling: #{funding_eligiblity_status_code}"
+    end
+
+    def funding_eligiblity_status_code
+      @funding_eligiblity_status_code ||= Services::FundingEligibility.new(
+        course: course,
+        institution: institution,
+        inside_catchment: inside_catchment?,
+        new_headteacher: new_headteacher?,
+      ).funding_eligiblity_status_code
+    end
+
+    delegate :course, :new_headteacher?, :inside_catchment?, to: :query_store
+  end
+end

--- a/app/lib/forms/possible_funding.rb
+++ b/app/lib/forms/possible_funding.rb
@@ -11,5 +11,11 @@ module Forms
     def course
       @course ||= Course.find(wizard.store["course_id"])
     end
+
+    def message_template
+      return "private_childcare_provider" if wizard.query_store.works_in_private_childcare_provider?
+
+      "school"
+    end
   end
 end

--- a/app/lib/forms/share_provider.rb
+++ b/app/lib/forms/share_provider.rb
@@ -15,11 +15,7 @@ module Forms
     end
 
     def previous_step
-      if wizard.query_store.works_in_school?
-        :choose_your_provider
-      else
-        :your_work
-      end
+      :choose_your_provider
     end
   end
 end

--- a/app/lib/forms/your_work.rb
+++ b/app/lib/forms/your_work.rb
@@ -9,11 +9,11 @@ module Forms
     end
 
     def next_step
-      :share_provider
+      :funding_your_npq
     end
 
     def previous_step
-      :choose_your_provider
+      :choose_your_npq
     end
   end
 end

--- a/app/lib/services/funding_eligibility.rb
+++ b/app/lib/services/funding_eligibility.rb
@@ -1,13 +1,22 @@
 module Services
   class FundingEligibility
     FUNDED_ELIGIBILITY_RESULT = :funded
+
     NO_INSTITUTION = :no_institution
     INELIGIBLE_ESTABLISHMENT_TYPE = :ineligible_establishment_type
     INELIGIBLE_INSTITUTION_TYPE = :ineligible_institution_type
+    PREVIOUSLY_FUNDED = :previously_funded
+
+    # EHCO
     NOT_NEW_HEADTEACHER_REQUESTING_ASO = :not_new_headteacher_requesting_aso
 
     # School
     SCHOOL_OUTSIDE_ENGLAND_OR_CROWN_DEPENDENCIES = :school_outside_england_or_crown_dependencies
+
+    # Early Years
+    EARLY_YEARS_OUTSIDE_ENGLAND_OR_CROWN_DEPENDENCIES = :early_years_outside_england_or_crown_dependencies
+    NOT_ON_EARLY_YEARS_REGISTER = :not_on_early_years_register
+    EARLY_YEARS_INVALID_NPQ = :early_years_invalid_npq
 
     attr_reader :institution, :course
 
@@ -34,12 +43,19 @@ module Services
           return NOT_NEW_HEADTEACHER_REQUESTING_ASO if course.aso? && !new_headteacher?
 
           FUNDED_ELIGIBILITY_RESULT
+        when "PrivateChildcareProvider"
+          # TODO: implement funding rejection for private childcare providers
+          FUNDED_ELIGIBILITY_RESULT
         when "LocalAuthority"
           FUNDED_ELIGIBILITY_RESULT
         else
           INELIGIBLE_INSTITUTION_TYPE
         end
       end
+    end
+
+    def ineligible_institution_type?
+      [NO_INSTITUTION, INELIGIBLE_INSTITUTION_TYPE].include?(funding_eligiblity_status_code)
     end
 
   private

--- a/app/lib/services/funding_eligibility.rb
+++ b/app/lib/services/funding_eligibility.rb
@@ -6,11 +6,15 @@ module Services
     INELIGIBLE_INSTITUTION_TYPE = :ineligible_institution_type
     NOT_NEW_HEADTEACHER_REQUESTING_ASO = :not_new_headteacher_requesting_aso
 
+    # School
+    SCHOOL_OUTSIDE_ENGLAND_OR_CROWN_DEPENDENCIES = :school_outside_england_or_crown_dependencies
+
     attr_reader :institution, :course
 
-    def initialize(institution:, course:, new_headteacher: false)
+    def initialize(institution:, course:, inside_catchment:, new_headteacher: false)
       @institution = institution
       @course = course
+      @inside_catchment = inside_catchment
       @new_headteacher = new_headteacher
     end
 
@@ -25,6 +29,7 @@ module Services
 
         case institution.class.name
         when "School"
+          return SCHOOL_OUTSIDE_ENGLAND_OR_CROWN_DEPENDENCIES unless inside_catchment?
           return INELIGIBLE_ESTABLISHMENT_TYPE unless eligible_establishment_type_codes.include?(institution.establishment_type_code)
           return NOT_NEW_HEADTEACHER_REQUESTING_ASO if course.aso? && !new_headteacher?
 
@@ -38,6 +43,10 @@ module Services
     end
 
   private
+
+    def inside_catchment?
+      @inside_catchment
+    end
 
     def new_headteacher?
       @new_headteacher

--- a/app/lib/services/handle_submission_for_store.rb
+++ b/app/lib/services/handle_submission_for_store.rb
@@ -126,6 +126,7 @@ module Services
       @funding_eligibility = Services::FundingEligibility.new(
         course: course,
         institution: institution(source: store["institution_identifier"]),
+        inside_catchment: query_store.inside_catchment?,
         new_headteacher: new_headteacher?,
       ).funded?
     end

--- a/app/lib/services/query_store.rb
+++ b/app/lib/services/query_store.rb
@@ -25,17 +25,17 @@ class Services::QueryStore
     store["works_in_childcare?"] == "yes"
   end
 
-  def work_in_nursery?
+  def works_in_nursery?
     store["works_in_nursery"] == "yes"
   end
 
   def works_in_public_childcare_provider?
-    work_in_nursery? &&
+    works_in_nursery? &&
       Forms::KindOfNursery::KIND_OF_NURSERY_PUBLIC_OPTIONS.include?(store["kind_of_nursery"])
   end
 
   def works_in_private_childcare_provider?
-    work_in_nursery? &&
+    works_in_nursery? &&
       Forms::KindOfNursery::KIND_OF_NURSERY_PRIVATE_OPTIONS.include?(store["kind_of_nursery"])
   end
 

--- a/app/lib/services/query_store.rb
+++ b/app/lib/services/query_store.rb
@@ -46,4 +46,8 @@ class Services::QueryStore
   def lead_provider
     @lead_provider ||= LeadProvider.find(store["lead_provider_id"])
   end
+
+  def new_headteacher?
+    store["aso_headteacher"] == "yes" && store["aso_new_headteacher"] == "yes"
+  end
 end

--- a/app/lib/services/query_store.rb
+++ b/app/lib/services/query_store.rb
@@ -29,6 +29,10 @@ class Services::QueryStore
     store["works_in_nursery"] == "yes"
   end
 
+  def has_ofsted_urn?
+    store["has_ofsted_urn"] == "yes"
+  end
+
   def works_in_public_childcare_provider?
     works_in_nursery? &&
       Forms::KindOfNursery::KIND_OF_NURSERY_PUBLIC_OPTIONS.include?(store["kind_of_nursery"])

--- a/app/lib/services/query_store.rb
+++ b/app/lib/services/query_store.rb
@@ -22,7 +22,7 @@ class Services::QueryStore
   end
 
   def works_in_childcare?
-    store["works_in_childcare?"] == "yes"
+    store["works_in_childcare"] == "yes"
   end
 
   def works_in_nursery?

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -13,7 +13,16 @@ class Application < ApplicationRecord
   }
 
   def calculate_funding_eligbility
-    Services::FundingEligibility.new(course: course, institution: school, new_headteacher: new_headteacher?).funded?
+    Services::FundingEligibility.new(
+      course: course,
+      institution: school,
+      inside_catchment: inside_catchment?,
+      new_headteacher: new_headteacher?
+    ).funded?
+  end
+
+  def inside_catchment?
+    %w[england jersey_guernsey_isle_of_man].include?(teacher_catchment)
   end
 
   def new_headteacher?

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -190,9 +190,7 @@ private
     ).funded?
   end
 
-  def new_headteacher?
-    store["aso_headteacher"] == "yes" && store["aso_new_headteacher"] == "yes"
-  end
+  delegate :new_headteacher?, to: :query_store
 
   def course
     Course.find(store["course_id"])

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -252,6 +252,7 @@ private
       your_work
       school_not_in_england
       possible_funding
+      ineligible_for_funding
       funding_your_npq
       share_provider
       check_answers

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -187,6 +187,7 @@ private
     !Services::FundingEligibility.new(
       course: course,
       institution: institution(source: store["institution_identifier"]),
+      inside_catchment: query_store.inside_catchment?,
       new_headteacher: new_headteacher?,
     ).funded?
   end

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -182,8 +182,6 @@ class RegistrationWizard
 private
 
   def needs_funding?
-    return true unless query_store.works_in_school?
-
     !Services::FundingEligibility.new(
       course: course,
       institution: institution(source: store["institution_identifier"]),

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -82,7 +82,7 @@ class RegistrationWizard
                                 value: store["works_in_nursery"].capitalize,
                                 change_step: :work_in_nursery)
 
-        if query_store.work_in_nursery?
+        if query_store.works_in_nursery?
           kind_of_nursery = store["kind_of_nursery"]
 
           array << OpenStruct.new(key: "What kind of nursery do you work in?",

--- a/app/views/registration_wizard/ineligible_for_funding.erb
+++ b/app/views/registration_wizard/ineligible_for_funding.erb
@@ -1,0 +1,11 @@
+<% content_for :title do %>
+  Your initial registration is complete
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "registration_wizard/ineligible_for_funding/#{@form.ineligible_template}", course_name: @form.course.name %>
+
+    <%= govuk_button_link_to "Continue", registration_wizard_show_path(@wizard.next_step_path) %>
+  </div>
+</div>

--- a/app/views/registration_wizard/ineligible_for_funding/early_years/_not_applying_for_NPQEY.html.erb
+++ b/app/views/registration_wizard/ineligible_for_funding/early_years/_not_applying_for_NPQEY.html.erb
@@ -1,0 +1,3 @@
+<h1 class="govuk-heading-xl">DfE scholarship funding is not available</h1>
+
+<p class="govuk-body">Pending Copy</p>

--- a/app/views/registration_wizard/ineligible_for_funding/early_years/_outside_catchment_or_not_on_early_years_register.html.erb
+++ b/app/views/registration_wizard/ineligible_for_funding/early_years/_outside_catchment_or_not_on_early_years_register.html.erb
@@ -1,0 +1,10 @@
+<h1 class="govuk-heading-xl">DfE scholarship funding is not available</h1>
+
+<p class="govuk-body">To be eligible for scholarship funding for the <%= course_name %> you must:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>Work in England, Jersey, Guernsey or the Isle of Man</li>
+  <li>Be registered on the Ofsted childcare and early education register or be registered with a Childminder Agency (CMA)</li>
+</ul>
+
+<p class="govuk-body">You can still register for <%= course_name %> but you need to pay for it another way. To find out more about your funding options please contact your course provider.</p>

--- a/app/views/registration_wizard/ineligible_for_funding/school/_has_already_been_funded.html.erb
+++ b/app/views/registration_wizard/ineligible_for_funding/school/_has_already_been_funded.html.erb
@@ -1,0 +1,9 @@
+<h1 class="govuk-heading-xl">DfE scholarship funding is not available</h1>
+
+<p class="govuk-body">Our records show that you have previously received scholarship funding for <b><%= course_name %></b>. If you have failed or withdrawn from this course, then you are not eligible for scholarship funding for the same NPQ again.</p>
+
+<p class="govuk-body">You can still register for <%= course_name %>, but you need to pay for it another way.</p>
+
+<%= govuk_details(summary_text: "I have not failed or withdrawn from this course") do %>
+  <p class="govuk-body">PENDING COPY</p>
+<% end %>

--- a/app/views/registration_wizard/ineligible_for_funding/school/_outside_catchment_or_ineligible_establishment.html.erb
+++ b/app/views/registration_wizard/ineligible_for_funding/school/_outside_catchment_or_ineligible_establishment.html.erb
@@ -1,0 +1,10 @@
+<h1 class="govuk-heading-xl">DfE scholarship funding is not available</h1>
+
+<p class="govuk-body">To be eligible for scholarship funding for the <%= course_name %> you must work:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>In England, Jersey, Guernsey or the Isle of Man</li>
+  <li>In a state-funded school, trust or 16 to 19 educational setting</li>
+</ul>
+
+<p class="govuk-body">You can still register for <%= course_name %>, but you need to pay for it another way. To find out more about your funding options please contact your course provider.</p>

--- a/app/views/registration_wizard/possible_funding.html.erb
+++ b/app/views/registration_wizard/possible_funding.html.erb
@@ -11,15 +11,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">You may qualify for DfE scholarship funding</h1>
-
-    <p class="govuk-body">
-      DfE scholarship funding may be available for the <%= @form.course.name %> course you have selected.
-    </p>
-
-    <p class="govuk-body">
-      Your training provider will give you more details and confirm if you qualify for funding.
-    </p>
+    <%= render "registration_wizard/possible_funding/#{@form.message_template}", course_name: @form.course.name %>
 
     <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
       <%= f.govuk_submit %>

--- a/app/views/registration_wizard/possible_funding/_private_childcare_provider.html.erb
+++ b/app/views/registration_wizard/possible_funding/_private_childcare_provider.html.erb
@@ -1,0 +1,9 @@
+<h1 class="govuk-heading-xl">If your provider accepts your application, you’ll qualify for DfE funding.</h1>
+
+<p class="govuk-body">
+  <b>From the information you have provided, DfE scholarship funding should be available for the <b><%= course_name %></b>.</b>
+</p>
+
+<p class="govuk-body">
+  You’ll only be eligible for DfE funding for each NPQ once. If you start an NPQ, and then withdraw or fail, you will not be funded again for the same course.
+</p>

--- a/app/views/registration_wizard/possible_funding/_school.html.erb
+++ b/app/views/registration_wizard/possible_funding/_school.html.erb
@@ -1,0 +1,9 @@
+<h1 class="govuk-heading-xl">You may qualify for DfE scholarship funding</h1>
+
+<p class="govuk-body">
+  DfE scholarship funding may be available for the <%= course_name %> course you have selected.
+</p>
+
+<p class="govuk-body">
+  Your training provider will give you more details and confirm if you qualify for funding.
+</p>

--- a/spec/features/happy_journeys_non_js_spec.rb
+++ b/spec/features/happy_journeys_non_js_spec.rb
@@ -262,6 +262,12 @@ RSpec.feature "Happy journeys", type: :feature do
     page.choose("NPQ for Headship (NPQH)")
     page.click_button("Continue")
 
+    expect(page).to have_text("DfE scholarship funding is not available")
+    expect(page).to have_text("To be eligible for scholarship funding for")
+    expect(page).to have_text("In England, Jersey, Guernsey or the Isle of Man")
+    expect(page).to have_text("In a state-funded school, trust or 16 to 19 educational setting")
+    page.click_link("Continue")
+
     expect(page).to have_text("Funding")
     page.choose "My trust is paying"
     page.click_button("Continue")
@@ -748,6 +754,11 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).not_to have_text("Additional Support Offer for new headteachers")
     page.choose("NPQ for Headship (NPQH)")
     page.click_button("Continue")
+
+    expect(page).to have_text("DfE scholarship funding is not available")
+    expect(page).to have_text("In England, Jersey, Guernsey or the Isle of Man")
+    expect(page).to have_text("In a state-funded school, trust or 16 to 19 educational setting")
+    page.click_link("Continue")
 
     expect(page).to have_text("How is your course being paid for?")
     page.choose "My employer is paying"

--- a/spec/features/happy_journeys_spec.rb
+++ b/spec/features/happy_journeys_spec.rb
@@ -113,6 +113,13 @@ RSpec.feature "Happy journeys", type: :feature do
     page.click_button("Continue")
 
     expect(page).to be_axe_clean
+    expect(page).to have_text("DfE scholarship funding is not available")
+    expect(page).to have_text("To be eligible for scholarship funding for")
+    expect(page).to have_text("In England, Jersey, Guernsey or the Isle of Man")
+    expect(page).to have_text("In a state-funded school, trust or 16 to 19 educational setting")
+    page.click_link("Continue")
+
+    expect(page).to be_axe_clean
     expect(page).to have_text("Funding")
     page.choose "My school or college is covering the cost", visible: :all
     page.click_button("Continue")
@@ -249,6 +256,12 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).to have_text("What are you applying for?")
     page.choose("NPQ for Headship (NPQH)", visible: :all)
     page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("DfE scholarship funding is not available")
+    expect(page).to have_text("In England, Jersey, Guernsey or the Isle of Man")
+    expect(page).to have_text("In a state-funded school, trust or 16 to 19 educational setting")
+    page.click_link("Continue")
 
     expect(page).to be_axe_clean
     expect(page).to have_text("Funding")
@@ -424,6 +437,13 @@ RSpec.feature "Happy journeys", type: :feature do
     page.click_button("Continue")
 
     expect(page).to be_axe_clean
+    expect(page).to have_text("DfE scholarship funding is not available")
+    expect(page).to have_text("To be eligible for scholarship funding for")
+    expect(page).to have_text("In England, Jersey, Guernsey or the Isle of Man")
+    expect(page).to have_text("In a state-funded school, trust or 16 to 19 educational setting")
+    page.click_link("Continue")
+
+    expect(page).to be_axe_clean
     expect(page).to have_text("How is your course being paid for?")
     page.choose "I am paying", visible: :all
     page.click_button("Continue")
@@ -541,6 +561,12 @@ RSpec.feature "Happy journeys", type: :feature do
     page.click_button("Continue")
 
     expect(page).to be_axe_clean
+    expect(page).to have_text("Tell us about where you work")
+    page.fill_in "Name of employer", with: "Big company"
+    page.fill_in "Role", with: "Trainer"
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
     expect(page).to have_text("How is your course being paid for?")
     page.choose "My employer is paying", visible: :all
     page.click_button("Continue")
@@ -548,12 +574,6 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).to be_axe_clean
     expect(page).to have_text("Select your provider")
     page.choose("Teach First", visible: :all)
-    page.click_button("Continue")
-
-    expect(page).to be_axe_clean
-    expect(page).to have_text("Tell us about where you work")
-    page.fill_in "Name of employer", with: "Big company"
-    page.fill_in "Role", with: "Trainer"
     page.click_button("Continue")
 
     expect(page).to be_axe_clean
@@ -694,6 +714,12 @@ RSpec.feature "Happy journeys", type: :feature do
     page.choose("NPQ for Senior Leadership (NPQSL)", visible: :all) # Needs changing to an early years course once added
     page.click_button("Continue")
 
+    expect(page).to have_text("DfE scholarship funding is not available")
+    expect(page).to have_text("To be eligible for scholarship funding for")
+    expect(page).to have_text("In England, Jersey, Guernsey or the Isle of Man")
+    expect(page).to have_text("In a state-funded school, trust or 16 to 19 educational setting")
+    page.click_link("Continue")
+
     expect(page).to be_axe_clean
     expect(page).to have_text("How is your course being paid for?")
     page.choose "My employer is paying", visible: :all
@@ -702,12 +728,6 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).to be_axe_clean
     expect(page).to have_text("Select your provider")
     page.choose("Teach First", visible: :all)
-    page.click_button("Continue")
-
-    expect(page).to be_axe_clean
-    expect(page).to have_text("Tell us about where you work")
-    page.fill_in "Name of employer", with: "Big company"
-    page.fill_in "Role", with: "Trainer"
     page.click_button("Continue")
 
     expect(page).to be_axe_clean
@@ -846,19 +866,12 @@ RSpec.feature "Happy journeys", type: :feature do
     page.click_button("Continue")
 
     expect(page).to be_axe_clean
-    expect(page).to have_text("How is your course being paid for?")
-    page.choose "My employer is paying", visible: :all
+    expect(page).to have_text("If your provider accepts your application, you’ll qualify for DfE funding.")
     page.click_button("Continue")
 
     expect(page).to be_axe_clean
     expect(page).to have_text("Select your provider")
     page.choose("Teach First", visible: :all)
-    page.click_button("Continue")
-
-    expect(page).to be_axe_clean
-    expect(page).to have_text("Tell us about where you work")
-    page.fill_in "Name of employer", with: "Big company"
-    page.fill_in "Role", with: "Trainer"
     page.click_button("Continue")
 
     expect(page).to be_axe_clean
@@ -878,7 +891,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(check_answers_page.summary_list["Course"].value).to eql("NPQ for Senior Leadership (NPQSL)")
     expect(check_answers_page.summary_list.key?("Have you been a headteacher for two years or more?")).to be_falsey
     expect(check_answers_page.summary_list.key?("School or college")).to be_falsey
-    expect(check_answers_page.summary_list["How is your NPQ being paid for?"].value).to eql("My employer is paying")
+    expect(check_answers_page.summary_list.key?("How is your NPQ being paid for?")).to be_falsey
 
     allow(ApplicationSubmissionJob).to receive(:perform_later).with(anything)
 

--- a/spec/features/sad_journeys_spec.rb
+++ b/spec/features/sad_journeys_spec.rb
@@ -113,6 +113,12 @@ RSpec.feature "Sad journeys", type: :feature do
     page.click_button("Continue")
 
     expect(page).to be_axe_clean
+    expect(page).to have_text("DfE scholarship funding is not available")
+    expect(page).to have_text("In England, Jersey, Guernsey or the Isle of Man")
+    expect(page).to have_text("In a state-funded school, trust or 16 to 19 educational setting")
+    page.click_link("Continue")
+
+    expect(page).to be_axe_clean
     expect(page).to have_text("Funding")
     page.choose "My trust is paying", visible: :all
     page.click_button("Continue")
@@ -356,6 +362,12 @@ RSpec.feature "Sad journeys", type: :feature do
     page.choose("NPQ for Senior Leadership (NPQSL)", visible: :all) # Needs changing to an early years course once added
     page.click_button("Continue")
 
+    expect(page).to have_text("DfE scholarship funding is not available")
+    expect(page).to have_text("To be eligible for scholarship funding for")
+    expect(page).to have_text("Work in England, Jersey, Guernsey or the Isle of Man")
+    expect(page).to have_text("Be registered on the Ofsted childcare and early education register or be registered with a Childminder Agency (CMA)")
+    page.click_link("Continue")
+
     expect(page).to be_axe_clean
     expect(page).to have_text("How is your course being paid for?")
     page.choose "My employer is paying", visible: :all
@@ -364,12 +376,6 @@ RSpec.feature "Sad journeys", type: :feature do
     expect(page).to be_axe_clean
     expect(page).to have_text("Select your provider")
     page.choose("Teach First", visible: :all)
-    page.click_button("Continue")
-
-    expect(page).to be_axe_clean
-    expect(page).to have_text("Tell us about where you work")
-    page.fill_in "Name of employer", with: "Big company"
-    page.fill_in "Role", with: "Trainer"
     page.click_button("Continue")
 
     expect(page).to be_axe_clean

--- a/spec/lib/forms/choose_your_npq_spec.rb
+++ b/spec/lib/forms/choose_your_npq_spec.rb
@@ -76,27 +76,77 @@ RSpec.describe Forms::ChooseYourNpq, type: :model do
       )
     end
 
-    context "when inside catchment and working in school" do
-      let(:store) { { teacher_catchment: "england", works_in_school: "yes" }.stringify_keys }
+    let(:store) {
+      {
+        teacher_catchment: teacher_catchment,
+        works_in_school: works_in_school,
+        works_in_childcare: works_in_childcare,
+        works_in_nursery: works_in_nursery,
+        kind_of_nursery: kind_of_nursery,
+        has_ofsted_urn: has_ofsted_urn
+      }.stringify_keys
+    }
 
-      it "returns choose_school" do
-        expect(subject.previous_step).to eql(:choose_school)
+    let(:teacher_catchment) { "another" }
+    let(:works_in_school) { "no" }
+    let(:works_in_childcare) { "no" }
+    let(:works_in_nursery) { "no" }
+    let(:kind_of_nursery) { nil }
+    let(:has_ofsted_urn) { "no" }
+
+    context "when inside catchment" do
+      let(:teacher_catchment) { "england" }
+
+      it "returns work_in_childcare" do
+        expect(subject.previous_step).to eql(:work_in_childcare)
       end
-    end
 
-    context "when outside catchment" do
-      let(:store) { { teacher_catchment: "another", works_in_school: "yes" }.stringify_keys }
+      context 'when working in school' do
+        let(:works_in_school) { "yes" }
 
-      it "return qualified_teacher_check" do
-        expect(subject.previous_step).to eql(:qualified_teacher_check)
+        it "returns choose_school" do
+          expect(subject.previous_step).to eql(:choose_school)
+        end
       end
-    end
 
-    context "when outside catchment" do
-      let(:store) { { teacher_catchment: "england", works_in_school: "no" }.stringify_keys }
+      context "when working in childcare" do
+        let(:works_in_childcare) { "yes" }
 
-      it "return qualified_teacher_check" do
-        expect(subject.previous_step).to eql(:qualified_teacher_check)
+        it "return have_ofsted_urn" do
+          expect(subject.previous_step).to eql(:have_ofsted_urn)
+        end
+
+        context "when working in a nursery" do
+          let(:works_in_nursery) { "yes" }
+
+          it "return have_ofsted_urn" do
+            expect(subject.previous_step).to eql(:have_ofsted_urn)
+          end
+
+          context "when working for a public childcare provider" do
+            let(:kind_of_nursery) { Forms::KindOfNursery::KIND_OF_NURSERY_PUBLIC_OPTIONS.sample }
+
+            it "return choose_childcare_provider" do
+              expect(subject.previous_step).to eql(:choose_childcare_provider)
+            end
+          end
+
+          context "when working for a private childcare provider" do
+            let(:kind_of_nursery) { Forms::KindOfNursery::KIND_OF_NURSERY_PRIVATE_OPTIONS.sample }
+
+            it "return have_ofsted_urn" do
+              expect(subject.previous_step).to eql(:have_ofsted_urn)
+            end
+
+            context "when user has declared they have an ofsted URN" do
+              let(:has_ofsted_urn) { "yes" }
+
+              it "return choose_private_childcare_provider" do
+                expect(subject.previous_step).to eql(:choose_private_childcare_provider)
+              end
+            end
+          end
+        end
       end
     end
   end

--- a/spec/lib/services/funding_eligibility_spec.rb
+++ b/spec/lib/services/funding_eligibility_spec.rb
@@ -3,8 +3,9 @@ require "rails_helper"
 RSpec.describe Services::FundingEligibility do
   let(:institution) { school }
   let(:course) { Course.all.find { |c| !c.aso? } }
+  let(:inside_catchment) { true }
 
-  subject { described_class.new(institution: institution, course: course) }
+  subject { described_class.new(institution: institution, course: course, inside_catchment: inside_catchment) }
 
   describe ".funded? && .funding_eligiblity_status_code" do
     context "in the special URN list" do
@@ -45,6 +46,7 @@ RSpec.describe Services::FundingEligibility do
                 described_class.new(
                   institution: institution,
                   course: course,
+                  inside_catchment: inside_catchment,
                   new_headteacher: true,
                 )
               end
@@ -75,6 +77,7 @@ RSpec.describe Services::FundingEligibility do
                 described_class.new(
                   institution: institution,
                   course: course,
+                  inside_catchment: inside_catchment,
                   new_headteacher: true,
                 )
               end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -7,7 +7,12 @@ RSpec.describe Application do
     subject { build(:application) }
 
     it "calls Services::FundingEligibility with correct params" do
-      allow(Services::FundingEligibility).to receive(:new).with(course: subject.course, institution: subject.school, new_headteacher: subject.new_headteacher?).and_return(mock_funding_service)
+      allow(Services::FundingEligibility).to receive(:new).with(
+        course: subject.course,
+        institution: subject.school,
+        inside_catchment: subject.inside_catchment?,
+        new_headteacher: subject.new_headteacher?
+      ).and_return(mock_funding_service)
 
       subject.calculate_funding_eligbility
 

--- a/spec/models/registration_wizard_spec.rb
+++ b/spec/models/registration_wizard_spec.rb
@@ -38,12 +38,13 @@ RSpec.describe RegistrationWizard do
   describe "#answers" do
     let(:school) { create(:school, establishment_type_code: "1") }
 
-    context "when ASO is selected course and not eligible for funding" do
+    context "when ASO is selected course and is eligible for funding" do
       let(:store) do
         {
           "date_of_birth" => 30.years.ago,
           "works_in_school" => "yes",
           "institution_identifier" => "School-#{school.urn}",
+          "teacher_catchment" => "england",
           "course_id" => Course.find_by(name: "Additional Support Offer for new headteachers").id,
           "lead_provider_id" => LeadProvider.all.sample.id,
           "funding_choice" => "school",
@@ -55,11 +56,11 @@ RSpec.describe RegistrationWizard do
       end
 
       it "does not show How is your NPQ being paid for?" do
-        expect(subject.answers.map(&:key)).not_to include("How is your NPQ being paid for?")
+        expect(subject.answers.map(&:key)).to_not include("How is your NPQ being paid for?")
       end
 
       it "does not show ASO funding option" do
-        expect(subject.answers.find { |el| el.key == "How is the Additional Support Offer being paid for?" }).to be_nil
+        expect(subject.answers.map(&:key)).to_not include("How is the Additional Support Offer being paid for?")
       end
     end
 


### PR DESCRIPTION
### Context

We want to inform people that they are ineligible for funding.

### Changes proposed in this pull request

This adds in a pathway through the app that informs the user that they are not eligible for funding and what conditions need to be met to achieve funding. It doesn’t specify exactly which condition they validated, but it should help.

Along with that, the “where do you work” page has been moved forwards to occur at the same point in the flow as the ineligible for funding pages as it largely fulfils the same role.

For now all applicants with a PrivateChildcareProvider institution will return funded? as true. This is a temporary measure, for now they will all be approved. This will be adjusted so they reflect the actual rules in subsequent PRs.

### Guidance to review

The ineligible for funding pages within the flowchart cannot all be reached yet as two aspects of the funding are not implemented, cohort 2 and an EY applicant not doing an EY NPQ. Other than this though, the two other NPQ ineligibility pages should be reachable. Along with that the tell us about where you work page should be reached as described in the Lucid flowchart attached to the epic.

To review copy for this page you can visit these paths to review each ineligibility message directly:
- `/registration/ineligible-for-funding?registration_wizard[version]=school/has_already_been_funded`
- `/registration/ineligible-for-funding?registration_wizard[version]=school/outside_catchment_or_ineligible_establishment`
- `/registration/ineligible-for-funding?registration_wizard[version]=early_years/outside_catchment_or_not_on_early_years_register`
- `/registration/ineligible-for-funding?registration_wizard[version]=early_years/not_applying_for_NPQEY`

