### PR TITLE
[CN-95] Show reduced list of LeadProviders for NPQEYL and NPQLL NPQs

### DIFF
--- a/app/lib/forms/choose_your_provider.rb
+++ b/app/lib/forms/choose_your_provider.rb
@@ -32,7 +32,7 @@ module Forms
     end
 
     def options
-      LeadProvider.all.each_with_index.map do |provider, index|
+      providers.each_with_index.map do |provider, index|
         OpenStruct.new(value: provider.id,
                        text: provider.name,
                        link_errors: index.zero?)
@@ -40,7 +40,7 @@ module Forms
     end
 
     def lead_provider
-      LeadProvider.find_by(id: lead_provider_id)
+      providers.find_by(id: lead_provider_id)
     end
 
     def course
@@ -56,6 +56,10 @@ module Forms
         inside_catchment: inside_catchment?,
         new_headteacher: new_headteacher?,
       ).funded?
+    end
+
+    def providers
+      LeadProvider.for(course: course)
     end
 
     def institution_identifier

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,4 +1,17 @@
 class Course < ApplicationRecord
+  COURSE_NAMES = {
+    NPQLT: "NPQ Leading Teaching (NPQLT)",
+    NPQLBC: "NPQ Leading Behaviour and Culture (NPQLBC)",
+    NPQLTD: "NPQ Leading Teacher Development (NPQLTD)",
+    NPQSL: "NPQ for Senior Leadership (NPQSL)",
+    NPQH: "NPQ for Headship (NPQH)",
+    NPQEL: "NPQ for Executive Leadership (NPQEL)",
+    ASO: "Additional Support Offer for new headteachers",
+    EHCO: "The Early Headship Coaching Offer",
+    NPQEYL: "NPQ Early Years Leadership (NPQEYL)",
+    NPQLL: "NPQ Leading Literacy (NPQLL)",
+  }.with_indifferent_access.freeze
+
   scope :ehco, -> { where(name: "The Early Headship Coaching Offer") }
 
   def npqh?

--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -1,2 +1,24 @@
 class LeadProvider < ApplicationRecord
+  # name => ecf_id
+  NPQEYL_AND_NPQLL_LEAD_PROVIDERS = {
+    "Ambition Institute" => "9e35e998-c63b-4136-89c4-e9e18ddde0ea",
+    "Education Development Trust" => "21e61f53-9b34-4384-a8f5-d8224dbf946d",
+    "School-Led Network" => "bc5e4e37-1d64-4149-a06b-ad10d3c55fd0",
+    "Teacher Development Trust" => "30fd937e-b93c-4f81-8fff-3c27544193f1",
+    "Teach First" => "a02ae582-f939-462f-90bc-cebf20fa8473",
+    "UCL Institute of Education" => "ef687b3d-c1c0-4566-a295-16d6fa5d0fa7",
+  }.freeze
+
+  def self.for(course:)
+    case course.name
+    when Course::COURSE_NAMES[:NPQEYL], Course::COURSE_NAMES[:NPQLL]
+      npqeyl_and_npqll_providers
+    else
+      all
+    end
+  end
+
+  def self.npqeyl_and_npqll_providers
+    where(ecf_id: NPQEYL_AND_NPQLL_LEAD_PROVIDERS.values)
+  end
 end

--- a/spec/lib/forms/choose_your_provider_spec.rb
+++ b/spec/lib/forms/choose_your_provider_spec.rb
@@ -72,4 +72,70 @@ RSpec.describe Forms::ChooseYourProvider, type: :model do
       end
     end
   end
+
+  describe ".options" do
+    subject do
+      form.options
+    end
+
+    let(:form) { described_class.new }
+
+    let(:store) do
+      { "course_id" => course_id }
+    end
+
+    let(:course) { Course.ehco }
+    let(:course_id) { course.id }
+
+    let(:expected_providers) { LeadProvider.all }
+
+    before do
+      form.wizard = RegistrationWizard.new(
+        current_step: :choose_your_npq,
+        store: store,
+        request: nil,
+      )
+    end
+
+    npqeyl_and_npqll_codes = %w[
+      NPQEYL
+      NPQLL
+    ].freeze
+    other_npq_codes = Course::COURSE_NAMES.keys - npqeyl_and_npqll_codes
+
+    other_npq_codes.each do |course_code|
+      course_name = Course::COURSE_NAMES[course_code]
+
+      context "when applying for #{course_code}" do
+        let(:course) { Course.find_by!(name: course_name) }
+        let(:expected_providers) { LeadProvider.all }
+
+        it "returns all options" do
+          expect(subject.map(&:value).sort).to eq(expected_providers.pluck(:id).sort)
+        end
+      end
+    end
+
+    npqeyl_and_npqll_codes.each do |course_code|
+      course_name = Course::COURSE_NAMES[course_code]
+
+      context "when applying for #{course_code}" do
+        let(:course) { Course.find_by!(name: course_name) }
+        let(:expected_providers) do
+          LeadProvider.where(name: [
+            "Ambition Institute",
+            "Education Development Trust",
+            "School-Led Network",
+            "Teacher Development Trust",
+            "Teach First",
+            "UCL Institute of Education",
+          ])
+        end
+
+        it "returns all options" do
+          expect(subject.map(&:value).sort).to eq(expected_providers.pluck(:id).sort)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

Not all providers provider all NPQs. NPQEYL and NPQLL only have a subset of providers available to them.

### Changes proposed in this pull request

- Add infrastructure for reducing available providers based on course selection
- Use new course provider selection system to restrict providers for NPQEYL and NPQLL course.
- Add in backend validation for lead provider selection.

### Guidance to review

1. Attempt to sign up for NPQEYL or NPQLL
2. Reach provider selection screen
3. Check that list is reduced to list of providers from ticket.
