### PR TITLE
[CN-200] Invalid lead provider clearing

### DIFF
--- a/app/lib/services/query_store.rb
+++ b/app/lib/services/query_store.rb
@@ -48,7 +48,7 @@ class Services::QueryStore
   end
 
   def lead_provider
-    @lead_provider ||= LeadProvider.find(store["lead_provider_id"])
+    @lead_provider ||= LeadProvider.find_by(id: store["lead_provider_id"])
   end
 
   def new_headteacher?

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -130,8 +130,14 @@ class RegistrationWizard
                                 value: institution(source: store["institution_identifier"]).name,
                                 change_step: :find_childcare_provider)
       elsif query_store.works_in_private_childcare_provider?
+        value = if query_store.has_ofsted_urn?
+                  institution(source: store["institution_identifier"]).provider_name
+                else
+                  "No Ofsted URN provided"
+                end
+
         array << OpenStruct.new(key: "Nursery",
-                                value: institution(source: store["institution_identifier"]).provider_name,
+                                value: value,
                                 change_step: :have_ofsted_urn)
       end
     end

--- a/spec/features/happy_journeys_spec.rb
+++ b/spec/features/happy_journeys_spec.rb
@@ -1461,4 +1461,207 @@ RSpec.feature "Happy journeys", type: :feature do
 
     expect(page).to be_axe_clean
   end
+  
+  scenario "registration journey changing NPQ to one LeadProvider no longer supports" do
+    visit "/"
+    expect(page).to have_text("Before you start")
+    page.click_link("Start now")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Have you already chosen an NPQ and provider?")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    # expect(page).to be_axe_clean
+    # TODO: aria-expanded
+    expect(page.current_path).to eql("/registration/teacher-catchment")
+    page.choose("England", visible: :all)
+    page.click_button("Continue")
+
+    expect(page.current_path).to eql("/registration/work-in-school")
+    page.choose("No", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page.current_path).to eql("/registration/teacher-reference-number")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page.current_path).to include("contact-details")
+    expect(page).to have_text("What's your email address?")
+    page.fill_in "What's your email address?", with: "user@example.com"
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Confirm your code")
+    expect(page).to have_text("user@example.com")
+    page.click_button("Continue")
+
+    code = ActionMailer::Base.deliveries.last[:personalisation].unparsed_value[:code]
+
+    expect(page).to be_axe_clean
+    page.fill_in "Enter your code", with: code
+    page.click_button("Continue")
+
+    stub_request(:post, "https://ecf-app.gov.uk/api/v1/participant-validation")
+      .with(
+        headers: {
+          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+        },
+        body: {
+          trn: "1234567",
+          date_of_birth: "1980-12-13",
+          full_name: "John Doe",
+          nino: "AB123456C",
+        },
+        )
+      .to_return(status: 200, body: participant_validator_response, headers: {})
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Check your details")
+    page.fill_in "Teacher reference number (TRN)", with: "1234567"
+    page.fill_in "Full name", with: "John Doe"
+    page.fill_in "Day", with: "13"
+    page.fill_in "Month", with: "12"
+    page.fill_in "Year", with: "1980"
+    page.fill_in "National Insurance number", with: "AB123456C"
+    page.click_button("Continue")
+
+    School.create!(urn: 100_000, name: "open manchester school", address_1: "street 1", town: "manchester", establishment_status_code: "1")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Do you work in early years or childcare?")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Do you work in a nursery?")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("What kind of nursery do you work in?")
+    public_nursery_type = [
+      "Local authority maintained nursery",
+      "Preschool class that's part of a school",
+    ].sample
+    page.choose(public_nursery_type, visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Where is your nursery?")
+    page.fill_in "Nursery location", with: "manchester"
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Choose your nursery")
+    expect(page).to have_text("Choose from nurseries located in manchester")
+    within ".npq-js-reveal" do
+      page.fill_in "Enter your nursery name", with: "open"
+    end
+
+    expect(page).to have_content("open manchester school")
+    page.find("#nursery-picker__option--0").click
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("What are you applying for?")
+    page.choose("NPQ for Senior Leadership (NPQSL)", visible: :all) # Needs changing to an early years course once added
+    page.click_button("Continue")
+
+    expect(page).to have_text("DfE scholarship funding is not available")
+    expect(page).to have_text("To be eligible for scholarship funding for")
+    expect(page).to have_text("state-funded schools")
+    expect(page).to have_text("state-funded 16 to 19 organisations")
+    expect(page).to have_text("independent special schools")
+    expect(page).to have_text("virtual schools")
+    expect(page).to have_text("hospital schools")
+    expect(page).to have_text("young offenders institutions")
+    page.click_link("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("How is your course being paid for?")
+    page.choose "My workplace is covering the cost", visible: :all
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Select your provider")
+    page.choose("Best Practice Network (home of Outstanding Leaders Partnership)", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Sharing your NPQ information")
+    page.check("Yes, I agree my information can be shared", visible: :all)
+    page.click_button("Continue")
+
+    check_answers_page = CheckAnswersPage.new
+
+    expect(page).to be_axe_clean
+    expect(check_answers_page).to be_displayed
+    expect(check_answers_page.summary_list["Full name"].value).to eql("John Doe")
+    expect(check_answers_page.summary_list["TRN"].value).to eql("1234567")
+    expect(check_answers_page.summary_list["Date of birth"].value).to eql("13 December 1980")
+    expect(check_answers_page.summary_list["National Insurance number"].value).to eql("AB123456C")
+    expect(check_answers_page.summary_list["Email"].value).to eql("user@example.com")
+    expect(check_answers_page.summary_list["Course"].value).to eql("NPQ for Senior Leadership (NPQSL)")
+    expect(check_answers_page.summary_list.key?("Have you been a headteacher for two years or more?")).to be_falsey
+    expect(check_answers_page.summary_list.key?("School or college")).to be_falsey
+    expect(check_answers_page.summary_list["How is your NPQ being paid for?"].value).to eql("My workplace is covering the cost")
+    expect(check_answers_page.summary_list["Lead provider"].value).to eql("Best Practice Network (home of Outstanding Leaders Partnership)")
+
+    page.click_link("Change", href: "/registration/choose-your-npq/change")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("What are you applying for?")
+    page.choose("NPQ for Early Years Leadership (NPQEYL)", visible: :all) # Needs changing to an early years course once added
+    page.click_button("Continue")
+
+    expect(page).to have_text("DfE scholarship funding is not available")
+    expect(page).to have_text("To be eligible for scholarship funding for")
+    expect(page).to have_text("state-funded schools")
+    expect(page).to have_text("state-funded 16 to 19 organisations")
+    expect(page).to have_text("independent special schools")
+    expect(page).to have_text("virtual schools")
+    expect(page).to have_text("hospital schools")
+    expect(page).to have_text("young offenders institutions")
+    page.click_link("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("How is your course being paid for?")
+    page.choose "My workplace is covering the cost", visible: :all
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Select your provider")
+    expect(page).to_not have_text("Best Practice Network (home of Outstanding Leaders Partnership)")
+    page.choose("Teacher Development Trust", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Sharing your NPQ information")
+    page.check("Yes, I agree my information can be shared", visible: :all)
+    page.click_button("Continue")
+
+    check_answers_page = CheckAnswersPage.new
+
+    expect(page).to be_axe_clean
+    expect(check_answers_page).to be_displayed
+    expect(check_answers_page.summary_list["Full name"].value).to eql("John Doe")
+    expect(check_answers_page.summary_list["TRN"].value).to eql("1234567")
+    expect(check_answers_page.summary_list["Date of birth"].value).to eql("13 December 1980")
+    expect(check_answers_page.summary_list["National Insurance number"].value).to eql("AB123456C")
+    expect(check_answers_page.summary_list["Email"].value).to eql("user@example.com")
+    expect(check_answers_page.summary_list["Course"].value).to eql("NPQ for Early Years Leadership (NPQEYL)")
+    expect(check_answers_page.summary_list.key?("Have you been a headteacher for two years or more?")).to be_falsey
+    expect(check_answers_page.summary_list.key?("School or college")).to be_falsey
+    expect(check_answers_page.summary_list["How is your NPQ being paid for?"].value).to eql("My workplace is covering the cost")
+    expect(check_answers_page.summary_list["Lead provider"].value).to eql("Teacher Development Trust")
+
+    allow(ApplicationSubmissionJob).to receive(:perform_later).with(anything)
+
+    page.click_button("Submit")
+
+    expect(page).to be_axe_clean
+  end
 end

--- a/spec/features/happy_journeys_spec.rb
+++ b/spec/features/happy_journeys_spec.rb
@@ -1570,14 +1570,14 @@ RSpec.feature "Happy journeys", type: :feature do
         headers: {
           "Authorization" => "Bearer ECFAPPBEARERTOKEN",
         },
-        )
+      )
       .to_return(
         status: 200,
         body: previously_funded_response(false),
         headers: {
           "Content-Type" => "application/vnd.api+json",
         },
-        )
+      )
 
     expect(page).to be_axe_clean
     expect(page).to have_text("What are you applying for?")
@@ -1631,14 +1631,14 @@ RSpec.feature "Happy journeys", type: :feature do
         headers: {
           "Authorization" => "Bearer ECFAPPBEARERTOKEN",
         },
-        )
+      )
       .to_return(
         status: 200,
         body: previously_funded_response(false),
         headers: {
           "Content-Type" => "application/vnd.api+json",
         },
-        )
+      )
 
     expect(page).to be_axe_clean
     expect(page).to have_text("What are you applying for?")

--- a/spec/features/happy_journeys_spec.rb
+++ b/spec/features/happy_journeys_spec.rb
@@ -1183,7 +1183,7 @@ RSpec.feature "Happy journeys", type: :feature do
     page.click_button("Continue")
 
     expect(page).to be_axe_clean
-    expect(page).to have_text("Do you have an Ofsted unique reference number (URN)?")
+    expect(page).to have_text("Do you or your employer have an Ofsted unique reference number (URN)?")
     page.choose("Yes", visible: :all)
     page.click_button("Continue")
 
@@ -1357,7 +1357,7 @@ RSpec.feature "Happy journeys", type: :feature do
     page.click_button("Continue")
 
     expect(page).to be_axe_clean
-    expect(page).to have_text("Do you have an Ofsted unique reference number (URN)?")
+    expect(page).to have_text("Do you or your employer have an Ofsted unique reference number (URN)?")
     page.choose("Yes", visible: :all)
     page.click_button("Continue")
 
@@ -1565,6 +1565,20 @@ RSpec.feature "Happy journeys", type: :feature do
     page.find("#nursery-picker__option--0").click
     page.click_button("Continue")
 
+    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=npq-senior-leadership")
+      .with(
+        headers: {
+          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+        },
+        )
+      .to_return(
+        status: 200,
+        body: previously_funded_response(false),
+        headers: {
+          "Content-Type" => "application/vnd.api+json",
+        },
+        )
+
     expect(page).to be_axe_clean
     expect(page).to have_text("What are you applying for?")
     page.choose("NPQ for Senior Leadership (NPQSL)", visible: :all) # Needs changing to an early years course once added
@@ -1611,6 +1625,20 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(check_answers_page.summary_list["Lead provider"].value).to eql("Best Practice Network (home of Outstanding Leaders Partnership)")
 
     page.click_link("Change", href: "/registration/choose-your-npq/change")
+
+    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=npq-early-years-leadership")
+      .with(
+        headers: {
+          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+        },
+        )
+      .to_return(
+        status: 200,
+        body: previously_funded_response(false),
+        headers: {
+          "Content-Type" => "application/vnd.api+json",
+        },
+        )
 
     expect(page).to be_axe_clean
     expect(page).to have_text("What are you applying for?")

--- a/spec/features/happy_journeys_spec.rb
+++ b/spec/features/happy_journeys_spec.rb
@@ -1461,7 +1461,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
     expect(page).to be_axe_clean
   end
-  
+
   scenario "registration journey changing NPQ to one LeadProvider no longer supports" do
     visit "/"
     expect(page).to have_text("Before you start")
@@ -1515,7 +1515,7 @@ RSpec.feature "Happy journeys", type: :feature do
           full_name: "John Doe",
           nino: "AB123456C",
         },
-        )
+      )
       .to_return(status: 200, body: participant_validator_response, headers: {})
 
     expect(page).to be_axe_clean

--- a/spec/lib/forms/choose_your_npq_spec.rb
+++ b/spec/lib/forms/choose_your_npq_spec.rb
@@ -37,7 +37,13 @@ RSpec.describe Forms::ChooseYourNpq, type: :model do
 
       context "nothing was actually changed" do
         let(:course) { Course.find_by(name: "NPQ for Headship (NPQH)") }
-        let(:store) { { course_id: course.id.to_s }.stringify_keys }
+        let(:lead_provider) { LeadProvider.for(course: course).first }
+        let(:store) {
+          {
+            course_id: course.id.to_s,
+            lead_provider_id: lead_provider.id
+          }.stringify_keys
+        }
         let(:request) { nil }
 
         before do
@@ -57,7 +63,15 @@ RSpec.describe Forms::ChooseYourNpq, type: :model do
         let(:course) { Course.find_by(name: "NPQ for Leading Teaching (NPQLT)") }
         let(:school) { create(:school) }
         let(:previous_course) { Course.find_by(name: "NPQ for Headship (NPQH)") }
-        let(:store) { { course_id: previous_course.id.to_s, institution_identifier: "School-#{school.urn}" }.stringify_keys }
+        let(:lead_providers) { LeadProvider.for(course: course) }
+        let(:lead_provider) { lead_providers.first }
+        let(:store) {
+          {
+            course_id: previous_course.id.to_s,
+            institution_identifier: "School-#{school.urn}",
+            lead_provider_id: lead_provider.id
+          }.stringify_keys
+        }
         let(:request) { nil }
 
         before do
@@ -82,8 +96,20 @@ RSpec.describe Forms::ChooseYourNpq, type: :model do
             )
         end
 
-        it "returns check_answers" do
-          expect(subject.next_step).to eql(:check_answers)
+        context 'when lead provider is valid for new course' do
+          let(:lead_providers) { LeadProvider.for(course: course) }
+
+          it "returns check_answers" do
+            expect(subject.next_step).to eql(:check_answers)
+          end
+        end
+
+        context 'when lead provider is not valid for new course' do
+          let(:lead_providers) { LeadProvider.where.not(id: LeadProvider.for(course: course)) }
+
+          it "redirects you towards picking your provider flow" do
+            expect(subject.next_step).to eql(:ineligible_for_funding)
+          end
         end
       end
     end

--- a/spec/lib/forms/choose_your_npq_spec.rb
+++ b/spec/lib/forms/choose_your_npq_spec.rb
@@ -38,12 +38,12 @@ RSpec.describe Forms::ChooseYourNpq, type: :model do
       context "nothing was actually changed" do
         let(:course) { Course.find_by(name: "NPQ for Headship (NPQH)") }
         let(:lead_provider) { LeadProvider.for(course: course).first }
-        let(:store) {
+        let(:store) do
           {
             course_id: course.id.to_s,
-            lead_provider_id: lead_provider.id
+            lead_provider_id: lead_provider.id,
           }.stringify_keys
-        }
+        end
         let(:request) { nil }
 
         before do
@@ -65,13 +65,13 @@ RSpec.describe Forms::ChooseYourNpq, type: :model do
         let(:previous_course) { Course.find_by(name: "NPQ for Headship (NPQH)") }
         let(:lead_providers) { LeadProvider.for(course: course) }
         let(:lead_provider) { lead_providers.first }
-        let(:store) {
+        let(:store) do
           {
             course_id: previous_course.id.to_s,
             institution_identifier: "School-#{school.urn}",
-            lead_provider_id: lead_provider.id
+            lead_provider_id: lead_provider.id,
           }.stringify_keys
-        }
+        end
         let(:request) { nil }
 
         before do
@@ -96,7 +96,7 @@ RSpec.describe Forms::ChooseYourNpq, type: :model do
             )
         end
 
-        context 'when lead provider is valid for new course' do
+        context "when lead provider is valid for new course" do
           let(:lead_providers) { LeadProvider.for(course: course) }
 
           it "returns check_answers" do
@@ -104,7 +104,7 @@ RSpec.describe Forms::ChooseYourNpq, type: :model do
           end
         end
 
-        context 'when lead provider is not valid for new course' do
+        context "when lead provider is not valid for new course" do
           let(:lead_providers) { LeadProvider.where.not(id: LeadProvider.for(course: course)) }
 
           it "redirects you towards picking your provider flow" do

--- a/spec/lib/forms/choose_your_npq_spec.rb
+++ b/spec/lib/forms/choose_your_npq_spec.rb
@@ -86,7 +86,21 @@ RSpec.describe Forms::ChooseYourNpq, type: :model do
               headers: {
                 "Authorization" => "Bearer ECFAPPBEARERTOKEN",
               },
-            )
+              )
+            .to_return(
+              status: 200,
+              body: previously_funded_response(false),
+              headers: {
+                "Content-Type" => "application/vnd.api+json",
+              },
+              )
+
+          stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding?npq_course_identifier=npq-leading-teaching")
+            .with(
+              headers: {
+                "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+              },
+              )
             .to_return(
               status: 200,
               body: previously_funded_response(false),

--- a/spec/lib/forms/choose_your_npq_spec.rb
+++ b/spec/lib/forms/choose_your_npq_spec.rb
@@ -86,21 +86,21 @@ RSpec.describe Forms::ChooseYourNpq, type: :model do
               headers: {
                 "Authorization" => "Bearer ECFAPPBEARERTOKEN",
               },
-              )
+            )
             .to_return(
               status: 200,
               body: previously_funded_response(false),
               headers: {
                 "Content-Type" => "application/vnd.api+json",
               },
-              )
+            )
 
           stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding?npq_course_identifier=npq-leading-teaching")
             .with(
               headers: {
                 "Authorization" => "Bearer ECFAPPBEARERTOKEN",
               },
-              )
+            )
             .to_return(
               status: 200,
               body: previously_funded_response(false),


### PR DESCRIPTION
### Context

There was a workaround within the system that allowed you to apply for an NPQ with a LeadProvider that didn't supply that NPQ. If you selected an NPQ they did provide, select the provider and then go back and change your NPQ, then you could submit with an invalid lead provider.

### Changes proposed in this pull request

- Check LeadProvider on the choose_your_npq form object after save and clear the lead provider if it is no longer valid.
- Check for if LeadProvider is invalid during choose_your_npq next step to ensure user is asked to continue the flow from there and select a new provider.

### Guidance to review

1. Select NPQLBC
2. Progress to Choose Your Provider page
3. Select "Best Practice Network (home of Outstanding Leaders Partnership)" provider
4. Progress to Check answers page
5. Choose to change your NPQ
6. Select NPQLTD
7. See that you return to check answers screen because LeadProvider remains valid  
8. Choose to change your NPQ
9. Select NPQEYL
10. See that you have not returned to check answers screen and are back in the flow and need to reselect your provider