### PR TITLE
Add FAQs

### DIFF
--- a/app/views/pages/faqs/_contents-list.html.erb
+++ b/app/views/pages/faqs/_contents-list.html.erb
@@ -1,0 +1,11 @@
+<nav class="contents-list" aria-label="Frequently asked questions">
+  <h2 class="contents-list__title">Contents</h2>
+
+  <ul class="contents-list__list">
+    <% questions_and_answers.each_key do |question| %>
+      <li class="contents-list__list-item">
+        <%= govuk_link_to(question, "#" + question.parameterize, class: "contents-list__link", no_visited_state: true) %>
+      </li>
+    <% end %>
+  </ul>
+</nav>

--- a/app/views/pages/faqs/_questions-and-answers.html.erb
+++ b/app/views/pages/faqs/_questions-and-answers.html.erb
@@ -1,0 +1,5 @@
+<% questions_and_answers.each do |question, answer_partial| %>
+  <section class="govuk-!-margin-top-9">
+    <%= render partial: answer_partial, locals: { question_id: question.parameterize } %>
+  </section>
+<% end %>

--- a/app/views/pages/faqs/early-years.html.erb
+++ b/app/views/pages/faqs/early-years.html.erb
@@ -1,0 +1,43 @@
+<% content_for :title do %>
+  NPQ FAQs: Early years and childcare
+<% end %>
+
+<% content_for(:before_content) { govuk_back_link(href: "/") } %>
+
+<h1 class="govuk-heading-xl">NPQ FAQs: Early years and childcare</h1>
+
+<% questions_and_answers = {
+  "What do I need to register for the NPQ for Early Years Leadership?" => "pages/faqs/questions-and-answers/what-do-i-need-to-register",
+  "Do I need a Teacher Reference Number even though I’m not a teacher?" => "pages/faqs/questions-and-answers/do-i-need-a-trn",
+  "How do I get a TRN?" => "pages/faqs/questions-and-answers/how-do-i-get-a-trn",
+  "How do I choose a provider?" => "pages/faqs/questions-and-answers/how-do-i-choose-a-provider",
+  "How is my NPQ paid for?" => "pages/faqs/questions-and-answers/how-is-my-npq-paid-for",
+  "Where do I find my Ofsted URN?" => "pages/faqs/questions-and-answers/where-do-i-find-my-ofsted-urn",
+  "What is a full and relevant qualification?" => "pages/faqs/questions-and-answers/what-is-a-full-and-relevant-qualification",
+  "How do I register for an NPQ?" => "pages/faqs/questions-and-answers/how-do-i-register-for-an-npq",
+  "I need more support" => "pages/faqs/questions-and-answers/i-need-more-support",
+} %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render(
+      partial: "pages/faqs/contents-list",
+      locals: { questions_and_answers: questions_and_answers }
+    ) %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <article class="govuk-grid-column-two-thirds">
+    <%= render(
+      partial: "pages/faqs/questions-and-answers",
+      locals: { questions_and_answers: questions_and_answers }
+    ) %>
+  </article>
+
+  <aside class="govuk-grid-column-one-third">
+    <p class="govuk-body">
+      Related content
+    </p>
+  </aside>
+</div>

--- a/app/views/pages/faqs/other-users.html.erb
+++ b/app/views/pages/faqs/other-users.html.erb
@@ -1,0 +1,43 @@
+<% content_for :title do %>
+  NPQ FAQs: I don’t work in a school or early years
+<% end %>
+
+<% content_for(:before_content) { govuk_back_link(href: "/") } %>
+
+<h1 class="govuk-heading-xl">NPQ FAQs: I don’t work in a school or early years</h1>
+
+<% questions_and_answers = {
+  "What do I need before registering for an NPQ?" => "pages/faqs/questions-and-answers/what-do-i-need-before-registering",
+  "Do I need a TRN if I'm not a teacher?" => "pages/faqs/questions-and-answers/do-i-need-a-trn-if-im-not-a-teacher",
+  "How do I get a TRN?" => "pages/faqs/questions-and-answers/how-do-i-get-a-trn",
+  "How do I choose a provider?" => "pages/faqs/questions-and-answers/how-do-i-choose-a-provider",
+  "How is my NPQ paid for?" => "pages/faqs/questions-and-answers/how-is-my-npq-paid-for",
+  "Where do I find my Ofsted URN?" => "pages/faqs/questions-and-answers/where-do-i-find-my-ofsted-urn",
+  "What is a full and relevant qualification?" => "pages/faqs/questions-and-answers/what-is-a-full-and-relevant-qualification",
+  "How do I register for an NPQ?" => "pages/faqs/questions-and-answers/how-do-i-register-for-an-npq",
+  "I need more support" => "pages/faqs/questions-and-answers/i-need-more-support",
+} %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render(
+      partial: "pages/faqs/contents-list",
+      locals: { questions_and_answers: questions_and_answers }
+    ) %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <article class="govuk-grid-column-two-thirds">
+    <%= render(
+      partial: "pages/faqs/questions-and-answers",
+      locals: { questions_and_answers: questions_and_answers }
+    ) %>
+  </article>
+
+  <aside class="govuk-grid-column-one-third">
+    <p class="govuk-body">
+      Related content
+    </p>
+  </aside>
+</div>

--- a/app/views/pages/faqs/questions-and-answers/_do-i-need-a-trn-if-im-not-a-teacher.html.erb
+++ b/app/views/pages/faqs/questions-and-answers/_do-i-need-a-trn-if-im-not-a-teacher.html.erb
@@ -1,0 +1,7 @@
+<%= tag.h2(class: "govuk-heading-m", id: question_id) do %>
+  Do I need a TRN if I’m not a teacher?
+<% end %>
+
+<p class="govuk-body">
+  Yes. Everyone who registers for an NPQ will need a TRN, even if you’re working in early years, further education or qualified as a teacher outside England.
+</p>

--- a/app/views/pages/faqs/questions-and-answers/_do-i-need-a-trn.html.erb
+++ b/app/views/pages/faqs/questions-and-answers/_do-i-need-a-trn.html.erb
@@ -1,0 +1,7 @@
+<%= tag.h2(class: "govuk-heading-m", id: question_id) do %>
+  Do I need a Teacher Reference Number even though I’m not a teacher?
+<% end %>
+
+<p class="govuk-body">
+  Yes. Everyone who registers for an NPQ will need a TRN, even if you’re working in early years, further education or qualified as a teacher outside England.
+</p>

--- a/app/views/pages/faqs/questions-and-answers/_how-do-i-choose-a-provider.html.erb
+++ b/app/views/pages/faqs/questions-and-answers/_how-do-i-choose-a-provider.html.erb
@@ -1,0 +1,49 @@
+<%= tag.h2(class: "govuk-heading-m", id: question_id) do %>
+  How do I choose a provider?
+<% end %>
+
+<p class="govuk-body">
+  The NPQ for Early Years Leadership is offered by the following lead training providers:
+</p>
+
+<ul class="govuk-list govuk-list--spaced govuk-list--bullet">
+  <li>
+    <a class="govuk-link" href="https://www.ambition.org.uk/">Ambition Institute</a>
+  </li>
+
+  <li>
+    <a class="govuk-link" href="https://www.outstandingleaders.org/npq">Best Practice Network (home of Outstanding Leaders Partnership)</a><br>Provides all courses. Partners with Teach First as their lead provider to deliver the NPQEYL.
+  </li>
+
+  <li>
+    <a class="govuk-link" href="https://www.cefel.org.uk/npq/">Church of England</a><br> Partners with Teacher Development Trust as their lead provider to deliver the NPQEYL.
+  </li>
+
+  <li>
+    <a class="govuk-link" href="https://www.educationdevelopmenttrust.com/npqs">Education Development Trust</a>
+  </li>
+
+  <li>
+    <a class="govuk-link" href="http://www.llse.org.uk/">LLSE</a><br>Provides all courses. Partners with Education Development Trust as their lead provider to deliver the NPQEYL.
+  </li>
+
+  <li>
+    <a class="govuk-link" href="https://www.school-led.org.uk/">School-Led Network </a>
+  </li>
+
+  <li>
+    <a class="govuk-link" href="https://tdtrust.org/npqs/">Teacher Development Trust</a>
+  </li>
+
+  <li>
+    <a class="govuk-link" href="http://www.teachfirst.org.uk/npqs">Teach First</a>
+  </li>
+
+  <li>
+    <a class="govuk-link" href="https://www.ucl.ac.uk/ioe/departments-and-centres/centres/ucl-centre-educational-leadership/national-professional-qualification-programmes">UCL Institute of Education</a>
+  </li>
+</ul>
+
+<p class="govuk-body">
+  You should look at their websites to see if they offer courses in your area and how they deliver training. Contact them if you have any questions.
+</p>

--- a/app/views/pages/faqs/questions-and-answers/_how-do-i-get-a-trn.html.erb
+++ b/app/views/pages/faqs/questions-and-answers/_how-do-i-get-a-trn.html.erb
@@ -1,0 +1,22 @@
+<%= tag.h2(class: "govuk-heading-m", id: question_id) do %>
+  How do I get a TRN?
+<% end %>
+
+<p class="govuk-body">
+  You need to apply to the Teaching Regulation Agency.
+</p>
+
+<p class="govuk-body">
+  Email <%= govuk_mail_to("qts.enquiries@education.gov.uk") %> with (all of the following):
+</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>your full legal name</li>
+  <li>your date of birth</li>
+  <li>a scanned copy or photo of one proof of ID - this can be your passport, driving licence (full or provisional), certificate of residence or birth certificate</li>
+  <li>“Request for a TRN” in the subject line of the email</li>
+</ul>
+
+<p class="govuk-body">
+  They aim to respond to your email within 5 working days.
+</p>

--- a/app/views/pages/faqs/questions-and-answers/_how-do-i-register-for-an-npq.html.erb
+++ b/app/views/pages/faqs/questions-and-answers/_how-do-i-register-for-an-npq.html.erb
@@ -1,0 +1,7 @@
+<%= tag.h2(class: "govuk-heading-m", id: question_id) do %>
+  How do I register for an NPQ?
+<% end %>
+
+<p class="govuk-body">
+  Visit the <%= govuk_link_to("Register for an NPQ service", "/") %>. Complete the steps on the service and your chosen provider will get in touch with more details.
+<p>

--- a/app/views/pages/faqs/questions-and-answers/_how-is-my-npq-paid-for.html.erb
+++ b/app/views/pages/faqs/questions-and-answers/_how-is-my-npq-paid-for.html.erb
@@ -1,0 +1,14 @@
+<%= tag.h2(class: "govuk-heading-m", id: question_id) do %>
+  How is my NPQ paid for?
+<% end %>
+
+<p class="govuk-body">There are a number of ways to pay for an NPQ: </p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>You can <%= govuk_link_to("read the guidance to see if you are eligible for DfE scholarship funding for the NPQ for Early Years Leadership", "https://www.gov.uk/government/publications/national-professional-qualifications-npqs-reforms/national-professional-qualifications-npqs-reforms#funding") %></li>
+  <li>You can pay for an NPQ yourself</li>
+  <li>Your employer can pay</li>
+  <li>You can split the cost with your employer</li>
+</ul>
+
+<p class="govuk-body">If you do not think you’re eligible for DfE scholarship funding, you should discuss how you’ll pay with your training provider.</p>

--- a/app/views/pages/faqs/questions-and-answers/_i-need-more-support.html.erb
+++ b/app/views/pages/faqs/questions-and-answers/_i-need-more-support.html.erb
@@ -1,0 +1,7 @@
+<%= tag.h2(class: "govuk-heading-m", id: question_id) do %>
+  I need more support
+<% end %>
+
+<p class="govuk-body">
+  Contact <%= govuk_mail_to("continuing-professional-development@digital.education.gov.uk") %> with any questions.
+</p>

--- a/app/views/pages/faqs/questions-and-answers/_what-do-i-do-if-ive-forgotten-my-trn.html.erb
+++ b/app/views/pages/faqs/questions-and-answers/_what-do-i-do-if-ive-forgotten-my-trn.html.erb
@@ -1,0 +1,8 @@
+<%= tag.h2(class: "govuk-heading-m", id: question_id) do %>
+  What to do if you’ve forgotten your TRN
+<% end %>
+
+<p class="govuk-body">If you’re a qualified teacher or have previously registered for an NPQ, you’ll have a TRN already. </p>
+
+<p class="govuk-body"><%= govuk_link_to("Find a lost TRN or check if you have one (opens in new tab)", "https://www.gov.uk/guidance/teacher-reference-number-trn#what-to-do-if-youve-forgotten-your-trn)", { target: "_blank" }) %></p>
+

--- a/app/views/pages/faqs/questions-and-answers/_what-do-i-need-before-registering.html.erb
+++ b/app/views/pages/faqs/questions-and-answers/_what-do-i-need-before-registering.html.erb
@@ -1,0 +1,11 @@
+<%= tag.h2(class: "govuk-heading-m", id: question_id) do %>
+  What do I need before registering for an NPQ?
+<% end %>
+
+<p class="govuk-body">Before you register, you’ll need to make sure you have done the following:</p>
+
+<ol class="govuk-list govuk-list--number">
+  <li>Got a Teacher Reference Number (TRN)</li>
+  <li>Chosen a training provider</li>
+  <li>Know how your NPQ is being paid for</li>
+</ol>

--- a/app/views/pages/faqs/questions-and-answers/_what-do-i-need-to-register.html.erb
+++ b/app/views/pages/faqs/questions-and-answers/_what-do-i-need-to-register.html.erb
@@ -1,0 +1,15 @@
+<%= tag.h2(class: "govuk-heading-m", id: question_id) do %>
+  What do I need to register for the NPQ for Early Years Leadership?
+<% end %>
+
+<p class="govuk-body">
+  Before you register, you’ll need to make sure you have done the following:
+</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>Got a Teacher Reference Number (TRN)</li>
+  <li>Chosen a training provider</li>
+  <li>Know how your NPQ is being paid for</li>
+</ul>
+
+<p class="govuk-body">You’ll need to know your Ofsted unique reference number (URN) if you or your employer are registered on the Ofsted Early Years Register, or you are registered through a Childminder Agency.</p>

--- a/app/views/pages/faqs/questions-and-answers/_what-is-a-full-and-relevant-qualification.html.erb
+++ b/app/views/pages/faqs/questions-and-answers/_what-is-a-full-and-relevant-qualification.html.erb
@@ -1,0 +1,11 @@
+<%= tag.h2(class: "govuk-heading-m", id: question_id) do %>
+  What is a full and relevant qualification?
+<% end %>
+
+<p class="govuk-body">
+  ‘Full and relevant qualifications’ are defined as level 3 qualifications (or higher) that demonstrate depth and level of learning appropriate to specified outcomes of full early years, childcare or playwork qualifications.
+</p>
+
+<p class="govuk-body">
+  The qualification should have valid, reliable assessment and awarding procedures and must include an element of assessed performance evidence.
+</p>

--- a/app/views/pages/faqs/questions-and-answers/_where-do-i-find-my-ofsted-urn.html.erb
+++ b/app/views/pages/faqs/questions-and-answers/_where-do-i-find-my-ofsted-urn.html.erb
@@ -1,0 +1,19 @@
+<%= tag.h2(class: "govuk-heading-m", id: question_id) do %>
+  Where do I find my Ofsted URN?
+<% end %>
+
+<p class="govuk-body">
+  You can <%= govuk_link_to("search the public Ofsted register (opens in a new tab)", "https://reports.ofsted.gov.uk/childcare", { target: "_blank" }) %> to find a URN.
+</p>
+
+<p class="govuk-body">
+  If your employer is registered with Ofsted or you're registered with a childminder agency (CMA), you can use their URN.
+</p>
+
+<p class="govuk-body">
+  If you’re a nanny or a childminder you may not be listed on the public Ofsted register. You’ll need to check your email or registration certificate to find your URN.
+</p>
+
+<p class="govuk-body">
+  If you or your employer have not registered with Ofsted then you will not have a URN.
+</p>

--- a/app/views/pages/faqs/schools.html.erb
+++ b/app/views/pages/faqs/schools.html.erb
@@ -1,0 +1,44 @@
+<% content_for :title do %>
+  NPQ FAQs: Schools, academy trusts or 16 to 19 educational settings
+<% end %>
+
+<% content_for(:before_content) { govuk_back_link(href: "/") } %>
+
+<h1 class="govuk-heading-xl">NPQ FAQs: Schools, academy trusts or 16 to 19 educational settings</h1>
+
+<% questions_and_answers = {
+  "What do I need before registering for an NPQ?" => "pages/faqs/questions-and-answers/what-do-i-need-before-registering",
+  "What do I do if I've forgotten my TRN" => "pages/faqs/questions-and-answers/what-do-i-do-if-ive-forgotten-my-trn",
+  "Do I need a TRN if I'm not a teacher?" => "pages/faqs/questions-and-answers/do-i-need-a-trn-if-im-not-a-teacher",
+  "How do I get a TRN?" => "pages/faqs/questions-and-answers/how-do-i-get-a-trn",
+  "How do I choose a provider?" => "pages/faqs/questions-and-answers/how-do-i-choose-a-provider",
+  "How is my NPQ paid for?" => "pages/faqs/questions-and-answers/how-is-my-npq-paid-for",
+  "Where do I find my ofsted URN?" => "pages/faqs/questions-and-answers/where-do-i-find-my-ofsted-urn",
+  "What is a full and relevant qualification?" => "pages/faqs/questions-and-answers/what-is-a-full-and-relevant-qualification",
+  "How do I register for an NPQ?" => "pages/faqs/questions-and-answers/how-do-i-register-for-an-npq",
+  "I need more support" => "pages/faqs/questions-and-answers/i-need-more-support",
+} %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render(
+      partial: "pages/faqs/contents-list",
+      locals: { questions_and_answers: questions_and_answers }
+    ) %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <article class="govuk-grid-column-two-thirds">
+    <%= render(
+      partial: "pages/faqs/questions-and-answers",
+      locals: { questions_and_answers: questions_and_answers }
+    ) %>
+  </article>
+
+  <aside class="govuk-grid-column-one-third">
+    <p class="govuk-body">
+      Related content
+    </p>
+  </aside>
+</div>

--- a/app/views/registration_wizard/start.html.erb
+++ b/app/views/registration_wizard/start.html.erb
@@ -9,6 +9,25 @@
       <li>for the Early Headship Coaching Offer</li>
     </ul>
 
+    <h2 class="govuk-heading-m">Frequently asked questions</h2>
+
+    <p class="govuk-body">Read our FAQs if you:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        work in
+        <%= govuk_link_to("early years or childcare", "/faqs/early-years") %>
+      </li>
+      <li>
+        work in a
+        <%= govuk_link_to("school, academy trust or 16 to 19 educational setting", "/faqs/schools") %>
+      </li>
+      <li>
+        <%= govuk_link_to("do not work in a school, childcare or early years", "/faqs/other-users") %>,
+        for example you work in a virtual school, hospital school or young offender institution
+      </li>
+    </ul>
+
     <h2 class="govuk-heading-m">Before you start</h2>
 
     <p class="govuk-body">You must:</p>

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -11,6 +11,7 @@ $govuk-image-url-function: frontend-image-url;
 
 @import "~govuk-frontend/govuk/all";
 @import "accessible-autocomplete";
+@import "contents-list";
 
 h1.govuk-fieldset__heading {
   margin-bottom: 10px;

--- a/app/webpacker/styles/contents-list.scss
+++ b/app/webpacker/styles/contents-list.scss
@@ -1,0 +1,46 @@
+// this is an abridged version of the contents list found in `govuk_publishing_components`
+// https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss
+.contents-list {
+  position: relative;
+  margin-bottom: 2em;
+  z-index: 1;
+  background: govuk-colour("white");
+  box-shadow: 0 20px 15px -10px govuk-colour("white");
+
+  &__title {
+    @include govuk-text-colour;
+    @include govuk-font($size: 16, $weight: regular, $line-height: 1.5);
+    margin: 0;
+  }
+
+  &__list {
+    @include govuk-text-colour;
+    @include govuk-font($size: 16);
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+  }
+
+  &__list-item {
+    padding-top: govuk-spacing(2);
+    line-height: 1.3;
+    list-style-type: none;
+
+    @include govuk-media-query($from: tablet) {
+      padding-top: govuk-spacing(6) / 4;
+    }
+
+    $contents-spacing: govuk-spacing(5);
+    position: relative;
+    padding-left: $contents-spacing;
+    padding-right: $contents-spacing;
+
+    &:before {
+      content: "—";
+      position: absolute;
+      left: 0;
+      width: govuk-spacing(4);
+      overflow: hidden;
+    }
+  }
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,10 @@ Rails.application.routes.draw do
   get "/privacy-policy", to: "pages#show", page: "privacy_policy"
   get "/accessibility-statement", to: "pages#show", page: "accessibility"
 
+  get "/faqs/early-years", to: "pages#show", page: "faqs/early-years"
+  get "/faqs/schools", to: "pages#show", page: "faqs/schools"
+  get "/faqs/other-users", to: "pages#show", page: "faqs/other-users"
+
   resource :cookie_preferences do
     member do
       post "hide"

--- a/spec/requests/faq_spec.rb
+++ b/spec/requests/faq_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe SchoolsController do
+  {
+    "/faqs/early-years" => [
+      "What do I need to register for the NPQ for Early Years Leadership",
+      "I need more support",
+    ],
+    "/faqs/schools" => [
+      "What do I need before registering for an NPQ",
+      "I need more support",
+    ],
+    "/faqs/other-users" => [
+      "What do I need before registering for an NPQ?",
+      "I need more support",
+    ],
+  }.each do |path, questions|
+    describe path do
+      before { get(path) }
+
+      it "renders the table of contents" do
+        expect(response.body).to match("Contents")
+        expect(response.body).to match("Frequently asked questions")
+      end
+
+      it "renders the questions correctly" do
+        questions.each { |q| expect(response.body).to match(q) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Ticket

https://dfedigital.atlassian.net/browse/CN-424

### Context and changes

There are now three pages of FAQs:

* early years
* schools
* other

Some of the questions are shared between sections so they're all stored in the same directory and referenced by partial. The approach was taken (rather than just hardcoding) to ensure contents list links always match the heading ids.

The CSS for the contents list [was lifted from GOV.UK Publishing Components](https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/stylesheets/govuk_publishing_components/components/_contents-list.scss).
