### PR TITLE
[CN-99] Fix bug related to changing answers

### DIFF
--- a/app/lib/forms/have_ofsted_urn.rb
+++ b/app/lib/forms/have_ofsted_urn.rb
@@ -10,6 +10,18 @@ module Forms
       ]
     end
 
+    # If you say you have no ofsted URN, then we should
+    # make sure you do not have an institution saved.
+    # This is to ensure people do not end up saying
+    # no but having invalid data where they entered
+    # one present.
+    def after_save
+      return if wizard.query_store.has_ofsted_urn?
+
+      wizard.store["institution_identifier"] = nil
+      wizard.store["institution_name"] = nil
+    end
+
     def next_step
       case has_ofsted_urn
       when "yes"


### PR DESCRIPTION
### Context

If you said “Yes” to this question, then entered a URN, then came back and said no, it would act forever as if you had said Yes, because your institution identifier would remain. By wiping it out if you say no, we can be sure that your no answer is respected.

### Changes proposed in this pull request

- Clear institution_identifier and institution_name if you say "no" to have_ofsted_urn question. 

### Guidance to review

1. Reach this page as a, so far, eligible for funding applicant
2. Say yes
3. Enter URN and select private childcare provider
4. Return to have_ofsted_urn page
5. Say no
6. On choose_your_npq page, select any NPQEYL
7. See ineligible for funding page instead of successful funding page
