### PR TITLE
[CN-232] [CN-230] Return applicants to flow when core data changed

### DIFF
--- a/app/controllers/registration_wizard_controller.rb
+++ b/app/controllers/registration_wizard_controller.rb
@@ -25,7 +25,7 @@ class RegistrationWizardController < ApplicationController
     @form.flag_as_changing_answer if params[:changing_answer] == "1"
 
     if @form.valid?
-      if @form.changing_answer? && @form.next_step != :check_answers
+      if @form.changing_answer? && @form.next_step != :check_answers && !@form.return_to_regular_flow?
         redirect_to registration_wizard_show_change_path(@wizard.next_step_path)
       else
         redirect_to registration_wizard_show_path(@wizard.next_step_path)

--- a/app/lib/forms/base.rb
+++ b/app/lib/forms/base.rb
@@ -45,6 +45,24 @@ module Forms
       @changing_answer
     end
 
+    # Determines whether to return user from /registration/:step/change paths
+    # to /registration/:step paths when data changes.
+    #
+    # This is used when something very core to the data being gathered changes.
+    #
+    # For example, if a user who said they didn't work in a school changes to
+    # say that they do work in a school or the other way around then we need to
+    # put them back into the regular flow to make sure they don't get sent back
+    # to the check answers page before they answer any new questions that may
+    # need answering.
+    def return_to_regular_flow_on_change?
+      false
+    end
+
+    def return_to_regular_flow?
+      return_to_regular_flow_on_change? && answers_will_change?
+    end
+
     def answers_will_change?
       !no_answers_will_change?
     end

--- a/app/lib/forms/teacher_catchment.rb
+++ b/app/lib/forms/teacher_catchment.rb
@@ -14,6 +14,10 @@ module Forms
       ]
     end
 
+    def return_to_regular_flow_on_change?
+      true
+    end
+
     def next_step
       if changing_answer?
         if answers_will_change?

--- a/app/lib/forms/work_in_childcare.rb
+++ b/app/lib/forms/work_in_childcare.rb
@@ -10,6 +10,10 @@ module Forms
       %i[works_in_childcare]
     end
 
+    def return_to_regular_flow_on_change?
+      true
+    end
+
     def next_step
       if wizard.query_store.inside_catchment? && works_in_childcare?
         :work_in_nursery

--- a/app/lib/forms/work_in_school.rb
+++ b/app/lib/forms/work_in_school.rb
@@ -14,6 +14,10 @@ module Forms
       true
     end
 
+    def return_to_regular_flow_on_change?
+      true
+    end
+
     def next_step
       :teacher_reference_number
     end

--- a/spec/features/happy_journeys_spec.rb
+++ b/spec/features/happy_journeys_spec.rb
@@ -1813,7 +1813,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(check_answers_page.summary_list["Email"].value).to eql("user@example.com")
     expect(check_answers_page.summary_list["Course"].value).to eql("NPQ for Senior Leadership (NPQSL)")
     expect(check_answers_page.summary_list.key?("Have you been a headteacher for two years or more?")).to be_falsey
-    expect(check_answers_page.summary_list.key?("School or college")).to be_falsey
+    expect(check_answers_page.summary_list.key?("Workplace")).to be_falsey
     expect(check_answers_page.summary_list["How is your NPQ being paid for?"].value).to eql("My workplace is covering the cost")
 
     page.click_link("Change", href: "/registration/work-in-school/change")
@@ -1921,7 +1921,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(check_answers_page.summary_list["Email"].value).to eql("user@example.com")
     expect(check_answers_page.summary_list["Course"].value).to eql("NPQ for Senior Leadership (NPQSL)")
     expect(check_answers_page.summary_list.key?("Have you been a headteacher for two years or more?")).to be_falsey
-    expect(check_answers_page.summary_list["School or college"].value).to eql("open manchester school")
+    expect(check_answers_page.summary_list["Workplace"].value).to eql("open manchester school")
     expect(check_answers_page.summary_list["How is your NPQ being paid for?"].value).to eql("My workplace is covering the cost")
 
     allow(ApplicationSubmissionJob).to receive(:perform_later).with(anything)
@@ -2191,7 +2191,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(check_answers_page.summary_list["Email"].value).to eql("user@example.com")
     expect(check_answers_page.summary_list["Course"].value).to eql("NPQ for Senior Leadership (NPQSL)")
     expect(check_answers_page.summary_list.key?("Have you been a headteacher for two years or more?")).to be_falsey
-    expect(check_answers_page.summary_list["School or college"].value).to eql("open manchester school")
+    expect(check_answers_page.summary_list["Workplace"].value).to eql("open manchester school")
     expect(check_answers_page.summary_list["How is your NPQ being paid for?"].value).to eql("My workplace is covering the cost")
 
     allow(ApplicationSubmissionJob).to receive(:perform_later).with(anything)

--- a/spec/features/happy_journeys_spec.rb
+++ b/spec/features/happy_journeys_spec.rb
@@ -2088,7 +2088,7 @@ RSpec.feature "Happy journeys", type: :feature do
     page.click_button("Continue")
 
     expect(page).to be_axe_clean
-    expect(page.current_path).to eql("contact-details")
+    expect(page.current_path).to eql("/registration/contact-details")
     expect(page).to have_text("What's your email address?")
     page.fill_in "What's your email address?", with: "user@example.com"
     page.click_button("Continue")

--- a/spec/features/happy_journeys_spec.rb
+++ b/spec/features/happy_journeys_spec.rb
@@ -1702,4 +1702,504 @@ RSpec.feature "Happy journeys", type: :feature do
 
     expect(page).to be_axe_clean
   end
+
+  scenario "registration journey changing do you work in a school from no to yes" do
+    visit "/"
+    expect(page).to have_text("Before you start")
+    page.click_link("Start now")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Have you already chosen an NPQ and provider?")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    # expect(page).to be_axe_clean
+    # TODO: aria-expanded
+    expect(page.current_path).to eql("/registration/teacher-catchment")
+    page.choose("England", visible: :all)
+    page.click_button("Continue")
+
+    expect(page.current_path).to eql("/registration/work-in-school")
+    page.choose("No", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page.current_path).to eql("/registration/teacher-reference-number")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page.current_path).to include("contact-details")
+    expect(page).to have_text("What's your email address?")
+    page.fill_in "What's your email address?", with: "user@example.com"
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Confirm your code")
+    expect(page).to have_text("user@example.com")
+    page.click_button("Continue")
+
+    code = ActionMailer::Base.deliveries.last[:personalisation].unparsed_value[:code]
+
+    expect(page).to be_axe_clean
+    page.fill_in "Enter your code", with: code
+    page.click_button("Continue")
+
+    stub_request(:post, "https://ecf-app.gov.uk/api/v1/participant-validation")
+      .with(
+        headers: {
+          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+        },
+        body: {
+          trn: "1234567",
+          date_of_birth: "1980-12-13",
+          full_name: "John Doe",
+          nino: "AB123456C",
+        },
+      )
+      .to_return(status: 200, body: participant_validator_response, headers: {})
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Check your details")
+    page.fill_in "Teacher reference number (TRN)", with: "1234567"
+    page.fill_in "Full name", with: "John Doe"
+    page.fill_in "Day", with: "13"
+    page.fill_in "Month", with: "12"
+    page.fill_in "Year", with: "1980"
+    page.fill_in "National Insurance number", with: "AB123456C"
+    page.click_button("Continue")
+
+    School.create!(urn: 100_000, name: "open manchester school", address_1: "street 1", town: "manchester", establishment_status_code: "1")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Do you work in early years or childcare?")
+    page.choose("No", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("What are you applying for?")
+    page.choose("NPQ for Senior Leadership (NPQSL)", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Tell us about where you work")
+    page.fill_in "Name of employer", with: "Big company"
+    page.fill_in "Role", with: "Trainer"
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("How is your course being paid for?")
+    page.choose "My workplace is covering the cost", visible: :all
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Select your provider")
+    page.choose("Teach First", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Sharing your NPQ information")
+    page.check("Yes, I agree my information can be shared", visible: :all)
+    page.click_button("Continue")
+
+    check_answers_page = CheckAnswersPage.new
+
+    expect(page).to be_axe_clean
+    expect(check_answers_page).to be_displayed
+    expect(check_answers_page.summary_list["Full name"].value).to eql("John Doe")
+    expect(check_answers_page.summary_list["TRN"].value).to eql("1234567")
+    expect(check_answers_page.summary_list["Date of birth"].value).to eql("13 December 1980")
+    expect(check_answers_page.summary_list["National Insurance number"].value).to eql("AB123456C")
+    expect(check_answers_page.summary_list["Email"].value).to eql("user@example.com")
+    expect(check_answers_page.summary_list["Course"].value).to eql("NPQ for Senior Leadership (NPQSL)")
+    expect(check_answers_page.summary_list.key?("Have you been a headteacher for two years or more?")).to be_falsey
+    expect(check_answers_page.summary_list.key?("School or college")).to be_falsey
+    expect(check_answers_page.summary_list["How is your NPQ being paid for?"].value).to eql("My workplace is covering the cost")
+
+    page.click_link("Change", href: "/registration/work-in-school/change")
+
+    expect(page.current_path).to eql("/registration/work-in-school/change")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page.current_path).to eql("/registration/teacher-reference-number")
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page.current_path).to include("contact-details")
+    expect(page).to have_text("What's your email address?")
+    page.click_button("Continue")
+
+    stub_request(:post, "https://ecf-app.gov.uk/api/v1/participant-validation")
+      .with(
+        headers: {
+          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+        },
+        body: {
+          trn: "1234567",
+          date_of_birth: "1980-12-13",
+          full_name: "John Doe",
+          nino: "AB123456C",
+        },
+      )
+      .to_return(status: 200, body: participant_validator_response, headers: {})
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Check your details")
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Where is your school, college or academy trust?")
+    page.fill_in "Workplace location", with: "manchester"
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Choose your workplace")
+    expect(page).to have_text("Choose from schools, trusts and 16 to 19 educational settings located in manchester")
+    within ".npq-js-reveal" do
+      page.fill_in "Enter the name of your workplace", with: "open"
+    end
+
+    expect(page).to have_content("open manchester school")
+    page.find("#school-picker__option--0").click
+    page.click_button("Continue")
+
+    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=npq-senior-leadership")
+      .with(
+        headers: {
+          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+        },
+      )
+      .to_return(
+        status: 200,
+        body: previously_funded_response(false),
+        headers: {
+          "Content-Type" => "application/vnd.api+json",
+        },
+      )
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("What are you applying for?")
+    page.choose("NPQ for Senior Leadership (NPQSL)", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("DfE scholarship funding is not available")
+    expect(page).to have_text("To be eligible for scholarship funding for")
+    expect(page).to have_text("state-funded schools")
+    expect(page).to have_text("state-funded 16 to 19 organisations")
+    expect(page).to have_text("independent special schools")
+    expect(page).to have_text("virtual schools")
+    expect(page).to have_text("hospital schools")
+    expect(page).to have_text("young offenders institutions")
+    page.click_link("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("How is your course being paid for?")
+    page.choose "My workplace is covering the cost", visible: :all
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Select your provider")
+    page.choose("Teach First", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Sharing your NPQ information")
+    page.check("Yes, I agree my information can be shared", visible: :all)
+    page.click_button("Continue")
+
+    check_answers_page = CheckAnswersPage.new
+
+    expect(page).to be_axe_clean
+    expect(check_answers_page).to be_displayed
+    expect(check_answers_page.summary_list["Full name"].value).to eql("John Doe")
+    expect(check_answers_page.summary_list["TRN"].value).to eql("1234567")
+    expect(check_answers_page.summary_list["Date of birth"].value).to eql("13 December 1980")
+    expect(check_answers_page.summary_list["National Insurance number"].value).to eql("AB123456C")
+    expect(check_answers_page.summary_list["Email"].value).to eql("user@example.com")
+    expect(check_answers_page.summary_list["Course"].value).to eql("NPQ for Senior Leadership (NPQSL)")
+    expect(check_answers_page.summary_list.key?("Have you been a headteacher for two years or more?")).to be_falsey
+    expect(check_answers_page.summary_list["School or college"].value).to eql("open manchester school")
+    expect(check_answers_page.summary_list["How is your NPQ being paid for?"].value).to eql("My workplace is covering the cost")
+
+    allow(ApplicationSubmissionJob).to receive(:perform_later).with(anything)
+
+    page.click_button("Submit")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Your initial registration is complete")
+    expect(page).to_not have_text("The Early Headship Coaching Offer is a package of structured face-to-face support for new headteachers.")
+  end
+
+  scenario "registration journey changing from outside of catchment area to inside" do
+    visit "/"
+    expect(page).to have_text("Before you start")
+    page.click_link("Start now")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Have you already chosen an NPQ and provider?")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    # expect(page).to be_axe_clean
+    # TODO: aria-expanded
+    expect(page.current_path).to eql("/registration/teacher-catchment")
+    page.choose("Another country", visible: :all)
+    within "[data-module='app-country-autocomplete'" do
+      page.fill_in "Which country do you teach in?", with: "Falk"
+    end
+
+    expect(page).to have_content("Falkland Islands")
+    page.find("#registration-wizard-teacher-catchment-country-field__option--0").click
+
+    page.click_button("Continue")
+
+    expect(page.current_path).to eql("/registration/work-in-school")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page.current_path).to eql("/registration/teacher-reference-number")
+    page.choose("I need a reminder", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("If you don’t know what your teacher reference number")
+    page.click_link("Back")
+
+    expect(page).to be_axe_clean
+    expect(page.current_path).to eql("/registration/teacher-reference-number")
+    page.choose("I do not have a TRN", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Get a Teacher Reference Number (TRN)")
+    page.click_link("Back")
+
+    expect(page).to be_axe_clean
+    expect(page.current_path).to eql("/registration/teacher-reference-number")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page.current_path).to include("contact-details")
+    expect(page).to have_text("What's your email address?")
+    page.fill_in "What's your email address?", with: "user@example.com"
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Confirm your code")
+    expect(page).to have_text("user@example.com")
+    page.click_button("Continue")
+
+    code = ActionMailer::Base.deliveries.last[:personalisation].unparsed_value[:code]
+
+    expect(page).to be_axe_clean
+    page.fill_in "Enter your code", with: code
+    page.click_button("Continue")
+
+    stub_request(:post, "https://ecf-app.gov.uk/api/v1/participant-validation")
+      .with(
+        headers: {
+          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+        },
+        body: {
+          trn: "1234567",
+          date_of_birth: "1980-12-13",
+          full_name: "John Doe",
+          nino: "",
+        },
+      )
+      .to_return(status: 200, body: participant_validator_response, headers: {})
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Check your details")
+    page.fill_in "Teacher reference number (TRN)", with: "1234567"
+    page.fill_in "Full name", with: "John Doe"
+    page.fill_in "Day", with: "13"
+    page.fill_in "Month", with: "12"
+    page.fill_in "Year", with: "1980"
+    page.click_button("Continue")
+
+    School.create!(urn: 100_000, name: "open manchester school", address_1: "street 1", town: "manchester", establishment_status_code: "1")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("What are you applying for?")
+    page.choose("NPQ for Senior Leadership (NPQSL)", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("DfE scholarship funding is not available")
+    expect(page).to have_text("To be eligible for scholarship funding for")
+    expect(page).to have_text("To be eligible for scholarship funding for")
+    expect(page).to have_text("state-funded schools")
+    expect(page).to have_text("state-funded 16 to 19 organisations")
+    expect(page).to have_text("independent special schools")
+    expect(page).to have_text("virtual schools")
+    expect(page).to have_text("hospital schools")
+    expect(page).to have_text("young offenders institutions")
+    page.click_link("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("How is your course being paid for?")
+    page.choose "I am paying", visible: :all
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Select your provider")
+    page.choose("Teach First", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Sharing your NPQ information")
+    page.check("Yes, I agree my information can be shared", visible: :all)
+    page.click_button("Continue")
+
+    check_answers_page = CheckAnswersPage.new
+
+    expect(page).to be_axe_clean
+    expect(check_answers_page).to be_displayed
+    expect(check_answers_page.summary_list["Full name"].value).to eql("John Doe")
+    expect(check_answers_page.summary_list["TRN"].value).to eql("1234567")
+    expect(check_answers_page.summary_list["Date of birth"].value).to eql("13 December 1980")
+    expect(check_answers_page.summary_list.key?("National Insurance number")).to be_falsey
+    expect(check_answers_page.summary_list["Email"].value).to eql("user@example.com")
+    expect(check_answers_page.summary_list["Course"].value).to eql("NPQ for Senior Leadership (NPQSL)")
+    expect(check_answers_page.summary_list.key?("Have you been a headteacher for two years or more?")).to be_falsey
+    expect(check_answers_page.summary_list["How is your NPQ being paid for?"].value).to eql("I am paying")
+
+    page.click_link("Change", href: "/registration/teacher-catchment/change")
+
+    # expect(page).to be_axe_clean
+    # TODO: aria-expanded
+    expect(page.current_path).to eql("/registration/teacher-catchment/change")
+    page.choose("England", visible: :all)
+    page.click_button("Continue")
+
+    expect(page.current_path).to eql("/registration/work-in-school")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page.current_path).to eql("/registration/teacher-reference-number")
+    page.choose("Yes", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page.current_path).to eql("contact-details")
+    expect(page).to have_text("What's your email address?")
+    page.fill_in "What's your email address?", with: "user@example.com"
+    page.click_button("Continue")
+
+    stub_request(:post, "https://ecf-app.gov.uk/api/v1/participant-validation")
+      .with(
+        headers: {
+          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+        },
+        body: {
+          trn: "1234567",
+          date_of_birth: "1980-12-13",
+          full_name: "John Doe",
+          nino: "AB123456C",
+        },
+      )
+      .to_return(status: 200, body: participant_validator_response, headers: {})
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Check your details")
+    page.fill_in "Teacher reference number (TRN)", with: "1234567"
+    page.fill_in "Full name", with: "John Doe"
+    page.fill_in "Day", with: "13"
+    page.fill_in "Month", with: "12"
+    page.fill_in "Year", with: "1980"
+    page.fill_in "National Insurance number", with: "AB123456C"
+    page.click_button("Continue")
+
+    School.create!(urn: 100_000, name: "open manchester school", address_1: "street 1", town: "manchester", establishment_status_code: "1")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Where is your school, college or academy trust?")
+    page.fill_in "Workplace location", with: "manchester"
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Choose your workplace")
+    expect(page).to have_text("Choose from schools, trusts and 16 to 19 educational settings located in manchester")
+    within ".npq-js-reveal" do
+      page.fill_in "Enter the name of your workplace", with: "open"
+    end
+
+    expect(page).to have_content("open manchester school")
+    page.find("#school-picker__option--0").click
+    page.click_button("Continue")
+
+    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=npq-senior-leadership")
+      .with(
+        headers: {
+          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+        },
+      )
+      .to_return(
+        status: 200,
+        body: previously_funded_response(false),
+        headers: {
+          "Content-Type" => "application/vnd.api+json",
+        },
+      )
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("What are you applying for?")
+    page.choose("NPQ for Senior Leadership (NPQSL)", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("DfE scholarship funding is not available")
+    expect(page).to have_text("To be eligible for scholarship funding for")
+    expect(page).to have_text("state-funded schools")
+    expect(page).to have_text("state-funded 16 to 19 organisations")
+    expect(page).to have_text("independent special schools")
+    expect(page).to have_text("virtual schools")
+    expect(page).to have_text("hospital schools")
+    expect(page).to have_text("young offenders institutions")
+    page.click_link("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("How is your course being paid for?")
+    page.choose "My workplace is covering the cost", visible: :all
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Select your provider")
+    page.choose("Teach First", visible: :all)
+    page.click_button("Continue")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Sharing your NPQ information")
+    page.check("Yes, I agree my information can be shared", visible: :all)
+    page.click_button("Continue")
+
+    check_answers_page = CheckAnswersPage.new
+
+    expect(page).to be_axe_clean
+    expect(check_answers_page).to be_displayed
+    expect(check_answers_page.summary_list["Full name"].value).to eql("John Doe")
+    expect(check_answers_page.summary_list["TRN"].value).to eql("1234567")
+    expect(check_answers_page.summary_list["Date of birth"].value).to eql("13 December 1980")
+    expect(check_answers_page.summary_list["National Insurance number"].value).to eql("AB123456C")
+    expect(check_answers_page.summary_list["Email"].value).to eql("user@example.com")
+    expect(check_answers_page.summary_list["Course"].value).to eql("NPQ for Senior Leadership (NPQSL)")
+    expect(check_answers_page.summary_list.key?("Have you been a headteacher for two years or more?")).to be_falsey
+    expect(check_answers_page.summary_list["School or college"].value).to eql("open manchester school")
+    expect(check_answers_page.summary_list["How is your NPQ being paid for?"].value).to eql("My workplace is covering the cost")
+
+    allow(ApplicationSubmissionJob).to receive(:perform_later).with(anything)
+
+    page.click_button("Submit")
+
+    expect(page).to be_axe_clean
+    expect(page).to have_text("Your initial registration is complete")
+    expect(page).to_not have_text("The Early Headship Coaching Offer is a package of structured face-to-face support for new headteachers.")
+  end
 end


### PR DESCRIPTION
### Context

https://dfedigital.atlassian.net/browse/CN-232
https://dfedigital.atlassian.net/browse/CN-230

This fixes a bug highlighted by sentry:
1. Say you don’t work in a school
2. Say you work in england
3. Say you don’t work in childcare
4. Reach the check your answers page without choosing a school
5. Click change on the do you work in a school question
6. Change your answer to yes
7. Attempt to finish your application

Instead of being asked what school you work at and appropriate other questions it will instead attempt to take you back to the check answers screen after the email entry question. At this stage it hits a 500 error because it doesn’t have a school name to output.

### Changes proposed in this pull request

So what I’ve done is made it so that certain key questions that determine flow will direct you to the regular flow instead of the /registration/:step/change flow where changing_answer? is set to true. Instead it behaves as if this is your first time through the flow because you have made a drastic change to your answers.

### Guidance to review

1. Say you don’t work in a school
2. Say you work in england
3. Say you don’t work in childcare
4. Reach the check your answers page without choosing a school
5. Click change on the do you work in a school question
6. Change your answer to yes
7. Attempt to finish your application

Expected outcome: you progress through the application and are asked for your school
Actual outcome: you are redirected to the check answers screen after the email question and hit a 500 error
