### PR TITLE
[CN-237] Don’t mark EHCO courses as eligible for funding

### DIFF
--- a/app/lib/services/eligibility/targeted_delivery_funding.rb
+++ b/app/lib/services/eligibility/targeted_delivery_funding.rb
@@ -1,10 +1,11 @@
 module Services
   module Eligibility
     class TargetedDeliveryFunding
-      attr_reader :institution
+      attr_reader :institution, :course
 
-      def initialize(institution:)
+      def initialize(institution:, course:)
         @institution = institution
+        @course = course
       end
 
       def call
@@ -14,6 +15,7 @@ module Services
         return false if institution.is_a?(PrivateChildcareProvider)
         return false if institution.number_of_pupils.nil?
         return false if institution.number_of_pupils.zero?
+        return false unless course.supports_targeted_delivery_funding?
 
         eligible_establishment_type_codes.include?(institution.establishment_type_code) &&
           institution.number_of_pupils < pupil_count_threshold

--- a/app/lib/services/handle_submission_for_store.rb
+++ b/app/lib/services/handle_submission_for_store.rb
@@ -176,6 +176,7 @@ module Services
     def targeted_delivery_funding_eligibility
       @targeted_delivery_funding_eligibility ||= Services::Eligibility::TargetedDeliveryFunding.new(
         institution: institution_from_store,
+        course:,
       ).call
     end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -33,6 +33,10 @@ class Course < ApplicationRecord
     find_by(name: COURSE_NAMES[code])
   end
 
+  def supports_targeted_delivery_funding?
+    !ehco? && !aso?
+  end
+
   def npqh?
     name == COURSE_NAMES[:NPQH]
   end

--- a/spec/features/happy_journeys_non_js_spec.rb
+++ b/spec/features/happy_journeys_non_js_spec.rb
@@ -261,6 +261,480 @@ RSpec.feature "Happy journeys", type: :feature do
     )
   end
 
+  scenario "registration journey that is able to receive targeted delivery funding" do
+    visit "/"
+    expect(page).to have_text("Before you start")
+    page.click_link("Start now")
+
+    expect(page).to have_text("Have you already chosen an NPQ and provider?")
+    page.choose("Yes")
+    page.click_button("Continue")
+
+    expect(page.current_path).to eql("/registration/teacher-catchment")
+    page.choose("England")
+    page.click_button("Continue")
+
+    expect(page.current_path).to eql("/registration/work-in-school")
+    page.choose("Yes")
+    page.click_button("Continue")
+
+    expect(page.current_path).to eql("/registration/teacher-reference-number")
+    page.choose("Yes")
+    page.click_button("Continue")
+
+    expect(page.current_path).to include("contact-details")
+    expect(page).to have_text("What's your email address?")
+    page.fill_in "What's your email address?", with: "user@example.com"
+    page.click_button("Continue")
+
+    expect(page).to have_text("Confirm your code")
+    expect(page).to have_text("user@example.com")
+    page.click_button("Continue")
+
+    code = ActionMailer::Base.deliveries.last[:personalisation].unparsed_value[:code]
+
+    page.fill_in "Enter your code", with: code
+    page.click_button("Continue")
+
+    stub_request(:post, "https://ecf-app.gov.uk/api/v1/participant-validation")
+      .with(
+        headers: {
+          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+        },
+        body: {
+          trn: "12345",
+          date_of_birth: "1980-12-13",
+          full_name: "John Doe",
+          nino: "AB123456C",
+        },
+      )
+      .to_return(status: 200, body: participant_validator_response(trn: "12345"), headers: {})
+
+    expect(page).to have_text("Check your details")
+    page.fill_in "Teacher reference number (TRN)", with: "RP12/345"
+    page.fill_in "Full name", with: "John Doe"
+    page.fill_in "Day", with: "13"
+    page.fill_in "Month", with: "12"
+    page.fill_in "Year", with: "1980"
+    page.fill_in "National Insurance number", with: "AB123456C"
+    page.click_button("Continue")
+
+    School.create!(
+      urn: 100_000,
+      name: "open manchester school",
+      address_1: "street 1",
+      town: "manchester",
+      establishment_status_code: "1",
+      establishment_type_code: "1",
+      high_pupil_premium: true,
+      number_of_pupils: 100,
+    )
+
+    expect(page).to have_text("Where is your school, college or academy trust?")
+    page.fill_in "Workplace location", with: "manchester"
+    page.click_button("Continue")
+
+    expect(page).to have_text("Choose your workplace")
+    expect(page).to have_text("Choose from schools, trusts and 16 to 19 educational settings located in manchester")
+
+    within ".npq-js-hidden" do
+      page.fill_in "Enter the name of your workplace", with: "open"
+    end
+    page.click_button("Continue")
+
+    expect(page).to have_text("Choose your workplace")
+    page.choose "open manchester school"
+    page.click_button("Continue")
+
+    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/RP12%2F345?npq_course_identifier=npq-senior-leadership")
+      .with(
+        headers: {
+          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+        },
+      )
+      .to_return(
+        status: 200,
+        body: previously_funded_response(false),
+        headers: {
+          "Content-Type" => "application/vnd.api+json",
+        },
+      )
+
+    expect(page).to have_text("What are you applying for?")
+    page.choose("NPQ for Senior Leadership (NPQSL)")
+    page.click_button("Continue")
+
+    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=npq-headship")
+      .with(
+        headers: {
+          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+        },
+      )
+      .to_return(
+        status: 200,
+        body: previously_funded_response(false),
+        headers: {
+          "Content-Type" => "application/vnd.api+json",
+        },
+      )
+
+    expect(page).to have_text("If your provider accepts your application, you’ll qualify for DfE funding")
+    page.click_button("Continue")
+
+    expect(page).to have_text("Select your provider")
+    page.choose("Teach First")
+    page.click_button("Continue")
+
+    expect(page).to have_text("Sharing your NPQ information")
+    page.check("Yes, I agree my information can be shared")
+    page.click_button("Continue")
+
+    check_answers_page = CheckAnswersPage.new
+
+    expect(check_answers_page).to be_displayed
+
+    summary_data = check_answers_page.summary_list.rows.map { |summary_item|
+      [summary_item.key, summary_item.value]
+    }.to_h
+
+    expect(summary_data).to eql(
+      "Where do you work?" => "England",
+      "Do you work in a school, academy trust, or 16 to 19 educational setting?" => "Yes",
+      "Full name" => "John Doe",
+      "TRN" => "RP12/345",
+      "Date of birth" => "13 December 1980",
+      "National Insurance number" => "AB123456C",
+      "Email" => "user@example.com",
+      "Course" => "NPQ for Senior Leadership (NPQSL)",
+      "Workplace" => "open manchester school",
+      "Lead provider" => "Teach First",
+    )
+
+    allow(ApplicationSubmissionJob).to receive(:perform_later).with(anything)
+
+    page.click_button("Submit")
+
+    expect(User.count).to eql(1)
+    expect(Application.count).to eql(1)
+
+    visit "/"
+    visit "/registration/confirmation"
+
+    expect(page.current_path).to eql("/")
+
+    expect(retrieve_latest_application_user_data).to eq(
+      "active_alert" => false,
+      "admin" => false,
+      "date_of_birth" => "1980-12-13",
+      "ecf_id" => nil,
+      "email" => "user@example.com",
+      "full_name" => "John Doe",
+      "national_insurance_number" => nil,
+      "otp_expires_at" => nil,
+      "otp_hash" => nil,
+      "trn" => "0012345",
+      "trn_auto_verified" => true,
+      "trn_verified" => true,
+    )
+    expect(retrieve_latest_application_data).to eq(
+      "cohort" => 2022,
+      "course_id" => Course.find_by_code(code: :NPQSL).id,
+      "ecf_id" => nil,
+      "eligible_for_funding" => true,
+      "employer_name" => nil,
+      "employment_role" => nil,
+      "funding_choice" => nil,
+      "funding_eligiblity_status_code" => "funded",
+      "headteacher_status" => nil,
+      "kind_of_nursery" => nil,
+      "lead_provider_id" => LeadProvider.find_by(name: "Teach First").id,
+      "private_childcare_provider_urn" => nil,
+      "school_urn" => "100000",
+      "targeted_delivery_funding_eligibility" => true,
+      "targeted_support_funding_eligibility" => false,
+      "teacher_catchment" => "england",
+      "teacher_catchment_country" => nil,
+      "ukprn" => nil,
+      "works_in_childcare" => false,
+      "works_in_nursery" => false,
+      "works_in_school" => true,
+      "raw_application_data" => {
+        "active_alert" => false,
+        "can_share_choices" => "1",
+        "chosen_provider" => "yes",
+        "confirmed_email" => "user@example.com",
+        "course_id" => Course.find_by_code(code: :NPQSL).id.to_s,
+        "date_of_birth" => "1980-12-13",
+        "email" => "user@example.com",
+        "full_name" => "John Doe",
+        "institution_identifier" => "School-100000",
+        "institution_location" => "manchester",
+        "institution_name" => "open",
+        "lead_provider_id" => "9",
+        "national_insurance_number" => "AB123456C",
+        "teacher_catchment" => "england",
+        "teacher_catchment_country" => nil,
+        "trn" => "RP12/345",
+        "trn_auto_verified" => true,
+        "trn_knowledge" => "yes",
+        "trn_verified" => true,
+        "verified_trn" => "12345",
+        "works_in_school" => "yes",
+      },
+    )
+  end
+
+  scenario "registration journey that would be able to receive targeted delivery funding but is applying for EHCO" do
+    visit "/"
+    expect(page).to have_text("Before you start")
+    page.click_link("Start now")
+
+    expect(page).to have_text("Have you already chosen an NPQ and provider?")
+    page.choose("Yes")
+    page.click_button("Continue")
+
+    expect(page.current_path).to eql("/registration/teacher-catchment")
+    page.choose("England")
+    page.click_button("Continue")
+
+    expect(page.current_path).to eql("/registration/work-in-school")
+    page.choose("Yes")
+    page.click_button("Continue")
+
+    expect(page.current_path).to eql("/registration/teacher-reference-number")
+    page.choose("Yes")
+    page.click_button("Continue")
+
+    expect(page.current_path).to include("contact-details")
+    expect(page).to have_text("What's your email address?")
+    page.fill_in "What's your email address?", with: "user@example.com"
+    page.click_button("Continue")
+
+    expect(page).to have_text("Confirm your code")
+    expect(page).to have_text("user@example.com")
+    page.click_button("Continue")
+
+    code = ActionMailer::Base.deliveries.last[:personalisation].unparsed_value[:code]
+
+    page.fill_in "Enter your code", with: code
+    page.click_button("Continue")
+
+    stub_request(:post, "https://ecf-app.gov.uk/api/v1/participant-validation")
+      .with(
+        headers: {
+          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+        },
+        body: {
+          trn: "12345",
+          date_of_birth: "1980-12-13",
+          full_name: "John Doe",
+          nino: "AB123456C",
+        },
+      )
+      .to_return(status: 200, body: participant_validator_response(trn: "12345"), headers: {})
+
+    expect(page).to have_text("Check your details")
+    page.fill_in "Teacher reference number (TRN)", with: "RP12/345"
+    page.fill_in "Full name", with: "John Doe"
+    page.fill_in "Day", with: "13"
+    page.fill_in "Month", with: "12"
+    page.fill_in "Year", with: "1980"
+    page.fill_in "National Insurance number", with: "AB123456C"
+    page.click_button("Continue")
+
+    School.create!(
+      urn: 100_000,
+      name: "open manchester school",
+      address_1: "street 1",
+      town: "manchester",
+      establishment_status_code: "1",
+      establishment_type_code: "1",
+      high_pupil_premium: true,
+      number_of_pupils: 100,
+    )
+
+    expect(page).to have_text("Where is your school, college or academy trust?")
+    page.fill_in "Workplace location", with: "manchester"
+    page.click_button("Continue")
+
+    expect(page).to have_text("Choose your workplace")
+    expect(page).to have_text("Choose from schools, trusts and 16 to 19 educational settings located in manchester")
+
+    within ".npq-js-hidden" do
+      page.fill_in "Enter the name of your workplace", with: "open"
+    end
+    page.click_button("Continue")
+
+    expect(page).to have_text("Choose your workplace")
+    page.choose "open manchester school"
+    page.click_button("Continue")
+
+    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/RP12%2F345?npq_course_identifier=npq-early-headship-coaching-offer")
+      .with(
+        headers: {
+          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+        },
+      )
+      .to_return(
+        status: 200,
+        body: previously_funded_response(false),
+        headers: {
+          "Content-Type" => "application/vnd.api+json",
+        },
+      )
+
+    expect(page).to have_text("What are you applying for?")
+    page.choose("Early Headship Coaching Offer")
+    page.click_button("Continue")
+
+    expect(page).to have_selector "h1", text: "Early Headship Coaching Offer"
+    page.click_link("Continue")
+
+    expect(page).to have_selector "h1", text: "Are you studying for, or have you completed an NPQ for Headship (NPQH)?"
+    page.choose "None of the above"
+    page.click_button("Continue")
+
+    expect(page).to have_selector "h1", text: "You cannot register for the Early Headship Coaching Offer"
+    page.click_link("Back")
+
+    expect(page).to have_selector "h1", text: "Are you studying for, or have you completed an NPQ for Headship (NPQH)?"
+    page.choose "I have completed an NPQH"
+    page.click_button("Continue")
+
+    expect(page).to have_selector "h1", text: "Are you a headteacher?"
+    page.choose "Yes"
+    page.click_button("Continue")
+
+    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=npq-early-headship-coaching-offer")
+      .with(
+        headers: {
+          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+        },
+      )
+      .to_return(
+        status: 200,
+        body: previously_funded_response(false),
+        headers: {
+          "Content-Type" => "application/vnd.api+json",
+        },
+      )
+
+    expect(page).to have_selector "h1", text: "Are you in your first 5 years of a headship?"
+    page.choose "Yes"
+    page.click_button("Continue")
+
+    expect(page).to have_selector "h1", text: "If your provider accepts your application, you’ll qualify for DfE scholarship funding"
+    page.click_button("Continue")
+
+    expect(page).to have_text("Select your provider")
+    page.choose("Teach First")
+    page.click_button("Continue")
+
+    expect(page).to have_text("Sharing your NPQ information")
+    page.check("Yes, I agree my information can be shared")
+    page.click_button("Continue")
+
+    check_answers_page = CheckAnswersPage.new
+
+    expect(check_answers_page).to be_displayed
+
+    summary_data = check_answers_page.summary_list.rows.map { |summary_item|
+      [summary_item.key, summary_item.value]
+    }.to_h
+
+    expect(summary_data).to eql(
+      "Where do you work?" => "England",
+      "Do you work in a school, academy trust, or 16 to 19 educational setting?" => "Yes",
+      "Full name" => "John Doe",
+      "TRN" => "RP12/345",
+      "Date of birth" => "13 December 1980",
+      "National Insurance number" => "AB123456C",
+      "Email" => "user@example.com",
+      "Workplace" => "open manchester school",
+      "Lead provider" => "Teach First",
+      "Are you a headteacher?" => "Yes",
+      "Are you in your first 5 years of a headship?" => "Yes",
+      "Course" => "Early Headship Coaching Offer",
+      "Have you completed an NPQH?" => "I have completed an NPQH",
+    )
+
+    allow(ApplicationSubmissionJob).to receive(:perform_later).with(anything)
+
+    page.click_button("Submit")
+
+    expect(User.count).to eql(1)
+    expect(Application.count).to eql(1)
+
+    visit "/"
+    visit "/registration/confirmation"
+
+    expect(page.current_path).to eql("/")
+
+    expect(retrieve_latest_application_user_data).to eq(
+      "active_alert" => false,
+      "admin" => false,
+      "date_of_birth" => "1980-12-13",
+      "ecf_id" => nil,
+      "email" => "user@example.com",
+      "full_name" => "John Doe",
+      "national_insurance_number" => nil,
+      "otp_expires_at" => nil,
+      "otp_hash" => nil,
+      "trn" => "0012345",
+      "trn_auto_verified" => true,
+      "trn_verified" => true,
+    )
+    expect(retrieve_latest_application_data).to eq(
+      "cohort" => 2021,
+      "course_id" => Course.find_by_code(code: :EHCO).id,
+      "ecf_id" => nil,
+      "eligible_for_funding" => true,
+      "employer_name" => nil,
+      "employment_role" => nil,
+      "funding_choice" => nil,
+      "funding_eligiblity_status_code" => "funded",
+      "headteacher_status" => "yes_in_first_five_years",
+      "kind_of_nursery" => nil,
+      "lead_provider_id" => LeadProvider.find_by(name: "Teach First").id,
+      "private_childcare_provider_urn" => nil,
+      "school_urn" => "100000",
+      "targeted_delivery_funding_eligibility" => false,
+      "targeted_support_funding_eligibility" => false,
+      "teacher_catchment" => "england",
+      "teacher_catchment_country" => nil,
+      "ukprn" => nil,
+      "works_in_childcare" => false,
+      "works_in_nursery" => false,
+      "works_in_school" => true,
+      "raw_application_data" => {
+        "active_alert" => false,
+        "aso_headteacher" => "yes",
+        "aso_new_headteacher" => "yes",
+        "can_share_choices" => "1",
+        "chosen_provider" => "yes",
+        "confirmed_email" => "user@example.com",
+        "course_id" => Course.find_by_code(code: :EHCO).id.to_s,
+        "date_of_birth" => "1980-12-13",
+        "email" => "user@example.com",
+        "full_name" => "John Doe",
+        "institution_identifier" => "School-100000",
+        "institution_location" => "manchester",
+        "institution_name" => "open",
+        "lead_provider_id" => "9",
+        "national_insurance_number" => "AB123456C",
+        "npqh_status" => "completed_npqh",
+        "teacher_catchment" => "england",
+        "teacher_catchment_country" => nil,
+        "trn" => "RP12/345",
+        "trn_auto_verified" => true,
+        "trn_knowledge" => "yes",
+        "trn_verified" => true,
+        "verified_trn" => "12345",
+        "works_in_school" => "yes",
+      },
+    )
+  end
+
   scenario "registration journey via using same name" do
     visit "/"
     expect(page).to have_text("Before you start")

--- a/spec/lib/services/eligibility/targeted_delivery_funding_spec.rb
+++ b/spec/lib/services/eligibility/targeted_delivery_funding_spec.rb
@@ -1,21 +1,60 @@
 require "rails_helper"
 
 RSpec.describe Services::Eligibility::TargetedDeliveryFunding do
+  unsupported_course_codes = %w[
+    EHCO
+    ASO
+  ].freeze
+  supported_course_codes = Course::COURSE_NAMES.keys - unsupported_course_codes
+
   describe "#call" do
+    let(:course_name) { Course::COURSE_NAMES[supported_course_codes.sample] }
+    let(:course) { Course.find_by!(name: course_name) }
+
     context "when eligible" do
       let(:institution) { build(:school, establishment_type_code: "1", number_of_pupils: 100) }
 
-      subject { described_class.new(institution:) }
+      subject { described_class.new(institution:, course:) }
 
       it "returns true" do
         expect(subject.call).to be_truthy
       end
     end
 
+    unsupported_course_codes.each do |course_code|
+      course_name = Course::COURSE_NAMES[course_code]
+
+      context "when applying for #{course_code}" do
+        let(:course) { Course.find_by!(name: course_name) }
+        let(:institution) { build(:school, establishment_type_code: "1", number_of_pupils: 100) }
+
+        subject { described_class.new(institution:, course:) }
+
+        it "returns false" do
+          expect(subject.call).to be_falsey
+        end
+      end
+    end
+
+    supported_course_codes.each do |course_code|
+      course_name = Course::COURSE_NAMES[course_code]
+
+      context "when applying for #{course_code}" do
+        let(:course) { Course.find_by!(name: course_name) }
+        let(:institution) { build(:school, establishment_type_code: "1", number_of_pupils: 100) }
+
+        subject { described_class.new(institution:, course:) }
+
+        it "returns true" do
+          expect(subject.call).to be_truthy
+        end
+      end
+    end
+
     context "when institution is an LA" do
       let(:institution) { build(:local_authority) }
 
-      subject { described_class.new(institution:) }
+      subject { described_class.new(institution:, course:) }
 
       it "returns false" do
         expect(subject.call).to be_falsey
@@ -25,7 +64,7 @@ RSpec.describe Services::Eligibility::TargetedDeliveryFunding do
     context "when correct type but pupil count to high" do
       let(:institution) { build(:school, establishment_type_code: "1", number_of_pupils: 600) }
 
-      subject { described_class.new(institution:) }
+      subject { described_class.new(institution:, course:) }
 
       it "returns false" do
         expect(subject.call).to be_falsey
@@ -35,7 +74,7 @@ RSpec.describe Services::Eligibility::TargetedDeliveryFunding do
     context "when incorrect type but pupil count low enough" do
       let(:institution) { build(:school, establishment_type_code: "4", number_of_pupils: 100) }
 
-      subject { described_class.new(institution:) }
+      subject { described_class.new(institution:, course:) }
 
       it "returns false" do
         expect(subject.call).to be_falsey
@@ -45,7 +84,7 @@ RSpec.describe Services::Eligibility::TargetedDeliveryFunding do
     context "when correct type but pupil count is zero" do
       let(:institution) { build(:school, establishment_type_code: "1", number_of_pupils: 0) }
 
-      subject { described_class.new(institution:) }
+      subject { described_class.new(institution:, course:) }
 
       it "returns false" do
         expect(subject.call).to be_falsey
@@ -55,7 +94,7 @@ RSpec.describe Services::Eligibility::TargetedDeliveryFunding do
     context "when correct type but pupil count is null" do
       let(:institution) { build(:school, establishment_type_code: "1", number_of_pupils: nil) }
 
-      subject { described_class.new(institution:) }
+      subject { described_class.new(institution:, course:) }
 
       it "returns false" do
         expect(subject.call).to be_falsey
@@ -65,7 +104,7 @@ RSpec.describe Services::Eligibility::TargetedDeliveryFunding do
     context "when FE applicable body" do
       let(:institution) { build(:school, ukprn: "10000350", number_of_pupils: 1000) }
 
-      subject { described_class.new(institution:) }
+      subject { described_class.new(institution:, course:) }
 
       it "returns true" do
         expect(subject.call).to be_truthy


### PR DESCRIPTION
### Context

[CN-237](https://dfedigital.atlassian.net/browse/CN-237)

### Changes proposed in this pull request

`targeted_delivery_funding_eligibility` no longer ever returns true for EHCO or ASO courses.


