### PR TITLE
Remove unneeded work in school localisation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,10 +42,6 @@ en:
           attributes:
             chosen_provider:
               blank: Select whether or not you have chosen an NPQ and provider
-        forms/work_in_school:
-          attributes:
-            works_in_school:
-              blank: Select whether or not you currently work in a school, college or academy trust?
         forms/share_provider:
           attributes:
             can_share_choices:


### PR DESCRIPTION
### Context

Removes the `work_in_school` entry from the locales file, it should have been dropped in #475
