### PR TITLE
Remove references to England/Crown Dependencies in catchment related funding eligibility status codes

### DIFF
--- a/app/lib/forms/ineligible_for_funding.rb
+++ b/app/lib/forms/ineligible_for_funding.rb
@@ -33,11 +33,11 @@ module Forms
         return version if VALID_PARTIALS.include?(version)
 
         case funding_eligiblity_status_code
-        when Services::FundingEligibility::SCHOOL_OUTSIDE_ENGLAND_OR_CROWN_DEPENDENCIES, Services::FundingEligibility::INELIGIBLE_ESTABLISHMENT_TYPE
+        when Services::FundingEligibility::SCHOOL_OUTSIDE_CATCHMENT, Services::FundingEligibility::INELIGIBLE_ESTABLISHMENT_TYPE
           return SCHOOL_OUTSIDE_CATCHMENT_OR_INELIGIBLE_ESTABLISHMENT
         when Services::FundingEligibility::PREVIOUSLY_FUNDED
           return SCHOOL_ALREADY_FUNDED
-        when Services::FundingEligibility::EARLY_YEARS_OUTSIDE_ENGLAND_OR_CROWN_DEPENDENCIES, Services::FundingEligibility::NOT_ON_EARLY_YEARS_REGISTER
+        when Services::FundingEligibility::EARLY_YEARS_OUTSIDE_CATCHMENT, Services::FundingEligibility::NOT_ON_EARLY_YEARS_REGISTER
           return EARLY_YEARS_OUTSIDE_CATCHMENT_OR_INELIGIBLE_ESTABLISHMENT
         when Services::FundingEligibility::EARLY_YEARS_INVALID_NPQ
           return EARLY_YEARS_NOT_APPLYING_FOR_NPQEY

--- a/app/lib/services/funding_eligibility.rb
+++ b/app/lib/services/funding_eligibility.rb
@@ -11,10 +11,10 @@ module Services
     NOT_NEW_HEADTEACHER_REQUESTING_ASO = :not_new_headteacher_requesting_aso
 
     # School
-    SCHOOL_OUTSIDE_ENGLAND_OR_CROWN_DEPENDENCIES = :school_outside_england_or_crown_dependencies
+    SCHOOL_OUTSIDE_CATCHMENT = :school_outside_catchment
 
     # Early Years
-    EARLY_YEARS_OUTSIDE_ENGLAND_OR_CROWN_DEPENDENCIES = :early_years_outside_england_or_crown_dependencies
+    EARLY_YEARS_OUTSIDE_CATCHMENT = :early_years_outside_catchment
     NOT_ON_EARLY_YEARS_REGISTER = :not_on_early_years_register
     EARLY_YEARS_INVALID_NPQ = :early_years_invalid_npq
 
@@ -38,13 +38,13 @@ module Services
 
         case institution.class.name
         when "School"
-          return SCHOOL_OUTSIDE_ENGLAND_OR_CROWN_DEPENDENCIES unless inside_catchment?
+          return SCHOOL_OUTSIDE_CATCHMENT unless inside_catchment?
           return INELIGIBLE_ESTABLISHMENT_TYPE unless eligible_establishment_type_codes.include?(institution.establishment_type_code)
           return NOT_NEW_HEADTEACHER_REQUESTING_ASO if course.aso? && !new_headteacher?
 
           FUNDED_ELIGIBILITY_RESULT
         when "PrivateChildcareProvider"
-          return EARLY_YEARS_OUTSIDE_ENGLAND_OR_CROWN_DEPENDENCIES unless inside_catchment?
+          return EARLY_YEARS_OUTSIDE_CATCHMENT unless inside_catchment?
           return EARLY_YEARS_INVALID_NPQ unless course.eyl?
           return NOT_ON_EARLY_YEARS_REGISTER unless institution.on_early_years_register?
 

--- a/spec/lib/services/funding_eligibility_spec.rb
+++ b/spec/lib/services/funding_eligibility_spec.rb
@@ -127,8 +127,8 @@ RSpec.describe Services::FundingEligibility do
         context "when outside catchment" do
           let(:inside_catchment) { false }
 
-          it "returns status code :early_years_outside_england_or_crown_dependencies" do
-            expect(subject.funding_eligiblity_status_code).to eq :early_years_outside_england_or_crown_dependencies
+          it "returns status code :early_years_outside_catchment" do
+            expect(subject.funding_eligiblity_status_code).to eq :early_years_outside_catchment
           end
 
           it "it is not eligible" do


### PR DESCRIPTION
### Context

What `inside_catchment?` means has and will change over time. Referring to specifics of what this means within status codes could lead to them becoming misleading.

### Changes proposed in this pull request

- Changes `school_outside_england_or_crown_dependencies` to `school_outside_catchment`
- Changes `early_years_outside_england_or_crown_dependencies` to `early_years_outside_catchment`

### Guidance to review

Apply for NPQ in a school/private childcare provider outside England, see that status code from rejection is one of the above new errors.