### PR TITLE
[CN-234] Add safe navigator for rendering date of birth

### DIFF
--- a/app/controllers/session_wizard_controller.rb
+++ b/app/controllers/session_wizard_controller.rb
@@ -22,10 +22,10 @@ class SessionWizardController < ApplicationController
         user_id = @form.user.id
         reset_session
         session["user_id"] = user_id
-        redirect_to account_path and return
+        redirect_to account_path
+      else
+        redirect_to session_wizard_show_path(@wizard.next_step_path)
       end
-
-      redirect_to session_wizard_show_path(@wizard.next_step_path)
     else
       render @wizard.current_step
     end

--- a/app/lib/services/query_store.rb
+++ b/app/lib/services/query_store.rb
@@ -54,4 +54,12 @@ class Services::QueryStore
   def new_headteacher?
     store["aso_headteacher"] == "yes" && store["aso_new_headteacher"] == "yes"
   end
+
+  def date_of_birth
+    store["date_of_birth"]
+  end
+
+  def formatted_date_of_birth
+    date_of_birth&.to_s(:govuk)
+  end
 end

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -61,7 +61,6 @@ class RegistrationWizard
   end
 
   def answers
-    dob = Forms::QualifiedTeacherCheck.new(store.select { |k, _v| k.starts_with?("date_of_birth") }).date_of_birth
     array = []
 
     array << OpenStruct.new(key: "Where do you work?",
@@ -100,15 +99,9 @@ class RegistrationWizard
                             value: store["trn"],
                             change_step: :qualified_teacher_check)
 
-    begin
-      array << OpenStruct.new(key: "Date of birth",
-                              value: dob.to_s(:govuk),
-                              change_step: :qualified_teacher_check)
-    rescue ArgumentError => e
-      Sentry.capture_exception(e, extra: { dob: dob })
-
-      raise e
-    end
+    array << OpenStruct.new(key: "Date of birth",
+                            value: query_store.formatted_date_of_birth,
+                            change_step: :qualified_teacher_check)
 
     if form_for_step(:qualified_teacher_check).national_insurance_number.present?
       array << OpenStruct.new(key: "National Insurance number",

--- a/app/views/registration_wizard/dqt_mismatch.html.erb
+++ b/app/views/registration_wizard/dqt_mismatch.html.erb
@@ -42,7 +42,7 @@
 
       <% summary_list.row do |row|
            row.key { "Date of birth" }
-           row.value { @wizard.store["date_of_birth"].to_s(:govuk) } %>
+           row.value { @wizard.query_store.formatted_date_of_birth } %>
       <% end %>
 
       <% if @wizard.store["national_insurance_number"].present? %>


### PR DESCRIPTION
### Context

https://dfedigital.atlassian.net/browse/CN-234

### Changes proposed in this pull request

I have attempted to track down how this is occurring but haven't been able to get a firm answer. Regardless of how this situation is reached, this PR will prevent a 500 error and allow the user to proceed. Adding in blocks to ensure this data is present before submission will be left up to a future ticket.

