### PR TITLE
[CN-204] Display the Ofsted description instead of the private nursery name

### DIFF
--- a/app/models/private_childcare_provider.rb
+++ b/app/models/private_childcare_provider.rb
@@ -59,4 +59,14 @@ class PrivateChildcareProvider < ApplicationRecord
   def on_early_years_register?
     early_years_individual_registers.include?("EYR")
   end
+
+  def registration_details
+    details = []
+
+    details << urn
+    details << name if name.present?
+    details << address_string if address_string.present?
+
+    details.join(" - ")
+  end
 end

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -88,6 +88,18 @@ class RegistrationWizard
           array << OpenStruct.new(key: "Type of nursery",
                                   value: I18n.t("registration_wizard.kind_of_nursery.#{kind_of_nursery}"),
                                   change_step: :kind_of_nursery)
+
+          if query_store.works_in_private_childcare_provider?
+            array << if query_store.has_ofsted_urn?
+                       OpenStruct.new(key: "Ofsted registration details",
+                                      value: institution(source: store["institution_identifier"]).registration_details,
+                                      change_step: :have_ofsted_urn)
+                     else
+                       OpenStruct.new(key: "Do you have a URN?",
+                                      value: store["has_ofsted_urn"].capitalize,
+                                      change_step: :have_ofsted_urn)
+                     end
+          end
         end
       end
     end
@@ -129,16 +141,6 @@ class RegistrationWizard
         array << OpenStruct.new(key: "Nursery",
                                 value: institution(source: store["institution_identifier"]).name,
                                 change_step: :find_childcare_provider)
-      elsif query_store.works_in_private_childcare_provider?
-        value = if query_store.has_ofsted_urn?
-                  institution(source: store["institution_identifier"]).provider_name
-                else
-                  "No Ofsted URN provided"
-                end
-
-        array << OpenStruct.new(key: "Nursery",
-                                value: value,
-                                change_step: :have_ofsted_urn)
       end
     end
 

--- a/spec/factories/private_childcare_provider.rb
+++ b/spec/factories/private_childcare_provider.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     sequence(:provider_name) { |n| "private childcare provider #{n}" }
     sequence(:provider_urn) { |n| (100_000 + n).to_s }
     provider_status { "Active" }
+    address_1 { "5 Charlotte Road" }
 
     trait :on_early_years_register do
       early_years_individual_registers { %w[EYR] }
@@ -10,6 +11,18 @@ FactoryBot.define do
 
     trait :on_all_registers do
       early_years_individual_registers { %w[CCR VCR EYR] }
+    end
+
+    trait :redacted do
+      provider_name { "REDACTED" }
+      address_1 { "REDACTED" }
+      address_2 { "REDACTED" }
+      address_3 { "REDACTED" }
+      town { "REDACTED" }
+      postcode { "REDACTED" }
+      postcode_without_spaces { "REDACTED" }
+      region { "London" }
+      ofsted_region { "London" }
     end
   end
 end

--- a/spec/features/happy_journeys_spec.rb
+++ b/spec/features/happy_journeys_spec.rb
@@ -1265,6 +1265,9 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(check_answers_page.summary_list.key?("Have you been a headteacher for two years or more?")).to be_falsey
     expect(check_answers_page.summary_list.key?("Workplace")).to be_falsey
     expect(check_answers_page.summary_list.key?("How is your NPQ being paid for?")).to be_falsey
+    expect(check_answers_page.summary_list["Do you work in early years or childcare?"].value).to eql("Yes")
+    expect(check_answers_page.summary_list["Do you work in a nursery?"].value).to eql("Yes")
+    expect(check_answers_page.summary_list["Ofsted registration details"].value).to eql("EY123456 - searchable childcare provider - street 1, manchester")
 
     allow(ApplicationSubmissionJob).to receive(:perform_later).with(anything)
 

--- a/spec/models/private_childcare_provider_spec.rb
+++ b/spec/models/private_childcare_provider_spec.rb
@@ -22,4 +22,22 @@ RSpec.describe PrivateChildcareProvider, type: :model do
       end
     end
   end
+
+  describe "#registration_details" do
+    context "with redacted info" do
+      let(:provider) { build(:private_childcare_provider, :redacted) }
+
+      it "displays only the urn and the region" do
+        expect(provider.registration_details).to eq("#{provider.urn} - #{provider.region}")
+      end
+    end
+
+    context "without redacted info" do
+      let(:provider) { build(:private_childcare_provider) }
+
+      it "displays the urn, provider name and address" do
+        expect(provider.registration_details).to eq("#{provider.urn} - #{provider.name} - #{provider.address_string}")
+      end
+    end
+  end
 end

--- a/spec/models/registration_wizard_spec.rb
+++ b/spec/models/registration_wizard_spec.rb
@@ -38,6 +38,22 @@ RSpec.describe RegistrationWizard do
   describe "#answers" do
     let(:school) { create(:school, establishment_type_code: "1") }
 
+    before do
+      stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/123456?npq_course_identifier=npq-additional-support-offer")
+        .with(
+          headers: {
+            "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+          },
+        )
+       .to_return(
+         status: 200,
+         body: previously_funded_response(false),
+         headers: {
+           "Content-Type" => "application/vnd.api+json",
+         },
+       )
+    end
+
     context "when ASO is selected course and is eligible for funding" do
       let(:store) do
         {
@@ -54,22 +70,6 @@ RSpec.describe RegistrationWizard do
           "aso_funding_choice" => "another",
           "trn" => "123456",
         }
-      end
-
-      before do
-        stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/123456?npq_course_identifier=npq-additional-support-offer")
-          .with(
-            headers: {
-              "Authorization" => "Bearer ECFAPPBEARERTOKEN",
-            },
-          )
-         .to_return(
-           status: 200,
-           body: previously_funded_response(false),
-           headers: {
-             "Content-Type" => "application/vnd.api+json",
-           },
-         )
       end
 
       it "does not show How is your NPQ being paid for?" do
@@ -95,24 +95,103 @@ RSpec.describe RegistrationWizard do
         }
       end
 
-      before do
-        stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/123456?npq_course_identifier=npq-additional-support-offer")
-          .with(
-            headers: {
-              "Authorization" => "Bearer ECFAPPBEARERTOKEN",
-            },
-          )
-         .to_return(
-           status: 200,
-           body: previously_funded_response(false),
-           headers: {
-             "Content-Type" => "application/vnd.api+json",
-           },
-         )
-      end
-
       it "shows ASO funding option" do
         expect(subject.answers.find { |el| el.key == "How is the Additional Support Offer being paid for?" }.value).to eql("The Early Headship Coaching Offer is being paid in another way")
+      end
+    end
+
+    context "when working in Local authority maintained nursery" do
+      let(:store) do
+        {
+          "chosen_provider" => "yes",
+          "teacher_catchment" => "england",
+          "teacher_catchment_country" => "",
+          "works_in_school" => "no",
+          "trn_knowledge" => "yes",
+          "trn" => "123456",
+          "full_name" => "Maia Mack",
+          "date_of_birth" => 30.years.ago,
+          "national_insurance_number" => "123420",
+          "trn_verified" => false,
+          "trn_auto_verified" => nil,
+          "verified_trn" => nil,
+          "works_in_childcare" => "yes",
+          "works_in_nursery" => "yes",
+          "kind_of_nursery" => "local_authority_maintained_nursery",
+          "institution_location" => "London",
+          "institution_name" => "",
+          "institution_identifier" => "School-#{school.urn}",
+          "course_id" => Course.find_by(name: "Additional Support Offer for new headteachers").id,
+          "lead_provider_id" => LeadProvider.all.sample.id,
+          "funding" => "self",
+        }
+      end
+
+      it "does not show Ofsted registration details" do
+        expect(subject.answers.map(&:key)).to_not include("Ofsted registration details")
+      end
+    end
+
+    context "when working in private nursery" do
+      let(:private_childcare_provider) { create(:private_childcare_provider) }
+      let(:store) do
+        {
+          "chosen_provider" => "yes",
+          "course_id" => Course.find_by(name: "Additional Support Offer for new headteachers").id,
+          "date_of_birth" => 30.years.ago,
+          "full_name" => "Tatyana Christensen",
+          "has_ofsted_urn" => has_ofsted_urn,
+          "institution_identifier" => institution_identifier,
+          "institution_location" => "manchester",
+          "institution_name" => "",
+          "kind_of_nursery" => "private_nursery",
+          "lead_provider_id" => LeadProvider.all.sample.id,
+          "national_insurance_number" => "123420",
+          "teacher_catchment" => "england",
+          "teacher_catchment_country" => "",
+          "trn" => "123456",
+          "trn_auto_verified" => nil,
+          "trn_knowledge" => "yes",
+          "trn_verified" => false,
+          "verified_trn" => nil,
+          "works_in_childcare" => "yes",
+          "works_in_nursery" => "yes",
+          "works_in_school" => "no",
+        }
+      end
+
+      context "without urn" do
+        let(:has_ofsted_urn) { "no" }
+        let(:institution_identifier) { "" }
+
+        it "does not show Ofsted registration details" do
+          expect(subject.answers.map(&:key)).to_not include("Ofsted registration details")
+        end
+
+        it "shows Do you have a URN?" do
+          expect(subject.answers.map(&:key)).to include("Do you have a URN?")
+        end
+
+        it "does not show Nursery" do
+          expect(subject.answers.map(&:key)).to_not include("Nursery")
+        end
+      end
+
+      context "with urn" do
+        let(:has_ofsted_urn) { "yes" }
+        let(:institution_identifier) { private_childcare_provider.identifier }
+
+        it "shows Ofsted registration details" do
+          expect(subject.answers.map(&:key)).to include("Ofsted registration details")
+        end
+
+        it "does not show Do you have a URN?" do
+          expect(subject.answers.map(&:key)).to_not include("Do you have a URN?")
+        end
+
+        it "does not show Nursery" do
+          expect(subject.answers.map(&:key)).to_not include("Nursery")
+        end
       end
     end
   end


### PR DESCRIPTION
in the check your answers page for EY users working in private nurseries

### Context

Ticket [CN-204](https://dfedigital.atlassian.net/browse/CN-204)

We want to replace the Nursery row in the check your answers page for EY users who work in private nurseries, with

- `Ofstead description details` when answering `yes` to the "Do you have a URN?" question. The value should be the same with the one displayed in the dropdown in the "Enter your or your employer's URN" page
- `Do you have a URN?` when answering `no` to the "Do you have a URN?" question

### Changes proposed in this pull request

Introduce the `PrivateChildcareProvider#registration_details` method to return the ofsted registration details in the required format (`UNR - provider name - provider address`). The method respects providers with redacted info.

Add the required rows in the wizard answers.

### Guidance to review

