### PR TITLE
Get an identity spike

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,9 @@ gem "sentry-rails"
 gem "sentry-ruby"
 gem "webpacker"
 
+gem 'omniauth'
+gem "omniauth-rails_csrf_protection"
+
 group :development, :test do
   gem "byebug", platforms: %i[mri mingw x64_mingw]
   gem "capybara"

--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem "webpacker"
 
 gem 'omniauth'
 gem "omniauth-rails_csrf_protection"
+gem "omniauth_openid_connect"
 
 group :development, :test do
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,9 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
+    aes_key_wrap (1.1.0)
     ast (2.4.2)
+    attr_required (1.0.1)
     axe-core-api (4.4.0)
       dumb_delegator
       virtus
@@ -83,6 +85,7 @@ GEM
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
+    bindata (2.4.10)
     bindex (0.8.1)
     bootsnap (1.12.0)
       msgpack (~> 1.2)
@@ -170,6 +173,7 @@ GEM
       deep_merge (~> 1.2.1)
     hashdiff (1.0.1)
     hashie (5.0.0)
+    httpclient (2.8.3)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     i18n-debug (1.2.0)
@@ -179,6 +183,10 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    json-jwt (1.14.0)
+      activesupport (>= 4.2)
+      aes_key_wrap
+      bindata
     json_api_client (1.21.0)
       activemodel (>= 3.2.0)
       activesupport (>= 3.2.0)
@@ -234,6 +242,20 @@ GEM
     omniauth-rails_csrf_protection (1.0.1)
       actionpack (>= 4.2)
       omniauth (~> 2.0)
+    omniauth_openid_connect (0.4.0)
+      addressable (~> 2.5)
+      omniauth (>= 1.9, < 3)
+      openid_connect (~> 1.1)
+    openid_connect (1.3.0)
+      activemodel
+      attr_required (>= 1.0.0)
+      json-jwt (>= 1.5.0)
+      rack-oauth2 (>= 1.6.1)
+      swd (>= 1.0.0)
+      tzinfo
+      validate_email
+      validate_url
+      webfinger (>= 1.0.1)
     pagy (5.10.1)
       activesupport
     parallel (1.22.1)
@@ -256,6 +278,12 @@ GEM
     rack (2.2.3.1)
     rack-attack (6.6.1)
       rack (>= 1.0, < 3)
+    rack-oauth2 (1.21.2)
+      activesupport
+      attr_required
+      httpclient
+      json-jwt (>= 1.11.0)
+      rack (>= 2.1.0)
     rack-protection (2.2.0)
       rack
     rack-proxy (0.7.0)
@@ -388,11 +416,21 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    swd (1.3.0)
+      activesupport (>= 3)
+      attr_required (>= 0.0.5)
+      httpclient (>= 2.4)
     thor (1.2.1)
     thread_safe (0.3.6)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
+    validate_email (0.1.6)
+      activemodel (>= 3.0)
+      mail (>= 2.2.5)
+    validate_url (1.0.15)
+      activemodel (>= 3.0.0)
+      public_suffix
     view_component (2.49.1)
       activesupport (>= 5.0.0, < 8.0)
       method_source (~> 1.0)
@@ -409,6 +447,9 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (~> 4.0)
+    webfinger (1.2.0)
+      activesupport
+      httpclient (>= 2.4)
     webmock (3.14.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -457,6 +498,7 @@ DEPENDENCIES
   mail-notify
   omniauth
   omniauth-rails_csrf_protection
+  omniauth_openid_connect
   pagy
   pg (>= 0.18, < 2.0)
   pg_search

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,6 +169,7 @@ GEM
       activesupport (>= 6.0)
       deep_merge (~> 1.2.1)
     hashdiff (1.0.1)
+    hashie (5.0.0)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     i18n-debug (1.2.0)
@@ -226,6 +227,13 @@ GEM
       racc (~> 1.4)
     notifications-ruby-client (5.3.0)
       jwt (>= 1.5, < 3)
+    omniauth (2.1.0)
+      hashie (>= 3.4.6)
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-rails_csrf_protection (1.0.1)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
     pagy (5.10.1)
       activesupport
     parallel (1.22.1)
@@ -248,6 +256,8 @@ GEM
     rack (2.2.3.1)
     rack-attack (6.6.1)
       rack (>= 1.0, < 3)
+    rack-protection (2.2.0)
+      rack
     rack-proxy (0.7.0)
       rack
     rack-test (1.1.0)
@@ -445,6 +455,8 @@ DEPENDENCIES
   lograge (>= 0.11.2)
   logstash-event
   mail-notify
+  omniauth
+  omniauth-rails_csrf_protection
   pagy
   pg (>= 0.18, < 2.0)
   pg_search

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,11 @@
+class SessionsController < ApplicationController
+  def new
+    render :new
+  end
+
+  def create
+    user_info = request.env['omniauth.auth']
+    flash[:success] = user_info
+    redirect_to login_path
+  end
+end

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,0 +1,7 @@
+<% if flash[:success] %>
+  <pre><%= raw JSON.pretty_generate(flash[:success]).gsub(" ", "&nbsp;") %></pre>
+<% end %>
+
+<%= form_tag('/auth/get_an_identity', method: 'post', data: {turbo: false}) do %>
+  <button type='submit'>Login with Get an Identity</button>
+<% end %>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,17 @@
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :openid_connect, {
+    name: :get_an_identity,
+    issuer: "http://localhost:3001",
+    discovery: true,
+    scope: [:trn],
+    response_type: :code,
+    client_options: {
+      port: 3001,
+      scheme: "http",
+      host: "localhost",
+      identifier: "boyQB2A0Hp0y_BVY2La5j9lOshSNWte-Pa8XwK9r8bM",
+      secret: "FEvTNrUXTypY5x1NWC0dbu6PakiX4wC4lUDkvBaR9EQ",
+      redirect_uri: "http://localhost:3000/auth/get_an_identity/callback",
+    },
+  }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
   get "/healthcheck", to: "monitoring#healthcheck", format: :json
 
+  get '/auth/:provider/callback', to: 'sessions#create'
+  get '/login', to: 'sessions#new'
+
   resources :schools, only: [:index]
   resources :institutions, only: [:index]
   resources :private_childcare_providers, only: [:index]


### PR DESCRIPTION
This integrates https://github.com/DFE-Digital/find-a-lost-trn/pull/265 in order to allow a user to:

- Go to a `/login` page
- Click a button
- Be redirected to Find a lost TRN where they can sign in, consent to share information with NPQ
- Arrive back to NPQ with a TRN in the omniauth params hash plus some other metadata

This isn't meant to be merged.

Returning a TRN to the NPQ Registration service:

![image](https://user-images.githubusercontent.com/1650875/179488845-9b250144-3a25-445f-b93d-eafe300c21ee.png)
