### PR TITLE
Send additional NPQ fields to BigQuery

### DIFF
--- a/app/lib/services/report.rb
+++ b/app/lib/services/report.rb
@@ -19,6 +19,13 @@ module Services
             a.headteacher_status,
             a.eligible_for_funding,
             a.funding_choice,
+            a.funding_eligiblity_status_code,
+            a.targeted_delivery_funding_eligibility,
+            a.works_in_nursery,
+            a.works_in_childcare,
+            a.kind_of_nursery,
+            a.private_childcare_provider_urn,
+            a.cohort,
             a.school_urn,
             a.school&.name,
             a.school&.establishment_type_name,
@@ -47,6 +54,13 @@ module Services
         headteacher_status
         eligible_for_funding
         funding_choice
+        funding_eligiblity_status_code
+        targeted_delivery_funding_eligibility
+        works_in_nursery
+        works_in_childcare
+        kind_of_nursery
+        private_childcare_provider_urn
+        cohort
         school_urn
         school_name
         establishment_type_name

--- a/spec/lib/services/report_spec.rb
+++ b/spec/lib/services/report_spec.rb
@@ -11,5 +11,40 @@ RSpec.describe Services::Report do
         expect { subject.call }.not_to raise_error
       end
     end
+
+    it "includes expected headers in CSV" do
+      expected_headers = %w[
+        user_id
+        ecf_user_id
+        user_created_at
+        trn_verified
+        trn_auto_verified
+        application_id
+        application_ecf_id
+        application_created_at
+        headteacher_status
+        eligible_for_funding
+        funding_choice
+        funding_eligiblity_status_code
+        targeted_delivery_funding_eligibility
+        works_in_nursery
+        works_in_childcare
+        kind_of_nursery
+        private_childcare_provider_urn
+        cohort
+        school_urn
+        school_name
+        establishment_type_name
+        high_pupil_premium
+        la_name
+        school_postcode
+        course_name
+        provider_name
+      ]
+
+      csv_headers = CSV.parse(subject.call).first
+
+      expect(csv_headers).to eq(expected_headers)
+    end
   end
 end


### PR DESCRIPTION
### Context

Ticket [CPDLP-1466](https://dfedigital.atlassian.net/browse/CPDLP-1466)

There's a request to add the following application fields to data piped to BigQuery:

- targeted_delivery_funding_eligibility
- works_in_nursery
- works_in_childcare
- kind_of_nursery
- cohort
- private_childcare_provider_urn
- funding_eligibility_status_code

### Changes proposed in this pull request

Add the fields to the `Report` service 

### Guidance to review
We have this [github workflow](https://github.com/DFE-Digital/npq-registration/actions/workflows/export_dashboard_report.yml) that pushes prod data to BigQuery every hour (can be also triggered manually). Check the new fields are in the `applications` BigQuery table after the workflow finishes.