### PR TITLE
Flip GIAS code ten schools to funded for all NPQs

### DIFF
--- a/app/lib/services/funding_eligibility.rb
+++ b/app/lib/services/funding_eligibility.rb
@@ -74,7 +74,7 @@ module Services
     end
 
     def eligible_establishment_type_codes
-      %w[1 2 3 5 6 7 8 12 14 15 18 24 26 28 31 32 33 34 35 36 38 39 40 41 42 43 44 45 46].freeze
+      %w[1 2 3 5 6 7 8 10 12 14 15 18 24 26 28 31 32 33 34 35 36 38 39 40 41 42 43 44 45 46].freeze
     end
 
     def eligible_urns

--- a/spec/lib/services/funding_eligibility_spec.rb
+++ b/spec/lib/services/funding_eligibility_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Services::FundingEligibility do
     end
 
     context "when institution is a School" do
-      %w[1 2 3 5 6 7 8 12 14 15 18 24 26 28 31 32 33 34 35 36 38 39 40 41 42 43 44 45 46].each do |eligible_gias_code|
+      %w[1 2 3 5 6 7 8 10 12 14 15 18 24 26 28 31 32 33 34 35 36 38 39 40 41 42 43 44 45 46].each do |eligible_gias_code|
         context "eligible establishment_type_code #{eligible_gias_code}" do
           let(:institution) { build(:school, establishment_type_code: eligible_gias_code) }
 
@@ -59,7 +59,7 @@ RSpec.describe Services::FundingEligibility do
         end
       end
 
-      %w[10 11 25 27 29 30 37 56].each do |ineligible_gias_code|
+      %w[11 25 27 29 30 37 56].each do |ineligible_gias_code|
         context "ineligible establishment_type_code #{ineligible_gias_code}" do
           let(:institution) { build(:school, establishment_type_code: ineligible_gias_code) }
 


### PR DESCRIPTION
### Context

[Ticket CN-65](https://dfedigital.atlassian.net/browse/CN-65)

All schools with GIAS code 10 will be eligible for funding from 1st of June 2022.

### Changes proposed in this pull request

Add code 10 to the `eligible_establishment_type_codes`.

### Guidance to review

The registration on production will open on 6 June which covers the 1st June 2022 requirement, so I didn't have to use any feature flags. In all other envs (dev/staging/sandboz) code 10 schools will be eligible the moment we merge this PR.

How to test it:
Go through the eligible school journey and make sure you choose a GIAS code 10 school (you can find one in your local db `School.where(establishment_type_code: 10)`). After choose an NPQ, you should see the funding eligibility page.
