### PR TITLE
Add Github Workflow for creating review apps when PRs are filed

### DIFF
--- a/.github/workflows/deploy_to_review_app.yml
+++ b/.github/workflows/deploy_to_review_app.yml
@@ -1,0 +1,122 @@
+name: Push PR to Review App
+on:
+  pull_request:
+    branches: [ main ]
+    types: [ opened, synchronize, reopened ]
+    paths-ignore:
+      - 'documentation/**'
+
+jobs:
+  deploy:
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Install CloudFoundry CLI
+        shell: bash
+        run: |
+          wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
+          echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+          sudo apt-get update
+          sudo apt-get install cf7-cli
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_DEV_PASSWORD }}
+
+      - name: Build and push docker image
+        uses: docker/build-push-action@v2
+        id: docker_build_push
+        with:
+          context: .
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+            GIT_COMMIT_SHA=${{ github.sha }}
+          push: true
+          tags: dfedigital/early-careers-framework-dev:npq-registration-review-app-${{ github.event.number }}
+
+      - name: Deploy to Gov.uk PaaS
+        id: deploy-to-paas
+        shell: bash
+        env:
+          CF_DOCKER_PASSWORD: ${{ secrets.DOCKER_DEV_PASSWORD }}
+          PAAS_ORGANISATION: dfe
+          # This is a shared PAAS space
+          PAAS_SPACE: earlycareers-framework-dev
+          ENV_STUB: review-app-${{ github.event.number }}
+          ENV_STUB_DB: review-app-db
+          APP_NAME: npq-registration
+          REMOTE_DOCKER_IMAGE_NAME: dfedigital/early-careers-framework-dev
+          CF_USERNAME: ${{ secrets.GOVPAAS_DEV_USERNAME }}
+          CF_PASSWORD: ${{ secrets.GOVPAAS_DEV_PASSWORD }}
+        run: |
+          cf api https://api.london.cloud.service.gov.uk
+          cf auth
+          cf target -o "${{ env.PAAS_ORGANISATION }}" -s "${{ env.PAAS_SPACE }}"
+          cf push "${{ env.APP_NAME }}"-"${{ env.ENV_STUB }}" \
+            --manifest ./config/manifests/review-app-manifest.yml \
+            --var DOCKER_IMAGE_ID="${{ steps.docker_build_push.outputs.digest }}" \
+            --var SECRET_KEY_BASE="${{ secrets.RAILS_SECRET_KEY_BASE_DEV }}" \
+            --var GOVUK_NOTIFY_API_KEY="${{ secrets.GOVUK_NOTIFY_API_KEY_DEV }}" \
+            --var APP_NAME="${{ env.APP_NAME }}" \
+            --var ENV_STUB="${{ env.ENV_STUB }}" \
+            --var ENV_STUB_DB="${{ env.ENV_STUB_DB }}" \
+            --var ECF_APP_BEARER_TOKEN="${{ secrets.ECF_APP_BEARER_TOKEN_DEV }}" \
+            --var SENTRY_DSN="${{ secrets.SENTRY_DSN }}" \
+            --docker-image "${{ env.REMOTE_DOCKER_IMAGE_NAME }}":"${{ env.APP_NAME }}"-"${{ env.ENV_STUB }}" \
+            --docker-username "${{ secrets.DOCKER_USERNAME }}" \
+            --strategy rolling
+
+      - name: Ensure review app base data is in place
+        id: seed-db
+        shell: bash
+        env:
+          CF_DOCKER_PASSWORD: ${{ secrets.DOCKER_DEV_PASSWORD }}
+          PAAS_ORGANISATION: dfe
+          # This is a shared PAAS space
+          PAAS_SPACE: earlycareers-framework-dev
+          ENV_STUB: review-app-${{ github.event.number }}
+          APP_NAME: npq-registration
+          CF_USERNAME: ${{ secrets.GOVPAAS_DEV_USERNAME }}
+          CF_PASSWORD: ${{ secrets.GOVPAAS_DEV_PASSWORD }}
+        run: |
+          cf api https://api.london.cloud.service.gov.uk
+          cf auth
+          cf target -o "${{ env.PAAS_ORGANISATION }}" -s "${{ env.PAAS_SPACE }}"
+
+          cf run-task "${{ env.APP_NAME }}"-"${{ env.ENV_STUB }}" \
+            --command "cd /app && /usr/local/bundle/bin/bundle exec rails db:seed" \
+            --process worker \
+            --name run-db-seed
+
+          cf run-task "${{ env.APP_NAME }}"-"${{ env.ENV_STUB }}" \
+            --command "cd /app && /usr/local/bundle/bin/bundle exec rails runner 'ImportGiasSchoolsJob.perform_later'" \
+            --process worker \
+            --name schedule_school_import
+
+          cf run-task "${{ env.APP_NAME }}"-"${{ env.ENV_STUB }}" \
+            --command "cd /app && /usr/local/bundle/bin/bundle exec rails \"private_childcare_providers:import[lib/private_childcare_providers/2021-08-31/childcare_providers.csv, childcare_providers]\"" \
+            --process worker \
+            --name import_childcare_providers
+
+          cf run-task "${{ env.APP_NAME }}"-"${{ env.ENV_STUB }}" \
+            --command "cd /app && /usr/local/bundle/bin/bundle exec rails \"private_childcare_providers:import[lib/private_childcare_providers/2021-08-31/childminder_agencies.csv, childminder_agencies]\"" \
+            --process worker \
+            --name import_childminder_agencies
+
+
+      - name: comment on PR
+        uses: unsplash/comment-on-pr@v1.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          msg: "Created review app at https://npq-registration-review-app-${{ github.event.number }}.london.cloudapps.digital"
+          check_for_duplicate_msg: true
+          duplicate_msg_pattern: Created review app at*

--- a/.github/workflows/destroy_review_app.yml
+++ b/.github/workflows/destroy_review_app.yml
@@ -1,0 +1,50 @@
+name: Destroy Review App
+on:
+  pull_request:
+    branches: [ main ]
+    types: [ closed ]
+
+jobs:
+  deploy:
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Install CloudFoundry CLI
+        shell: bash
+        run: |
+          wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
+          echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+          sudo apt-get update
+          sudo apt-get install cf7-cli
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_DEV_PASSWORD }}
+
+      - name: Destroy app on Gov.uk PaaS
+        id: deploy-to-paas
+        shell: bash
+        env:
+          CF_DOCKER_PASSWORD: ${{ secrets.DOCKER_DEV_PASSWORD }}
+          PAAS_ORGANISATION: dfe
+          # This is a shared PAAS space
+          PAAS_SPACE: earlycareers-framework-dev
+          ENV_STUB: review-app-${{ github.event.number }}
+          ENV_STUB_DB: review-app-db
+          APP_NAME: npq-registration
+          CF_USERNAME: ${{ secrets.GOVPAAS_DEV_USERNAME }}
+          CF_PASSWORD: ${{ secrets.GOVPAAS_DEV_PASSWORD }}
+        run: |
+          cf api https://api.london.cloud.service.gov.uk
+          cf auth
+          cf target -o "${{ env.PAAS_ORGANISATION }}" -s "${{ env.PAAS_SPACE }}"
+          cf unbind-service "${{ env.APP_NAME }}"-"${{ env.ENV_STUB }}" "${{ env.APP_NAME }}"-"${{ env.ENV_STUB_DB }}"
+          cf delete -r -f "${{ env.APP_NAME }}"-"${{ env.ENV_STUB }}"

--- a/config/manifests/review-app-manifest.yml
+++ b/config/manifests/review-app-manifest.yml
@@ -1,0 +1,32 @@
+---
+applications:
+- name: ((APP_NAME))-((ENV_STUB))
+  processes:
+  - type: web
+    disk_quota: 2G
+    memory: 512M
+    health-check-http-endpoint: /healthcheck.json
+    health-check-type: http
+    health-check-invocation-timeout: 10
+    instances: 1
+  - type: worker
+    disk_quota: 2G
+    health-check-type: process
+    instances: 1
+    command: bundle exec rake jobs:work
+  services:
+    - ((APP_NAME))-((ENV_STUB_DB))
+  env:
+    DOCKER_IMAGE_ID: ((DOCKER_IMAGE_ID))
+    ENV: $HOME/.profile
+    SERVICE_ENV: development
+    SENTRY_CURRENT_ENV: development
+    SECRET_KEY_BASE: ((SECRET_KEY_BASE))
+    RAILS_LOG_TO_STDOUT: true
+    RAILS_SERVE_STATIC_FILES: true
+    GOVUK_NOTIFY_API_KEY: ((GOVUK_NOTIFY_API_KEY))
+    GOOGLE_TAG_MANAGER_ID: "GTM-N58Z5PG"
+    GOOGLE_ANALYTICS_ID: "G-4QYNT5ZME8"
+    ECF_APP_BASE_URL: "https://ecf-dev.london.cloudapps.digital"
+    ECF_APP_BEARER_TOKEN: ((ECF_APP_BEARER_TOKEN))
+    SENTRY_DSN: ((SENTRY_DSN))


### PR DESCRIPTION
### Changes proposed in this pull request

Adds two Github actions:
- Push PR to Review App: On PR opening, reopening, or push deploys branch as a dedicated app, uses the shared review-app DB for storage.
- Destroy Review App: On PR closing deletes review app.

You can see below the message posted by Github actions linking to the reivew app.