### PR TITLE
Remove ability to show specific ineligibility page

### DIFF
--- a/app/controllers/registration_wizard_controller.rb
+++ b/app/controllers/registration_wizard_controller.rb
@@ -2,8 +2,7 @@ class RegistrationWizardController < ApplicationController
   def show
     @wizard = RegistrationWizard.new(current_step: params[:step].underscore,
                                      store: store,
-                                     request: request,
-                                     params: wizard_params)
+                                     request: request)
 
     @form = @wizard.form
     @form.flag_as_changing_answer if params[:changing_answer] == "1"

--- a/app/lib/forms/ineligible_for_funding.rb
+++ b/app/lib/forms/ineligible_for_funding.rb
@@ -7,18 +7,7 @@ module Forms
     EARLY_YEARS_OUTSIDE_CATCHMENT_OR_INELIGIBLE_ESTABLISHMENT = "early_years/outside_catchment_or_not_on_early_years_register".freeze
     EARLY_YEARS_NOT_APPLYING_FOR_NPQEY = "early_years/not_applying_for_NPQEY".freeze
 
-    VALID_PARTIALS = [
-      SCHOOL_OUTSIDE_CATCHMENT_OR_INELIGIBLE_ESTABLISHMENT,
-      SCHOOL_ALREADY_FUNDED,
-      EARLY_YEARS_OUTSIDE_CATCHMENT_OR_INELIGIBLE_ESTABLISHMENT,
-      EARLY_YEARS_NOT_APPLYING_FOR_NPQEY,
-    ].freeze
-
     attr_accessor :version
-
-    def self.permitted_params
-      [:version]
-    end
 
     def next_step
       :funding_your_npq
@@ -29,26 +18,22 @@ module Forms
     end
 
     def ineligible_template
-      @ineligible_template ||= begin
-        return version if VALID_PARTIALS.include?(version)
-
-        case funding_eligiblity_status_code
-        when Services::FundingEligibility::SCHOOL_OUTSIDE_CATCHMENT, Services::FundingEligibility::INELIGIBLE_ESTABLISHMENT_TYPE
-          return SCHOOL_OUTSIDE_CATCHMENT_OR_INELIGIBLE_ESTABLISHMENT
-        when Services::FundingEligibility::PREVIOUSLY_FUNDED
-          return SCHOOL_ALREADY_FUNDED
-        when Services::FundingEligibility::EARLY_YEARS_OUTSIDE_CATCHMENT, Services::FundingEligibility::NOT_ON_EARLY_YEARS_REGISTER
-          return EARLY_YEARS_OUTSIDE_CATCHMENT_OR_INELIGIBLE_ESTABLISHMENT
-        when Services::FundingEligibility::EARLY_YEARS_INVALID_NPQ
-          return EARLY_YEARS_NOT_APPLYING_FOR_NPQEY
-        when Services::FundingEligibility::NO_INSTITUTION
-          if query_store.works_in_school?
-            return SCHOOL_OUTSIDE_CATCHMENT_OR_INELIGIBLE_ESTABLISHMENT
-          else
-            return EARLY_YEARS_OUTSIDE_CATCHMENT_OR_INELIGIBLE_ESTABLISHMENT
-          end
-        end
-      end
+      @ineligible_template ||= case funding_eligiblity_status_code
+                               when Services::FundingEligibility::SCHOOL_OUTSIDE_CATCHMENT, Services::FundingEligibility::INELIGIBLE_ESTABLISHMENT_TYPE
+                                 return SCHOOL_OUTSIDE_CATCHMENT_OR_INELIGIBLE_ESTABLISHMENT
+                               when Services::FundingEligibility::PREVIOUSLY_FUNDED
+                                 return SCHOOL_ALREADY_FUNDED
+                               when Services::FundingEligibility::EARLY_YEARS_OUTSIDE_CATCHMENT, Services::FundingEligibility::NOT_ON_EARLY_YEARS_REGISTER
+                                 return EARLY_YEARS_OUTSIDE_CATCHMENT_OR_INELIGIBLE_ESTABLISHMENT
+                               when Services::FundingEligibility::EARLY_YEARS_INVALID_NPQ
+                                 return EARLY_YEARS_NOT_APPLYING_FOR_NPQEY
+                               when Services::FundingEligibility::NO_INSTITUTION
+                                 if query_store.works_in_school?
+                                   return SCHOOL_OUTSIDE_CATCHMENT_OR_INELIGIBLE_ESTABLISHMENT
+                                 else
+                                   return EARLY_YEARS_OUTSIDE_CATCHMENT_OR_INELIGIBLE_ESTABLISHMENT
+                                 end
+                               end
 
       raise "Missing status code handling: #{funding_eligiblity_status_code}"
     end


### PR DESCRIPTION
### Context

This was put in place for testing purposes, it is no longer needed and would be undesirable after release so I'm removing it.

### Changes proposed in this pull request

- Remove param being passed through to registration wizard show pages
- Remove versions param from app/lib/forms/ineligible_for_funding.rb

### Guidance to review

