### PR TITLE
Refactor portion of radio type questions to use govuk-form-builder localisation

### DIFF
--- a/app/lib/forms/aso_headteacher.rb
+++ b/app/lib/forms/aso_headteacher.rb
@@ -27,25 +27,9 @@ module Forms
     end
 
     def options
-      options_array.each_with_index.map do |option, index|
-        OpenStruct.new(value: option[:value],
-                       text: option[:text],
-                       link_errors: index.zero?)
-      end
-    end
-
-  private
-
-    def options_array
       [
-        {
-          text: "Yes",
-          value: "yes",
-        },
-        {
-          text: "No",
-          value: "no",
-        },
+        build_option_struct(value: "yes", link_errors: true),
+        build_option_struct(value: "no"),
       ]
     end
   end

--- a/app/lib/forms/aso_new_headteacher.rb
+++ b/app/lib/forms/aso_new_headteacher.rb
@@ -30,11 +30,10 @@ module Forms
     end
 
     def options
-      options_array.each_with_index.map do |option, index|
-        OpenStruct.new(value: option[:value],
-                       text: option[:text],
-                       link_errors: index.zero?)
-      end
+      [
+        build_option_struct(value: "yes", link_errors: true),
+        build_option_struct(value: "no"),
+      ]
     end
 
   private
@@ -55,19 +54,6 @@ module Forms
 
     def new_headteacher?
       aso_new_headteacher == "yes"
-    end
-
-    def options_array
-      [
-        {
-          text: "Yes",
-          value: "yes",
-        },
-        {
-          text: "No",
-          value: "no",
-        },
-      ]
     end
   end
 end

--- a/app/lib/forms/base.rb
+++ b/app/lib/forms/base.rb
@@ -90,7 +90,7 @@ module Forms
         value:,
         link_errors:,
         divider:,
-        revealed_question:
+        revealed_question:,
       )
     end
   end

--- a/app/lib/forms/base.rb
+++ b/app/lib/forms/base.rb
@@ -83,17 +83,15 @@ module Forms
       wizard.query_store
     end
 
-    def option_locale_scope
-      raise NotImplementedError
-    end
+    def build_option_struct(value:, link_errors: false, divider: false, include_if: true)
+      return unless include_if
 
-    def build_option_struct(value:, link_errors: false, divider: false)
       options = {
         value:,
         link_errors:,
       }
 
-      options[:divider] = divider if divide
+      options[:divider] = divider if divider
 
       OpenStruct.new(options)
     end

--- a/app/lib/forms/base.rb
+++ b/app/lib/forms/base.rb
@@ -83,7 +83,7 @@ module Forms
       wizard.query_store
     end
 
-    def build_option_struct(value:, link_errors: false, divider: false, include_if: true)
+    def build_option_struct(value:, link_errors: false, divider: false, include_if: true, opts: {})
       return unless include_if
 
       options = {
@@ -92,6 +92,8 @@ module Forms
       }
 
       options[:divider] = divider if divider
+
+      options.merge!(opts) if opts.present?
 
       OpenStruct.new(options)
     end

--- a/app/lib/forms/base.rb
+++ b/app/lib/forms/base.rb
@@ -83,9 +83,7 @@ module Forms
       wizard.query_store
     end
 
-    def build_option_struct(value:, link_errors: false, divider: false, include_if: true, revealed_question: nil)
-      return unless include_if
-
+    def build_option_struct(value:, link_errors: false, divider: false, revealed_question: nil)
       Forms::QuestionTypes::RadioOption.new(
         value:,
         link_errors:,

--- a/app/lib/forms/base.rb
+++ b/app/lib/forms/base.rb
@@ -83,19 +83,15 @@ module Forms
       wizard.query_store
     end
 
-    def build_option_struct(value:, link_errors: false, divider: false, include_if: true, opts: {})
+    def build_option_struct(value:, link_errors: false, divider: false, include_if: true, revealed_question: nil)
       return unless include_if
 
-      options = {
+      Forms::QuestionTypes::RadioOption.new(
         value:,
         link_errors:,
-      }
-
-      options[:divider] = divider if divider
-
-      options.merge!(opts) if opts.present?
-
-      OpenStruct.new(options)
+        divider:,
+        revealed_question:
+      )
     end
   end
 end

--- a/app/lib/forms/base.rb
+++ b/app/lib/forms/base.rb
@@ -82,5 +82,20 @@ module Forms
     def query_store
       wizard.query_store
     end
+
+    def option_locale_scope
+      raise NotImplementedError
+    end
+
+    def build_option_struct(value:, link_errors: false, divider: false)
+      options = {
+        value:,
+        link_errors:,
+      }
+
+      options[:divider] = divider if divide
+
+      OpenStruct.new(options)
+    end
   end
 end

--- a/app/lib/forms/funding_your_aso.rb
+++ b/app/lib/forms/funding_your_aso.rb
@@ -22,19 +22,10 @@ module Forms
 
     def options
       [
-        OpenStruct.new(value: "school",
-                       text: "My workplace is covering the cost",
-                       link_errors: true),
-        OpenStruct.new(value: "trust",
-                       text: "My trust is paying",
-                       link_errors: false),
-        OpenStruct.new(value: "self",
-                       text: "I am paying",
-                       link_errors: false),
-        OpenStruct.new(value: "another",
-                       text: "The Early Headship Coaching Offer is being paid in another way",
-                       hint: "For example, I am sharing the costs with my workplace",
-                       link_errors: false),
+        build_option_struct(value: "school", link_errors: true),
+        build_option_struct(value: "trust"),
+        build_option_struct(value: "self"),
+        build_option_struct(value: "another")
       ].freeze
     end
   end

--- a/app/lib/forms/funding_your_aso.rb
+++ b/app/lib/forms/funding_your_aso.rb
@@ -25,7 +25,7 @@ module Forms
         build_option_struct(value: "school", link_errors: true),
         build_option_struct(value: "trust"),
         build_option_struct(value: "self"),
-        build_option_struct(value: "another")
+        build_option_struct(value: "another"),
       ].freeze
     end
   end

--- a/app/lib/forms/funding_your_npq.rb
+++ b/app/lib/forms/funding_your_npq.rb
@@ -24,16 +24,21 @@ module Forms
       @course ||= Course.find(wizard.store["course_id"])
     end
 
+    def question
+      Forms::QuestionTypes::RadioButtonGroup.new(
+        name: :funding,
+        options:,
+      )
+    end
+
     def options
       [
         build_option_struct(value: "school", link_errors: true),
         build_option_struct(value: "trust", include_if: works_in_school? && inside_catchment?),
         build_option_struct(value: "self"),
-        build_option_struct(value: "another")
+        build_option_struct(value: "another"),
       ].compact.freeze
     end
-
-  private
 
     delegate :query_store, to: :wizard
     delegate :works_in_school?, :inside_catchment?, to: :query_store

--- a/app/lib/forms/funding_your_npq.rb
+++ b/app/lib/forms/funding_your_npq.rb
@@ -34,7 +34,7 @@ module Forms
     def options
       [
         build_option_struct(value: "school", link_errors: true),
-        build_option_struct(value: "trust", include_if: works_in_school? && inside_catchment?),
+        (build_option_struct(value: "trust") if works_in_school? && inside_catchment?),
         build_option_struct(value: "self"),
         build_option_struct(value: "another"),
       ].compact.freeze

--- a/app/lib/forms/funding_your_npq.rb
+++ b/app/lib/forms/funding_your_npq.rb
@@ -26,22 +26,14 @@ module Forms
 
     def options
       [
-        option("school", "My workplace is covering the cost", link_errors: true),
-        (option("trust", "My trust is paying") if works_in_school? && inside_catchment?),
-        option("self", "I am paying"),
-        option("another", "My NPQ is being paid in another way", "For example, I am sharing the costs with my workplace"),
+        build_option_struct(value: "school", link_errors: true),
+        build_option_struct(value: "trust", include_if: works_in_school? && inside_catchment?),
+        build_option_struct(value: "self"),
+        build_option_struct(value: "another")
       ].compact.freeze
     end
 
-    def title
-      "How is your course being paid for?"
-    end
-
   private
-
-    def option(value, text, description = nil, link_errors: false)
-      OpenStruct.new(value:, text:, description:, link_errors:)
-    end
 
     delegate :query_store, to: :wizard
     delegate :works_in_school?, :inside_catchment?, to: :query_store

--- a/app/lib/forms/have_ofsted_urn.rb
+++ b/app/lib/forms/have_ofsted_urn.rb
@@ -41,12 +41,8 @@ module Forms
 
     def options
       [
-        OpenStruct.new(value: "yes",
-                       text: "Yes",
-                       link_errors: true),
-        OpenStruct.new(value: "no",
-                       text: "No",
-                       link_errors: false),
+        build_option_struct(value: "yes", link_errors: true),
+        build_option_struct(value: "no"),
       ]
     end
   end

--- a/app/lib/forms/npqh_status.rb
+++ b/app/lib/forms/npqh_status.rb
@@ -27,33 +27,11 @@ module Forms
     end
 
     def options
-      options_array.each_with_index.map do |option, index|
-        OpenStruct.new(value: option[:value],
-                       text: option[:text],
-                       link_errors: index.zero?)
-      end
-    end
-
-  private
-
-    def options_array
       [
-        {
-          text: "I have completed an NPQH",
-          value: "completed_npqh",
-        },
-        {
-          text: "I am still studying for an NPQH",
-          value: "studying_npqh",
-        },
-        {
-          text: "I am about to start an NPQH",
-          value: "will_start_npqh",
-        },
-        {
-          text: "None of the above",
-          value: "none",
-        },
+        build_option_struct(value: "completed_npqh", link_errors: true),
+        build_option_struct(value: "studying_npqh"),
+        build_option_struct(value: "will_start_npqh"),
+        build_option_struct(value: "none", divider: true),
       ]
     end
   end

--- a/app/lib/forms/question_types/auto_complete_country.rb
+++ b/app/lib/forms/question_types/auto_complete_country.rb
@@ -1,0 +1,6 @@
+module Forms
+  module QuestionTypes
+    class AutoCompleteCountry < Base
+    end
+  end
+end

--- a/app/lib/forms/question_types/radio_option.rb
+++ b/app/lib/forms/question_types/radio_option.rb
@@ -1,0 +1,17 @@
+module Forms
+  module QuestionTypes
+    class RadioOption
+      attr_reader :value,
+                  :link_errors,
+                  :divider,
+                  :revealed_question
+
+      def initialize(value:, link_errors: false, divider: false, revealed_question: nil)
+        @value = value
+        @link_errors = link_errors
+        @divider = divider
+        @revealed_question = revealed_question
+      end
+    end
+  end
+end

--- a/app/lib/forms/teacher_catchment.rb
+++ b/app/lib/forms/teacher_catchment.rb
@@ -58,7 +58,7 @@ module Forms
       ]
     end
 
-    private
+  private
 
     def autocomplete_country_question
       Forms::QuestionTypes::AutoCompleteCountry.new(name: :teacher_catchment_country)

--- a/app/lib/forms/teacher_catchment.rb
+++ b/app/lib/forms/teacher_catchment.rb
@@ -40,6 +40,13 @@ module Forms
       :provider_check
     end
 
+    def question
+      Forms::QuestionTypes::RadioButtonGroup.new(
+        name: :teacher_catchment,
+        options:,
+      )
+    end
+
     def options
       [
         build_option_struct(value: "england", link_errors: true),
@@ -47,8 +54,14 @@ module Forms
         build_option_struct(value: "wales"),
         build_option_struct(value: "northern_ireland"),
         build_option_struct(value: "jersey_guernsey_isle_of_man"),
-        build_option_struct(value: "another", divider: "or", opts: { country_autocomplete: true }),
+        build_option_struct(value: "another", divider: true, revealed_question: autocomplete_country_question),
       ]
+    end
+
+    private
+
+    def autocomplete_country_question
+      Forms::QuestionTypes::AutoCompleteCountry.new(name: :teacher_catchment_country)
     end
   end
 end

--- a/app/lib/forms/teacher_catchment.rb
+++ b/app/lib/forms/teacher_catchment.rb
@@ -42,24 +42,12 @@ module Forms
 
     def options
       [
-        OpenStruct.new(value: "england",
-                       text: "England",
-                       link_errors: true),
-        OpenStruct.new(value: "scotland",
-                       text: "Scotland",
-                       link_errors: false),
-        OpenStruct.new(value: "wales",
-                       text: "Wales",
-                       link_errors: false),
-        OpenStruct.new(value: "northern_ireland",
-                       text: "Northern Ireland",
-                       link_errors: false),
-        OpenStruct.new(value: "jersey_guernsey_isle_of_man",
-                       text: "Jersey, Guernsey or the Isle of Man",
-                       link_errors: false),
-        OpenStruct.new(value: "another",
-                       text: "Another country",
-                       link_errors: false),
+        build_option_struct(value: "england", link_errors: true),
+        build_option_struct(value: "scotland"),
+        build_option_struct(value: "wales"),
+        build_option_struct(value: "northern_ireland"),
+        build_option_struct(value: "jersey_guernsey_isle_of_man"),
+        build_option_struct(value: "another", divider: "or", opts: { country_autocomplete: true }),
       ]
     end
   end

--- a/app/lib/forms/work_in_nursery.rb
+++ b/app/lib/forms/work_in_nursery.rb
@@ -29,5 +29,12 @@ module Forms
     def works_in_nursery?
       works_in_nursery == "yes"
     end
+
+    def options
+      [
+        build_option_struct(value: "yes", link_errors: true),
+        build_option_struct(value: "no"),
+      ]
+    end
   end
 end

--- a/app/lib/forms/your_employment.rb
+++ b/app/lib/forms/your_employment.rb
@@ -19,11 +19,11 @@ module Forms
 
     def options
       [
-        build_option(value: "local_authority_virtual_school", link_errors: true),
-        build_option(value: "hospital_school"),
-        build_option(value: "young_offender_institution"),
-        build_option(value: "local_authority_supply_teacher"),
-        build_option(value: "other", divider: true),
+        build_option_struct(value: "local_authority_virtual_school", link_errors: true),
+        build_option_struct(value: "hospital_school"),
+        build_option_struct(value: "young_offender_institution"),
+        build_option_struct(value: "local_authority_supply_teacher"),
+        build_option_struct(value: "other", divider: true),
       ].freeze
     end
 
@@ -33,19 +33,6 @@ module Forms
 
     def previous_step
       :qualified_teacher_check
-    end
-
-  private
-
-    def build_option(value:, link_errors: false, divider: false)
-      options = {
-        value:,
-        link_errors:,
-      }
-
-      options[:divider] = divider if divider
-
-      OpenStruct.new(options)
     end
   end
 end

--- a/app/lib/services/query_store.rb
+++ b/app/lib/services/query_store.rb
@@ -9,11 +9,11 @@ class Services::QueryStore
     store["teacher_catchment"] == "england"
   end
 
-  def where_teach_humanized
+  def teacher_catchment_humanized
     if store["teacher_catchment"] == "another"
       store["teacher_catchment_country"]
     else
-      I18n.t(store["teacher_catchment"], scope: %i[activemodel attributes forms/teacher_catchment teacher_catchment])
+      I18n.t(store["teacher_catchment"], scope: %i[helpers label registration_wizard teacher_catchment_options])
     end
   end
 

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -64,7 +64,7 @@ class RegistrationWizard
     array = []
 
     array << OpenStruct.new(key: "Where do you work?",
-                            value: query_store.where_teach_humanized,
+                            value: query_store.teacher_catchment_humanized,
                             change_step: :teacher_catchment)
 
     work_setting = store["work_setting"]

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -97,7 +97,7 @@ class RegistrationWizard
 
     if inside_catchment? && query_store.works_in_childcare?
       array << OpenStruct.new(key: "Do you work in a nursery?",
-                              value: store["works_in_nursery"].capitalize,
+                              value: I18n.t(store["works_in_nursery"], scope: "helpers.label.registration_wizard.works_in_nursery_options"),
                               change_step: :work_in_nursery)
 
       if query_store.works_in_nursery?

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -70,7 +70,7 @@ class RegistrationWizard
     work_setting = store["work_setting"]
 
     array << OpenStruct.new(key: "What setting do you work in?",
-                            value: I18n.t("registration_wizard.work_setting.#{work_setting}"),
+                            value: I18n.t(store["work_setting"], scope: "helpers.label.registration_wizard.work_setting_options"),
                             change_step: :work_setting)
 
     array << OpenStruct.new(key: "Full name",
@@ -104,7 +104,7 @@ class RegistrationWizard
         kind_of_nursery = store["kind_of_nursery"]
 
         array << OpenStruct.new(key: "Type of nursery",
-                                value: I18n.t("registration_wizard.kind_of_nursery.#{kind_of_nursery}"),
+                                value: I18n.t(kind_of_nursery, scope: "helpers.label.registration_wizard.kind_of_nursery_options"),
                                 change_step: :kind_of_nursery)
       end
 
@@ -115,7 +115,7 @@ class RegistrationWizard
                                   change_step: :have_ofsted_urn)
                  else
                    OpenStruct.new(key: "Do you have a URN?",
-                                  value: store["has_ofsted_urn"].capitalize,
+                                  value: I18n.t(store["has_ofsted_urn"], scope: "helpers.label.registration_wizard.has_ofsted_urn_options"),
                                   change_step: :have_ofsted_urn)
                  end
       end
@@ -154,31 +154,31 @@ class RegistrationWizard
     unless eligible_for_funding?
       if course.aso?
         array << OpenStruct.new(key: "How is the Additional Support Offer being paid for?",
-                                value: I18n.t(store["aso_funding_choice"], scope: "registration_wizard.funding_your_aso.funding_options"),
+                                value: I18n.t(store["aso_funding_choice"], scope: "helpers.label.registration_wizard.aso_funding_choice_options"),
                                 change_step: :funding_your_aso)
       elsif course.ehco?
         array << OpenStruct.new(key: "How is your EHCO being paid for?",
-                                value: I18n.t(store["aso_funding_choice"], scope: "registration_wizard.funding_your_aso.funding_options"),
+                                value: I18n.t(store["aso_funding_choice"], scope: "helpers.label.registration_wizard.aso_funding_choice_options"),
                                 change_step: :funding_your_aso)
       elsif query_store.works_in_school? || query_store.works_in_childcare?
         array << OpenStruct.new(key: "How is your NPQ being paid for?",
-                                value: I18n.t(store["funding"], scope: "registration_wizard.funding_your_npq.funding_options"),
+                                value: I18n.t(store["funding"], scope: "helpers.label.registration_wizard.funding_options"),
                                 change_step: :funding_your_npq)
       end
     end
 
     if course.ehco?
       array << OpenStruct.new(key: "Have you completed an NPQH?",
-                              value: I18n.t(store["npqh_status"], scope: "activemodel.attributes.forms/npqh_status.status_options"),
+                              value: I18n.t(store["npqh_status"], scope: "helpers.label.registration_wizard.npqh_status_options"),
                               change_step: :npqh_status)
 
       array << OpenStruct.new(key: "Are you a headteacher?",
-                              value: store["aso_headteacher"].capitalize,
+                              value: I18n.t(store["aso_headteacher"], scope: "helpers.label.registration_wizard.aso_headteacher_options"),
                               change_step: :aso_headteacher)
 
       if store["aso_headteacher"] == "yes"
         array << OpenStruct.new(key: "Are you in your first 5 years of a headship?",
-                                value: store["aso_new_headteacher"].capitalize,
+                                value: I18n.t(store["aso_new_headteacher"], scope: "helpers.label.registration_wizard.aso_new_headteacher_options"),
                                 change_step: :aso_new_headteacher)
       end
     end

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -162,7 +162,7 @@ class RegistrationWizard
                                 change_step: :funding_your_aso)
       elsif query_store.works_in_school? || query_store.works_in_childcare?
         array << OpenStruct.new(key: "How is your NPQ being paid for?",
-                                value: I18n.t(store["funding"], scope: "activemodel.attributes.forms/funding_your_npq.funding_options"),
+                                value: I18n.t(store["funding"], scope: "registration_wizard.funding_your_npq.funding_options"),
                                 change_step: :funding_your_npq)
       end
     end

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -154,11 +154,11 @@ class RegistrationWizard
     unless eligible_for_funding?
       if course.aso?
         array << OpenStruct.new(key: "How is the Additional Support Offer being paid for?",
-                                value: I18n.t(store["aso_funding_choice"], scope: "activemodel.attributes.forms/funding_your_aso.funding_options"),
+                                value: I18n.t(store["aso_funding_choice"], scope: "registration_wizard.funding_your_aso.funding_options"),
                                 change_step: :funding_your_aso)
       elsif course.ehco?
         array << OpenStruct.new(key: "How is your EHCO being paid for?",
-                                value: I18n.t(store["aso_funding_choice"], scope: "activemodel.attributes.forms/funding_your_aso.funding_options"),
+                                value: I18n.t(store["aso_funding_choice"], scope: "registration_wizard.funding_your_aso.funding_options"),
                                 change_step: :funding_your_aso)
       elsif query_store.works_in_school? || query_store.works_in_childcare?
         array << OpenStruct.new(key: "How is your NPQ being paid for?",

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -67,8 +67,6 @@ class RegistrationWizard
                             value: query_store.teacher_catchment_humanized,
                             change_step: :teacher_catchment)
 
-    work_setting = store["work_setting"]
-
     array << OpenStruct.new(key: "What setting do you work in?",
                             value: I18n.t(store["work_setting"], scope: "helpers.label.registration_wizard.work_setting_options"),
                             change_step: :work_setting)

--- a/app/views/registration_wizard/aso_headteacher.html.erb
+++ b/app/views/registration_wizard/aso_headteacher.html.erb
@@ -22,7 +22,11 @@
             }
           ) do %>
         <% @form.options.each do |struct| %>
-          <%= f.govuk_radio_button :aso_headteacher, struct.value, label: { text: struct.text }, hint: { text: struct.hint }, link_errors: struct.link_errors %>
+          <%=
+            f.govuk_radio_button :aso_headteacher,
+                                 struct.value,
+                                 link_errors: struct.link_errors
+          %>
         <% end %>
       <% end %>
 

--- a/app/views/registration_wizard/aso_new_headteacher.html.erb
+++ b/app/views/registration_wizard/aso_new_headteacher.html.erb
@@ -22,7 +22,7 @@
             }
           ) do %>
         <% @form.options.each do |struct| %>
-          <%= f.govuk_radio_button :aso_new_headteacher, struct.value, label: { text: struct.text }, hint: { text: struct.hint }, link_errors: struct.link_errors %>
+          <%= f.govuk_radio_button :aso_new_headteacher, struct.value, link_errors: struct.link_errors %>
         <% end %>
       <% end %>
 

--- a/app/views/registration_wizard/funding_your_aso.html.erb
+++ b/app/views/registration_wizard/funding_your_aso.html.erb
@@ -24,8 +24,6 @@
         <% @form.options.each do |struct| %>
           <%= f.govuk_radio_button :aso_funding_choice,
             struct.value,
-            label: { text: struct.text },
-            hint: { text: struct.hint },
             link_errors: struct.link_errors %>
         <% end %>
       <% end %>

--- a/app/views/registration_wizard/funding_your_npq.html.erb
+++ b/app/views/registration_wizard/funding_your_npq.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-  <%= @form.errors.present? ? "Error: " : nil %><%= @form.title %>
+  <%= @form.errors.present? ? "Error: " : nil %><%= t("helpers.legend.registration_wizard.funding") %>
 <% end %>
 
 <% content_for :before_content do %>
@@ -18,11 +18,9 @@
         @form.options,
         :value,
         :text,
-        :description,
         legend: {
           tag: "h1",
-          size: "xl",
-          text: @form.title,
+          size: "xl"
         },
         bold_labels: false
       %>

--- a/app/views/registration_wizard/funding_your_npq.html.erb
+++ b/app/views/registration_wizard/funding_your_npq.html.erb
@@ -1,31 +1,7 @@
-<% content_for :title do %>
-  <%= @form.errors.present? ? "Error: " : nil %><%= t("helpers.legend.registration_wizard.funding") %>
-<% end %>
-
-<% content_for :before_content do %>
-  <%= render GovukComponent::BackLinkComponent.new(
-    text: "Back",
-    href: registration_wizard_show_path(@wizard.previous_step_path)
-  ) %>
-<% end %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
-      <%= f.govuk_error_summary %>
-
-      <%= f.govuk_collection_radio_buttons :funding,
-        @form.options,
-        :value,
-        :text,
-        legend: {
-          tag: "h1",
-          size: "xl"
-        },
-        bold_labels: false
-      %>
-
-      <%= f.govuk_submit %>
-    <% end %>
-  </div>
-</div>
+<%=
+  render(
+    'registration_wizard/shared/question_page',
+    form: @form,
+    wizard: @wizard,
+  )
+%>

--- a/app/views/registration_wizard/have_ofsted_urn.html.erb
+++ b/app/views/registration_wizard/have_ofsted_urn.html.erb
@@ -30,7 +30,11 @@
         <% end %>
 
         <% @form.options.each do |struct| %>
-          <%= f.govuk_radio_button :has_ofsted_urn, struct.value, label: { text: struct.text }, hint: { text: struct.hint }, link_errors: struct.link_errors %>
+          <%=
+            f.govuk_radio_button :has_ofsted_urn,
+                                 struct.value,
+                                 link_errors: struct.link_errors
+          %>
         <% end %>
       <% end %>
 

--- a/app/views/registration_wizard/kind_of_nursery.html.erb
+++ b/app/views/registration_wizard/kind_of_nursery.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-  <%= @form.errors.present? ? "Error: " : nil %>What kind of nursery do you work in?
+  <%= @form.errors.present? ? "Error: " : nil %><%= t('helpers.legend.registration_wizard.kind_of_nursery') %>
 <% end %>
 
 <% content_for :before_content do %>
@@ -16,7 +16,6 @@
 
       <%= f.govuk_radio_buttons_fieldset(:kind_of_nursery,
                                          legend: {
-                                           text: "What kind of nursery do you work in?",
                                            tag: "h1",
                                            size: "xl"
                                          }
@@ -26,7 +25,6 @@
             f.govuk_radio_button(
               :kind_of_nursery,
               nursery_kind,
-              label: { text: t(".#{nursery_kind}") },
               link_errors: index == 0
             )
           %>

--- a/app/views/registration_wizard/npqh_status.html.erb
+++ b/app/views/registration_wizard/npqh_status.html.erb
@@ -22,14 +22,15 @@
             }
           ) do %>
         <% @form.options.each do |struct| %>
-          <% if @form.options.last == struct %>
+          <% if struct.divider %>
             <%= f.govuk_radio_divider %>
           <% end %>
 
-          <%= f.govuk_radio_button :npqh_status, struct.value,
-            label: { text: struct.text },
-            hint: { text: struct.hint },
-            link_errors: struct.link_errors %>
+          <%=
+            f.govuk_radio_button :npqh_status,
+                                 struct.value,
+                                 link_errors: struct.link_errors
+          %>
         <% end %>
       <% end %>
 

--- a/app/views/registration_wizard/shared/questions/_auto_complete_country.html.erb
+++ b/app/views/registration_wizard/shared/questions/_auto_complete_country.html.erb
@@ -1,0 +1,11 @@
+<div data-module="app-country-autocomplete">
+  <%=
+    form.govuk_collection_select(
+      question.name,
+      Services::AutocompleteCountries.as_open_structs,
+      :name,
+      :name,
+      options: { include_blank: true }
+    )
+  %>
+</div>

--- a/app/views/registration_wizard/shared/questions/_radio_button_group.html.erb
+++ b/app/views/registration_wizard/shared/questions/_radio_button_group.html.erb
@@ -7,12 +7,11 @@
     }
   ) do
 %>
-  <% question.options.each do |struct| %>
-    <% if struct.divider %>
-      <%= form.govuk_radio_divider %>
-    <% end  %>
-
-    <%= form.govuk_radio_button(question.name, struct.value, link_errors: struct.link_errors) %>
-
-  <% end %>
+  <%=
+    render(
+      partial: "registration_wizard/shared/questions/radio_option",
+      locals: { form: form, question: question },
+      collection: question.options
+    )
+  %>
 <% end  %>

--- a/app/views/registration_wizard/shared/questions/_radio_option.html.erb
+++ b/app/views/registration_wizard/shared/questions/_radio_option.html.erb
@@ -1,0 +1,15 @@
+<% if radio_option.divider %>
+  <%= form.govuk_radio_divider %>
+<% end  %>
+
+<%= form.govuk_radio_button(question.name, radio_option.value, link_errors: radio_option.link_errors) do %>
+  <% if radio_option.revealed_question.present? %>
+    <%=
+      render(
+        "registration_wizard/shared/questions/#{radio_option.revealed_question.type}",
+        form: form,
+        question: radio_option.revealed_question
+      )
+    %>
+  <% end %>
+<% end  %>

--- a/app/views/registration_wizard/teacher_catchment.html.erb
+++ b/app/views/registration_wizard/teacher_catchment.html.erb
@@ -1,52 +1,7 @@
-<% content_for :title do %>
-  <%= @form.errors.present? ? "Error: " : nil %>Where do you work?
-<% end %>
-
-<% content_for :before_content do %>
-  <%= render GovukComponent::BackLinkComponent.new(
-    text: "Back",
-    href: registration_wizard_show_path(@wizard.previous_step_path)
-  ) %>
-<% end %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
-      <%= f.govuk_error_summary %>
-
-      <%= f.govuk_radio_buttons_fieldset(:lead_provider_id,
-            legend: {
-              text: "Where do you work?",
-              size: "xl",
-              tag: "h1"
-            }
-          ) do %>
-
-        <% @form.options.each do |struct| %>
-          <% if struct.divider.present? %>
-            <%= f.govuk_radio_divider(struct.divider) %>
-          <% end  %>
-
-          <%= f.govuk_radio_button :teacher_catchment, struct.value, label: { text: struct.text }, link_errors: struct.link_errors do %>
-            <% if struct.country_autocomplete %>
-              <div data-module="app-country-autocomplete">
-                <%= f.govuk_collection_select(
-                    :teacher_catchment_country,
-                    Services::AutocompleteCountries.as_open_structs,
-                    :name,
-                    :name,
-                    label: {
-                      text: "Which country do you teach in?"
-                    },
-                    options: { include_blank: true }
-                ) %>
-              </div>
-            <% end %>
-          <% end %>
-        <% end %>
-      <% end %>
-
-      <%= f.govuk_submit %>
-    <% end %>
-  </div>
-</div>
+<%=
+  render(
+    'registration_wizard/shared/question_page',
+    form: @form,
+    wizard: @wizard,
+  )
+%>

--- a/app/views/registration_wizard/teacher_catchment.html.erb
+++ b/app/views/registration_wizard/teacher_catchment.html.erb
@@ -23,12 +23,12 @@
           ) do %>
 
         <% @form.options.each do |struct| %>
-          <% if @form.options.last != struct %>
-            <%= f.govuk_radio_button :teacher_catchment, struct.value, label: { text: struct.text }, link_errors: struct.link_errors %>
-          <% else %>
-            <%= f.govuk_radio_divider %>
+          <% if struct.divider.present? %>
+            <%= f.govuk_radio_divider(struct.divider) %>
+          <% end  %>
 
-            <%= f.govuk_radio_button :teacher_catchment, struct.value, label: { text: struct.text }, link_errors: struct.link_errors do %>
+          <%= f.govuk_radio_button :teacher_catchment, struct.value, label: { text: struct.text }, link_errors: struct.link_errors do %>
+            <% if struct.country_autocomplete %>
               <div data-module="app-country-autocomplete">
                 <%= f.govuk_collection_select(
                     :teacher_catchment_country,

--- a/app/views/registration_wizard/work_in_nursery.html.erb
+++ b/app/views/registration_wizard/work_in_nursery.html.erb
@@ -21,8 +21,14 @@
                                            size: "xl"
                                          }
                                         ) do %>
-        <%= f.govuk_radio_button :works_in_nursery, "yes", label: { text: "Yes" }, link_errors: true %>
-        <%= f.govuk_radio_button :works_in_nursery, "no", label: { text: "No" } %>
+
+        <% @form.options.each do |struct| %>
+          <%=
+            f.govuk_radio_button :works_in_nursery,
+                                 struct.value,
+                                 link_errors: struct.link_errors
+          %>
+        <% end %>
       <% end %>
 
       <%= f.govuk_submit %>

--- a/app/views/registration_wizard/work_setting.html.erb
+++ b/app/views/registration_wizard/work_setting.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-  <%= @form.errors.present? ? "Error: " : nil %>What setting do you work in?
+  <%= @form.errors.present? ? "Error: " : nil %><%= t("helpers.legend.registration_wizard.work_setting") %>
 <% end %>
 
 <% content_for :before_content do %>
@@ -16,21 +16,16 @@
 
       <%= f.govuk_radio_buttons_fieldset(:work_setting,
                                          legend: {
-                                           text: "What setting do you work in?",
                                            tag: "h1",
                                            size: "xl"
                                          }
                                         ) do %>
-        <%= f.govuk_radio_button(:work_setting, "early_years_or_childcare", label: { text: "Early years or childcare" }, link_errors: true) %>
-        <%= f.govuk_radio_button(:work_setting, "a_school", label: { text: "A school" }) %>
-        <%= f.govuk_radio_button(:work_setting, "an_academy_trust", label: { text: "An academy trust" }) %>
-        <%= f.govuk_radio_button(:work_setting, "a_16_to_19_educational_setting", label: { text: "A 16 to 19 educational setting" }) %>
+        <%= f.govuk_radio_button(:work_setting, "early_years_or_childcare", link_errors: true) %>
+        <%= f.govuk_radio_button(:work_setting, "a_school") %>
+        <%= f.govuk_radio_button(:work_setting, "an_academy_trust") %>
+        <%= f.govuk_radio_button(:work_setting, "a_16_to_19_educational_setting") %>
         <%= f.govuk_radio_divider %>
-        <%= f.govuk_radio_button(:work_setting,
-          "other",
-          label: { text: "Other" },
-          hint: { text: "For example a local authority, at a hospital school or young offender institution"  },
-        ) %>
+        <%= f.govuk_radio_button(:work_setting, "other") %>
       <% end %>
 
       <%= f.govuk_submit %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -223,3 +223,7 @@ en:
           studying_npqh: I am still studying for an NPQH
           will_start_npqh: I am about to start an NPQH
           none: None of the above
+
+        has_ofsted_urn_options:
+          "yes": "Yes"
+          "no": "No"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,12 +10,6 @@ en:
           trust: My trust is paying
           self: I am paying
           another: My NPQ is being paid in another way
-      forms/funding_your_aso:
-        funding_options:
-          school: My workplace is covering the cost
-          trust: My trust is paying
-          self: I am paying
-          another: The Early Headship Coaching Offer is being paid in another way
       forms/teacher_catchment:
         teacher_catchment:
           one : nil # workaround
@@ -187,6 +181,8 @@ en:
           other: "For example a local authority, at a hospital school or young offender institution"
         employment_role: "For example: Administrator, business manager"
         employer_name: "For example 'Essex County Council', or 'I'm self employed'"
+        aso_funding_choice_options:
+          another: For example, I am sharing the costs with my workplace
     label:
       registration_wizard:
         kind_of_nursery_options:
@@ -211,3 +207,9 @@ en:
         employment_role: "What is your role?"
 
         employer_name: "What organisation are you employed by?"
+
+        aso_funding_choice_options:
+          school: "My workplace is covering the cost"
+          trust: "My trust is paying"
+          self: "I am paying"
+          another: "The Early Headship Coaching Offer is being paid in another way"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -174,21 +174,17 @@ en:
               blank: Enter an email address
               invalid: This email is invalid
               taken: This email has already been registered for interest
-  registration_wizard:
-    work_setting:
-      early_years_or_childcare: Early years or childcare
-      a_school: A school
-      an_academy_trust: An academy trust
-      a_16_to_19_educational_setting: A 16 to 19 educational setting
-      other: Other
 
   helpers:
     legend:
       registration_wizard:
         kind_of_nursery: "What kind of nursery do you work in?"
         employment_type: "How are you employed?"
+        work_setting: "What setting do you work in?"
     hint:
       registration_wizard:
+        work_setting_options:
+          other: "For example a local authority, at a hospital school or young offender institution"
         employment_role: "For example: Administrator, business manager"
         employer_name: "For example 'Essex County Council', or 'I'm self employed'"
     label:
@@ -197,6 +193,13 @@ en:
           local_authority_maintained_nursery: "Local authority maintained nursery"
           preschool_class_as_part_of_school: "Preschool class that's part of a school"
           private_nursery: "Private nursery"
+
+        work_setting_options:
+          early_years_or_childcare: "Early years or childcare"
+          a_school: "A school"
+          an_academy_trust: "An academy trust"
+          a_16_to_19_educational_setting: "A 16 to 19 educational setting"
+          other: "Other"
 
         employment_type_options:
           local_authority_virtual_school: "In a virtual school (local authority run organisations that support the education of children in care)"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,13 +13,6 @@ en:
       forms/teacher_catchment:
         teacher_catchment:
           one : nil # workaround
-      forms/npqh_status:
-        status_options:
-          completed_npqh: I have completed an NPQH
-          studying_npqh: I am still studying for an NPQH
-          will_start_npqh: I am about to start an NPQH
-          none: None of the above
-
     errors:
       models:
         forms/chosen_start_date:
@@ -225,3 +218,8 @@ en:
           jersey_guernsey_isle_of_man: "Jersey, Guernsey or the Isle of Man"
           another: "Another country"
 
+        npqh_status_options:
+          completed_npqh: I have completed an NPQH
+          studying_npqh: I am still studying for an NPQH
+          will_start_npqh: I am about to start an NPQH
+          none: None of the above

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -231,3 +231,7 @@ en:
         aso_headteacher_options:
           "yes": "Yes"
           "no": "No"
+
+        aso_new_headteacher_options:
+          "yes": "Yes"
+          "no": "No"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,12 +13,6 @@ en:
       forms/teacher_catchment:
         teacher_catchment:
           one : nil # workaround
-          england: England
-          scotland: Scotland
-          wales: Wales
-          northern_ireland: Northern Ireland
-          jersey_guernsey_isle_of_man: Jersey, Guernsey or the Isle of Man
-          another: Another country
       forms/npqh_status:
         status_options:
           completed_npqh: I have completed an NPQH
@@ -222,3 +216,12 @@ en:
           trust: "My trust is paying"
           self: "I am paying"
           another: "My NPQ is being paid in another way"
+
+        teacher_catchment_options:
+          england: "England"
+          scotland: "Scotland"
+          wales: "Wales"
+          northern_ireland: "Northern Ireland"
+          jersey_guernsey_isle_of_man: "Jersey, Guernsey or the Isle of Man"
+          another: "Another country"
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -175,6 +175,7 @@ en:
         kind_of_nursery: "What kind of nursery do you work in?"
         employment_type: "How are you employed?"
         work_setting: "What setting do you work in?"
+        funding: "How is your course being paid for?"
     hint:
       registration_wizard:
         work_setting_options:
@@ -182,7 +183,9 @@ en:
         employment_role: "For example: Administrator, business manager"
         employer_name: "For example 'Essex County Council', or 'I'm self employed'"
         aso_funding_choice_options:
-          another: For example, I am sharing the costs with my workplace
+          another: "For example, I am sharing the costs with my workplace"
+        funding_options:
+          another: "For example, I am sharing the costs with my workplace"
     label:
       registration_wizard:
         kind_of_nursery_options:
@@ -213,3 +216,9 @@ en:
           trust: "My trust is paying"
           self: "I am paying"
           another: "The Early Headship Coaching Offer is being paid in another way"
+
+        funding_options:
+          school: "My workplace is covering the cost"
+          trust: "My trust is paying"
+          self: "I am paying"
+          another: "My NPQ is being paid in another way"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -227,3 +227,7 @@ en:
         has_ofsted_urn_options:
           "yes": "Yes"
           "no": "No"
+
+        aso_headteacher_options:
+          "yes": "Yes"
+          "no": "No"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -164,6 +164,7 @@ en:
         work_setting: "What setting do you work in?"
         funding: "How is your course being paid for?"
         teacher_catchment: "Where do you work?"
+        works_in_nursery: "Do you work in a nursery?"
     hint:
       registration_wizard:
         work_setting_options:
@@ -236,5 +237,9 @@ en:
           "no": "No"
 
         aso_new_headteacher_options:
+          "yes": "Yes"
+          "no": "No"
+
+        works_in_nursery_options:
           "yes": "Yes"
           "no": "No"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -175,11 +175,6 @@ en:
               invalid: This email is invalid
               taken: This email has already been registered for interest
   registration_wizard:
-    kind_of_nursery:
-      local_authority_maintained_nursery: Local authority maintained nursery
-      preschool_class_as_part_of_school: Preschool class that's part of a school
-      private_nursery: Private nursery
-
     work_setting:
       early_years_or_childcare: Early years or childcare
       a_school: A school
@@ -190,6 +185,7 @@ en:
   helpers:
     legend:
       registration_wizard:
+        kind_of_nursery: "What kind of nursery do you work in?"
         employment_type: "How are you employed?"
     hint:
       registration_wizard:
@@ -197,6 +193,11 @@ en:
         employer_name: "For example 'Essex County Council', or 'I'm self employed'"
     label:
       registration_wizard:
+        kind_of_nursery_options:
+          local_authority_maintained_nursery: "Local authority maintained nursery"
+          preschool_class_as_part_of_school: "Preschool class that's part of a school"
+          private_nursery: "Private nursery"
+
         employment_type_options:
           local_authority_virtual_school: "In a virtual school (local authority run organisations that support the education of children in care)"
           hospital_school: "In a hospital school"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -163,6 +163,7 @@ en:
         employment_type: "How are you employed?"
         work_setting: "What setting do you work in?"
         funding: "How is your course being paid for?"
+        teacher_catchment: "Where do you work?"
     hint:
       registration_wizard:
         work_setting_options:
@@ -217,6 +218,8 @@ en:
           northern_ireland: "Northern Ireland"
           jersey_guernsey_isle_of_man: "Jersey, Guernsey or the Isle of Man"
           another: "Another country"
+
+        teacher_catchment_country: "Which country do you teach in?"
 
         npqh_status_options:
           completed_npqh: I have completed an NPQH

--- a/spec/features/happy_journeys/js/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
+++ b/spec/features/happy_journeys/js/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
@@ -65,7 +65,7 @@ RSpec.feature "Happy journeys", type: :feature do
     end
 
     public_nursery_type_key = Forms::KindOfNursery::KIND_OF_NURSERY_PUBLIC_OPTIONS.sample
-    public_nursery_type = I18n.t("registration_wizard.kind_of_nursery.#{public_nursery_type_key}")
+    public_nursery_type = I18n.t(public_nursery_type_key, scope: "helpers.label.registration_wizard.kind_of_nursery_options")
 
     expect_page_to_have(path: "/registration/kind-of-nursery", submit_form: true) do
       expect(page).to have_text("What kind of nursery do you work in?")

--- a/spec/features/happy_journeys/js/changing_npq_to_one_leadprovider_no_longer_supports_spec.rb
+++ b/spec/features/happy_journeys/js/changing_npq_to_one_leadprovider_no_longer_supports_spec.rb
@@ -66,7 +66,7 @@ RSpec.feature "Happy journeys", type: :feature do
     end
 
     public_nursery_type_key = Forms::KindOfNursery::KIND_OF_NURSERY_PUBLIC_OPTIONS.sample
-    public_nursery_type = I18n.t("registration_wizard.kind_of_nursery.#{public_nursery_type_key}")
+    public_nursery_type = I18n.t(public_nursery_type_key, scope: "helpers.label.registration_wizard.kind_of_nursery_options")
 
     expect_page_to_have(path: "/registration/kind-of-nursery", submit_form: true) do
       expect(page).to have_text("What kind of nursery do you work in?")

--- a/spec/features/happy_journeys/js/while_working_at_public_nursery_spec.rb
+++ b/spec/features/happy_journeys/js/while_working_at_public_nursery_spec.rb
@@ -65,7 +65,7 @@ RSpec.feature "Happy journeys", type: :feature do
     end
 
     public_nursery_type_key = Forms::KindOfNursery::KIND_OF_NURSERY_PUBLIC_OPTIONS.sample
-    public_nursery_type = I18n.t("registration_wizard.kind_of_nursery.#{public_nursery_type_key}")
+    public_nursery_type = I18n.t(public_nursery_type_key, scope: "helpers.label.registration_wizard.kind_of_nursery_options")
 
     expect_page_to_have(path: "/registration/kind-of-nursery", submit_form: true) do
       expect(page).to have_text("What kind of nursery do you work in?")


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/npq-registration/pull/505 began the process of moving towards leveraging the built in govuk-form-builder localisation, this PR is a follow up to continue that work.

It also set up a generic _question_page template that could be used to fully abstract how a page is rendered away from the form using it. I've used that in a few of the updated questions here as well.

Further PRs will be required to get this all fully swapped over.

### Changes proposed in this pull request

- Upgrade the following pages to use govuk-form-builder's built in localisation
  - /registration/aso-headteacher
  - /registration/work-in-nursery
  - /registration/aso-new-headteacher
  - /registration/aso-headteacher
  - /registration/have-ofsted-urn
  - /registration/funding-your-npq
  - /registration/work-setting
  - /registration/kind-of-nursery
  - /registration/npqh-status
  - /registration/funding-your-aso
  - /registration/teacher-catchment
  - /registration/work-in-nursery
- Upgrade the following to use the shared question_page partial
  - /registration/funding-your-npq
  - /registration/teacher-catchment

### Guidance to review

Go through the above paths and make sure that they are identical to their appearance before the change.

