### PR TITLE
[CN-217] Look up correct institution when calling Application.calculate_funding_eligibility

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -13,7 +13,7 @@ class Application < ApplicationRecord
     private_nursery: "private_nursery",
   }
 
-  def calculate_funding_eligbility
+  def calculate_funding_eligibility
     Services::FundingEligibility.new(
       course: course,
       institution: institution,
@@ -38,7 +38,7 @@ class Application < ApplicationRecord
     %w[yes_when_course_starts yes_in_first_five_years yes_in_first_two_years].include?(headteacher_status)
   end
 
-  private
+private
 
   def private_childcare_provider_institution?
     works_in_nursery? && private_nursery?

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -5,6 +5,7 @@ class Application < ApplicationRecord
   belongs_to :course
   belongs_to :lead_provider
   belongs_to :school, foreign_key: "school_urn", primary_key: "urn", optional: true
+  belongs_to :private_childcare_provider, foreign_key: "private_childcare_provider_urn", primary_key: "provider_urn", optional: true
 
   enum kind_of_nursery: {
     local_authority_maintained_nursery: "local_authority_maintained_nursery",
@@ -15,11 +16,18 @@ class Application < ApplicationRecord
   def calculate_funding_eligbility
     Services::FundingEligibility.new(
       course: course,
-      institution: school,
+      institution: institution,
       inside_catchment: inside_catchment?,
       new_headteacher: new_headteacher?,
       trn: user.trn,
     ).funded?
+  end
+
+  def institution
+    return private_childcare_provider if private_childcare_provider_institution?
+    return school if school_institution?
+
+    nil
   end
 
   def inside_catchment?
@@ -28,5 +36,19 @@ class Application < ApplicationRecord
 
   def new_headteacher?
     %w[yes_when_course_starts yes_in_first_five_years yes_in_first_two_years].include?(headteacher_status)
+  end
+
+  private
+
+  def private_childcare_provider_institution?
+    works_in_nursery? && private_nursery?
+  end
+
+  def school_institution?
+    works_in_public_childcare_provider? || works_in_school?
+  end
+
+  def works_in_public_childcare_provider?
+    works_in_nursery? && (local_authority_maintained_nursery? || preschool_class_as_part_of_school?)
   end
 end

--- a/spec/factories/applications.rb
+++ b/spec/factories/applications.rb
@@ -2,14 +2,45 @@ require "securerandom"
 
 FactoryBot.define do
   factory :application do
+    application_for_school
+
     user
     course { Course.all.sample }
     lead_provider { LeadProvider.all.sample }
-    school_urn { rand(100_000..999_999).to_s }
     headteacher_status { "no" }
 
     trait :with_ecf_id do
       ecf_id { SecureRandom.uuid }
+    end
+
+    trait :application_for_school do
+      school { build(:school) }
+      private_childcare_provider_urn { nil }
+
+      works_in_school { true }
+      works_in_childcare { false }
+      works_in_nursery { false }
+      kind_of_nursery { nil }
+    end
+
+    trait :application_for_private_childcare_provider do
+      school_urn { nil }
+      private_childcare_provider { build(:private_childcare_provider) }
+
+      works_in_school { false }
+      works_in_childcare { true }
+      works_in_nursery { true }
+      kind_of_nursery { Forms::KindOfNursery::KIND_OF_NURSERY_PRIVATE_OPTIONS.sample }
+    end
+
+    trait :application_for_public_childcare_provider do
+      school { build(:school) }
+      private_childcare_provider_urn { nil }
+
+      works_in_school { false }
+      works_in_childcare { true }
+      works_in_nursery { true }
+      kind_of_nursery { Forms::KindOfNursery::KIND_OF_NURSERY_PUBLIC_OPTIONS.sample }
     end
   end
 end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -4,20 +4,60 @@ RSpec.describe Application do
   describe "#calculate_funding_eligbility" do
     let(:mock_funding_service) { instance_double(Services::FundingEligibility, "funded?": true) }
 
-    subject { build(:application) }
+    subject { create(:application, kind_of_application) }
 
-    it "calls Services::FundingEligibility with correct params" do
-      allow(Services::FundingEligibility).to receive(:new).with(
-        course: subject.course,
-        institution: subject.school,
-        inside_catchment: subject.inside_catchment?,
-        new_headteacher: subject.new_headteacher?,
-        trn: subject.user.trn,
-      ).and_return(mock_funding_service)
+    context "application_for_school" do
+      let(:kind_of_application) { :application_for_school }
 
-      subject.calculate_funding_eligbility
+      it "calls Services::FundingEligibility with correct params" do
+        allow(Services::FundingEligibility).to receive(:new).with(
+          course: subject.course,
+          institution: subject.school,
+          inside_catchment: subject.inside_catchment?,
+          new_headteacher: subject.new_headteacher?,
+          trn: subject.user.trn,
+          ).and_return(mock_funding_service)
 
-      expect(mock_funding_service).to have_received(:funded?)
+        subject.calculate_funding_eligbility
+
+        expect(mock_funding_service).to have_received(:funded?)
+      end
+    end
+
+    context "application_for_private_childcare_provider" do
+      let(:kind_of_application) { :application_for_private_childcare_provider }
+
+      it "calls Services::FundingEligibility with correct params" do
+        allow(Services::FundingEligibility).to receive(:new).with(
+          course: subject.course,
+          institution: subject.private_childcare_provider,
+          inside_catchment: subject.inside_catchment?,
+          new_headteacher: subject.new_headteacher?,
+          trn: subject.user.trn,
+          ).and_return(mock_funding_service)
+
+        subject.calculate_funding_eligbility
+
+        expect(mock_funding_service).to have_received(:funded?)
+      end
+    end
+
+    context "application_for_public_childcare_provider" do
+      let(:kind_of_application) { :application_for_public_childcare_provider }
+
+      it "calls Services::FundingEligibility with correct params" do
+        allow(Services::FundingEligibility).to receive(:new).with(
+          course: subject.course,
+          institution: subject.school,
+          inside_catchment: subject.inside_catchment?,
+          new_headteacher: subject.new_headteacher?,
+          trn: subject.user.trn,
+          ).and_return(mock_funding_service)
+
+        subject.calculate_funding_eligbility
+
+        expect(mock_funding_service).to have_received(:funded?)
+      end
     end
   end
 end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Application do
-  describe "#calculate_funding_eligbility" do
+  describe "#calculate_funding_eligibility" do
     let(:mock_funding_service) { instance_double(Services::FundingEligibility, "funded?": true) }
 
     subject { create(:application, kind_of_application) }
@@ -16,9 +16,9 @@ RSpec.describe Application do
           inside_catchment: subject.inside_catchment?,
           new_headteacher: subject.new_headteacher?,
           trn: subject.user.trn,
-          ).and_return(mock_funding_service)
+        ).and_return(mock_funding_service)
 
-        subject.calculate_funding_eligbility
+        subject.calculate_funding_eligibility
 
         expect(mock_funding_service).to have_received(:funded?)
       end
@@ -34,9 +34,9 @@ RSpec.describe Application do
           inside_catchment: subject.inside_catchment?,
           new_headteacher: subject.new_headteacher?,
           trn: subject.user.trn,
-          ).and_return(mock_funding_service)
+        ).and_return(mock_funding_service)
 
-        subject.calculate_funding_eligbility
+        subject.calculate_funding_eligibility
 
         expect(mock_funding_service).to have_received(:funded?)
       end
@@ -52,9 +52,9 @@ RSpec.describe Application do
           inside_catchment: subject.inside_catchment?,
           new_headteacher: subject.new_headteacher?,
           trn: subject.user.trn,
-          ).and_return(mock_funding_service)
+        ).and_return(mock_funding_service)
 
-        subject.calculate_funding_eligbility
+        subject.calculate_funding_eligibility
 
         expect(mock_funding_service).to have_received(:funded?)
       end


### PR DESCRIPTION
### Context

Minor bug, found whilst working on CN-217. calculate_funding_eligibility did not use the correct institution. As calculate_funding_eligibility isn't actually used anywhere other than the specs, this has not impacted any applications.

### Changes proposed in this pull request

- Rename Application.calculate_funding_eligbility to Application.calculate_funding_eligibility
- Use the correct institution in Application.calculate_funding_eligibility
