### PR TITLE
Port ECF email validator for use with registration interest emails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,8 @@ group :test do
 
   gem "axe-core-capybara"
   gem "axe-core-rspec"
+
+  gem "with_model"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -411,6 +411,8 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    with_model (2.1.6)
+      activerecord (>= 5.2)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.5.4)
@@ -465,6 +467,7 @@ DEPENDENCIES
   webdrivers
   webmock
   webpacker
+  with_model
 
 RUBY VERSION
    ruby 2.7.4p191

--- a/app/models/registration_interest.rb
+++ b/app/models/registration_interest.rb
@@ -3,13 +3,13 @@ class RegistrationInterest < ApplicationRecord
             presence: true,
             length: { maximum: 128 },
             uniqueness: { case_sensitive: false },
-            email: true
+            notify_email: true
 
   scope :not_yet_notified, -> { where(notified: false) }
   scope :random_sample, ->(count) { order("RANDOM()").first(count) }
 
   # We did not originally valid email format so we need to check this before sending
   def valid_email?
-    EmailValidator.valid?(email)
+    NotifyEmailValidator.valid?(value)
   end
 end

--- a/app/validators/notify_email_validator.rb
+++ b/app/validators/notify_email_validator.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Notify email validation https://github.com/alphagov/notifications-utils/blob/acbe764fb7f12c7a8b0696156283fbcb5073fcd7/notifications_utils/recipients.py#L494
+class NotifyEmailValidator < ActiveModel::EachValidator
+  HOSTNAME_PART_REGEX = /\A(xn|[a-z0-9]+)(-?-[a-z0-9]+)*\z/i.freeze
+  TLD_REGEX = /\A([a-z]{2,63}|xn--([a-z0-9]+-)*[a-z0-9]+)\z/i.freeze
+  EMAIL_REGEX = /\A[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~\\-]+@([^.@][^@\s]+)\z/.freeze
+
+  def validate_each(record, attribute, value)
+    record.errors.add(attribute, I18n.t("errors.email.invalid")) unless NotifyEmailValidator.valid?(value)
+  end
+
+  def self.valid?(email)
+    return false if email.blank?
+
+    email_match = email.match(EMAIL_REGEX)
+    return false unless email_match
+    return false if email.length > 320
+    return false if email.include?("..")
+
+    hostname = email_match[1]
+    return false unless hostname.last.match(/[a-z0-9]/i)
+
+    parts = hostname.split(".")
+    return false if hostname.length > 253 || parts.length < 2
+    return false if parts.any? { |part| part.blank? || part.length > 63 || part.match(HOSTNAME_PART_REGEX).nil? }
+    return false unless parts.last.match(TLD_REGEX)
+
+    true
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require "simplecov"
 SimpleCov.start "rails"
 
 require "webmock/rspec"
+require "with_model"
 
 WebMock.disable_net_connect!(
   allow_localhost: true,
@@ -24,6 +25,8 @@ WebMock.disable_net_connect!(
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  config.extend WithModel
+
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.

--- a/spec/validators/notify_email_validator_spec.rb
+++ b/spec/validators/notify_email_validator_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe NotifyEmailValidator do
+  with_model :user do
+    table do |t|
+      t.string :email
+    end
+
+    model do
+      validates :email, notify_email: true
+    end
+  end
+
+  # Test cases from https://github.com/alphagov/notifications-utils/blob/2432e1881cf7a5005a8d69c2ddc1597add96acc3/tests/test_recipient_validation.py
+  # The following valid emails addresses are not accepted: japanese-info@例え.テスト, info@german-financial-services.vermögensberatung
+  # This is because we do not transform to punycode
+  it "correctly identifies valid email addresses" do
+    valid_email_addresses = %w[
+      email@domain.com
+      email@domain.COM
+      firstname.lastname@domain.com
+      firstname.o\'lastname@domain.com
+      email@subdomain.domain.com
+      firstname+lastname@domain.com
+      1234567890@domain.com
+      email@domain-one.com
+      _______@domain.com
+      email@domain.name
+      email@domain.superlongtld
+      email@domain.co.jp
+      firstname-lastname@domain.com
+      info@german-financial-services.reallylongarbitrarytldthatiswaytoohugejustincase
+      email@double--hyphen.com
+    ]
+    valid_email_addresses.each do |email|
+      expect(User.new(email: email)).to be_valid
+    end
+  end
+
+  it "correctly identifies invalid email addresses" do
+    invalid_email_addresses = [
+      "email@123.123.123.123",
+      "email@[123.123.123.123]",
+      "plainaddress",
+      "@no-local-part.com",
+      "Outlook Contact <outlook-contact@domain.com>",
+      "no-at.domain.com",
+      "no-tld@domain",
+      ";beginning-semicolon@domain.co.uk",
+      "middle-semicolon@domain.co;uk",
+      "trailing-semicolon@domain.com;",
+      '"email+leading-quotes@domain.com',
+      'email+middle"-quotes@domain.com',
+      '"quoted-local-part"@domain.com',
+      '"quoted@domain.com"',
+      "lots-of-dots@domain..gov..uk",
+      "two-dots..in-local@domain.com",
+      "trailing-dot-in-domain@domain.com.",
+      "multiple@domains@domain.com",
+      "spaces in local@domain.com",
+      "spaces-in-domain@dom ain.com",
+      "underscores-in-domain@dom_ain.com",
+      "pipe-in-domain@example.com|gov.uk",
+      "comma,in-local@gov.uk",
+      "comma-in-domain@domain,gov.uk",
+      "pound-sign-in-local£@domain.com",
+      "local-with-’-apostrophe@domain.com",
+      "local-with-”-quotes@domain.com",
+      "domain-starts-with-a-dot@.domain.com",
+      "brackets(in)local@domain.com",
+      "email-too-long-#{'a' * 320}@example.com",
+      "incorrect-punycode@xn---something.com",
+    ]
+    invalid_email_addresses.each do |email|
+      expect(User.new(email: email)).not_to be_valid
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://sentry.io/organizations/dfe-teacher-services/issues/3333847739

### Changes proposed in this pull request

- Port ECF email validator for use with registration interest emails