### PR TITLE
[CN-308] Retrospectively remove ECHO from targeted support funding eligibility

### DIFF
--- a/app/lib/services/ehco/targeted_delivery_funding_eligibility_updater.rb
+++ b/app/lib/services/ehco/targeted_delivery_funding_eligibility_updater.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Services
+  module Ehco
+    class TargetedDeliveryFundingEligibilityUpdater
+      class << self
+        delegate :run, to: :new
+      end
+
+      def run
+        logger = Logger.new($stdout)
+        logger.info "Updating EHCO NPQ Applications, this may take a couple of minutes..."
+
+        ehco_course = Course.ehco.first
+
+        arel_table = Application.arel_table
+        npq_applications = Application.where(course: ehco_course)
+                                      .where(targeted_delivery_funding_eligibility: true)
+                                      .where(arel_table[:created_at].gteq(Services::Feature::REGISTRATION_OPEN_DATE))
+
+        updated_count = 0
+
+        npq_applications.find_each do |npq_application|
+          logger.info "Updating EHCO NPQ Application ID##{npq_application.id}"
+          npq_application.update!(targeted_delivery_funding_eligibility: false)
+
+          updated_count += 1
+        rescue StandardError => e
+          logger.error "Encountered errors while updating EHCO NPQ Application #{npq_application.id}: #{e.message}"
+        end
+
+        logger.info "Updated EHCO NPQ Application count: #{updated_count}"
+      end
+    end
+  end
+end

--- a/lib/tasks/ehco/update_targeted_delivery_funding_eligibility.rake
+++ b/lib/tasks/ehco/update_targeted_delivery_funding_eligibility.rake
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rake"
+
+namespace :ehco do
+  namespace :update_targeted_delivery_funding_eligibility do
+    desc "DRY RUN: Marks targeted_delivery_funding_eligibility on all EHCO NPQ applications as false"
+    task dry_run: :environment do
+      Application.transaction do
+        Services::Ehco::TargetedDeliveryFundingEligibilityUpdater.run
+
+        raise ActiveRecord::Rollback
+      end
+    end
+
+    desc "Marks targeted_delivery_funding_eligibility on all EHCO NPQ applications as false"
+    task run: :environment do
+      Services::Ehco::TargetedDeliveryFundingEligibilityUpdater.run
+    end
+  end
+end

--- a/spec/lib/services/ehco/targeted_delivery_funding_eligibility_updater_spec.rb
+++ b/spec/lib/services/ehco/targeted_delivery_funding_eligibility_updater_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Services::Ehco::TargetedDeliveryFundingEligibilityUpdater do
+  subject { described_class.run }
+
+  let(:ehco_course) { Course.ehco.first }
+
+  let(:applicable_application_hash) do
+    {
+      course: ehco_course,
+      targeted_delivery_funding_eligibility: true,
+      created_at: Services::Feature::REGISTRATION_OPEN_DATE + 1.day,
+    }
+  end
+
+  let!(:application_with_targeted_funding_set)     { create(:application, applicable_application_hash) }
+  let!(:application_with_targeted_funding_set_two) { create(:application, applicable_application_hash) }
+  let!(:application_before_cutoff)                 { create(:application, applicable_application_hash.merge(created_at: Services::Feature::REGISTRATION_OPEN_DATE - 1.day)) }
+  let!(:application_wrong_course)                  { create(:application, applicable_application_hash.merge(course: Course.npqeyl.first)) }
+  let!(:application_not_marked_for_funding)        { create(:application, applicable_application_hash.merge(targeted_delivery_funding_eligibility: false)) }
+
+  it "updates the targeted_delivery_funding_eligibility flag for applicable records" do
+    expect { subject }.to change {
+      [
+        application_with_targeted_funding_set,
+        application_with_targeted_funding_set_two,
+      ].each(&:reload).map(&:targeted_delivery_funding_eligibility)
+    }.from([true, true]).to([false, false])
+  end
+
+  it "does not update the targeted_delivery_funding_eligibility flag for inapplicable records" do
+    expect { subject }.to_not(change do
+      [
+        application_before_cutoff,
+        application_wrong_course,
+        application_not_marked_for_funding,
+      ].each(&:reload).map(&:targeted_delivery_funding_eligibility)
+    end)
+  end
+end


### PR DESCRIPTION
### Context

https://dfedigital.atlassian.net/browse/CN-308

### Changes proposed in this pull request

Adds rake task that updates `targeted_delivery_funding_eligibility` to false for all Application records with the EHCO course, `targeted_delivery_funding_eligibility` set to true, and where created after the relaunch.

### Guidance to review

1. Create an Application record with these attributes:
```
  course == Course.ehco.first
  created_at >= Services::Feature::REGISTRATION_OPEN_DATE
  targeted_delivery_funding_eligibility == true
```
2. Run ehco:update_targeted_delivery_funding_eligibility:dry_run 
3. See that it has shown that this record will be updated
4. Check that targeted_delivery_funding_eligibility change has not been persisted.
5. Run ehco:update_targeted_delivery_funding_eligibility:run
6. Check that targeted_delivery_funding_eligibility change has been persisted.
