### PR TITLE
[CN-101] Display EHCO NPQ to all applicants

### DIFF
--- a/app/lib/forms/choose_your_npq.rb
+++ b/app/lib/forms/choose_your_npq.rb
@@ -69,7 +69,7 @@ module Forms
     end
 
     def course
-      Course.find_by(id: course_id)
+      courses.find_by(id: course_id)
     end
 
   private

--- a/app/lib/forms/choose_your_npq.rb
+++ b/app/lib/forms/choose_your_npq.rb
@@ -75,11 +75,7 @@ module Forms
   private
 
     def courses
-      if wizard.query_store.inside_catchment? && wizard.query_store.works_in_school?
-        Course.where(display: true).order(:position)
-      else
-        Course.where(display: true).order(:position) - Course.ehco
-      end
+      Course.where(display: true).order(:position)
     end
 
     def previous_course

--- a/spec/lib/forms/choose_your_npq_spec.rb
+++ b/spec/lib/forms/choose_your_npq_spec.rb
@@ -150,4 +150,92 @@ RSpec.describe Forms::ChooseYourNpq, type: :model do
       end
     end
   end
+
+  describe ".options" do
+    subject do
+      form.options
+    end
+
+    let(:form) { described_class.new }
+
+    let(:store) do
+      {
+        "works_in_school" => works_in_school,
+        "teacher_catchment" => teacher_catchment,
+        "works_in_childcare" => works_in_childcare,
+      }
+    end
+
+    let(:works_in_school) { "no" }
+    let(:teacher_catchment) { "scotland" }
+    let(:works_in_childcare) { "no" }
+
+    let(:expected_courses) { Course.where(display: true) }
+
+    before do
+      form.wizard = RegistrationWizard.new(
+        current_step: :choose_your_npq,
+        store: store,
+        request: nil,
+      )
+    end
+
+    context "when inside catchment" do
+      let(:teacher_catchment) { "england" }
+
+      context "when not working in school or childcare" do
+        let(:works_in_school) { "no" }
+        let(:works_in_childcare) { "no" }
+
+        it "returns all options" do
+          expect(subject.map(&:value).sort).to eq(expected_courses.pluck(:id).sort)
+        end
+      end
+
+      context "when working in a school" do
+        let(:works_in_school) { "yes" }
+
+        it "returns all options" do
+          expect(subject.map(&:value).sort).to eq(expected_courses.pluck(:id).sort)
+        end
+      end
+
+      context "when working in childcare" do
+        let(:works_in_childcare) { "yes" }
+
+        it "returns all options" do
+          expect(subject.map(&:value).sort).to eq(expected_courses.pluck(:id).sort)
+        end
+      end
+    end
+
+    context "when outside catchment" do
+      let(:teacher_catchment) { "scotland" }
+
+      context "when not working in school or childcare" do
+        let(:works_in_school) { "no" }
+        let(:works_in_childcare) { "no" }
+
+        it "returns all options" do
+          expect(subject.map(&:value).sort).to eq(expected_courses.pluck(:id).sort)
+        end
+      end
+
+      context "when working in a school" do
+        let(:works_in_school) { "yes" }
+
+        it "returns all options" do
+          expect(subject.map(&:value).sort).to eq(expected_courses.pluck(:id).sort)
+        end
+      end
+
+      context "when working in childcare" do
+        let(:works_in_childcare) { "yes" }
+
+        it "returns all options" do
+          expect(subject.map(&:value).sort).to eq(expected_courses.pluck(:id).sort)
+        end
+      end
+    end
+  end
 end

--- a/spec/lib/forms/choose_your_npq_spec.rb
+++ b/spec/lib/forms/choose_your_npq_spec.rb
@@ -13,6 +13,16 @@ RSpec.describe Forms::ChooseYourNpq, type: :model do
       subject.valid?
       expect(subject.errors[:course_id]).to be_blank
     end
+
+    it "course for course_id must be available to applicant" do
+      subject.course_id = Course.where(display: false).first
+      subject.valid?
+      expect(subject.errors[:course_id]).to be_present
+
+      subject.course_id = Course.first.id
+      subject.valid?
+      expect(subject.errors[:course_id]).to be_blank
+    end
   end
 
   describe "#next_step" do


### PR DESCRIPTION
### Context

All applicants should see the EHCO NPQ on the choose your NPQ page.

### Changes proposed in this pull request

- Remove exception that removed the EHCO NPQ from the list of available NPQs
- Add specs to verify correctness of choose your NPQ options

### Guidance to review

1. Select a non-england catchment or say "No" to the "Do you work in a school question"
2. Continue through the form till the Choose your NPQ page
3. Confirm that EHCO is present

