### PR TITLE
[CN-391] Update copy for School and Public Nursery flows

### DIFF
--- a/app/lib/forms/choose_childcare_provider.rb
+++ b/app/lib/forms/choose_childcare_provider.rb
@@ -32,7 +32,7 @@ module Forms
       :find_childcare_provider
     end
 
-    def display_childcare_providers?
+    def display_no_javascript_fallback_form?
       wizard.store["institution_location"].present? && wizard.store["institution_name"].present?
     end
 
@@ -60,7 +60,7 @@ module Forms
     end
 
     def validate_childcare_provider_name_returns_results
-      if display_childcare_providers? && possible_institutions.blank?
+      if display_no_javascript_fallback_form? && possible_institutions.blank?
         errors.add(:institution_name, :no_results, location: institution_location, name: institution_name)
       end
     end

--- a/app/lib/forms/choose_private_childcare_provider.rb
+++ b/app/lib/forms/choose_private_childcare_provider.rb
@@ -8,6 +8,7 @@ module Forms
     validates :institution_name, length: { maximum: 64 }
 
     validate :validate_institution_exists
+    validate :validate_private_childcare_provider_name_returns_results
 
     def self.permitted_params
       %i[
@@ -17,16 +18,44 @@ module Forms
     end
 
     def next_step
-      :choose_your_npq
+      if no_js_fallback_search_loop? || institution_identifier.blank?
+        :choose_private_childcare_provider
+      else
+        :choose_your_npq
+      end
     end
 
     def previous_step
       :have_ofsted_urn
     end
 
-  private
+    def display_no_javascript_fallback_form?
+      wizard.store["institution_location"].present? && wizard.store["institution_name"].present?
+    end
+
+    def possible_institutions
+      return @possible_institutions if @possible_institutions
+
+      @possible_institutions = PrivateChildcareProvider
+                                .search_by_urn(institution_name)
+                                .limit(10)
+    end
+
+    private
+
+    def no_js_fallback_search_loop?
+      institution_identifier == "other"
+    end
+
+    def validate_private_childcare_provider_name_returns_results
+      if display_no_javascript_fallback_form? && possible_institutions.blank?
+        errors.add(:institution_name, :no_results, location: institution_location, name: institution_name)
+      end
+    end
 
     def validate_institution_exists
+      return if no_js_fallback_search_loop?
+      return if institution_identifier.blank?
       return if institution(source: institution_identifier).present?
 
       errors.add(:institution_identifier, :invalid, urn: institution_identifier)

--- a/app/lib/forms/choose_private_childcare_provider.rb
+++ b/app/lib/forms/choose_private_childcare_provider.rb
@@ -41,7 +41,7 @@ module Forms
                                 .limit(10)
     end
 
-    private
+  private
 
     def no_js_fallback_search_loop?
       institution_identifier == "other"

--- a/app/lib/forms/choose_school.rb
+++ b/app/lib/forms/choose_school.rb
@@ -30,7 +30,7 @@ module Forms
       :find_school
     end
 
-    def display_schools?
+    def display_no_javascript_fallback_form?
       wizard.store["institution_location"].present? && wizard.store["institution_name"].present?
     end
 
@@ -62,7 +62,7 @@ module Forms
     end
 
     def validate_school_name_returns_results
-      if display_schools? && possible_institutions.blank?
+      if display_no_javascript_fallback_form? && possible_institutions.blank?
         errors.add(:institution_name, :no_results, location: institution_location, name: institution_name)
       end
     end

--- a/app/views/registration_wizard/choose_childcare_provider.html.erb
+++ b/app/views/registration_wizard/choose_childcare_provider.html.erb
@@ -27,8 +27,12 @@
                                  hint: { text: hint } %>
         <% else %>
           <%= f.govuk_radio_buttons_fieldset(:institution_identifier, legend: { size: 'xl', text: js_fallback_question, tag: "h1" }) do %>
-            <% @form.possible_institutions.each do |institution| %>
-              <%= f.govuk_radio_button :institution_identifier, institution.identifier, label: { text: institution.name }, hint: { text: institution.address_string }, link_errors: true %>
+            <% @form.possible_institutions.each_with_index do |institution, count| %>
+              <%= f.govuk_radio_button :institution_identifier,
+                                       institution.identifier,
+                                       label: { text: institution.name },
+                                       hint: { text: institution.address_string },
+                                       link_errors: count.zero? %>
             <% end %>
             <%= f.govuk_radio_divider %>
             <%= f.govuk_radio_button :institution_identifier, 'other', label: { text: "Nursery not shown above" } do %>

--- a/app/views/registration_wizard/choose_childcare_provider.html.erb
+++ b/app/views/registration_wizard/choose_childcare_provider.html.erb
@@ -16,7 +16,7 @@
 
       <h1 class="govuk-heading-xl">Choose your nursery</h1>
 
-      <% if @form.display_childcare_providers? %>
+      <% if @form.display_no_javascript_fallback_form? %>
         <% if @form.possible_institutions.blank? %>
           <p class="govuk-body">Choose from nurseries located in <strong><%= @form.wizard.store["institution_location"] %></strong></p>
 

--- a/app/views/registration_wizard/choose_childcare_provider.html.erb
+++ b/app/views/registration_wizard/choose_childcare_provider.html.erb
@@ -1,5 +1,10 @@
+<% question = "What's the name of your nursery?" %>
+<% hint = "Search for nurseries located in #{@form.wizard.store["institution_location"]}." %>
+<% js_fallback_question = "Please choose from nurseries located in #{@form.wizard.store["institution_location"]}" %>
+
 <% content_for :title do %>
-  <%= @form.errors.present? ? "Error: " : nil %>Choose your nursery
+  <%= @form.errors.present? ? "Error: " : nil %><%= question %>
+
 <% end %>
 
 <% content_for :before_content do %>
@@ -14,39 +19,39 @@
     <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-xl">Choose your nursery</h1>
-
       <% if @form.display_no_javascript_fallback_form? %>
         <% if @form.possible_institutions.blank? %>
-          <p class="govuk-body">Choose from nurseries located in <strong><%= @form.wizard.store["institution_location"] %></strong></p>
-
-          <p class="govuk-body">No nurseries were found with that name, please try again</p>
-
           <%= f.govuk_text_field :institution_name,
                                  width: "full",
-                                 label: { text: "Enter your nursery name" } %>
+                                 label: { text: question, size: "xl", tag: "h1" },
+                                 hint: { text: hint } %>
         <% else %>
-          <%= f.govuk_radio_buttons_fieldset(:institution_identifier, legend: { size: 'm', text: "Please choose from nurseries located in #{@form.wizard.store["institution_location"]}" }) do %>
+          <%= f.govuk_radio_buttons_fieldset(:institution_identifier, legend: { size: 'xl', text: js_fallback_question, tag: "h1" }) do %>
             <% @form.possible_institutions.each do |institution| %>
               <%= f.govuk_radio_button :institution_identifier, institution.identifier, label: { text: institution.name }, hint: { text: institution.address_string }, link_errors: true %>
             <% end %>
             <%= f.govuk_radio_divider %>
             <%= f.govuk_radio_button :institution_identifier, 'other', label: { text: "Nursery not shown above" } do %>
-              <%= f.govuk_text_field :institution_name, label: { text: "Search for another nursery name" } %>
+              <%= f.govuk_text_field :institution_name, hint: { text: hint }, label: { hidden: true, text: question } %>
             <% end %>
           <% end %>
         <% end %>
       <% else %>
-        <p class="govuk-body">Choose from nurseries located in <%= @form.wizard.store["institution_location"] %></p>
         <div class="npq-js-hidden">
           <%= f.govuk_text_field :institution_name,
                                  width: "full",
-                                 label: { text: "Enter your nursery name", class: "govuk-label govuk-label--s" } %>
+                                 label: { text: question, size: "xl", tag: "h1" },
+                                 hint: { text: hint } %>
         </div>
 
         <div class="npq-js-reveal">
           <div class="govuk-form-group">
-            <%= f.label :institution_identifier, "Enter your nursery name", class: "govuk-label govuk-label--s", for: "nursery-picker" %>
+            <h1 class="govuk-label-wrapper">
+              <%= f.label :institution_identifier, question, class: "govuk-label govuk-label--xl", for: "nursery-picker" %>
+            </h1>
+
+            <span class="govuk-hint" id="nursery-picker-hint"><%= hint %></span>
+
             <%= f.text_field :institution_identifier, data: { location: @form.wizard.store["institution_location"] }, id: "nursery-picker" %>
           </div>
         </div>

--- a/app/views/registration_wizard/choose_private_childcare_provider.html.erb
+++ b/app/views/registration_wizard/choose_private_childcare_provider.html.erb
@@ -26,12 +26,12 @@
                                  hint: { text: hint } %>
         <% else %>
           <%= f.govuk_radio_buttons_fieldset(:institution_identifier, legend: { size: 'xl', text: js_fallback_question, tag: "h1" }) do %>
-            <% @form.possible_institutions.each do |institution| %>
+            <% @form.possible_institutions.each_with_index do |institution, count| %>
               <%= f.govuk_radio_button :institution_identifier,
                                        institution.identifier,
                                        label: { text: [institution.urn, institution.name].compact.join(" - ") },
                                        hint: { text: institution.address_string },
-                                       link_errors: true %>
+                                       link_errors: count.zero? %>
             <% end %>
             <%= f.govuk_radio_divider %>
             <%= f.govuk_radio_button :institution_identifier, 'other', label: { text: "My employer is not shown above" } do %>

--- a/app/views/registration_wizard/choose_private_childcare_provider.html.erb
+++ b/app/views/registration_wizard/choose_private_childcare_provider.html.erb
@@ -1,5 +1,5 @@
 <% question = "Enter your or your employer's URN" %>
-<% hint = "For example EY456789." %>
+<% hint = "For example EY456789" %>
 <% js_fallback_question = "Please choose your employer" %>
 
 <% content_for :title do %>

--- a/app/views/registration_wizard/choose_private_childcare_provider.html.erb
+++ b/app/views/registration_wizard/choose_private_childcare_provider.html.erb
@@ -1,5 +1,6 @@
 <% question = "Enter your or your employer's URN" %>
 <% hint = "For example EY456789." %>
+<% js_fallback_question = "Please choose your employer" %>
 
 <% content_for :title do %>
   <%= @form.errors.present? ? "Error: " : nil %><%= question %>
@@ -17,26 +18,49 @@
     <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <div class="npq-js-hidden">
-        <%= f.govuk_text_field :institution_name,
-                               width: "full",
-                               label: { text: question, size: "xl", tag: "h1" },
-                               hint: { text: hint } %>
-      </div>
-
-      <div class="npq-js-reveal">
-        <div class="govuk-form-group">
-          <h1 class="govuk-label-wrapper">
-            <%= f.label :institution_identifier, question, class: "govuk-label govuk-label--xl", for: "private-childcare-provider-picker" %>
-          </h1>
-
-          <span class="govuk-hint" id="private-childcare-provider-picker-hint"><%= hint %></span>
-
-          <%= f.text_field :institution_identifier, data: { location: @form.wizard.store["institution_location"] }, id: "private-childcare-provider-picker" %>
+      <% if @form.display_no_javascript_fallback_form? %>
+        <% if @form.possible_institutions.blank? %>
+          <%= f.govuk_text_field :institution_name,
+                                 width: "full",
+                                 label: { text: question, size: "xl", tag: "h1" },
+                                 hint: { text: hint } %>
+        <% else %>
+          <%= f.govuk_radio_buttons_fieldset(:institution_identifier, legend: { size: 'xl', text: js_fallback_question, tag: "h1" }) do %>
+            <% @form.possible_institutions.each do |institution| %>
+              <%= f.govuk_radio_button :institution_identifier,
+                                       institution.identifier,
+                                       label: { text: [institution.urn, institution.name].compact.join(" - ") },
+                                       hint: { text: institution.address_string },
+                                       link_errors: true %>
+            <% end %>
+            <%= f.govuk_radio_divider %>
+            <%= f.govuk_radio_button :institution_identifier, 'other', label: { text: "My employer is not shown above" } do %>
+              <%= f.govuk_text_field :institution_name, hint: { text: question }, label: { hidden: true, text: question } %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% else %>
+        <div class="npq-js-hidden">
+          <%= f.govuk_text_field :institution_name,
+                                 width: "full",
+                                 label: { text: question, size: "xl", tag: "h1" },
+                                 hint: { text: hint } %>
         </div>
-      </div>
-      <%= f.govuk_submit %>
 
+        <div class="npq-js-reveal">
+          <div class="govuk-form-group">
+            <h1 class="govuk-label-wrapper">
+              <%= f.label :institution_identifier, question, class: "govuk-label govuk-label--xl", for: "private-childcare-provider-picker" %>
+            </h1>
+
+            <span class="govuk-hint" id="private-childcare-provider-picker-hint"><%= hint %></span>
+
+            <%= f.text_field :institution_identifier, data: { location: @form.wizard.store["institution_location"] }, id: "private-childcare-provider-picker" %>
+          </div>
+        </div>
+      <% end %>
+
+        <%= f.govuk_submit %>
     <% end %>
   </div>
 </div>

--- a/app/views/registration_wizard/choose_private_childcare_provider.html.erb
+++ b/app/views/registration_wizard/choose_private_childcare_provider.html.erb
@@ -1,5 +1,8 @@
+<% question = "Enter your or your employer's URN" %>
+<% hint = "For example EY456789." %>
+
 <% content_for :title do %>
-  <%= @form.errors.present? ? "Error: " : nil %>Choose your nursery
+  <%= @form.errors.present? ? "Error: " : nil %><%= question %>
 <% end %>
 
 <% content_for :before_content do %>
@@ -17,17 +20,19 @@
       <div class="npq-js-hidden">
         <%= f.govuk_text_field :institution_name,
                                width: "full",
-                               label: { text: "Enter your nursery name", class: "govuk-label govuk-label--s" } %>
+                               label: { text: question, size: "xl", tag: "h1" },
+                               hint: { text: hint } %>
       </div>
-
-      <%= f.label :institution_identifier, class: "govuk-label govuk-label--s", for: "private-childcare-provider-picker" do %>
-        <h1 class="govuk-heading-xl">Enter your or your employer's URN</h1>
-      <% end %>
 
       <div class="npq-js-reveal">
         <div class="govuk-form-group">
-          <span class="govuk-hint" id="private-childcare-provider-picker__hint">For example EY456789</span>
-          <%= f.text_field(:institution_identifier, id: "private-childcare-provider-picker", "aria-label" => "Enter your or your employer's URN") %>
+          <h1 class="govuk-label-wrapper">
+            <%= f.label :institution_identifier, question, class: "govuk-label govuk-label--xl", for: "private-childcare-provider-picker" %>
+          </h1>
+
+          <span class="govuk-hint" id="private-childcare-provider-picker-hint"><%= hint %></span>
+
+          <%= f.text_field :institution_identifier, data: { location: @form.wizard.store["institution_location"] }, id: "private-childcare-provider-picker" %>
         </div>
       </div>
       <%= f.govuk_submit %>

--- a/app/views/registration_wizard/choose_school.html.erb
+++ b/app/views/registration_wizard/choose_school.html.erb
@@ -1,5 +1,9 @@
+<% question = "What's the name of your workplace?" %>
+<% hint = "Search for schools or 16 to 19 educational settings located in #{@form.wizard.store["institution_location"]}. If you work for a trust, enter one of their schools." %>
+<% js_fallback_question = "Please choose from schools or 16 to 19 educational settings located in #{@form.wizard.store["institution_location"]}." %>
+
 <% content_for :title do %>
-  <%= @form.errors.present? ? "Error: " : nil %>Choose your workplace
+  <%= @form.errors.present? ? "Error: " : nil %><%= question %>
 <% end %>
 
 <% content_for :before_content do %>
@@ -14,39 +18,39 @@
     <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-xl">Choose your workplace</h1>
-
       <% if @form.display_no_javascript_fallback_form? %>
         <% if @form.possible_institutions.blank? %>
-          <p class="govuk-body">Please choose from schools, trusts and 16 to 19 educational settings located in <strong><%= @form.wizard.store["institution_location"] %></strong></p>
-
-          <p class="govuk-body">No schools or colleges were found with that name, please try again</p>
-
           <%= f.govuk_text_field :institution_name,
                                  width: "full",
-                                 label: { text: "Enter the name of your workplace" } %>
+                                 label: { text: question, size: "xl", tag: "h1" },
+                                 hint: { text: hint } %>
         <% else %>
-          <%= f.govuk_radio_buttons_fieldset(:institution_identifier, legend: { size: 'm', text: "Please choose from schools located in #{@form.wizard.store["institution_location"]}" }) do %>
+          <%= f.govuk_radio_buttons_fieldset(:institution_identifier, legend: { size: 'xl', text: js_fallback_question, tag: "h1" }) do %>
             <% @form.possible_institutions.each do |institution| %>
               <%= f.govuk_radio_button :institution_identifier, institution.identifier, label: { text: institution.name }, hint: { text: institution.address_string }, link_errors: true %>
             <% end %>
             <%= f.govuk_radio_divider %>
             <%= f.govuk_radio_button :institution_identifier, 'other', label: { text: "School or college not shown above" } do %>
-              <%= f.govuk_text_field :institution_name, label: { text: "Search for another workplace" } %>
+              <%= f.govuk_text_field :institution_name, hint: { text: hint }, label: { hidden: true, text: question } %>
             <% end %>
           <% end %>
         <% end %>
       <% else %>
-        <p class="govuk-body">Choose from schools, trusts and 16 to 19 educational settings located in <%= @form.wizard.store["institution_location"] %></p>
         <div class="npq-js-hidden">
           <%= f.govuk_text_field :institution_name,
                                  width: "full",
-                                 label: { text: "Enter the name of your workplace", class: "govuk-label govuk-label--s" } %>
+                                 label: { text: question, size: "xl", tag: "h1" },
+                                 hint: { text: hint } %>
         </div>
 
         <div class="npq-js-reveal">
           <div class="govuk-form-group">
-            <%= f.label :institution_identifier, "Enter the name of your workplace", class: "govuk-label govuk-label--s", for: "school-picker" %>
+            <h1 class="govuk-label-wrapper">
+              <%= f.label :institution_identifier, question, class: "govuk-label govuk-label--xl", for: "school-picker" %>
+            </h1>
+
+            <span class="govuk-hint" id="school-picker-hint"><%= hint %></span>
+
             <%= f.text_field :institution_identifier, data: { location: @form.wizard.store["institution_location"] }, id: "school-picker" %>
           </div>
         </div>

--- a/app/views/registration_wizard/choose_school.html.erb
+++ b/app/views/registration_wizard/choose_school.html.erb
@@ -26,8 +26,12 @@
                                  hint: { text: hint } %>
         <% else %>
           <%= f.govuk_radio_buttons_fieldset(:institution_identifier, legend: { size: 'xl', text: js_fallback_question, tag: "h1" }) do %>
-            <% @form.possible_institutions.each do |institution| %>
-              <%= f.govuk_radio_button :institution_identifier, institution.identifier, label: { text: institution.name }, hint: { text: institution.address_string }, link_errors: true %>
+            <% @form.possible_institutions.each_with_index do |institution, count| %>
+              <%= f.govuk_radio_button :institution_identifier,
+                                       institution.identifier,
+                                       label: { text: institution.name },
+                                       hint: { text: institution.address_string },
+                                       link_errors: count.zero? %>
             <% end %>
             <%= f.govuk_radio_divider %>
             <%= f.govuk_radio_button :institution_identifier, 'other', label: { text: "School or college not shown above" } do %>

--- a/app/views/registration_wizard/choose_school.html.erb
+++ b/app/views/registration_wizard/choose_school.html.erb
@@ -16,7 +16,7 @@
 
       <h1 class="govuk-heading-xl">Choose your workplace</h1>
 
-      <% if @form.display_schools? %>
+      <% if @form.display_no_javascript_fallback_form? %>
         <% if @form.possible_institutions.blank? %>
           <p class="govuk-body">Please choose from schools, trusts and 16 to 19 educational settings located in <strong><%= @form.wizard.store["institution_location"] %></strong></p>
 

--- a/app/views/registration_wizard/find_childcare_provider.html.erb
+++ b/app/views/registration_wizard/find_childcare_provider.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-  <%= @form.errors.present? ? "Error: " : nil %>Where is your nursery?
+  <%= @form.errors.present? ? "Error: " : nil %>Where is your nursery located?
 <% end %>
 
 <% content_for :before_content do %>
@@ -14,16 +14,10 @@
     <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-xl">Where is your nursery?</h1>
-
-      <p class="govuk-body">We need this information to check if you can access Department for Education funding.</p>
-
-      <%= render GovukComponent::InsetTextComponent.new(text: "You can only select nurseries in England, Guernsey, Jersey or the Isle of Man. If your workplace is outside these locations, check with your training provider.") %>
-
       <%= f.govuk_text_field :institution_location,
                              width: "three-quarters",
-                             hint: { text: "Enter town, city or postcode" },
-                             label: { text: "Nursery location", class: "govuk-label--s" } %>
+                             label: { text: "Where is your nursery located?", size: "xl", tag: "h1" },
+                             hint: { text: "Enter the town, city or the first part of the postcode. For example Chester or CH1." } %>
 
       <%= f.govuk_submit %>
     <% end %>

--- a/app/views/registration_wizard/find_school.html.erb
+++ b/app/views/registration_wizard/find_school.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-  <%= @form.errors.present? ? "Error: " : nil %>Where is your school, college or academy trust?
+  <%= @form.errors.present? ? "Error: " : nil %>Where is your workplace located?
 <% end %>
 
 <% content_for :before_content do %>
@@ -14,18 +14,13 @@
     <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-xl">Where is your school, college or academy trust?</h1>
-
-      <p class="govuk-body">We need this information to check if you can access Department for Education funding.</p>
-
-      <%= render GovukComponent::InsetTextComponent.new(text: "You can only select schools, trusts and 16 to 19 educational settings in England, Guernsey, Jersey or the Isle of Man. If your workplace is outside these locations, check with your training provider.") %>
-
       <%= f.govuk_text_field :institution_location,
                              width: "three-quarters",
-                             hint: { text: "Enter town, city or postcode" },
-                             label: { text: "Workplace location", class: "govuk-label--s" } %>
+                             label: { text: "Where is your workplace located?", size: "xl", tag: "h1" },
+                             hint: { text: "Enter the town, city or the first part of the postcode. For example Chester or CH1." } %>
 
       <%= f.govuk_submit %>
     <% end %>
   </div>
 </div>
+

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -17,7 +17,6 @@ if (document.querySelector('#school-picker')) {
   institutionPicker.enhanceSelectElement({
     selectElement: document.querySelector('#school-picker'),
     lookupPath: 'institutions',
-    placeholder: "Start typing to search schools and colleges",
   })
 }
 

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -24,7 +24,6 @@ if (document.querySelector('#nursery-picker')) {
   institutionPicker.enhanceSelectElement({
     selectElement: document.querySelector('#nursery-picker'),
     lookupPath: 'institutions',
-    placeholder: "Start typing to search nurseries",
   })
 }
 

--- a/spec/features/happy_journeys/js/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
+++ b/spec/features/happy_journeys/js/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
@@ -123,10 +123,9 @@ RSpec.feature "Happy journeys", type: :feature do
     end
 
     expect_page_to_have(path: "/registration/choose-school", submit_form: true) do
-      expect(page).to have_text("Choose your workplace")
-      expect(page).to have_text("Choose from schools, trusts and 16 to 19 educational settings located in manchester")
+      expect(page).to have_text("Search for schools or 16 to 19 educational settings located in manchester. If you work for a trust, enter one of their schools.")
       within ".npq-js-reveal" do
-        page.fill_in "Enter the name of your workplace", with: "open"
+        page.fill_in "What's the name of your workplace?", with: "open"
       end
 
       expect(page).to have_content("open manchester school")

--- a/spec/features/happy_journeys/js/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
+++ b/spec/features/happy_journeys/js/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
@@ -119,8 +119,7 @@ RSpec.feature "Happy journeys", type: :feature do
     end
 
     expect_page_to_have(path: "/registration/find-school", submit_form: true) do
-      expect(page).to have_text("Where is your school, college or academy trust?")
-      page.fill_in "Workplace location", with: "manchester"
+      page.fill_in "Where is your workplace located?", with: "manchester"
     end
 
     expect_page_to_have(path: "/registration/choose-school", submit_form: true) do

--- a/spec/features/happy_journeys/js/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
+++ b/spec/features/happy_journeys/js/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
@@ -78,10 +78,10 @@ RSpec.feature "Happy journeys", type: :feature do
     end
 
     expect_page_to_have(path: "/registration/choose-childcare-provider", submit_form: true) do
-      expect(page).to have_text("Choose your nursery")
-      expect(page).to have_text("Choose from nurseries located in manchester")
+      expect(page).to have_text("What's the name of your nursery?")
+      expect(page).to have_text("Search for nurseries located in manchester")
       within ".npq-js-reveal" do
-        page.fill_in "Enter your nursery name", with: "open"
+        page.fill_in "What's the name of your nursery?", with: "open"
       end
 
       expect(page).to have_content("open manchester school")

--- a/spec/features/happy_journeys/js/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
+++ b/spec/features/happy_journeys/js/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
@@ -73,8 +73,8 @@ RSpec.feature "Happy journeys", type: :feature do
     end
 
     expect_page_to_have(path: "/registration/find-childcare-provider", submit_form: true) do
-      expect(page).to have_text("Where is your nursery?")
-      page.fill_in "Nursery location", with: "manchester"
+      expect(page).to have_text("Where is your nursery located?")
+      page.fill_in "Where is your nursery located?", with: "manchester"
     end
 
     expect_page_to_have(path: "/registration/choose-childcare-provider", submit_form: true) do

--- a/spec/features/happy_journeys/js/changing_from_outside_of_catchment_area_to_inside_spec.rb
+++ b/spec/features/happy_journeys/js/changing_from_outside_of_catchment_area_to_inside_spec.rb
@@ -161,8 +161,7 @@ RSpec.feature "Happy journeys", type: :feature do
     School.create!(urn: 100_000, name: "open manchester school", address_1: "street 1", town: "manchester", establishment_status_code: "1")
 
     expect_page_to_have(path: "/registration/find-school", submit_form: true) do
-      expect(page).to have_text("Where is your school, college or academy trust?")
-      page.fill_in "Workplace location", with: "manchester"
+      page.fill_in "Where is your workplace located?", with: "manchester"
     end
 
     expect_page_to_have(path: "/registration/choose-school", submit_form: true) do

--- a/spec/features/happy_journeys/js/changing_from_outside_of_catchment_area_to_inside_spec.rb
+++ b/spec/features/happy_journeys/js/changing_from_outside_of_catchment_area_to_inside_spec.rb
@@ -165,11 +165,10 @@ RSpec.feature "Happy journeys", type: :feature do
     end
 
     expect_page_to_have(path: "/registration/choose-school", submit_form: true) do
-      expect(page).to have_text("Choose your workplace")
-      expect(page).to have_text("Choose from schools, trusts and 16 to 19 educational settings located in manchester")
+      expect(page).to have_text("Search for schools or 16 to 19 educational settings located in manchester. If you work for a trust, enter one of their schools.")
 
       within ".npq-js-reveal" do
-        page.fill_in "Enter the name of your workplace", with: "open"
+        page.fill_in "What's the name of your workplace?", with: "open"
       end
 
       expect(page).to have_content("open manchester school")

--- a/spec/features/happy_journeys/js/changing_npq_to_one_leadprovider_no_longer_supports_spec.rb
+++ b/spec/features/happy_journeys/js/changing_npq_to_one_leadprovider_no_longer_supports_spec.rb
@@ -74,8 +74,8 @@ RSpec.feature "Happy journeys", type: :feature do
     end
 
     expect_page_to_have(path: "/registration/find-childcare-provider", submit_form: true) do
-      expect(page).to have_text("Where is your nursery?")
-      page.fill_in "Nursery location", with: "manchester"
+      expect(page).to have_text("Where is your nursery located?")
+      page.fill_in "Where is your nursery located?", with: "manchester"
     end
 
     expect_page_to_have(path: "/registration/choose-childcare-provider", submit_form: true) do

--- a/spec/features/happy_journeys/js/changing_npq_to_one_leadprovider_no_longer_supports_spec.rb
+++ b/spec/features/happy_journeys/js/changing_npq_to_one_leadprovider_no_longer_supports_spec.rb
@@ -79,10 +79,10 @@ RSpec.feature "Happy journeys", type: :feature do
     end
 
     expect_page_to_have(path: "/registration/choose-childcare-provider", submit_form: true) do
-      expect(page).to have_text("Choose your nursery")
-      expect(page).to have_text("Choose from nurseries located in manchester")
+      expect(page).to have_text("What's the name of your nursery?")
+      expect(page).to have_text("Search for nurseries located in manchester")
       within ".npq-js-reveal" do
-        page.fill_in "Enter your nursery name", with: "open"
+        page.fill_in "What's the name of your nursery?", with: "open"
       end
 
       expect(page).to have_content("open manchester school")

--- a/spec/features/happy_journeys/js/via_using_old_name_and_not_headship_spec.rb
+++ b/spec/features/happy_journeys/js/via_using_old_name_and_not_headship_spec.rb
@@ -71,8 +71,7 @@ RSpec.feature "Happy journeys", type: :feature do
     School.create!(urn: 100_000, name: "open manchester school", address_1: "street 1", town: "manchester", establishment_status_code: "1")
 
     expect_page_to_have(path: "/registration/find-school", submit_form: true) do
-      expect(page).to have_text("Where is your school, college or academy trust?")
-      page.fill_in "Workplace location", with: "manchester"
+      page.fill_in "Where is your workplace located?", with: "manchester"
     end
 
     expect_page_to_have(path: "/registration/choose-school", submit_form: true) do

--- a/spec/features/happy_journeys/js/via_using_old_name_and_not_headship_spec.rb
+++ b/spec/features/happy_journeys/js/via_using_old_name_and_not_headship_spec.rb
@@ -75,11 +75,10 @@ RSpec.feature "Happy journeys", type: :feature do
     end
 
     expect_page_to_have(path: "/registration/choose-school", submit_form: true) do
-      expect(page).to have_text("Choose your workplace")
-      expect(page).to have_text("Choose from schools, trusts and 16 to 19 educational settings located in manchester")
+      expect(page).to have_text("Search for schools or 16 to 19 educational settings located in manchester. If you work for a trust, enter one of their schools.")
 
       within ".npq-js-reveal" do
-        page.fill_in "Enter the name of your workplace", with: "open"
+        page.fill_in "What's the name of your workplace?", with: "open"
       end
 
       expect(page).to have_content("open manchester school")

--- a/spec/features/happy_journeys/js/via_using_same_name_spec.rb
+++ b/spec/features/happy_journeys/js/via_using_same_name_spec.rb
@@ -74,11 +74,10 @@ RSpec.feature "Happy journeys", type: :feature do
     end
 
     expect_page_to_have(path: "/registration/choose-school", submit_form: true) do
-      expect(page).to have_text("Choose your workplace")
-      expect(page).to have_text("Choose from schools, trusts and 16 to 19 educational settings located in manchester")
+      expect(page).to have_text("Search for schools or 16 to 19 educational settings located in manchester. If you work for a trust, enter one of their schools.")
 
       within ".npq-js-reveal" do
-        page.fill_in "Enter the name of your workplace", with: "open"
+        page.fill_in "What's the name of your workplace?", with: "open"
       end
 
       expect(page).to have_content("open manchester school")

--- a/spec/features/happy_journeys/js/via_using_same_name_spec.rb
+++ b/spec/features/happy_journeys/js/via_using_same_name_spec.rb
@@ -70,8 +70,7 @@ RSpec.feature "Happy journeys", type: :feature do
     School.create!(urn: 100_002, name: "open newcastle school", address_1: "street 3", town: "newcastle", establishment_status_code: "1")
 
     expect_page_to_have(path: "/registration/find-school", submit_form: true) do
-      expect(page).to have_text("Where is your school, college or academy trust?")
-      page.fill_in "Workplace location", with: "manchester"
+      page.fill_in "Where is your workplace located?", with: "manchester"
     end
 
     expect_page_to_have(path: "/registration/choose-school", submit_form: true) do

--- a/spec/features/happy_journeys/js/while_working_at_public_nursery_spec.rb
+++ b/spec/features/happy_journeys/js/while_working_at_public_nursery_spec.rb
@@ -78,10 +78,10 @@ RSpec.feature "Happy journeys", type: :feature do
     end
 
     expect_page_to_have(path: "/registration/choose-childcare-provider", submit_form: true) do
-      expect(page).to have_text("Choose your nursery")
-      expect(page).to have_text("Choose from nurseries located in manchester")
+      expect(page).to have_text("What's the name of your nursery?")
+      expect(page).to have_text("Search for nurseries located in manchester")
       within ".npq-js-reveal" do
-        page.fill_in "Enter your nursery name", with: "open"
+        page.fill_in "What's the name of your nursery?", with: "open"
       end
 
       expect(page).to have_content("open manchester school")

--- a/spec/features/happy_journeys/js/while_working_at_public_nursery_spec.rb
+++ b/spec/features/happy_journeys/js/while_working_at_public_nursery_spec.rb
@@ -73,8 +73,8 @@ RSpec.feature "Happy journeys", type: :feature do
     end
 
     expect_page_to_have(path: "/registration/find-childcare-provider", submit_form: true) do
-      expect(page).to have_text("Where is your nursery?")
-      page.fill_in "Nursery location", with: "manchester"
+      expect(page).to have_text("Where is your nursery located?")
+      page.fill_in "Where is your nursery located?", with: "manchester"
     end
 
     expect_page_to_have(path: "/registration/choose-childcare-provider", submit_form: true) do

--- a/spec/features/happy_journeys/non_js/able_to_receive_targeted_delivery_funding_spec.rb
+++ b/spec/features/happy_journeys/non_js/able_to_receive_targeted_delivery_funding_spec.rb
@@ -77,8 +77,7 @@ RSpec.feature "Happy journeys", type: :feature do
     )
 
     expect_page_to_have(path: "/registration/find-school", submit_form: true) do
-      expect(page).to have_text("Where is your school, college or academy trust?")
-      page.fill_in "Workplace location", with: "manchester"
+      page.fill_in "Where is your workplace located?", with: "manchester"
     end
 
     expect_page_to_have(path: "/registration/choose-school", submit_form: true) do

--- a/spec/features/happy_journeys/non_js/able_to_receive_targeted_delivery_funding_spec.rb
+++ b/spec/features/happy_journeys/non_js/able_to_receive_targeted_delivery_funding_spec.rb
@@ -81,16 +81,15 @@ RSpec.feature "Happy journeys", type: :feature do
     end
 
     expect_page_to_have(path: "/registration/choose-school", submit_form: true) do
-      expect(page).to have_text("Choose your workplace")
-      expect(page).to have_text("Choose from schools, trusts and 16 to 19 educational settings located in manchester")
+      expect(page).to have_text("Search for schools or 16 to 19 educational settings located in manchester. If you work for a trust, enter one of their schools.")
 
       within ".npq-js-hidden" do
-        page.fill_in "Enter the name of your workplace", with: "open"
+        page.fill_in "What's the name of your workplace?", with: "open"
       end
 
       page.click_button("Continue")
 
-      expect(page).to have_text("Choose your workplace")
+      expect(page).to have_text("What's the name of your workplace?")
       page.choose "open manchester school"
     end
 

--- a/spec/features/happy_journeys/non_js/funded_ehco_registration_journey_spec.rb
+++ b/spec/features/happy_journeys/non_js/funded_ehco_registration_journey_spec.rb
@@ -70,8 +70,7 @@ RSpec.feature "Happy journeys", type: :feature do
     School.create!(urn: 100_002, name: "open newcastle school", address_1: "street 3", town: "newcastle", establishment_status_code: "1")
 
     expect_page_to_have(path: "/registration/find-school", submit_form: true) do
-      expect(page).to have_text("Where is your school, college or academy trust?")
-      page.fill_in "Workplace location", with: "manchester"
+      page.fill_in "Where is your workplace located?", with: "manchester"
     end
 
     expect_page_to_have(path: "/registration/choose-school", submit_form: true) do

--- a/spec/features/happy_journeys/non_js/funded_ehco_registration_journey_spec.rb
+++ b/spec/features/happy_journeys/non_js/funded_ehco_registration_journey_spec.rb
@@ -74,16 +74,15 @@ RSpec.feature "Happy journeys", type: :feature do
     end
 
     expect_page_to_have(path: "/registration/choose-school", submit_form: true) do
-      expect(page).to have_text("Choose your workplace")
-      expect(page).to have_text("Choose from schools, trusts and 16 to 19 educational settings located in manchester")
+      expect(page).to have_text("Search for schools or 16 to 19 educational settings located in manchester. If you work for a trust, enter one of their schools.")
 
       within ".npq-js-hidden" do
-        page.fill_in "Enter the name of your workplace", with: "open"
+        page.fill_in "What's the name of your workplace?", with: "open"
       end
 
       page.click_button("Continue")
 
-      expect(page).to have_text("Choose your workplace")
+      expect(page).to have_text("What's the name of your workplace?")
       page.choose "open manchester school"
     end
 

--- a/spec/features/happy_journeys/non_js/other_funded_ehco_registration_journey_spec.rb
+++ b/spec/features/happy_journeys/non_js/other_funded_ehco_registration_journey_spec.rb
@@ -73,16 +73,15 @@ RSpec.feature "Happy journeys", type: :feature do
     end
 
     expect_page_to_have(path: "/registration/choose-school", submit_form: true) do
-      expect(page).to have_text("Choose your workplace")
-      expect(page).to have_text("Choose from schools, trusts and 16 to 19 educational settings located in manchester")
+      expect(page).to have_text("Search for schools or 16 to 19 educational settings located in manchester. If you work for a trust, enter one of their schools.")
 
       within ".npq-js-hidden" do
-        page.fill_in "Enter the name of your workplace", with: "open"
+        page.fill_in "What's the name of your workplace?", with: "open"
       end
 
       page.click_button("Continue")
 
-      expect(page).to have_text("Choose your workplace")
+      expect(page).to have_text("What's the name of your workplace?")
       page.choose "open manchester school"
     end
 

--- a/spec/features/happy_journeys/non_js/other_funded_ehco_registration_journey_spec.rb
+++ b/spec/features/happy_journeys/non_js/other_funded_ehco_registration_journey_spec.rb
@@ -69,8 +69,7 @@ RSpec.feature "Happy journeys", type: :feature do
     School.create!(urn: 100_002, name: "open newcastle school", address_1: "street 3", town: "newcastle", establishment_status_code: "1")
 
     expect_page_to_have(path: "/registration/find-school", submit_form: true) do
-      expect(page).to have_text("Where is your school, college or academy trust?")
-      page.fill_in "Workplace location", with: "manchester"
+      page.fill_in "Where is your workplace located?", with: "manchester"
     end
 
     expect_page_to_have(path: "/registration/choose-school", submit_form: true) do

--- a/spec/features/happy_journeys/non_js/via_using_old_name_and_not_headship_spec.rb
+++ b/spec/features/happy_journeys/non_js/via_using_old_name_and_not_headship_spec.rb
@@ -86,8 +86,7 @@ RSpec.feature "Happy journeys", type: :feature do
     )
 
     expect_page_to_have(path: "/registration/find-school", submit_form: true) do
-      expect(page).to have_text("Where is your school, college or academy trust?")
-      page.fill_in "Workplace location", with: "manchester"
+      page.fill_in "Where is your workplace located?", with: "manchester"
     end
 
     expect_page_to_have(path: "/registration/choose-school", submit_form: true) do

--- a/spec/features/happy_journeys/non_js/via_using_old_name_and_not_headship_spec.rb
+++ b/spec/features/happy_journeys/non_js/via_using_old_name_and_not_headship_spec.rb
@@ -90,16 +90,15 @@ RSpec.feature "Happy journeys", type: :feature do
     end
 
     expect_page_to_have(path: "/registration/choose-school", submit_form: true) do
-      expect(page).to have_text("Choose your workplace")
-      expect(page).to have_text("Choose from schools, trusts and 16 to 19 educational settings located in manchester")
+      expect(page).to have_text("Search for schools or 16 to 19 educational settings located in manchester. If you work for a trust, enter one of their schools.")
 
       within ".npq-js-hidden" do
-        page.fill_in "Enter the name of your workplace", with: "open"
+        page.fill_in "What's the name of your workplace?", with: "open"
       end
 
       page.click_button("Continue")
 
-      expect(page).to have_text("Choose your workplace")
+      expect(page).to have_text("What's the name of your workplace?")
       page.choose "open manchester school"
     end
 

--- a/spec/features/happy_journeys/non_js/via_using_same_name_spec.rb
+++ b/spec/features/happy_journeys/non_js/via_using_same_name_spec.rb
@@ -71,16 +71,15 @@ RSpec.feature "Happy journeys", type: :feature do
     end
 
     expect_page_to_have(path: "/registration/choose-school", submit_form: true) do
-      expect(page).to have_text("Choose your workplace")
-      expect(page).to have_text("Choose from schools, trusts and 16 to 19 educational settings located in manchester")
+      expect(page).to have_text("Search for schools or 16 to 19 educational settings located in manchester. If you work for a trust, enter one of their schools.")
 
       within ".npq-js-hidden" do
-        page.fill_in "Enter the name of your workplace", with: "open"
+        page.fill_in "What's the name of your workplace?", with: "open"
       end
 
       page.click_button("Continue")
 
-      expect(page).to have_text("Choose your workplace")
+      expect(page).to have_text("What's the name of your workplace?")
       page.choose "open manchester school"
     end
 

--- a/spec/features/happy_journeys/non_js/via_using_same_name_spec.rb
+++ b/spec/features/happy_journeys/non_js/via_using_same_name_spec.rb
@@ -67,8 +67,7 @@ RSpec.feature "Happy journeys", type: :feature do
     School.create!(urn: 100_002, name: "open newcastle school", address_1: "street 3", town: "newcastle", establishment_status_code: "1")
 
     expect_page_to_have(path: "/registration/find-school", submit_form: true) do
-      expect(page).to have_text("Where is your school, college or academy trust?")
-      page.fill_in "Workplace location", with: "manchester"
+      page.fill_in "Where is your workplace located?", with: "manchester"
     end
 
     expect_page_to_have(path: "/registration/choose-school", submit_form: true) do

--- a/spec/features/sad_journeys/applying_for_ehco_but_not_new_headteacher_spec.rb
+++ b/spec/features/sad_journeys/applying_for_ehco_but_not_new_headteacher_spec.rb
@@ -76,11 +76,10 @@ RSpec.feature "Happy journeys", type: :feature do
     end
 
     expect_page_to_have(path: "/registration/choose-school", submit_form: true) do
-      expect(page).to have_text("Choose your workplace")
-      expect(page).to have_text("Choose from schools, trusts and 16 to 19 educational settings located in manchester")
+      expect(page).to have_text("Search for schools or 16 to 19 educational settings located in manchester. If you work for a trust, enter one of their schools.")
 
       within ".npq-js-reveal" do
-        page.fill_in "Enter the name of your workplace", with: "open"
+        page.fill_in "What's the name of your workplace?", with: "open"
       end
 
       expect(page).to have_content("open manchester school")

--- a/spec/features/sad_journeys/applying_for_ehco_but_not_new_headteacher_spec.rb
+++ b/spec/features/sad_journeys/applying_for_ehco_but_not_new_headteacher_spec.rb
@@ -72,8 +72,7 @@ RSpec.feature "Happy journeys", type: :feature do
     School.create!(urn: 100_000, name: "open manchester school", address_1: "street 1", town: "manchester", establishment_status_code: "1")
 
     expect_page_to_have(path: "/registration/find-school", submit_form: true) do
-      expect(page).to have_text("Where is your school, college or academy trust?")
-      page.fill_in "Workplace location", with: "manchester"
+      page.fill_in "Where is your workplace located?", with: "manchester"
     end
 
     expect_page_to_have(path: "/registration/choose-school", submit_form: true) do

--- a/spec/features/sad_journeys/dqt_mismatch_spec.rb
+++ b/spec/features/sad_journeys/dqt_mismatch_spec.rb
@@ -92,8 +92,7 @@ RSpec.feature "Happy journeys", type: :feature do
     School.create!(urn: 100_002, name: "open newcastle school", address_1: "street 3", town: "newcastle", establishment_status_code: "1")
 
     expect_page_to_have(path: "/registration/find-school", submit_form: true) do
-      expect(page).to have_text("Where is your school, college or academy trust?")
-      page.fill_in "Workplace location", with: "manchester"
+      page.fill_in "Where is your workplace located?", with: "manchester"
     end
 
     expect_page_to_have(path: "/registration/choose-school", submit_form: true) do

--- a/spec/features/sad_journeys/dqt_mismatch_spec.rb
+++ b/spec/features/sad_journeys/dqt_mismatch_spec.rb
@@ -96,11 +96,10 @@ RSpec.feature "Happy journeys", type: :feature do
     end
 
     expect_page_to_have(path: "/registration/choose-school", submit_form: true) do
-      expect(page).to have_text("Choose your workplace")
-      expect(page).to have_text("Choose from schools, trusts and 16 to 19 educational settings located in manchester")
+      expect(page).to have_text("Search for schools or 16 to 19 educational settings located in manchester. If you work for a trust, enter one of their schools.")
 
       within ".npq-js-reveal" do
-        page.fill_in "Enter the name of your workplace", with: "open"
+        page.fill_in "What's the name of your workplace?", with: "open"
       end
 
       expect(page).to have_content("open manchester school")

--- a/spec/features/sad_journeys/school_not_in_england_spec.rb
+++ b/spec/features/sad_journeys/school_not_in_england_spec.rb
@@ -66,10 +66,8 @@ RSpec.feature "Happy journeys", type: :feature do
     end
 
     expect_page_to_have(path: "/registration/choose-school", submit_form: true) do
-      expect(page).to have_text("Choose your workplace")
-
       within ".npq-js-reveal" do
-        page.fill_in "Enter the name of your workplace", with: "open"
+        page.fill_in "What's the name of your workplace?", with: "open"
       end
 
       expect(page).to have_content("open welsh school")
@@ -84,7 +82,7 @@ RSpec.feature "Happy journeys", type: :feature do
     end
 
     expect_page_to_have(path: "/registration/choose-school", submit_form: false) do
-      expect(page).to have_text("Choose your workplace")
+      expect(page).to have_text("What's the name of your workplace?")
     end
 
     expect(retrieve_latest_application_user_data).to eq(nil)

--- a/spec/features/sad_journeys/school_not_in_england_spec.rb
+++ b/spec/features/sad_journeys/school_not_in_england_spec.rb
@@ -62,8 +62,7 @@ RSpec.feature "Happy journeys", type: :feature do
     School.create!(urn: 100_000, name: "open welsh school", county: "Wrexham", establishment_status_code: "1", establishment_type_code: "30")
 
     expect_page_to_have(path: "/registration/find-school", submit_form: true) do
-      expect(page).to have_text("Where is your school, college or academy trust?")
-      page.fill_in "Workplace location", with: "wrexham"
+      page.fill_in "Where is your workplace located?", with: "wrexham"
     end
 
     expect_page_to_have(path: "/registration/choose-school", submit_form: true) do


### PR DESCRIPTION
### Context

https://dfedigital.atlassian.net/browse/CN-391

### Changes proposed in this pull request

#### Ticket changes 

- Update copy on find-school page
- Update copy on choose-school page
- Update copy on find-childcare-provider page
- Update copy on choose childcare provider page

#### Other changes 

- Rename the display_…? methods to be descriptive
  I renamed the display_schools? and display_childcare_providers? methods to display_no_javascript_fallback_form?. I did this to make it immediately obvious what they control. That these sections of code are in place to enable to no-js fallback for selecting your institution.
- Fix copy on choose-private-childcare-provider page
- Add no-JS flow to private childcare provider form

### Guidance to review

Ticket on Jira details the required copy and has links to the prototype. Compare copy on find-school , choose-school, find-childcare-provider, and choose-childcare-provider pages to the prototypes to confirm copy is up to date.

Also, testing the no-js flows are functional in the two updated flows and the newly added section for the private childcare provider flow by moving through each interface having disabled javascript. To do this, open the dev console, hit ctrl+shift+p (windows) or cmd+shift+p (macos) and type javascript to find the `Disable Javascript` option in the dropdown.

