### PR TITLE
[CN-122] Turn registration back on

### DIFF
--- a/app/lib/services/feature.rb
+++ b/app/lib/services/feature.rb
@@ -6,7 +6,7 @@ module Services
 
     class << self
       def registration_closed?
-        features_enabled? && registration_closed_due_to_timing?
+        features_enabled? && (registration_closed_due_to_timing? || registration_closed_via_env_variable?)
       end
 
       # We only enable these feature in prod.
@@ -16,6 +16,10 @@ module Services
 
       def registration_closed_due_to_timing?
         REGISTRATION_CLOSED.cover?(Time.zone.now)
+      end
+
+      def registration_closed_via_env_variable?
+        ENV.fetch("REGISTRATION_CLOSED", "false") == "true"
       end
     end
   end

--- a/app/lib/services/feature.rb
+++ b/app/lib/services/feature.rb
@@ -1,15 +1,21 @@
 module Services
   class Feature
-    REGISTRATION_CLOSED = (Time.zone.parse("12 March 00:00")..).freeze
+    REGISTRATION_CLOSE_DATE = Time.zone.parse("12 March 2022 00:00")
+    REGISTRATION_OPEN_DATE = Time.zone.parse("6 June 2022 12:00")
+    REGISTRATION_CLOSED = (REGISTRATION_CLOSE_DATE..REGISTRATION_OPEN_DATE).freeze
 
     class << self
       def registration_closed?
-        features_enabled? && REGISTRATION_CLOSED.cover?(Time.zone.now)
+        features_enabled? && registration_closed_due_to_timing?
       end
 
       # We only enable these feature in prod.
       def features_enabled?
         ENV["SERVICE_ENV"] == "production"
+      end
+
+      def registration_closed_due_to_timing?
+        REGISTRATION_CLOSED.cover?(Time.zone.now)
       end
     end
   end

--- a/spec/lib/services/feature_spec.rb
+++ b/spec/lib/services/feature_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 RSpec.describe Services::Feature do
   describe "#registration_closed?" do
-    let(:start_time) { Services::Feature::REGISTRATION_CLOSED.first }
-    let(:end_time)   { Services::Feature::REGISTRATION_CLOSED.last }
+    let(:start_time) { Services::Feature::REGISTRATION_CLOSE_DATE }
+    let(:end_time)   { Services::Feature::REGISTRATION_OPEN_DATE }
 
     before do
       allow(Services::Feature).to receive(:features_enabled?).and_return(true)
@@ -25,14 +25,12 @@ RSpec.describe Services::Feature do
       end
     end
 
-    # Service doesn't have a re-open date currently.
-    #
-    # context "after the closure period" do
-    #   before { travel_to end_time + 1 }
+    context "after the closure period" do
+      before { travel_to end_time + 1 }
 
-    #   it "returns false" do
-    #     expect(described_class.registration_closed?).to eql(false)
-    #   end
-    # end
+      it "returns false" do
+        expect(described_class.registration_closed?).to eql(false)
+      end
+    end
   end
 end

--- a/spec/lib/services/feature_spec.rb
+++ b/spec/lib/services/feature_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Services::Feature do
 
     before do
       allow(Services::Feature).to receive(:features_enabled?).and_return(true)
+      allow(ENV).to receive(:fetch).with("REGISTRATION_CLOSED", "false").and_return("false")
     end
 
     context "before the closure period" do
@@ -14,6 +15,16 @@ RSpec.describe Services::Feature do
 
       it "returns false" do
         expect(described_class.registration_closed?).to eql(false)
+      end
+
+      context "when REGISTRATION_CLOSED env variable is set" do
+        before do
+          allow(ENV).to receive(:fetch).with("REGISTRATION_CLOSED", "false").and_return("true")
+        end
+
+        it "returns true" do
+          expect(described_class.registration_closed?).to eql(true)
+        end
       end
     end
 
@@ -23,6 +34,16 @@ RSpec.describe Services::Feature do
       it "returns true" do
         expect(described_class.registration_closed?).to eql(true)
       end
+
+      context "when REGISTRATION_CLOSED env variable is set" do
+        before do
+          allow(ENV).to receive(:fetch).with("REGISTRATION_CLOSED", "false").and_return("true")
+        end
+
+        it "returns true" do
+          expect(described_class.registration_closed?).to eql(true)
+        end
+      end
     end
 
     context "after the closure period" do
@@ -30,6 +51,16 @@ RSpec.describe Services::Feature do
 
       it "returns false" do
         expect(described_class.registration_closed?).to eql(false)
+      end
+
+      context "when REGISTRATION_CLOSED env variable is set" do
+        before do
+          allow(ENV).to receive(:fetch).with("REGISTRATION_CLOSED", "false").and_return("true")
+        end
+
+        it "returns true" do
+          expect(described_class.registration_closed?).to eql(true)
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

In preparation for the relaunch next month I'm preparing this PR that will reopen registration once merged and deployed.

### Changes proposed in this pull request

- Removes permanent closing
- Adds in an env variable for closing registration arbitrarily if required.
