### PR TITLE
new ehco applications applied 2021 cohort

### DIFF
--- a/app/lib/services/handle_submission_for_store.rb
+++ b/app/lib/services/handle_submission_for_store.rb
@@ -39,7 +39,7 @@ module Services
           works_in_nursery: store["works_in_nursery"] == "yes",
           works_in_childcare: store["works_in_childcare"] == "yes",
           kind_of_nursery: store["kind_of_nursery"],
-          cohort: Application::TARGET_COHORT,
+          cohort: course.default_cohort,
           raw_application_data: raw_application_data,
         )
 

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -1,6 +1,4 @@
 class Application < ApplicationRecord
-  TARGET_COHORT = 2022
-
   belongs_to :user
   belongs_to :course
   belongs_to :lead_provider

--- a/db/migrate/20220628094940_add_default_cohort_to_courses.rb
+++ b/db/migrate/20220628094940_add_default_cohort_to_courses.rb
@@ -1,0 +1,5 @@
+class AddDefaultCohortToCourses < ActiveRecord::Migration[6.1]
+  def change
+    add_column :courses, :default_cohort, :integer, default: 2022
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_17_131203) do
+ActiveRecord::Schema.define(version: 2022_06_28_094940) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 2022_06_17_131203) do
     t.text "description"
     t.integer "position", default: 0
     t.boolean "display", default: true
+    t.integer "default_cohort", default: 2022
   end
 
   create_table "delayed_jobs", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,7 @@ def seed_courses!
     { position: 6, name: "NPQ for Headship (NPQH)", ecf_id: "0f7d6578-a12c-4498-92a0-2ee0f18e0768", display: true },
     { position: 7, name: "NPQ for Executive Leadership (NPQEL)", ecf_id: "aef853f2-9b48-4b6a-9d2a-91b295f5ca9a", display: true },
     { position: 8, name: "NPQ for Early Years Leadership (NPQEYL)", ecf_id: "66dff4af-a518-498f-9042-36a41f9e8aa7", display: true },
-    { position: 9, name: "Early Headship Coaching Offer", ecf_id: "0222d1a8-a8e1-42e3-a040-2c585f6c194a", description: "The Early Headship Coaching Offer is a package of structured face-to-face support for new headteachers.", display: true },
+    { position: 9, name: "Early Headship Coaching Offer", ecf_id: "0222d1a8-a8e1-42e3-a040-2c585f6c194a", description: "The Early Headship Coaching Offer is a package of structured face-to-face support for new headteachers.", display: true, default_cohort: 2021 },
   ].each do |hash|
     course = Course.find_or_initialize_by(ecf_id: hash[:ecf_id])
     course.update!(
@@ -17,6 +17,12 @@ def seed_courses!
       description: hash[:description],
       position: hash[:position],
       display: hash[:display],
+    )
+
+    next if hash[:default_cohort].nil?
+
+    course.update!(
+      default_cohort: hash[:default_cohort],
     )
   end
 end

--- a/spec/features/happy_journeys_non_js_spec.rb
+++ b/spec/features/happy_journeys_non_js_spec.rb
@@ -681,7 +681,7 @@ RSpec.feature "Happy journeys", type: :feature do
       "trn_verified" => true,
     )
     expect(retrieve_latest_application_data).to eq(
-      "cohort" => 2022,
+      "cohort" => 2021,
       "course_id" => Course.find_by_code(code: :EHCO).id,
       "ecf_id" => nil,
       "eligible_for_funding" => false,
@@ -924,7 +924,7 @@ RSpec.feature "Happy journeys", type: :feature do
       "trn_verified" => true,
     )
     expect(retrieve_latest_application_data).to eq(
-      "cohort" => 2022,
+      "cohort" => 2021,
       "course_id" => Course.find_by_code(code: :EHCO).id,
       "ecf_id" => nil,
       "eligible_for_funding" => true,

--- a/spec/features/happy_journeys_spec.rb
+++ b/spec/features/happy_journeys_spec.rb
@@ -2313,7 +2313,7 @@ RSpec.feature "Happy journeys", type: :feature do
       "trn_verified" => true,
     )
     expect(retrieve_latest_application_data).to eq(
-      "cohort" => 2022,
+      "cohort" => 2021,
       "course_id" => Course.find_by_code(code: :EHCO).id,
       "ecf_id" => nil,
       "eligible_for_funding" => false,

--- a/spec/features/sad_journeys_spec.rb
+++ b/spec/features/sad_journeys_spec.rb
@@ -771,7 +771,7 @@ RSpec.feature "Sad journeys", type: :feature do
       "trn_verified" => true,
     )
     expect(retrieve_latest_application_data).to eq(
-      "cohort" => 2022,
+      "cohort" => 2021,
       "course_id" => Course.find_by_code(code: :EHCO).id,
       "ecf_id" => nil,
       "eligible_for_funding" => false,

--- a/spec/lib/services/handle_submission_for_store_spec.rb
+++ b/spec/lib/services/handle_submission_for_store_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe Services::HandleSubmissionForStore do
         })
         expect(user.applications.reload.count).to eq 1
         expect(stable_as_json(user.applications.last)).to match({
-          "cohort" => 2022,
+          "cohort" => 2021,
           "course_id" => course.id,
           "ecf_id" => nil,
           "eligible_for_funding" => false,
@@ -272,6 +272,26 @@ RSpec.describe Services::HandleSubmissionForStore do
     end
 
     context "when applying for EHCO" do
+      context "happy path" do
+        let(:store) do
+          {
+            "confirmed_email" => user.email,
+            "trn_verified" => false,
+            "trn" => "12345",
+            "course_id" => Course.ehco.first.id,
+            "institution_identifier" => "School-#{school.urn}",
+            "lead_provider_id" => LeadProvider.all.sample.id,
+            "aso_headteacher" => "yes",
+            "aso_new_headteacher" => "no",
+          }
+        end
+
+        it "applies 2021 cohort" do
+          subject.call
+          expect(user.applications.first.cohort).to eql(2021)
+        end
+      end
+
       context "a headteacher for over five years" do
         let(:store) do
           {


### PR DESCRIPTION
### Context

- https://dfedigital.atlassian.net/browse/CPDLP-1472
- The business and providers and EHCO declarations to be paid for ASAP
- Therefore we will apply EHCO to the 2021 cohort so they can be paid out before the 2022 cohort starts

### Changes proposed in this pull request

- All new EHCO applications will be applied the 2021 cohort
- Everything else remains the same with 2022 cohort

### Guidance to review

- none