### PR TITLE
[CN-91] Fix bug where NPQH info showed for EHCO applicants

### DIFF
--- a/app/lib/forms/confirmation.rb
+++ b/app/lib/forms/confirmation.rb
@@ -16,8 +16,8 @@ module Forms
       wizard.store["submitted"] = true
     end
 
-    def display_ehco_information?
-      course.ehco?
+    def display_npqh_information?
+      course.npqh?
     end
 
     def ehco_more_information_url

--- a/app/views/registration_wizard/confirmation.html.erb
+++ b/app/views/registration_wizard/confirmation.html.erb
@@ -20,7 +20,7 @@
 
     <p class="govuk-body">They will provide details of timings, costs and deadlines.</p>
 
-    <% if @form.display_ehco_information?  %>
+    <% if @form.display_npqh_information?  %>
       <h2 class="govuk-heading-m">Early Headship Coaching Offer</h2>
 
       <p class="govuk-body">The Early Headship Coaching Offer is a package of structured face-to-face support for new headteachers.</p>

--- a/spec/features/happy_journeys_non_js_spec.rb
+++ b/spec/features/happy_journeys_non_js_spec.rb
@@ -300,7 +300,7 @@ RSpec.feature "Happy journeys", type: :feature do
     page.click_button("Submit")
 
     expect(page).to have_text("Your initial registration is complete")
-    expect(page).to_not have_text("The Early Headship Coaching Offer is a package of structured face-to-face support for new headteachers.")
+    expect(page).to have_text("The Early Headship Coaching Offer is a package of structured face-to-face support for new headteachers.")
 
     expect(User.count).to eql(1)
 
@@ -474,7 +474,7 @@ RSpec.feature "Happy journeys", type: :feature do
     page.click_button("Submit")
 
     expect(page).to have_text("Your initial registration is complete")
-    expect(page).to have_text("The Early Headship Coaching Offer is a package of structured face-to-face support for new headteachers.")
+    expect(page).to_not have_text("The Early Headship Coaching Offer is a package of structured face-to-face support for new headteachers.")
 
     expect(User.count).to eql(1)
 
@@ -648,7 +648,7 @@ RSpec.feature "Happy journeys", type: :feature do
     page.click_button("Submit")
 
     expect(page).to have_text("Your initial registration is complete")
-    expect(page).to have_text("The Early Headship Coaching Offer is a package of structured face-to-face support for new headteachers.")
+    expect(page).to_not have_text("The Early Headship Coaching Offer is a package of structured face-to-face support for new headteachers.")
 
     expect(User.count).to eql(1)
 
@@ -791,7 +791,7 @@ RSpec.feature "Happy journeys", type: :feature do
     page.click_button("Submit")
 
     expect(page).to have_text("Your initial registration is complete")
-    expect(page).to_not have_text("The Early Headship Coaching Offer is a package of structured face-to-face support for new headteachers.")
+    expect(page).to have_text("The Early Headship Coaching Offer is a package of structured face-to-face support for new headteachers.")
 
     expect(User.count).to eql(1)
 

--- a/spec/features/happy_journeys_spec.rb
+++ b/spec/features/happy_journeys_spec.rb
@@ -298,7 +298,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
     expect(page).to be_axe_clean
     expect(page).to have_text("Your initial registration is complete")
-    expect(page).to_not have_text("The Early Headship Coaching Offer is a package of structured face-to-face support for new headteachers.")
+    expect(page).to have_text("The Early Headship Coaching Offer is a package of structured face-to-face support for new headteachers.")
 
     expect(User.count).to eql(1)
 


### PR DESCRIPTION
### Context

This was displaying for the wrong applicants.

### Changes proposed in this pull request

Display for the correct applicants.

### Guidance to review

Go through the flow applying for the NPQH NPQ and see that the NPQH information is displayed on the confirmation page.

