### PR TITLE
[CN-47] Validate registration interest emails and allow sending to all remaining recipients

### DIFF
--- a/app/jobs/registration_open_notification_job.rb
+++ b/app/jobs/registration_open_notification_job.rb
@@ -2,8 +2,16 @@ class RegistrationOpenNotificationJob < ApplicationJob
   queue_as :default
 
   def perform(registration_interest:)
-    RegistrationOpenNotificationMailer.notification_open_mail(to: registration_interest.email).deliver_now
+    send_notification(registration_interest)
 
     registration_interest.update!(notified: true)
+  end
+
+  private
+
+  def send_notification(registration_interest)
+    return unless registration_interest.valid_email?
+
+    RegistrationOpenNotificationMailer.notification_open_mail(to: registration_interest.email).deliver_now
   end
 end

--- a/app/jobs/registration_open_notification_job.rb
+++ b/app/jobs/registration_open_notification_job.rb
@@ -7,7 +7,7 @@ class RegistrationOpenNotificationJob < ApplicationJob
     registration_interest.update!(notified: true)
   end
 
-  private
+private
 
   def send_notification(registration_interest)
     return unless registration_interest.valid_email?

--- a/app/lib/forms/contact_details.rb
+++ b/app/lib/forms/contact_details.rb
@@ -17,7 +17,7 @@ module Forms
       harrischaffordhundred.org.uk
       llse.org.uk
       realgroup.co.uk
-      teacherdevelopmenttrust.org 
+      teacherdevelopmenttrust.org
       uclconsultants.com
     ].freeze
 

--- a/app/lib/forms/registration_interest_notification.rb
+++ b/app/lib/forms/registration_interest_notification.rb
@@ -4,8 +4,8 @@ module Forms
 
     attr_accessor :email
 
-    validates :email, presence: true, length: { maximum: 128 }
     validate :validate_unique_email
+    validates :email, presence: true, length: { maximum: 128 }, email: true
 
     def validate_unique_email
       return if RegistrationInterest.find_by(email: email).blank?

--- a/app/models/registration_interest.rb
+++ b/app/models/registration_interest.rb
@@ -2,8 +2,14 @@ class RegistrationInterest < ApplicationRecord
   validates :email,
             presence: true,
             length: { maximum: 128 },
-            uniqueness: { case_sensitive: false }
+            uniqueness: { case_sensitive: false },
+            email: true
 
   scope :not_yet_notified, -> { where(notified: false) }
   scope :random_sample, ->(count) { order("RANDOM()").first(count) }
+
+  # We did not originally valid email format so we need to check this before sending
+  def valid_email?
+    EmailValidator.valid?(email)
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -162,8 +162,8 @@ en:
               inclusion: Select an option
             email:
               blank: Enter an email address
-              invalid: This email has already been registered for interest
-              taken: You have already registered to be notified
+              invalid: This email is invalid
+              taken: This email has already been registered for interest
   registration_wizard:
     kind_of_nursery:
       local_authority_maintained_nursery: Local authority maintained nursery

--- a/lib/tasks/registration_interest.rake
+++ b/lib/tasks/registration_interest.rake
@@ -3,10 +3,10 @@ namespace :registration_interest do
   task :send_notifications, %i[count] => :environment do |_t, args|
     count = args["count"]
 
-    recipients = if args["count"] == "all"
+    recipients = if count == "all"
                    RegistrationInterest.not_yet_notified
                  else
-                   count = args["count"].to_i
+                   count = count.to_i
                    RegistrationInterest.not_yet_notified.random_sample(count)
                  end
 

--- a/lib/tasks/registration_interest.rake
+++ b/lib/tasks/registration_interest.rake
@@ -1,9 +1,18 @@
 namespace :registration_interest do
   desc "Send notifications to users indicating NPQ applications are open"
   task :send_notifications, %i[count] => :environment do |_t, args|
-    count = args["count"].to_i
+    count = args["count"]
 
-    RegistrationInterest.not_yet_notified.random_sample(count).each do |registration_interest|
+    recipients = if args["count"] == "all"
+                   RegistrationInterest.not_yet_notified
+                 else
+                   count = args["count"].to_i
+                   RegistrationInterest.not_yet_notified.random_sample(count)
+                 end
+
+    puts("Sending registration opening notification to #{recipients.count} unnotified registered emails")
+
+    recipients.each do |registration_interest|
       RegistrationOpenNotificationJob.perform_later(registration_interest: registration_interest)
     end
   end

--- a/spec/lib/forms/registration_interest_notification_spec.rb
+++ b/spec/lib/forms/registration_interest_notification_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Forms::RegistrationInterestNotification, type: :model do
         it "shows the form is invalid when trying to register again" do
           subject.email = existing_registration.email
           subject.valid?
-          expect(subject.errors[:email]).to include("You have already registered to be notified")
+          expect(subject.errors[:email]).to include("This email has already been registered for interest")
         end
       end
     end


### PR DESCRIPTION
### Context

https://dfedigital.atlassian.net/browse/CN-47

### Changes proposed in this pull request

- Add email validation to RegistrationInterests
- Remove non-breaking space from test domains array
- Add ability to send notification to all emails