### PR TITLE
Early Years funding

### DIFF
--- a/app/lib/services/funding_eligibility.rb
+++ b/app/lib/services/funding_eligibility.rb
@@ -44,7 +44,10 @@ module Services
 
           FUNDED_ELIGIBILITY_RESULT
         when "PrivateChildcareProvider"
-          # TODO: implement funding rejection for private childcare providers
+          return EARLY_YEARS_OUTSIDE_ENGLAND_OR_CROWN_DEPENDENCIES unless inside_catchment?
+          return EARLY_YEARS_INVALID_NPQ unless course.eyl?
+          return NOT_ON_EARLY_YEARS_REGISTER unless institution.on_early_years_register?
+
           FUNDED_ELIGIBILITY_RESULT
         when "LocalAuthority"
           FUNDED_ELIGIBILITY_RESULT

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -29,4 +29,8 @@ class Course < ApplicationRecord
   def ehco?
     name == "The Early Headship Coaching Offer"
   end
+
+  def eyl?
+    name == "NPQ Early Years Leadership (NPQEYL)"
+  end
 end

--- a/app/models/private_childcare_provider.rb
+++ b/app/models/private_childcare_provider.rb
@@ -55,4 +55,8 @@ class PrivateChildcareProvider < ApplicationRecord
   def identifier
     "PrivateChildcareProvider-#{urn}"
   end
+
+  def on_early_years_register?
+    early_years_individual_registers.include?("EYR")
+  end
 end

--- a/app/views/registration_wizard/ineligible_for_funding/early_years/_not_applying_for_NPQEY.html.erb
+++ b/app/views/registration_wizard/ineligible_for_funding/early_years/_not_applying_for_NPQEY.html.erb
@@ -1,3 +1,14 @@
+<% content_for :title do %>
+  <%= @form.errors.present? ? "Error: " : nil %> DfE scholarship funding is not available
+<% end %>
+
+<% content_for :before_content do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: "Back",
+    href: registration_wizard_show_path(@wizard.previous_step_path)
+  ) %>
+<% end %>
+
 <h1 class="govuk-heading-xl">DfE scholarship funding is not available</h1>
 
 <p class="govuk-body">Pending Copy</p>

--- a/app/views/registration_wizard/possible_funding/_private_childcare_provider.html.erb
+++ b/app/views/registration_wizard/possible_funding/_private_childcare_provider.html.erb
@@ -1,7 +1,7 @@
 <h1 class="govuk-heading-xl">If your provider accepts your application, you’ll qualify for DfE funding.</h1>
 
 <p class="govuk-body">
-  <b>From the information you have provided, DfE scholarship funding should be available for the <b><%= course_name %></b>.</b>
+  From the information you have provided, DfE scholarship funding should be available for the <b><%= course_name %></b>.
 </p>
 
 <p class="govuk-body">

--- a/spec/factories/private_childcare_provider.rb
+++ b/spec/factories/private_childcare_provider.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  factory :private_childcare_provider do
+    sequence(:provider_name) { |n| "private childcare provider #{n}" }
+    sequence(:provider_urn) { |n| (100_000 + n).to_s }
+    provider_status { "Active" }
+
+    trait :on_early_years_register do
+      early_years_individual_registers { %w[EYR] }
+    end
+
+    trait :on_all_registers do
+      early_years_individual_registers { %w[CCR VCR EYR] }
+    end
+  end
+end

--- a/spec/features/happy_journeys_spec.rb
+++ b/spec/features/happy_journeys_spec.rb
@@ -990,7 +990,11 @@ RSpec.feature "Happy journeys", type: :feature do
     page.choose("Yes", visible: :all)
     page.click_button("Continue")
 
-    PrivateChildcareProvider.create!(provider_urn: "EY123456", provider_name: "searchable childcare provider", address_1: "street 1", town: "manchester")
+    PrivateChildcareProvider.create!(
+      provider_urn: "EY123456", provider_name: "searchable childcare provider",
+      address_1: "street 1", town: "manchester",
+      early_years_individual_registers: %w[CCR VCR EYR]
+    )
 
     expect(page).to be_axe_clean
     expect(page).to have_text("Enter your or your employer's URN")
@@ -1002,9 +1006,21 @@ RSpec.feature "Happy journeys", type: :feature do
     page.find("#private-childcare-provider-picker__option--0").click
     page.click_button("Continue")
 
+    eyl_course = ["NPQ Early Years Leadership (NPQEYL)"]
+    ineligible_courses = Forms::ChooseYourNpq.new.options.map(&:text) - eyl_course
+
+    ineligible_courses.each do |course|
+      expect(page).to have_text("What are you applying for?")
+      page.choose(course, visible: :all)
+      page.click_button("Continue")
+
+      expect(page).not_to have_text("If your provider accepts your application, you’ll qualify for DfE funding.")
+      page.click_link("Back")
+    end
+
     expect(page).to be_axe_clean
     expect(page).to have_text("What are you applying for?")
-    page.choose("NPQ for Senior Leadership (NPQSL)", visible: :all) # Needs changing to an early years course once added
+    page.choose("NPQ Early Years Leadership (NPQEYL)", visible: :all)
     page.click_button("Continue")
 
     expect(page).to be_axe_clean
@@ -1030,7 +1046,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(check_answers_page.summary_list["Date of birth"].value).to eql("13 December 1980")
     expect(check_answers_page.summary_list.key?("National Insurance number")).to be_falsey
     expect(check_answers_page.summary_list["Email"].value).to eql("user@example.com")
-    expect(check_answers_page.summary_list["Course"].value).to eql("NPQ for Senior Leadership (NPQSL)")
+    expect(check_answers_page.summary_list["Course"].value).to eql("NPQ Early Years Leadership (NPQEYL)")
     expect(check_answers_page.summary_list.key?("Have you been a headteacher for two years or more?")).to be_falsey
     expect(check_answers_page.summary_list.key?("School or college")).to be_falsey
     expect(check_answers_page.summary_list.key?("How is your NPQ being paid for?")).to be_falsey

--- a/spec/lib/services/funding_eligibility_spec.rb
+++ b/spec/lib/services/funding_eligibility_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 RSpec.describe Services::FundingEligibility do
-  let(:institution) { school }
   let(:course) { Course.all.find { |c| !c.aso? } }
   let(:inside_catchment) { true }
 
@@ -9,7 +8,7 @@ RSpec.describe Services::FundingEligibility do
 
   describe ".funded? && .funding_eligiblity_status_code" do
     context "in the special URN list" do
-      let(:school) { build(:school, urn: "146816") }
+      let(:institution) { build(:school, urn: "146816") }
 
       Course.all.each do |course|
         context "studying #{course.name}" do
@@ -26,7 +25,7 @@ RSpec.describe Services::FundingEligibility do
     context "when institution is a School" do
       %w[1 2 3 5 6 7 8 12 14 15 18 24 26 28 31 32 33 34 35 36 38 39 40 41 42 43 44 45 46].each do |eligible_gias_code|
         context "eligible establishment_type_code #{eligible_gias_code}" do
-          let(:school) { build(:school, establishment_type_code: eligible_gias_code) }
+          let(:institution) { build(:school, establishment_type_code: eligible_gias_code) }
 
           it "returns true" do
             expect(subject.funded?).to be_truthy
@@ -62,7 +61,7 @@ RSpec.describe Services::FundingEligibility do
 
       %w[10 11 25 27 29 30 37 56].each do |ineligible_gias_code|
         context "ineligible establishment_type_code #{ineligible_gias_code}" do
-          let(:school) { build(:school, establishment_type_code: ineligible_gias_code) }
+          let(:institution) { build(:school, establishment_type_code: ineligible_gias_code) }
 
           it "returns false" do
             expect(subject.funded?).to be_falsey
@@ -105,6 +104,61 @@ RSpec.describe Services::FundingEligibility do
       it "is eligible" do
         expect(subject.funded?).to be_truthy
         expect(subject.funding_eligiblity_status_code).to eq :funded
+      end
+    end
+
+    context "when institution is a PrivateChildcareProvider" do
+      context "when meets all the funding criteria" do
+        let(:institution) { build(:private_childcare_provider, :on_early_years_register) }
+        let(:course) { Course.all.find(&:eyl?) }
+        let(:inside_catchment) { true }
+
+        it "is eligible" do
+          expect(subject.funded?).to be_truthy
+          expect(subject.funding_eligiblity_status_code).to eq :funded
+        end
+      end
+
+      context "when does not meets all the funding criteria" do
+        let(:institution) { build(:private_childcare_provider, :on_early_years_register) }
+        let(:course) { Course.all.find(&:eyl?) }
+        let(:inside_catchment) { true }
+
+        context "when outside catchment" do
+          let(:inside_catchment) { false }
+
+          it "returns status code :early_years_outside_england_or_crown_dependencies" do
+            expect(subject.funding_eligiblity_status_code).to eq :early_years_outside_england_or_crown_dependencies
+          end
+
+          it "it is not eligible" do
+            expect(subject.funded?).to be false
+          end
+        end
+
+        context "when NPQ course is not Early Year Leadership" do
+          let(:course) { Course.all.find { |c| !c.eyl? } }
+
+          it "returns status code :early_years_invalid_npq" do
+            expect(subject.funding_eligiblity_status_code).to eq :early_years_invalid_npq
+          end
+
+          it "it is not eligible" do
+            expect(subject.funded?).to be false
+          end
+        end
+
+        context "when institution is not on early years register" do
+          let(:institution) { build(:private_childcare_provider, early_years_individual_registers: []) }
+
+          it "returns status code :not_on_early_years_register" do
+            expect(subject.funding_eligiblity_status_code).to eq :not_on_early_years_register
+          end
+
+          it "it is not eligible" do
+            expect(subject.funded?).to be false
+          end
+        end
       end
     end
   end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe Course do
+  describe "#eyl?" do
+    context "when the course name is NPQEYL" do
+      let(:course) { described_class.new(name: "NPQ Early Years Leadership (NPQEYL)") }
+
+      it "returns true" do
+        expect(course.eyl?).to be true
+      end
+    end
+
+    context "when the course name is not NPQEYL" do
+      let(:course) { described_class.new(name: "something") }
+
+      it "returns false" do
+        expect(course.eyl?).to be false
+      end
+    end
+  end
+end

--- a/spec/models/private_childcare_provider_spec.rb
+++ b/spec/models/private_childcare_provider_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe PrivateChildcareProvider, type: :model do
+  describe "#on_early_years_register?" do
+    let(:provider) do
+      described_class.new(early_years_individual_registers: early_years_individual_registers)
+    end
+
+    context "when the provider is on the early year register" do
+      let(:early_years_individual_registers) { %w[CCR VCR EYR] }
+
+      it "returns true" do
+        expect(provider.on_early_years_register?).to be true
+      end
+    end
+
+    context "when the provider is not on the early year register" do
+      let(:early_years_individual_registers) { %w[CCR VCR] }
+
+      it "returns false" do
+        expect(provider.on_early_years_register?).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

[Ticket](https://dfedigital.atlassian.net/browse/CN-98)

We want to add funding eligibility for Early Years when:
1. providers are on the Early Years register or CMA
2. candidates want to do EYL
3. candidates are not abroad

### Changes proposed in this pull request

1. Add back button and page title to the `not applying for NPQEY` partial
2. Fix the copy styling in the early years funding partial
3. Add a method in the `PrivateChildcareProvider` to easily check if provider is on the Early Years Register
4. Add method to `Course` to easily check if course is `NPQ Early Years Leadership`
5. Add the funding rejection for private childcare providers

### Guidance to review

**Eligible journey**
Start the application and
1. choose working in England
2. choose not working in a school
3. choose working in childcare
4. choose working in nursery
5. choose working in private nursery
6. enter a URN of an employer that is on Early Years Register
7. choose NPQ Early Years Leadership (NPQEYL)

Then you should see possible funding page

**Ineligible journeys**
_Case 1_
Follow the Eligible journey above, but choose working in `Wales`. 
You should see the `outside catchment` ineligibility copy after choosing the NPQ Early Years Leadership.

_Case 2_
Follow the Eligible journey above, but enter a URN of an employer not in Early Years Register. 
You should see the `not on early year register` ineligibility copy after choosing the NPQ Early Years Leadership.

_Case 3_
Follow the Eligible journey above, but choose some other NPQ. 
You should see `not applying for NPQEY` ineligibility copy.

