### PR TITLE
Attempted deployment fix by requiring default gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,8 @@ gem "sentry-rails"
 gem "sentry-ruby"
 gem "webpacker"
 
+gem "net-imap", require: false
+gem "net-pop", require: false
 gem "net-smtp", require: false
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,6 +222,14 @@ GEM
     msgpack (1.5.2)
     multi_json (1.15.0)
     multipart-post (2.1.1)
+    net-imap (0.2.3)
+      digest
+      net-protocol
+      strscan
+    net-pop (0.1.1)
+      digest
+      net-protocol
+      timeout
     net-protocol (0.1.3)
       timeout
     net-smtp (0.3.1)
@@ -390,6 +398,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    strscan (3.0.3)
     thor (1.2.1)
     thread_safe (0.3.6)
     timeout (0.3.0)
@@ -458,6 +467,8 @@ DEPENDENCIES
   lograge (>= 0.11.2)
   logstash-event
   mail-notify
+  net-imap
+  net-pop
   net-smtp
   pagy
   pg (>= 0.18, < 2.0)


### PR DESCRIPTION
### Context and changes

When moving to Ruby 3.1 some parts of the standard library [were moved to default gems](https://bugs.ruby-lang.org/issues/17873). While we're on Rails 6.x they need to be included in the gem file, as discussed in [this GitHub issue](https://github.com/mikel/mail/pull/1439#issuecomment-1002792758).

```
gem 'net-smtp'
gem 'net-imap'
gem 'net-pop'
```

Once we upgrade to Rails 7 these requirments can be dropped.

### Background

The relevant part of the log:


```
$ cf logs npq-registration-dev --recent
...
2022-07-20T11:26:40.86+0100 [APP/PROC/WEB/0] ERR /usr/local/bundle/gems/bootsnap-1.12.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:27:in `require': cannot load such file -- net/pop
```
