### PR TITLE
  [CN-204] Hide the school full address in the Check your answers page

### DIFF
--- a/app/models/private_childcare_provider.rb
+++ b/app/models/private_childcare_provider.rb
@@ -64,8 +64,7 @@ class PrivateChildcareProvider < ApplicationRecord
     details = []
 
     details << urn
-    details << name if name.present?
-    details << address_string if address_string.present?
+    details << (name.presence || address_string)
 
     details.join(" - ")
   end

--- a/spec/features/happy_journeys_spec.rb
+++ b/spec/features/happy_journeys_spec.rb
@@ -1785,7 +1785,7 @@ RSpec.feature "Happy journeys", type: :feature do
       "Course" => "NPQ for Early Years Leadership (NPQEYL)",
       "Do you work in early years or childcare?" => "Yes",
       "Do you work in a nursery?" => "Yes",
-      "Ofsted registration details" => "EY123456 - searchable childcare provider - street 1, manchester",
+      "Ofsted registration details" => "EY123456 - searchable childcare provider",
       "Do you work in a school, academy trust, or 16 to 19 educational setting?" => "No",
       "Lead provider" => "Teach First",
       "Type of nursery" => "Private nursery",
@@ -2294,7 +2294,7 @@ RSpec.feature "Happy journeys", type: :feature do
       "Do you work in a school, academy trust, or 16 to 19 educational setting?" => "No",
       "Do you work in early years or childcare?" => "Yes",
       "Lead provider" => "Teach First",
-      "Ofsted registration details" => "EY123456 - searchable childcare provider - street 1, manchester",
+      "Ofsted registration details" => "EY123456 - searchable childcare provider",
       "Type of nursery" => "Private nursery",
       "Where do you work?" => "England",
     )

--- a/spec/models/private_childcare_provider_spec.rb
+++ b/spec/models/private_childcare_provider_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe PrivateChildcareProvider, type: :model do
     context "without redacted info" do
       let(:provider) { build(:private_childcare_provider) }
 
-      it "displays the urn, provider name and address" do
+      it "displays only the urn and name" do
         expect(provider.registration_details).to eq("#{provider.urn} - #{provider.name}")
       end
     end

--- a/spec/models/private_childcare_provider_spec.rb
+++ b/spec/models/private_childcare_provider_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe PrivateChildcareProvider, type: :model do
       let(:provider) { build(:private_childcare_provider) }
 
       it "displays the urn, provider name and address" do
-        expect(provider.registration_details).to eq("#{provider.urn} - #{provider.name} - #{provider.address_string}")
+        expect(provider.registration_details).to eq("#{provider.urn} - #{provider.name}")
       end
     end
   end


### PR DESCRIPTION
### Context

We want to hide the full address from the Ofsted description in the Check your answers page

### Changes proposed in this pull request

Update the `PrivateChildcareProvider#registration_details` method to return the `urn and name` when info is not redacted and `urn - region` when info is redacted

### Guidance to review

