### PR TITLE
Update the Course names and positions

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,18 +1,18 @@
 class Course < ApplicationRecord
   COURSE_NAMES = {
-    NPQLT: "NPQ Leading Teaching (NPQLT)",
-    NPQLBC: "NPQ Leading Behaviour and Culture (NPQLBC)",
-    NPQLTD: "NPQ Leading Teacher Development (NPQLTD)",
+    ASO: "Additional Support Offer for new headteachers",
+    NPQLT: "NPQ for Leading Teaching (NPQLT)",
+    NPQLBC: "NPQ for Leading Behaviour and Culture (NPQLBC)",
+    NPQLTD: "NPQ for Leading Teacher Development (NPQLTD)",
+    NPQLL: "NPQ for Leading Literacy (NPQLL)",
     NPQSL: "NPQ for Senior Leadership (NPQSL)",
     NPQH: "NPQ for Headship (NPQH)",
     NPQEL: "NPQ for Executive Leadership (NPQEL)",
-    ASO: "Additional Support Offer for new headteachers",
-    EHCO: "The Early Headship Coaching Offer",
-    NPQEYL: "NPQ Early Years Leadership (NPQEYL)",
-    NPQLL: "NPQ Leading Literacy (NPQLL)",
+    NPQEYL: "NPQ for Early Years Leadership (NPQEYL)",
+    EHCO: "Early Headship Coaching Offer",
   }.with_indifferent_access.freeze
 
-  scope :ehco, -> { where(name: "The Early Headship Coaching Offer") }
+  scope :ehco, -> { where(name: "Early Headship Coaching Offer") }
 
   def npqh?
     name == "NPQ for Headship (NPQH)"
@@ -27,10 +27,10 @@ class Course < ApplicationRecord
   end
 
   def ehco?
-    name == "The Early Headship Coaching Offer"
+    name == "Early Headship Coaching Offer"
   end
 
   def eyl?
-    name == "NPQ Early Years Leadership (NPQEYL)"
+    name == "NPQ for Early Years Leadership (NPQEYL)"
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,15 +1,15 @@
 def seed_courses!
   [
-    { name: "NPQ Leading Teaching (NPQLT)", ecf_id: "15c52ed8-06b5-426e-81a2-c2664978a0dc" },
-    { name: "NPQ Leading Behaviour and Culture (NPQLBC)", ecf_id: "7d47a0a6-fa74-4587-92cc-cd1e4548a2e5" },
-    { name: "NPQ Leading Teacher Development (NPQLTD)", ecf_id: "29fee78b-30ce-4b93-ba21-80be2fde286f" },
+    { name: "Additional Support Offer for new headteachers", ecf_id: "7fbefdd4-dd2d-4a4f-8995-d59e525124b7", description: "The Additional Support Offer is a targeted support package for new headteachers." },
+    { name: "NPQ for Leading Teaching (NPQLT)", ecf_id: "15c52ed8-06b5-426e-81a2-c2664978a0dc" },
+    { name: "NPQ for Leading Behaviour and Culture (NPQLBC)", ecf_id: "7d47a0a6-fa74-4587-92cc-cd1e4548a2e5" },
+    { name: "NPQ for Leading Teacher Development (NPQLTD)", ecf_id: "29fee78b-30ce-4b93-ba21-80be2fde286f" },
+    { name: "NPQ for Leading Literacy (NPQLL)", ecf_id: "829fcd45-e39d-49a9-b309-26d26debfa90" },
     { name: "NPQ for Senior Leadership (NPQSL)", ecf_id: "a42736ad-3d0b-401d-aebe-354ef4c193ec" },
     { name: "NPQ for Headship (NPQH)", ecf_id: "0f7d6578-a12c-4498-92a0-2ee0f18e0768" },
     { name: "NPQ for Executive Leadership (NPQEL)", ecf_id: "aef853f2-9b48-4b6a-9d2a-91b295f5ca9a" },
-    { name: "Additional Support Offer for new headteachers", ecf_id: "7fbefdd4-dd2d-4a4f-8995-d59e525124b7", description: "The Additional Support Offer is a targeted support package for new headteachers." },
-    { name: "The Early Headship Coaching Offer", ecf_id: "0222d1a8-a8e1-42e3-a040-2c585f6c194a", description: "The Early Headship Coaching Offer is a package of structured face-to-face support for new headteachers." },
-    { name: "NPQ Early Years Leadership (NPQEYL)", ecf_id: "66dff4af-a518-498f-9042-36a41f9e8aa7" },
-    { name: "NPQ Leading Literacy (NPQLL)", ecf_id: "829fcd45-e39d-49a9-b309-26d26debfa90" },
+    { name: "NPQ for Early Years Leadership (NPQEYL)", ecf_id: "66dff4af-a518-498f-9042-36a41f9e8aa7" },
+    { name: "Early Headship Coaching Offer", ecf_id: "0222d1a8-a8e1-42e3-a040-2c585f6c194a", description: "The Early Headship Coaching Offer is a package of structured face-to-face support for new headteachers." },
   ].each do |hash|
     Course.find_or_create_by!(name: hash[:name], ecf_id: hash[:ecf_id], description: hash[:description])
   end
@@ -17,16 +17,16 @@ end
 
 def update_course_positions!
   [
-    { position: 3, name: "NPQ Leading Teaching (NPQLT)", ecf_id: "15c52ed8-06b5-426e-81a2-c2664978a0dc" },
-    { position: 1, name: "NPQ Leading Behaviour and Culture (NPQLBC)", ecf_id: "7d47a0a6-fa74-4587-92cc-cd1e4548a2e5" },
-    { position: 4, name: "NPQ Leading Teacher Development (NPQLTD)", ecf_id: "29fee78b-30ce-4b93-ba21-80be2fde286f" },
+    { position: 0, name: "Additional Support Offer for new headteachers", ecf_id: "7fbefdd4-dd2d-4a4f-8995-d59e525124b7" },
+    { position: 1, name: "NPQ for Leading Teaching (NPQLT)", ecf_id: "15c52ed8-06b5-426e-81a2-c2664978a0dc" },
+    { position: 2, name: "NPQ for Leading Behaviour and Culture (NPQLBC)", ecf_id: "7d47a0a6-fa74-4587-92cc-cd1e4548a2e5" },
+    { position: 3, name: "NPQ for Leading Teacher Development (NPQLTD)", ecf_id: "29fee78b-30ce-4b93-ba21-80be2fde286f" },
+    { position: 4, name: "NPQ for Leading Literacy (NPQLL)", ecf_id: "829fcd45-e39d-49a9-b309-26d26debfa90" },
     { position: 5, name: "NPQ for Senior Leadership (NPQSL)", ecf_id: "a42736ad-3d0b-401d-aebe-354ef4c193ec" },
     { position: 6, name: "NPQ for Headship (NPQH)", ecf_id: "0f7d6578-a12c-4498-92a0-2ee0f18e0768" },
     { position: 7, name: "NPQ for Executive Leadership (NPQEL)", ecf_id: "aef853f2-9b48-4b6a-9d2a-91b295f5ca9a" },
-    { position: 0, name: "Additional Support Offer for new headteachers", ecf_id: "7fbefdd4-dd2d-4a4f-8995-d59e525124b7", description: "The Additional Support Offer is a targeted support package for new headteachers." },
-    { position: 9, name: "The Early Headship Coaching Offer", ecf_id: "0222d1a8-a8e1-42e3-a040-2c585f6c194a" },
-    { position: 8, name: "NPQ Early Years Leadership (NPQEYL)", ecf_id: "66dff4af-a518-498f-9042-36a41f9e8aa7" },
-    { position: 2, name: "NPQ Leading Literacy (NPQLL)", ecf_id: "829fcd45-e39d-49a9-b309-26d26debfa90" },
+    { position: 8, name: "NPQ for Early Years Leadership (NPQEYL)", ecf_id: "66dff4af-a518-498f-9042-36a41f9e8aa7" },
+    { position: 9, name: "Early Headship Coaching Offer", ecf_id: "0222d1a8-a8e1-42e3-a040-2c585f6c194a" },
   ].each do |hash|
     Course.find_by!(ecf_id: hash[:ecf_id]).update!(position: hash[:position])
   end

--- a/lib/tasks/courses.rake
+++ b/lib/tasks/courses.rake
@@ -1,0 +1,58 @@
+namespace :courses do
+  desc "Update courses"
+  task update: :environment do
+    Rake::Task["courses:update_names"].invoke
+    Rake::Task["courses:update_positions"].invoke
+  end
+
+  desc "Update courses names"
+  task update_names: :environment do
+    Rails.logger.info("Updating courses names")
+    ensure_courses_exist!
+
+    courses.each do |hash|
+      Course.find_by!(ecf_id: hash[:ecf_id]).update!(name: hash[:name])
+    end
+
+    Rails.logger.info("Courses names update finished")
+  end
+
+  desc "Update courses positions"
+  task update_positions: :environment do
+    Rails.logger.info("Updating courses positions")
+    ensure_courses_exist!
+
+    courses.each do |hash|
+      Course.find_by!(ecf_id: hash[:ecf_id]).update!(position: hash[:position])
+    end
+
+    Rails.logger.info("Courses positions update finished")
+  end
+end
+
+def courses
+  [
+    { ecf_id: "7fbefdd4-dd2d-4a4f-8995-d59e525124b7", position: 0, name: "Additional Support Offer for new headteachers" },
+    { ecf_id: "15c52ed8-06b5-426e-81a2-c2664978a0dc", position: 1, name: "NPQ for Leading Teaching (NPQLT)" },
+    { ecf_id: "7d47a0a6-fa74-4587-92cc-cd1e4548a2e5", position: 2, name: "NPQ for Leading Behaviour and Culture (NPQLBC)" },
+    { ecf_id: "29fee78b-30ce-4b93-ba21-80be2fde286f", position: 3, name: "NPQ for Leading Teacher Development (NPQLTD)" },
+    { ecf_id: "829fcd45-e39d-49a9-b309-26d26debfa90", position: 4, name: "NPQ for Leading Literacy (NPQLL)" },
+    { ecf_id: "a42736ad-3d0b-401d-aebe-354ef4c193ec", position: 5, name: "NPQ for Senior Leadership (NPQSL)" },
+    { ecf_id: "0f7d6578-a12c-4498-92a0-2ee0f18e0768", position: 6, name: "NPQ for Headship (NPQH)" },
+    { ecf_id: "aef853f2-9b48-4b6a-9d2a-91b295f5ca9a", position: 7, name: "NPQ for Executive Leadership (NPQEL)" },
+    { ecf_id: "66dff4af-a518-498f-9042-36a41f9e8aa7", position: 8, name: "NPQ for Early Years Leadership (NPQEYL)" },
+    { ecf_id: "0222d1a8-a8e1-42e3-a040-2c585f6c194a", position: 9, name: "Early Headship Coaching Offer" },
+  ]
+end
+
+def ensure_courses_exist!
+  ecf_ids = courses.map { |c| c[:ecf_id] }
+  all_courses_exist = Course.where(ecf_id: ecf_ids).count == ecf_ids.count
+
+  error_msg = "Task aborted! Trying to update courses that do not exist."
+
+  unless all_courses_exist
+    Rails.logger.error(error_msg)
+    abort(error_msg)
+  end
+end

--- a/spec/features/happy_journeys_non_js_spec.rb
+++ b/spec/features/happy_journeys_non_js_spec.rb
@@ -419,7 +419,7 @@ RSpec.feature "Happy journeys", type: :feature do
     page.click_button("Continue")
 
     expect(page).to have_text("What are you applying for?")
-    page.choose("The Early Headship Coaching Offer")
+    page.choose("Early Headship Coaching Offer")
     page.click_button("Continue")
 
     expect(page).to have_selector "h1", text: "Early Headship Coaching Offer"
@@ -465,7 +465,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(check_answers_page.summary_list["Date of birth"].value).to eql("13 December 1980")
     expect(check_answers_page.summary_list["National Insurance number"].value).to eql("AB123456C")
     expect(check_answers_page.summary_list["Email"].value).to eql("user@example.com")
-    expect(check_answers_page.summary_list["Course"].value).to eql("The Early Headship Coaching Offer")
+    expect(check_answers_page.summary_list["Course"].value).to eql("Early Headship Coaching Offer")
     expect(check_answers_page.summary_list["Lead provider"].value).to eql("Teach First")
     expect(check_answers_page.summary_list["School or college"].value).to eql("open manchester school")
 
@@ -500,7 +500,7 @@ RSpec.feature "Happy journeys", type: :feature do
     visit "/account"
 
     expect(page).to have_text("Teach First")
-    expect(page).to have_text("The Early Headship Coaching Offer")
+    expect(page).to have_text("Early Headship Coaching Offer")
 
     visit "/registration/check-answers"
 
@@ -593,7 +593,7 @@ RSpec.feature "Happy journeys", type: :feature do
     page.click_button("Continue")
 
     expect(page).to have_text("What are you applying for?")
-    page.choose("The Early Headship Coaching Offer")
+    page.choose("Early Headship Coaching Offer")
     page.click_button("Continue")
 
     expect(page).to have_selector "h1", text: "Early Headship Coaching Offer"
@@ -639,7 +639,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(check_answers_page.summary_list["Date of birth"].value).to eql("13 December 1980")
     expect(check_answers_page.summary_list["National Insurance number"].value).to eql("AB123456C")
     expect(check_answers_page.summary_list["Email"].value).to eql("user@example.com")
-    expect(check_answers_page.summary_list["Course"].value).to eql("The Early Headship Coaching Offer")
+    expect(check_answers_page.summary_list["Course"].value).to eql("Early Headship Coaching Offer")
     expect(check_answers_page.summary_list["Lead provider"].value).to eql("Teach First")
     expect(check_answers_page.summary_list["School or college"].value).to eql("open manchester school")
 
@@ -677,7 +677,7 @@ RSpec.feature "Happy journeys", type: :feature do
     visit "/account"
 
     expect(page).to have_text("Teach First")
-    expect(page).to have_text("The Early Headship Coaching Offer")
+    expect(page).to have_text("Early Headship Coaching Offer")
 
     visit "/registration/check-answers"
 

--- a/spec/features/happy_journeys_spec.rb
+++ b/spec/features/happy_journeys_spec.rb
@@ -1006,7 +1006,7 @@ RSpec.feature "Happy journeys", type: :feature do
     page.find("#private-childcare-provider-picker__option--0").click
     page.click_button("Continue")
 
-    eyl_course = ["NPQ Early Years Leadership (NPQEYL)"]
+    eyl_course = ["NPQ for Early Years Leadership (NPQEYL)"]
     ineligible_courses = Forms::ChooseYourNpq.new.options.map(&:text) - eyl_course
 
     ineligible_courses.each do |course|
@@ -1020,7 +1020,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
     expect(page).to be_axe_clean
     expect(page).to have_text("What are you applying for?")
-    page.choose("NPQ Early Years Leadership (NPQEYL)", visible: :all)
+    page.choose("NPQ for Early Years Leadership (NPQEYL)", visible: :all)
     page.click_button("Continue")
 
     expect(page).to be_axe_clean
@@ -1047,7 +1047,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(check_answers_page.summary_list["Date of birth"].value).to eql("13 December 1980")
     expect(check_answers_page.summary_list.key?("National Insurance number")).to be_falsey
     expect(check_answers_page.summary_list["Email"].value).to eql("user@example.com")
-    expect(check_answers_page.summary_list["Course"].value).to eql("NPQ Early Years Leadership (NPQEYL)")
+    expect(check_answers_page.summary_list["Course"].value).to eql("NPQ for Early Years Leadership (NPQEYL)")
     expect(check_answers_page.summary_list.key?("Have you been a headteacher for two years or more?")).to be_falsey
     expect(check_answers_page.summary_list.key?("School or college")).to be_falsey
     expect(check_answers_page.summary_list.key?("How is your NPQ being paid for?")).to be_falsey

--- a/spec/lib/forms/choose_your_npq_spec.rb
+++ b/spec/lib/forms/choose_your_npq_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Forms::ChooseYourNpq, type: :model do
       subject.valid?
       expect(subject.errors[:course_id]).to be_present
 
-      subject.course_id = Course.first.id
+      subject.course_id = Course.where(display: true).first.id
       subject.valid?
       expect(subject.errors[:course_id]).to be_blank
     end
@@ -19,7 +19,7 @@ RSpec.describe Forms::ChooseYourNpq, type: :model do
       subject.valid?
       expect(subject.errors[:course_id]).to be_present
 
-      subject.course_id = Course.first.id
+      subject.course_id = Course.where(display: true).first.id
       subject.valid?
       expect(subject.errors[:course_id]).to be_blank
     end
@@ -54,7 +54,7 @@ RSpec.describe Forms::ChooseYourNpq, type: :model do
       end
 
       context "when changing to something other than headship" do
-        let(:course) { Course.first }
+        let(:course) { Course.find_by(name: "NPQ for Leading Teaching (NPQLT)") }
         let(:school) { create(:school) }
         let(:previous_course) { Course.find_by(name: "NPQ for Headship (NPQH)") }
         let(:store) { { course_id: previous_course.id.to_s, institution_identifier: "School-#{school.urn}" }.stringify_keys }

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Course do
   describe "#eyl?" do
     context "when the course name is NPQEYL" do
-      let(:course) { described_class.new(name: "NPQ Early Years Leadership (NPQEYL)") }
+      let(:course) { described_class.new(name: "NPQ for Early Years Leadership (NPQEYL)") }
 
       it "returns true" do
         expect(course.eyl?).to be true


### PR DESCRIPTION
### Context

[Ticket CN-160](https://dfedigital.atlassian.net/browse/CN-160)

We want to update the course names and their order to:
```
NPQ for Leading Teaching (NPQLT)
NPQ for Leading Behaviour and Culture (NPQLBC)
NPQ for Leading Teacher Development (NPQLTD)
NPQ for Leading Literacy (NPQLL)
NPQ for Senior Leadership (NPQSL)
NPQ for Headship (NPQH)
NPQ for Executive Leadership (NPQEL)
NPQ for Early Years Leadership (NPQEYL)
Early Headship Coaching Offer
```

### Changes proposed in this pull request

1. update the course names in the Course model
2. update the seeds file

### Guidance to review

1. re-seed your local DBs with `rails db:seed:replant` and `RAILS_ENV=test rails db:seed:replant`. Warning: It will wipe out data from all the tables in your local envs and you may need to re-run the imports (see [README](https://github.com/DFE-Digital/npq-registration/blob/course-names-and-positions/README.md#importing-schools))
2. go through the journey until you reach the `What you are applying for?` page
3. check the names and order are as expected