### PR TITLE
Solve missing interpolation argument bug when validating institution identifiers

### DIFF
--- a/app/lib/forms/choose_private_childcare_provider.rb
+++ b/app/lib/forms/choose_private_childcare_provider.rb
@@ -4,10 +4,9 @@ module Forms
 
     attr_accessor :institution_name, :institution_identifier
 
-    validates :institution_identifier, format: { with: /\APrivateChildcareProvider-.+\z/, unless: -> { institution_identifier.blank? || institution_identifier == "other" } }
     validates :institution_name, length: { maximum: 64 }
 
-    validate :validate_institution_exists
+    validate :validate_institution_identifier
     validate :validate_private_childcare_provider_name_returns_results
 
     def self.permitted_params
@@ -53,12 +52,16 @@ module Forms
       end
     end
 
-    def validate_institution_exists
+    def validate_institution_identifier
       return if no_js_fallback_search_loop?
       return if institution_identifier.blank?
+
+      errors.add(:institution_identifier, :invalid, urn: institution_identifier) unless
+        institution_identifier.start_with?("PrivateChildcareProvider-")
+
       return if institution(source: institution_identifier).present?
 
-      errors.add(:institution_identifier, :invalid, urn: institution_identifier)
+      errors.add(:institution_identifier, :no_results, urn: institution_identifier.split("-").last)
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -119,7 +119,8 @@ en:
         forms/choose_private_childcare_provider:
           attributes:
             institution_identifier:
-              invalid: No private childcare providers with the URN %{urn} were found, please try again
+              no_results: No private childcare providers with the URN %{urn} were found, please try again
+              invalid: No matching private childcare provider found
         forms/choose_school:
           attributes:
             institution_name:

--- a/spec/lib/forms/choose_private_childcare_provider_spec.rb
+++ b/spec/lib/forms/choose_private_childcare_provider_spec.rb
@@ -30,6 +30,26 @@ RSpec.describe Forms::ChoosePrivateChildcareProvider, type: :model do
         expect(subject).to be_valid
       end
 
+      it "is invalid when the institution_identifier contains a URN that doesn't exist" do
+        missing_identifier = "PrivateChildcareProvider-000000"
+        expected_message = "No private childcare providers with the URN 000000 were found, please try again"
+
+        subject.institution_identifier = missing_identifier
+
+        expect(subject).to be_invalid
+        expect(subject.errors.messages[:institution_identifier]).to include(expected_message)
+      end
+
+      it "is invalid when the institution_identifier is in the wrong format" do
+        invalid_identifier = "PrivateChildcareProvider/999876"
+        expected_message = "No matching private childcare provider found"
+
+        subject.institution_identifier = invalid_identifier
+
+        expect(subject).to be_invalid
+        expect(subject.errors.messages[:institution_identifier]).to include(expected_message)
+      end
+
       it { is_expected.to validate_length_of(:institution_name).is_at_most(64) }
     end
   end

--- a/spec/lib/forms/choose_private_childcare_provider_spec.rb
+++ b/spec/lib/forms/choose_private_childcare_provider_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe Forms::ChoosePrivateChildcareProvider, type: :model do
+  let(:current_step) { :choose_private_childcare_provider }
+  let(:store) { { "works_in_childcare" => "yes" } }
+  let(:request) { nil }
+
+  let(:wizard) do
+    RegistrationWizard.new(current_step:, store:, request:)
+  end
+
+  describe "validations" do
+    before { create(:private_childcare_provider, provider_urn: "123456") }
+
+    subject { described_class.new(wizard:) }
+
+    describe "#institution_identifier" do
+      it "can have institution_identifier as empty string" do
+        subject.institution_identifier = ""
+        expect(subject).to be_valid
+      end
+
+      it "can have institution_identifier as 'other'" do
+        subject.institution_identifier = "other"
+        expect(subject).to be_valid
+      end
+
+      it "can have institution_identifier as 'PrivateChildcareProvider-123456'" do
+        subject.institution_identifier = "PrivateChildcareProvider-123456"
+        expect(subject).to be_valid
+      end
+
+      it { is_expected.to validate_length_of(:institution_name).is_at_most(64) }
+    end
+  end
+
+  describe "#next_step" do
+    context "when institution_identifier is blank" do
+      it "is choose_private_childcare_provider" do
+        expect(subject.next_step).to eql(:choose_private_childcare_provider)
+      end
+    end
+
+    context "when institution_identifier is present" do
+      before { allow(subject).to receive(:institution_identifier).and_return("12345") }
+
+      it "is choose_private_childcare_provider" do
+        expect(subject.next_step).to eql(:choose_your_npq)
+      end
+    end
+  end
+
+  describe "#previous_step" do
+    it { expect(subject.previous_step).to eql(:have_ofsted_urn) }
+  end
+end


### PR DESCRIPTION
### Context

[This bug](https://sentry.io/organizations/dfe-teacher-services/issues/3294833521/?project=5817541) has popped up a few times in Sentry over the last few months. The error message is

```
I18n::MissingInterpolationArgument: missing interpolation argument :urn in "No private
childcare providers with the URN %{urn} were found, please try again" ({:model=>
"Choose private childcare provider", :attribute=>"Institution identifier", :value=>
"School-123456"} given)
```

It happens because the `:invalid` error message in the locales file expects a `urn:` argument, which it received from the custom error message but not from the validates format macro.

### Changes proposed in this pull request

- Add choose private childcare provider step specs
- Move institution identifier validation to method
