### PR TITLE
[CN-97] Update the copy in the funding your npq page

### DIFF
--- a/app/lib/forms/funding_your_npq.rb
+++ b/app/lib/forms/funding_your_npq.rb
@@ -26,11 +26,11 @@ module Forms
 
     def options
       [
-        (option("school", "My school or college is covering the cost", link_errors: true) if works_in_school?),
+        (option("school", "My workplace is covering the cost", link_errors: true) if works_in_school?),
         (option("trust", "My trust is paying") if works_in_school? && inside_catchment?),
         (option("employer", "My employer is paying") if !inside_catchment? || !works_in_school?),
         option("self", "I am paying"),
-        option("another", "My NPQ is being paid in another way", "For example, I am sharing the costs with my school or college"),
+        option("another", "My NPQ is being paid in another way", "For example, I am sharing the costs with my workplace"),
       ].compact.freeze
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,14 +6,14 @@ en:
     attributes:
       forms/funding_your_npq:
         funding_options:
-          school: My school or college is covering the cost
+          school: My workplace is covering the cost
           trust: My trust is paying
           employer: My employer is paying
           self: I am paying
           another: My NPQ is being paid in another way
       forms/funding_your_aso:
         funding_options:
-          school: My school or college is covering the cost
+          school: My workplace is covering the cost
           trust: My trust is paying
           self: I am paying
           another: The Additional Support Offer is being paid in another way

--- a/spec/features/happy_journeys_spec.rb
+++ b/spec/features/happy_journeys_spec.rb
@@ -114,7 +114,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
     expect(page).to be_axe_clean
     expect(page).to have_text("Funding")
-    page.choose "My school or college is covering the cost", visible: :all
+    page.choose "My workplace is covering the cost", visible: :all
     page.click_button("Continue")
 
     expect(page).to be_axe_clean
@@ -139,7 +139,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(check_answers_page.summary_list["Course"].value).to eql("NPQ for Senior Leadership (NPQSL)")
     expect(check_answers_page.summary_list.key?("Have you been a headteacher for two years or more?")).to be_falsey
     expect(check_answers_page.summary_list["School or college"].value).to eql("open manchester school")
-    expect(check_answers_page.summary_list["How is your NPQ being paid for?"].value).to eql("My school or college is covering the cost")
+    expect(check_answers_page.summary_list["How is your NPQ being paid for?"].value).to eql("My workplace is covering the cost")
 
     allow(ApplicationSubmissionJob).to receive(:perform_later).with(anything)
 


### PR DESCRIPTION
### Context

We want to update the copy in the funding your npq page

### Changes proposed in this pull request

Updated the copy based on the latest lucid flows.

I could see the same copy in the lucid flows for the `funding your aso` page too, so both pages were updated to keep the answers consistent.

### Guidance to review

