### PR TITLE
Reject funded NPQs

### DIFF
--- a/app/lib/ecf_api/base.rb
+++ b/app/lib/ecf_api/base.rb
@@ -13,6 +13,12 @@ module EcfApi
     end
   end
 
+  class RawParser
+    def self.parse(_klass, response)
+      response.body.presence || {}
+    end
+  end
+
   class Base < JsonApiClient::Resource
     self.site = "#{ENV['ECF_APP_BASE_URL']}/api/v1/"
     self.connection_class = ConnectionWithAuthHeader

--- a/app/lib/ecf_api/npq_funding.rb
+++ b/app/lib/ecf_api/npq_funding.rb
@@ -1,0 +1,9 @@
+module EcfApi
+  class NpqFunding < Base
+    self.parser = RawParser
+
+    def self.table_name
+      "npq-funding"
+    end
+  end
+end

--- a/app/lib/forms/aso_new_headteacher.rb
+++ b/app/lib/forms/aso_new_headteacher.rb
@@ -15,8 +15,11 @@ module Forms
     end
 
     def next_step
-      if eligible_for_funding?
+      case funding_eligiblity_status_code
+      when :funded
         :aso_possible_funding
+      when :previously_funded
+        :aso_previously_funded
       else
         :aso_funding_not_available
       end
@@ -40,13 +43,14 @@ module Forms
       Course.find_by(id: wizard.store["course_id"])
     end
 
-    def eligible_for_funding?
+    def funding_eligiblity_status_code
       Services::FundingEligibility.new(
         course: course,
         institution: institution,
         inside_catchment: wizard.query_store.inside_catchment?,
         new_headteacher: new_headteacher?,
-      ).funded?
+        trn: @wizard.store["trn"],
+      ).funding_eligiblity_status_code
     end
 
     def new_headteacher?

--- a/app/lib/forms/aso_previously_funded.rb
+++ b/app/lib/forms/aso_previously_funded.rb
@@ -1,0 +1,15 @@
+module Forms
+  class AsoPreviouslyFunded < Base
+    def previous_step
+      if wizard.store["aso_headteacher"] == "yes"
+        :aso_new_headteacher
+      else
+        :aso_headteacher
+      end
+    end
+
+    def next_step
+      :funding_your_aso
+    end
+  end
+end

--- a/app/lib/forms/choose_your_npq.rb
+++ b/app/lib/forms/choose_your_npq.rb
@@ -88,6 +88,7 @@ module Forms
         institution: institution,
         inside_catchment: inside_catchment?,
         new_headteacher: new_headteacher?,
+        trn: wizard.store["trn"],
       ).funded?
     end
 
@@ -97,6 +98,7 @@ module Forms
         institution: institution,
         inside_catchment: inside_catchment?,
         new_headteacher: new_headteacher?,
+        trn: wizard.store["trn"],
       )
     end
 

--- a/app/lib/forms/choose_your_provider.rb
+++ b/app/lib/forms/choose_your_provider.rb
@@ -57,6 +57,7 @@ module Forms
         institution: institution(source: institution_identifier),
         inside_catchment: inside_catchment?,
         new_headteacher: new_headteacher?,
+        trn: wizard.store["trn"],
       ).funded?
     end
 

--- a/app/lib/forms/ineligible_for_funding.rb
+++ b/app/lib/forms/ineligible_for_funding.rb
@@ -59,6 +59,7 @@ module Forms
         institution: institution,
         inside_catchment: inside_catchment?,
         new_headteacher: new_headteacher?,
+        trn: wizard.store["trn"],
       ).funding_eligiblity_status_code
     end
 

--- a/app/lib/services/funding_eligibility.rb
+++ b/app/lib/services/funding_eligibility.rb
@@ -21,11 +21,12 @@ module Services
 
     attr_reader :institution, :course
 
-    def initialize(institution:, course:, inside_catchment:, new_headteacher: false)
+    def initialize(institution:, course:, inside_catchment:, trn:, new_headteacher: false)
       @institution = institution
       @course = course
       @inside_catchment = inside_catchment
       @new_headteacher = new_headteacher
+      @trn = trn
     end
 
     def funded?
@@ -35,6 +36,7 @@ module Services
     def funding_eligiblity_status_code
       @funding_eligiblity_status_code ||= begin
         return NO_INSTITUTION if institution.nil?
+        return PREVIOUSLY_FUNDED if previously_funded?
         return FUNDED_ELIGIBILITY_RESULT if eligible_urns.include?(institution.urn)
 
         case institution.class.name
@@ -114,6 +116,12 @@ module Services
         133545
         130504
       ]
+    end
+
+    def previously_funded?
+      results = EcfApi::NpqFunding.with_params(npq_course_identifier: course.identifier).find(@trn)
+
+      results["previously_funded"] == true
     end
   end
 end

--- a/app/lib/services/handle_submission_for_store.rb
+++ b/app/lib/services/handle_submission_for_store.rb
@@ -127,6 +127,7 @@ module Services
         institution: institution(source: store["institution_identifier"]),
         inside_catchment: query_store.inside_catchment?,
         new_headteacher: new_headteacher?,
+        trn: store["trn"],
       )
     end
 

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -18,6 +18,7 @@ class Application < ApplicationRecord
       institution: school,
       inside_catchment: inside_catchment?,
       new_headteacher: new_headteacher?,
+      trn: user.trn,
     ).funded?
   end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -12,6 +12,19 @@ class Course < ApplicationRecord
     EHCO: "Early Headship Coaching Offer",
   }.with_indifferent_access.freeze
 
+  COURSE_ECF_ID_TO_IDENTIFIER_MAPPING = {
+    "15c52ed8-06b5-426e-81a2-c2664978a0dc" => "npq-leading-teaching",
+    "7d47a0a6-fa74-4587-92cc-cd1e4548a2e5" => "npq-leading-behaviour-culture",
+    "29fee78b-30ce-4b93-ba21-80be2fde286f" => "npq-leading-teaching-development",
+    "a42736ad-3d0b-401d-aebe-354ef4c193ec" => "npq-senior-leadership",
+    "0f7d6578-a12c-4498-92a0-2ee0f18e0768" => "npq-headship",
+    "aef853f2-9b48-4b6a-9d2a-91b295f5ca9a" => "npq-executive-leadership",
+    "7fbefdd4-dd2d-4a4f-8995-d59e525124b7" => "npq-additional-support-offer",
+    "0222d1a8-a8e1-42e3-a040-2c585f6c194a" => "npq-early-headship-coaching-offer",
+    "66dff4af-a518-498f-9042-36a41f9e8aa7" => "npq-early-years-leadership",
+    "829fcd45-e39d-49a9-b309-26d26debfa90" => "npq-leading-literacy",
+  }.with_indifferent_access.freeze
+
   scope :aso, -> { where(name: COURSE_NAMES[:ASO]) }
   scope :ehco, -> { where(name: COURSE_NAMES[:EHCO]) }
   scope :npqeyl, -> { where(name: COURSE_NAMES[:NPQEYL]) }
@@ -34,5 +47,9 @@ class Course < ApplicationRecord
 
   def eyl?
     name == COURSE_NAMES[:NPQEYL]
+  end
+
+  def identifier
+    COURSE_ECF_ID_TO_IDENTIFIER_MAPPING[ecf_id]
   end
 end

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -191,6 +191,7 @@ private
       institution: institution(source: store["institution_identifier"]),
       inside_catchment: query_store.inside_catchment?,
       new_headteacher: new_headteacher?,
+      trn: store["trn"],
     ).funded?
   end
 
@@ -238,6 +239,7 @@ private
       aso_headteacher
       aso_new_headteacher
       aso_funding_not_available
+      aso_previously_funded
       aso_possible_funding
       funding_your_aso
       choose_your_npq

--- a/app/views/registration_wizard/aso_previously_funded.html.erb
+++ b/app/views/registration_wizard/aso_previously_funded.html.erb
@@ -1,0 +1,34 @@
+<% content_for :title do %>
+  DfE scholarship funding not available
+<% end %>
+
+<% content_for :before_content do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: "Back",
+    href: registration_wizard_show_path(@wizard.previous_step_path)
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">DfE scholarship funding is not available</h1>
+
+    <p class="govuk-body">Our records show that you are already registered to study <b>Early Headship Coaching Offer</b> (previously known as the Additional Support Offer).</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        You can only receive scholarship funding to study this offer with one provider. If you do not wish to proceed with your current provider you will need to contact them.
+      </li>
+
+      <li>
+        If you have previously withdrawn from this offer, then you're not eligible for scholarship funding for the same offer again. If you do not believe you’ve withdrawn from this course please email <%= govuk_mail_to "continuing-professional-development@digital.education.gov.uk", "continuing-professional-development@digital.education.gov.uk" %>
+      </li>
+    </ul>
+
+    <p class="govuk-body">
+      You can <%= link_to('go back and select an NPQ', registration_wizard_show_path(@wizard.previous_step_path)) %> or continue with your registration for the Early Headship Coaching Offer. You'll need to pay for it another way. Contact your course provider to discuss your funding options.
+    </p>
+
+    <%= govuk_button_link_to "Continue", registration_wizard_show_path(@wizard.next_step_path) %>
+  </div>
+</div>

--- a/app/views/registration_wizard/ineligible_for_funding/school/_has_already_been_funded.html.erb
+++ b/app/views/registration_wizard/ineligible_for_funding/school/_has_already_been_funded.html.erb
@@ -4,7 +4,7 @@
 
 <h1 class="govuk-heading-xl">DfE scholarship funding is not available</h1>
 
-<p class="govuk-body">Our records show that you are already registered to study NPQ for <b><%= course_name %></b>.</p>
+<p class="govuk-body">Our records show that you are already registered to study <b><%= course_name %></b>.</p>
 
 <ul class="govuk-list govuk-list--bullet">
   <li>
@@ -12,10 +12,10 @@
   </li>
 
   <li>
-    If you have previously failed or withdrawn from this course, then you're not eligible for scholarship funding for the same NPQ again. If you do not believe you've failed or withdrawn from this course please email <%= mail_to "continuing-professional-development@digital.education.gov.uk", "continuing-professional-development@digital.education.gov.uk" %>
+    If you have previously failed or withdrawn from this course, then you're not eligible for scholarship funding for the same NPQ again. If you do not believe you've failed or withdrawn from this course please email <%= govuk_mail_to "continuing-professional-development@digital.education.gov.uk", "continuing-professional-development@digital.education.gov.uk" %>
   </li>
 </ul>
 
 <p class="govuk-body">
-  You can go <%= link_to('back and select a different NPQ', registration_wizard_show_path(@wizard.previous_step_path)) %> or continue with your registration for <%= course_name %>. You'll need to pay for it another way. Contact your course provider to discuss your funding options.
+  You can <%= link_to('go back and select a different NPQ', registration_wizard_show_path(@wizard.previous_step_path)) %> or continue with your registration for the <%= course_name %>. You'll need to pay for it another way. Contact your course provider to discuss your funding options.
 </p>

--- a/spec/features/happy_journeys_non_js_spec.rb
+++ b/spec/features/happy_journeys_non_js_spec.rb
@@ -108,9 +108,37 @@ RSpec.feature "Happy journeys", type: :feature do
     page.choose "open manchester school"
     page.click_button("Continue")
 
+    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/RP12%2F345?npq_course_identifier=npq-senior-leadership")
+      .with(
+        headers: {
+          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+        },
+      )
+      .to_return(
+        status: 200,
+        body: previously_funded_response(false),
+        headers: {
+          "Content-Type" => "application/vnd.api+json",
+        },
+      )
+
     expect(page).to have_text("What are you applying for?")
     page.choose("NPQ for Senior Leadership (NPQSL)")
     page.click_button("Continue")
+
+    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=npq-headship")
+      .with(
+        headers: {
+          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+        },
+      )
+      .to_return(
+        status: 200,
+        body: previously_funded_response(false),
+        headers: {
+          "Content-Type" => "application/vnd.api+json",
+        },
+      )
 
     expect(page).to have_text("If your provider accepts your application, you’ll qualify for DfE funding")
     page.click_button("Continue")
@@ -250,6 +278,20 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).to have_text("Choose your workplace")
     page.choose "open manchester school"
     page.click_button("Continue")
+
+    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=npq-headship")
+      .with(
+        headers: {
+          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+        },
+      )
+      .to_return(
+        status: 200,
+        body: previously_funded_response(false),
+        headers: {
+          "Content-Type" => "application/vnd.api+json",
+        },
+      )
 
     expect(page).to have_text("What are you applying for?")
     page.choose("NPQ for Headship (NPQH)")
@@ -433,6 +475,20 @@ RSpec.feature "Happy journeys", type: :feature do
     page.choose "No"
     page.click_button("Continue")
 
+    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=npq-early-headship-coaching-offer")
+      .with(
+        headers: {
+          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+        },
+      )
+      .to_return(
+        status: 200,
+        body: previously_funded_response(false),
+        headers: {
+          "Content-Type" => "application/vnd.api+json",
+        },
+      )
+
     expect(page).to have_selector "h1", text: "DfE scholarship funding is not available"
     page.click_button("Continue")
 
@@ -602,6 +658,20 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).to have_selector "h1", text: "Are you a headteacher?"
     page.choose "Yes"
     page.click_button("Continue")
+
+    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=npq-early-headship-coaching-offer")
+      .with(
+        headers: {
+          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+        },
+      )
+      .to_return(
+        status: 200,
+        body: previously_funded_response(false),
+        headers: {
+          "Content-Type" => "application/vnd.api+json",
+        },
+      )
 
     expect(page).to have_selector "h1", text: "Are you in your first 5 years of a headship?"
     page.choose "Yes"

--- a/spec/features/happy_journeys_spec.rb
+++ b/spec/features/happy_journeys_spec.rb
@@ -103,6 +103,20 @@ RSpec.feature "Happy journeys", type: :feature do
     page.find("#school-picker__option--0").click
     page.click_button("Continue")
 
+    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=npq-senior-leadership")
+      .with(
+        headers: {
+          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+        },
+      )
+      .to_return(
+        status: 200,
+        body: previously_funded_response(false),
+        headers: {
+          "Content-Type" => "application/vnd.api+json",
+        },
+      )
+
     expect(page).to be_axe_clean
     expect(page).to have_text("What are you applying for?")
     page.choose("NPQ for Senior Leadership (NPQSL)", visible: :all)
@@ -246,6 +260,20 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).to have_content("open manchester school")
     page.find("#school-picker__option--0").click
     page.click_button("Continue")
+
+    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=npq-headship")
+      .with(
+        headers: {
+          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+        },
+      )
+      .to_return(
+        status: 200,
+        body: previously_funded_response(false),
+        headers: {
+          "Content-Type" => "application/vnd.api+json",
+        },
+      )
 
     expect(page).to be_axe_clean
     expect(page).to have_text("What are you applying for?")
@@ -832,6 +860,20 @@ RSpec.feature "Happy journeys", type: :feature do
     page.find("#nursery-picker__option--0").click
     page.click_button("Continue")
 
+    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=npq-senior-leadership")
+      .with(
+        headers: {
+          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+        },
+      )
+      .to_return(
+        status: 200,
+        body: previously_funded_response(false),
+        headers: {
+          "Content-Type" => "application/vnd.api+json",
+        },
+      )
+
     expect(page).to be_axe_clean
     expect(page).to have_text("What are you applying for?")
     page.choose("NPQ for Senior Leadership (NPQSL)", visible: :all) # Needs changing to an early years course once added
@@ -987,7 +1029,24 @@ RSpec.feature "Happy journeys", type: :feature do
     page.find("#private-childcare-provider-picker__option--0").click
     page.click_button("Continue")
 
+    Course::COURSE_ECF_ID_TO_IDENTIFIER_MAPPING.each_value do |course_identifier|
+      stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=#{course_identifier}")
+        .with(
+          headers: {
+            "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+          },
+        )
+        .to_return(
+          status: 200,
+          body: previously_funded_response(false),
+          headers: {
+            "Content-Type" => "application/vnd.api+json",
+          },
+        )
+    end
+
     eyl_course = ["NPQ for Early Years Leadership (NPQEYL)"]
+
     ineligible_courses = Forms::ChooseYourNpq.new.options.map(&:text) - eyl_course
 
     ineligible_courses.each do |course|
@@ -1032,6 +1091,369 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(check_answers_page.summary_list.key?("Have you been a headteacher for two years or more?")).to be_falsey
     expect(check_answers_page.summary_list.key?("School or college")).to be_falsey
     expect(check_answers_page.summary_list.key?("How is your NPQ being paid for?")).to be_falsey
+
+    allow(ApplicationSubmissionJob).to receive(:perform_later).with(anything)
+
+    page.click_button("Submit")
+
+    expect(page).to be_axe_clean
+  end
+
+  scenario "registration journey while working at private nursery" do
+    visit "/"
+    expect(page).to have_text("Before you start")
+    page.click_link("Start now")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Have you already chosen an NPQ and provider?")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    # expect(page).to be_axe_clean
+    # TODO: aria-expanded
+    expect(page.current_path).to eql("/registration/teacher-catchment")
+    page.choose("England", visible: :all)
+    page.click_button("Continue")
+
+    expect(page.current_path).to eql("/registration/work-in-school")
+    page.choose("No", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page.current_path).to eql("/registration/teacher-reference-number")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page.current_path).to include("contact-details")
+    expect(page).to have_text("What's your email address?")
+    page.fill_in "What's your email address?", with: "user@example.com"
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Confirm your code")
+    expect(page).to have_text("user@example.com")
+    page.click_button("Continue")
+
+    code = ActionMailer::Base.deliveries.last[:personalisation].unparsed_value[:code]
+
+    expect(page).to be_axe_clean
+    page.fill_in "Enter your code", with: code
+    page.click_button("Continue")
+
+    stub_request(:post, "https://ecf-app.gov.uk/api/v1/participant-validation")
+      .with(
+        headers: {
+          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+        },
+        body: {
+          trn: "1234567",
+          date_of_birth: "1980-12-13",
+          full_name: "John Doe",
+          nino: "AB123456C",
+        },
+      )
+      .to_return(status: 200, body: participant_validator_response, headers: {})
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Check your details")
+    page.fill_in "Teacher reference number (TRN)", with: "1234567"
+    page.fill_in "Full name", with: "John Doe"
+    page.fill_in "Day", with: "13"
+    page.fill_in "Month", with: "12"
+    page.fill_in "Year", with: "1980"
+    page.fill_in "National Insurance number", with: "AB123456C"
+    page.click_button("Continue")
+
+    School.create!(urn: 100_000, name: "open manchester school", address_1: "street 1", town: "manchester", establishment_status_code: "1")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Do you work in early years or childcare?")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Do you work in a nursery?")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("What kind of nursery do you work in?")
+    page.choose("Private nursery", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Do you have an Ofsted unique reference number (URN)?")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    PrivateChildcareProvider.create!(
+      provider_urn: "EY123456", provider_name: "searchable childcare provider",
+      address_1: "street 1", town: "manchester",
+      early_years_individual_registers: %w[CCR VCR EYR]
+    )
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Enter your or your employer's URN")
+    within ".npq-js-reveal" do
+      page.fill_in "private-childcare-provider-picker", with: "EY123"
+    end
+
+    expect(page).to have_content("EY123456 - searchable childcare provider - street 1, manchester")
+    page.find("#private-childcare-provider-picker__option--0").click
+    page.click_button("Continue")
+
+    Course::COURSE_ECF_ID_TO_IDENTIFIER_MAPPING.each_value do |course_identifier|
+      stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=#{course_identifier}")
+        .with(
+          headers: {
+            "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+          },
+        )
+        .to_return(
+          status: 200,
+          body: previously_funded_response(false),
+          headers: {
+            "Content-Type" => "application/vnd.api+json",
+          },
+        )
+    end
+
+    eyl_course = ["NPQ for Early Years Leadership (NPQEYL)"]
+
+    ineligible_courses = Forms::ChooseYourNpq.new.options.map(&:text) - eyl_course
+
+    ineligible_courses.each do |course|
+      expect(page).to have_text("What are you applying for?")
+      page.choose(course, visible: :all)
+      page.click_button("Continue")
+
+      expect(page).not_to have_text("If your provider accepts your application, you’ll qualify for DfE funding")
+      page.click_link("Back")
+    end
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("What are you applying for?")
+    page.choose("NPQ for Early Years Leadership (NPQEYL)", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("If your provider accepts your application, you’ll qualify for DfE funding")
+    expect(page).to have_text("You’ll only be eligible for DfE funding for this NPQ once. If you start this NPQ, and then withdraw or fail, you will not be funded again for the same course.")
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Select your provider")
+    page.choose("Teach First", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Sharing your NPQ information")
+    page.check("Yes, I agree my information can be shared", visible: :all)
+    page.click_button("Continue")
+
+    check_answers_page = CheckAnswersPage.new
+
+    expect(page).to be_axe_clean
+    expect(check_answers_page).to be_displayed
+    expect(check_answers_page.summary_list["Full name"].value).to eql("John Doe")
+    expect(check_answers_page.summary_list["TRN"].value).to eql("1234567")
+    expect(check_answers_page.summary_list["Date of birth"].value).to eql("13 December 1980")
+    expect(check_answers_page.summary_list["National Insurance number"].value).to eql("AB123456C")
+    expect(check_answers_page.summary_list["Email"].value).to eql("user@example.com")
+    expect(check_answers_page.summary_list["Course"].value).to eql("NPQ for Early Years Leadership (NPQEYL)")
+    expect(check_answers_page.summary_list.key?("Have you been a headteacher for two years or more?")).to be_falsey
+    expect(check_answers_page.summary_list.key?("School or college")).to be_falsey
+    expect(check_answers_page.summary_list.key?("How is your NPQ being paid for?")).to be_falsey
+
+    allow(ApplicationSubmissionJob).to receive(:perform_later).with(anything)
+
+    page.click_button("Submit")
+
+    expect(page).to be_axe_clean
+  end
+
+  scenario "registration journey when previously funded" do
+    visit "/"
+    expect(page).to have_text("Before you start")
+    page.click_link("Start now")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Have you already chosen an NPQ and provider?")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    # expect(page).to be_axe_clean
+    # TODO: aria-expanded
+    expect(page.current_path).to eql("/registration/teacher-catchment")
+    page.choose("England", visible: :all)
+    page.click_button("Continue")
+
+    expect(page.current_path).to eql("/registration/work-in-school")
+    page.choose("No", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page.current_path).to eql("/registration/teacher-reference-number")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page.current_path).to include("contact-details")
+    expect(page).to have_text("What's your email address?")
+    page.fill_in "What's your email address?", with: "user@example.com"
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Confirm your code")
+    expect(page).to have_text("user@example.com")
+    page.click_button("Continue")
+
+    code = ActionMailer::Base.deliveries.last[:personalisation].unparsed_value[:code]
+
+    expect(page).to be_axe_clean
+    page.fill_in "Enter your code", with: code
+    page.click_button("Continue")
+
+    stub_request(:post, "https://ecf-app.gov.uk/api/v1/participant-validation")
+      .with(
+        headers: {
+          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+        },
+        body: {
+          trn: "1234567",
+          date_of_birth: "1980-12-13",
+          full_name: "John Doe",
+          nino: "AB123456C",
+        },
+      )
+      .to_return(status: 200, body: participant_validator_response, headers: {})
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Check your details")
+    page.fill_in "Teacher reference number (TRN)", with: "1234567"
+    page.fill_in "Full name", with: "John Doe"
+    page.fill_in "Day", with: "13"
+    page.fill_in "Month", with: "12"
+    page.fill_in "Year", with: "1980"
+    page.fill_in "National Insurance number", with: "AB123456C"
+    page.click_button("Continue")
+
+    School.create!(urn: 100_000, name: "open manchester school", address_1: "street 1", town: "manchester", establishment_status_code: "1")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Do you work in early years or childcare?")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Do you work in a nursery?")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("What kind of nursery do you work in?")
+    page.choose("Private nursery", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Do you have an Ofsted unique reference number (URN)?")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    PrivateChildcareProvider.create!(
+      provider_urn: "EY123456", provider_name: "searchable childcare provider",
+      address_1: "street 1", town: "manchester",
+      early_years_individual_registers: %w[CCR VCR EYR]
+    )
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Enter your or your employer's URN")
+    within ".npq-js-reveal" do
+      page.fill_in "private-childcare-provider-picker", with: "EY123"
+    end
+
+    expect(page).to have_content("EY123456 - searchable childcare provider - street 1, manchester")
+    page.find("#private-childcare-provider-picker__option--0").click
+    page.click_button("Continue")
+
+    %w[npq-early-headship-coaching-offer npq-early-years-leadership].each do |identifier|
+      stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=#{identifier}")
+        .with(
+          headers: {
+            "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+          },
+        )
+        .to_return(
+          status: 200,
+          body: previously_funded_response(true),
+          headers: {
+            "Content-Type" => "application/vnd.api+json",
+          },
+        )
+    end
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("What are you applying for?")
+    page.choose("NPQ for Early Years Leadership (NPQEYL)", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("DfE scholarship funding is not available")
+    expect(page).to have_text("You can only receive scholarship funding to study this NPQ with one provider")
+    expect(page).to have_text("If you have previously failed or withdrawn from this course")
+    expect(page).to have_text("You can go back and select a different NPQ")
+    page.click_link("Back")
+
+    page.choose("Early Headship Coaching Offer", visible: :all)
+    page.click_button("Continue")
+
+    expect(page.current_path).to eql("/registration/about-ehco")
+    page.click_link("Continue")
+    expect(page.current_path).to eql("/registration/npqh-status")
+    page.choose("I have completed an NPQH", visible: :all)
+    page.click_button("Continue")
+    expect(page.current_path).to eql("/registration/aso-headteacher")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+    expect(page.current_path).to eql("/registration/aso-new-headteacher")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("DfE scholarship funding is not available")
+    expect(page).to have_text("You can only receive scholarship funding to study this offer with one provider")
+    expect(page).to have_text("If you have previously withdrawn from this offer")
+    page.click_link("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("How is the Early Headship Coaching Offer being paid for?")
+    page.choose "I am paying", visible: :all
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Select your provider")
+    page.choose("Teach First", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Sharing your NPQ information")
+    page.check("Yes, I agree my information can be shared", visible: :all)
+    page.click_button("Continue")
+
+    check_answers_page = CheckAnswersPage.new
+
+    expect(page).to be_axe_clean
+    expect(check_answers_page).to be_displayed
+    expect(check_answers_page.summary_list["Full name"].value).to eql("John Doe")
+    expect(check_answers_page.summary_list["TRN"].value).to eql("1234567")
+    expect(check_answers_page.summary_list["Date of birth"].value).to eql("13 December 1980")
+    expect(check_answers_page.summary_list["National Insurance number"].value).to eql("AB123456C")
+    expect(check_answers_page.summary_list["Email"].value).to eql("user@example.com")
+    expect(check_answers_page.summary_list["Course"].value).to eql("Early Headship Coaching Offer")
+    expect(check_answers_page.summary_list.key?("Have you been a headteacher for two years or more?")).to be_falsey
+    expect(check_answers_page.summary_list.key?("School or college")).to be_falsey
+    expect(check_answers_page.summary_list["How is the Early Headship Coaching Offer being paid for?"].value).to eql("I am paying")
 
     allow(ApplicationSubmissionJob).to receive(:perform_later).with(anything)
 

--- a/spec/features/sad_journeys_spec.rb
+++ b/spec/features/sad_journeys_spec.rb
@@ -102,6 +102,20 @@ RSpec.feature "Sad journeys", type: :feature do
     page.find("#school-picker__option--0").click
     page.click_button("Continue")
 
+    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=npq-senior-leadership")
+      .with(
+        headers: {
+          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+        },
+      )
+      .to_return(
+        status: 200,
+        body: previously_funded_response(false),
+        headers: {
+          "Content-Type" => "application/vnd.api+json",
+        },
+      )
+
     expect(page).to be_axe_clean
     expect(page).to have_text("What are you applying for?")
     page.choose("NPQ for Senior Leadership (NPQSL)", visible: :all)
@@ -491,6 +505,20 @@ RSpec.feature "Sad journeys", type: :feature do
     expect(page).to have_content("open manchester school")
     page.find("#school-picker__option--0").click
     page.click_button("Continue")
+
+    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=npq-early-headship-coaching-offer")
+      .with(
+        headers: {
+          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+        },
+      )
+      .to_return(
+        status: 200,
+        body: previously_funded_response(false),
+        headers: {
+          "Content-Type" => "application/vnd.api+json",
+        },
+      )
 
     expect(page).to be_axe_clean
     expect(page).to have_text("What are you applying for?")

--- a/spec/lib/forms/check_answers_spec.rb
+++ b/spec/lib/forms/check_answers_spec.rb
@@ -22,6 +22,22 @@ RSpec.describe Forms::CheckAnswers do
   let(:wizard) { RegistrationWizard.new(current_step: :check_answers, store: store, request: request) }
 
   describe "#after_save" do
+    before do
+      stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=#{course.identifier}")
+        .with(
+          headers: {
+            "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+          },
+        )
+        .to_return(
+          status: 200,
+          body: previously_funded_response(false),
+          headers: {
+            "Content-Type" => "application/vnd.api+json",
+          },
+        )
+    end
+
     context "when verified_trn and entered trn differ" do
       it "uses verified_trn" do
         subject.wizard = wizard

--- a/spec/lib/forms/choose_your_npq_spec.rb
+++ b/spec/lib/forms/choose_your_npq_spec.rb
@@ -66,6 +66,20 @@ RSpec.describe Forms::ChooseYourNpq, type: :model do
             store: store,
             request: request,
           )
+
+          stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding?npq_course_identifier=npq-headship")
+            .with(
+              headers: {
+                "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+              },
+            )
+            .to_return(
+              status: 200,
+              body: previously_funded_response(false),
+              headers: {
+                "Content-Type" => "application/vnd.api+json",
+              },
+            )
         end
 
         it "returns check_answers" do

--- a/spec/lib/services/handle_submission_for_store_spec.rb
+++ b/spec/lib/services/handle_submission_for_store_spec.rb
@@ -28,6 +28,22 @@ RSpec.describe Services::HandleSubmissionForStore do
     }
   end
 
+  before do
+    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/12345?npq_course_identifier=#{course.identifier}")
+      .with(
+        headers: {
+          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+        },
+      )
+      .to_return(
+        status: 200,
+        body: previously_funded_response(false),
+        headers: {
+          "Content-Type" => "application/vnd.api+json",
+        },
+      )
+  end
+
   subject { described_class.new(store: store) }
 
   describe "#call" do
@@ -266,6 +282,22 @@ RSpec.describe Services::HandleSubmissionForStore do
             "aso_headteacher" => "yes",
             "aso_new_headteacher" => "no",
           }
+        end
+
+        before do
+          stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/12345?npq_course_identifier=npq-early-headship-coaching-offer")
+            .with(
+              headers: {
+                "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+              },
+            )
+            .to_return(
+              status: 200,
+              body: previously_funded_response(false),
+              headers: {
+                "Content-Type" => "application/vnd.api+json",
+              },
+            )
         end
 
         it "returns headteacher_status as yes_over_five_years" do

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Application do
         institution: subject.school,
         inside_catchment: subject.inside_catchment?,
         new_headteacher: subject.new_headteacher?,
+        trn: subject.user.trn,
       ).and_return(mock_funding_service)
 
       subject.calculate_funding_eligbility

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1,6 +1,23 @@
 require "rails_helper"
 
 RSpec.describe Course do
+  describe "COURSE_ECF_ID_TO_IDENTIFIER_MAPPING constant" do
+    it "returns a hash with the ecf_id to identifier mapping" do
+      expect(described_class::COURSE_ECF_ID_TO_IDENTIFIER_MAPPING).to eq({
+        "15c52ed8-06b5-426e-81a2-c2664978a0dc" => "npq-leading-teaching",
+        "7d47a0a6-fa74-4587-92cc-cd1e4548a2e5" => "npq-leading-behaviour-culture",
+        "29fee78b-30ce-4b93-ba21-80be2fde286f" => "npq-leading-teaching-development",
+        "a42736ad-3d0b-401d-aebe-354ef4c193ec" => "npq-senior-leadership",
+        "0f7d6578-a12c-4498-92a0-2ee0f18e0768" => "npq-headship",
+        "aef853f2-9b48-4b6a-9d2a-91b295f5ca9a" => "npq-executive-leadership",
+        "7fbefdd4-dd2d-4a4f-8995-d59e525124b7" => "npq-additional-support-offer",
+        "0222d1a8-a8e1-42e3-a040-2c585f6c194a" => "npq-early-headship-coaching-offer",
+        "66dff4af-a518-498f-9042-36a41f9e8aa7" => "npq-early-years-leadership",
+        "829fcd45-e39d-49a9-b309-26d26debfa90" => "npq-leading-literacy",
+      })
+    end
+  end
+
   describe "#eyl?" do
     context "when the course name is NPQEYL" do
       let(:course) { described_class.new(name: "NPQ for Early Years Leadership (NPQEYL)") }
@@ -16,6 +33,14 @@ RSpec.describe Course do
       it "returns false" do
         expect(course.eyl?).to be false
       end
+    end
+  end
+
+  describe "#identifier" do
+    let(:course) { described_class.find_by(name: "NPQ for Senior Leadership (NPQSL)") }
+
+    it "returns the ecf identifier of the course" do
+      expect(course.identifier).to eq("npq-senior-leadership")
     end
   end
 end

--- a/spec/models/registration_wizard_spec.rb
+++ b/spec/models/registration_wizard_spec.rb
@@ -52,7 +52,24 @@ RSpec.describe RegistrationWizard do
           "aso_new_headteacher" => "yes",
           "aso_funding" => "yes",
           "aso_funding_choice" => "another",
+          "trn" => "123456",
         }
+      end
+
+      before do
+        stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/123456?npq_course_identifier=npq-additional-support-offer")
+          .with(
+            headers: {
+              "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+            },
+          )
+         .to_return(
+           status: 200,
+           body: previously_funded_response(false),
+           headers: {
+             "Content-Type" => "application/vnd.api+json",
+           },
+         )
       end
 
       it "does not show How is your NPQ being paid for?" do
@@ -74,7 +91,24 @@ RSpec.describe RegistrationWizard do
           "lead_provider_id" => LeadProvider.all.sample.id,
           "aso_funding" => "yes",
           "aso_funding_choice" => "another",
+          "trn" => "123456",
         }
+      end
+
+      before do
+        stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/123456?npq_course_identifier=npq-additional-support-offer")
+          .with(
+            headers: {
+              "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+            },
+          )
+         .to_return(
+           status: 200,
+           body: previously_funded_response(false),
+           headers: {
+             "Content-Type" => "application/vnd.api+json",
+           },
+         )
       end
 
       it "shows ASO funding option" do

--- a/spec/support/api_responses.rb
+++ b/spec/support/api_responses.rb
@@ -24,3 +24,9 @@ def participant_validator_response(trn: "1234567", active_alert: false)
     },
   }.to_json
 end
+
+def previously_funded_response(previously_funded)
+  {
+    previously_funded: previously_funded,
+  }.to_json
+end


### PR DESCRIPTION
### Context

[Ticket CN-22](https://dfedigital.atlassian.net/browse/CN-22)

We want users to not be eligible for scholarship funding for the same NPQ, if they have already received one in the past.

### Changes proposed in this pull request

- Added the NpqFunding class to handle the api call
- Added a custom parser for the NpqFunding to parse the response from the ECF API
- Update the ineligibility copy
- Add an ineligibility page for the EHCO NPQ (a.k.a ASO)
- Update the funding eligibility service to require a TRN
- Added course mappings for the ECF course identifiers

### Guidance to review
The previously funded eligibility check is institution agnostic - will run for Schools, Early Years etc.

Also, the npq funding endpoint in the ECF API requires a TRN and a course identifier, but the NPQ service only knows the `ecf_id`. It make sense to update the ECF API at some point to require the `ecf_id` instead, but for now I have added a mapping in the `Course` model to resolve the `identifier` based on the `ecf_id`.

#### How to test
Run NPQ and ECF services on your local and go through an eligible journey. Choose users and NPQs that were funded in the past and then check the copy in the ineligibility page is correct.
 