### PR TITLE
[CN-432] Remove 'how are you paying' page from non-school flow

### DIFF
--- a/app/lib/forms/work_setting.rb
+++ b/app/lib/forms/work_setting.rb
@@ -27,7 +27,9 @@ module Forms
         wizard.store["works_in_school"] = "no"
         wizard.store["works_in_childcare"] = "no"
 
-        %w[works_in_nursery kind_of_nursery has_ofsted_urn].map { |field| wizard.store.delete(field) }
+        %w[funding works_in_nursery kind_of_nursery has_ofsted_urn].map do |field|
+          wizard.store.delete(field)
+        end
       else
         raise(ArgumentError, "invalid work setting #{work_setting}")
       end

--- a/app/lib/forms/your_work.rb
+++ b/app/lib/forms/your_work.rb
@@ -9,6 +9,8 @@ module Forms
     end
 
     def next_step
+      return :choose_your_provider if wizard.query_store.works_in_other?
+
       :funding_your_npq
     end
 

--- a/app/lib/services/query_store.rb
+++ b/app/lib/services/query_store.rb
@@ -29,6 +29,10 @@ class Services::QueryStore
     store["works_in_nursery"] == "yes"
   end
 
+  def works_in_other?
+    store["work_setting"] == "other"
+  end
+
   def has_ofsted_urn?
     store["has_ofsted_urn"] == "yes"
   end

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -138,19 +138,19 @@ class RegistrationWizard
                             change_step: :choose_your_npq)
 
     unless eligible_for_funding?
-      array << if course.aso?
-                 OpenStruct.new(key: "How is the Additional Support Offer being paid for?",
+      if course.aso?
+        array << OpenStruct.new(key: "How is the Additional Support Offer being paid for?",
                                 value: I18n.t(store["aso_funding_choice"], scope: "activemodel.attributes.forms/funding_your_aso.funding_options"),
                                 change_step: :funding_your_aso)
-               elsif course.ehco?
-                 OpenStruct.new(key: "How is your EHCO being paid for?",
+      elsif course.ehco?
+        array << OpenStruct.new(key: "How is your EHCO being paid for?",
                                 value: I18n.t(store["aso_funding_choice"], scope: "activemodel.attributes.forms/funding_your_aso.funding_options"),
                                 change_step: :funding_your_aso)
-               else
-                 OpenStruct.new(key: "How is your NPQ being paid for?",
+      elsif query_store.works_in_school? || query_store.works_in_childcare?
+        array << OpenStruct.new(key: "How is your NPQ being paid for?",
                                 value: I18n.t(store["funding"], scope: "activemodel.attributes.forms/funding_your_npq.funding_options"),
                                 change_step: :funding_your_npq)
-               end
+      end
     end
 
     if course.ehco?

--- a/spec/features/happy_journeys/js/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
+++ b/spec/features/happy_journeys/js/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
@@ -65,11 +65,6 @@ RSpec.feature "Happy journeys", type: :feature do
       page.fill_in "Role", with: "Trainer"
     end
 
-    expect_page_to_have(path: "/registration/funding-your-npq", submit_form: true) do
-      expect(page).to have_text("How is your course being paid for?")
-      page.choose "My workplace is covering the cost", visible: :all
-    end
-
     expect_page_to_have(path: "/registration/choose-your-provider", submit_form: true) do
       expect(page).to have_text("Select your provider")
       page.choose("Teach First", visible: :all)
@@ -89,7 +84,6 @@ RSpec.feature "Happy journeys", type: :feature do
           "National Insurance number" => "AB123456C",
           "Email" => "user@example.com",
           "Course" => "NPQ for Senior Leadership (NPQSL)",
-          "How is your NPQ being paid for?" => "My workplace is covering the cost",
           "What setting do you work in?" => "Other",
           "Employer" => "Big company",
           "Lead provider" => "Teach First",

--- a/spec/features/happy_journeys/js/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
+++ b/spec/features/happy_journeys/js/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
@@ -174,11 +174,6 @@ RSpec.feature "Happy journeys", type: :feature do
       page.fill_in "Role", with: "Trainer"
     end
 
-    expect_page_to_have(path: "/registration/funding-your-npq", submit_form: true) do
-      expect(page).to have_text("How is your course being paid for?")
-      page.choose "I am paying", visible: :all
-    end
-
     expect_page_to_have(path: "/registration/choose-your-provider", submit_form: true) do
       expect(page).to have_text("Select your provider")
       page.choose("Teach First", visible: :all)
@@ -202,7 +197,6 @@ RSpec.feature "Happy journeys", type: :feature do
           "Course" => "NPQ for Senior Leadership (NPQSL)",
           "Employer" => "Big company",
           "Role" => "Trainer",
-          "How is your NPQ being paid for?" => "I am paying",
           "What setting do you work in?" => "Other",
           "Lead provider" => "Teach First",
           "Where do you work?" => "England",
@@ -237,7 +231,7 @@ RSpec.feature "Happy journeys", type: :feature do
       "eligible_for_funding" => false,
       "employer_name" => "Big company",
       "employment_role" => "Trainer",
-      "funding_choice" => "self",
+      "funding_choice" => nil,
       "funding_eligiblity_status_code" => "no_institution",
       "headteacher_status" => nil,
       "kind_of_nursery" => nil,
@@ -264,7 +258,6 @@ RSpec.feature "Happy journeys", type: :feature do
         "employer_name" => "Big company",
         "employment_role" => "Trainer",
         "full_name" => "John Doe",
-        "funding" => "self",
         "institution_identifier" => "School-100000",
         "institution_location" => "manchester",
         "institution_name" => "",

--- a/spec/features/happy_journeys/js/while_not_currently_working_at_school_spec.rb
+++ b/spec/features/happy_journeys/js/while_not_currently_working_at_school_spec.rb
@@ -66,11 +66,6 @@ RSpec.feature "Happy journeys", type: :feature do
       page.fill_in "Role", with: "Trainer"
     end
 
-    expect_page_to_have(path: "/registration/funding-your-npq", submit_form: true) do
-      expect(page).to have_text("How is your course being paid for?")
-      page.choose "My workplace is covering the cost", visible: :all
-    end
-
     expect_page_to_have(path: "/registration/choose-your-provider", submit_form: true) do
       expect(page).to have_text("Select your provider")
       page.choose("Teach First", visible: :all)
@@ -92,7 +87,6 @@ RSpec.feature "Happy journeys", type: :feature do
           "National Insurance number" => "AB123456C",
           "Email" => "user@example.com",
           "Course" => "NPQ for Senior Leadership (NPQSL)",
-          "How is your NPQ being paid for?" => "My workplace is covering the cost",
           "What setting do you work in?" => "Other",
           "Employer" => "Big company",
           "Lead provider" => "Teach First",
@@ -128,7 +122,7 @@ RSpec.feature "Happy journeys", type: :feature do
       "eligible_for_funding" => false,
       "employer_name" => "Big company",
       "employment_role" => "Trainer",
-      "funding_choice" => "school",
+      "funding_choice" => nil,
       "funding_eligiblity_status_code" => "no_institution",
       "headteacher_status" => nil,
       "kind_of_nursery" => nil,
@@ -155,7 +149,6 @@ RSpec.feature "Happy journeys", type: :feature do
         "employer_name" => "Big company",
         "employment_role" => "Trainer",
         "full_name" => "John Doe",
-        "funding" => "school",
         "lead_provider_id" => "9",
         "national_insurance_number" => "AB123456C",
         "teacher_catchment" => "england",

--- a/spec/features/happy_journeys/js/while_working_in_neither_a_school_nor_childcare_spec.rb
+++ b/spec/features/happy_journeys/js/while_working_in_neither_a_school_nor_childcare_spec.rb
@@ -73,11 +73,6 @@ RSpec.feature "Happy journeys", type: :feature do
       page.fill_in "Role", with: "Trainer"
     end
 
-    expect_page_to_have(path: "/registration/funding-your-npq", submit_form: true) do
-      expect(page).to have_text("How is your course being paid for?")
-      page.choose "I am paying", visible: :all
-    end
-
     expect_page_to_have(path: "/registration/choose-your-provider", submit_form: true) do
       expect(page).to have_text("Select your provider")
       page.choose("Teach First", visible: :all)
@@ -101,7 +96,6 @@ RSpec.feature "Happy journeys", type: :feature do
           "Course" => "NPQ for Early Years Leadership (NPQEYL)",
           "Employer" => "Big company",
           "Role" => "Trainer",
-          "How is your NPQ being paid for?" => "I am paying",
           "What setting do you work in?" => "Other",
           "Lead provider" => "Teach First",
           "Where do you work?" => "England",
@@ -135,7 +129,7 @@ RSpec.feature "Happy journeys", type: :feature do
       "eligible_for_funding" => false,
       "employer_name" => "Big company",
       "employment_role" => "Trainer",
-      "funding_choice" => "self",
+      "funding_choice" => nil,
       "funding_eligiblity_status_code" => "no_institution",
       "headteacher_status" => nil,
       "kind_of_nursery" => nil,
@@ -162,7 +156,6 @@ RSpec.feature "Happy journeys", type: :feature do
         "employer_name" => "Big company",
         "employment_role" => "Trainer",
         "full_name" => "John Doe",
-        "funding" => "self",
         "lead_provider_id" => "9",
         "national_insurance_number" => "AB123456C",
         "teacher_catchment" => "england",


### PR DESCRIPTION
### Context

Follows on from #475

Jira Ticket: [CN-432](https://dfedigital.atlassian.net/browse/CN-432)

### Changes proposed in this pull request

The 'how are you paying' page could confuse non-school users so it has been removed. The corresponding answer has been removed on the check your answers page for any users who don't work in a school or in early years.

### Review guidance

The original ticket states:

> A user selects ‘no’ to both the ‘works in a school’ 'works in early years childcare’ questions

These questions were combined into a single page ('what setting do you work in?') in #475 so this has been interpreted to mean the user picked 'Other'.
