### PR TITLE
Refactor EHCO questions to use question_page templates introduced in #512

### DIFF
--- a/app/lib/forms/aso_headteacher.rb
+++ b/app/lib/forms/aso_headteacher.rb
@@ -26,6 +26,10 @@ module Forms
       :npqh_status
     end
 
+    def question
+      Forms::QuestionTypes::RadioButtonGroup.new(name: :aso_headteacher, options:)
+    end
+
     def options
       [
         build_option_struct(value: "yes", link_errors: true),

--- a/app/lib/forms/aso_new_headteacher.rb
+++ b/app/lib/forms/aso_new_headteacher.rb
@@ -29,6 +29,10 @@ module Forms
       :aso_headteacher
     end
 
+    def question
+      Forms::QuestionTypes::RadioButtonGroup.new(name: :aso_new_headteacher, options:)
+    end
+
     def options
       [
         build_option_struct(value: "yes", link_errors: true),

--- a/app/lib/forms/funding_your_aso.rb
+++ b/app/lib/forms/funding_your_aso.rb
@@ -20,6 +20,13 @@ module Forms
       :aso_funding_not_available
     end
 
+    def question
+      Forms::QuestionTypes::RadioButtonGroup.new(
+        name: :aso_funding_choice,
+        options:,
+      )
+    end
+
     def options
       [
         build_option_struct(value: "school", link_errors: true),

--- a/app/views/registration_wizard/about_ehco.html.erb
+++ b/app/views/registration_wizard/about_ehco.html.erb
@@ -1,40 +1,33 @@
-<% content_for :title do %>
-  Early Headship Coaching Offer
+<%=
+  render(
+    'registration_wizard/shared/copy_page',
+    form: @form,
+    wizard: @wizard,
+  ) do
+%>
+  <h1 class="govuk-heading-xl">Early Headship Coaching Offer</h1>
+
+  <p class="govuk-body">The Early Headship Coaching Offer is a package of structured face-to-face support for new headteachers.</p>
+
+  <h2 class="govuk-heading-m">Who is this for?</h2>
+
+  <p class="govuk-body">You can register for the Early Headship Coaching Offer if you:</p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li>have completed an NPQH</li>
+    <li>are studying for an NPQH</li>
+    <li>are about to start an NPQH</li>
+  </ul>
+
+  <h2 class="govuk-heading-m">How is this paid for?</h2>
+
+  <p class="govuk-body">
+    You may be eligible for DfE scholarship funding if you're employed in a state-funded school or a state-funded 16 to 19 educational setting in England upon starting the training.
+  </p>
+
+  <p class="govuk-body">Or you can pay the cost of your Early Headship Coaching Offer another way.</p>
+
+  <p class="govuk-body"><%= govuk_link_to "Read more about the Early Headship Coaching Offer.", "https://www.gov.uk/government/publications/national-professional-qualifications-npqs-reforms/national-professional-qualifications-npqs-reforms#additional-support-offer-for-the-npq-in-headship" %></p>
+
+  <%= govuk_button_link_to "Continue", registration_wizard_show_path(@wizard.next_step_path) %>
 <% end %>
-
-<% content_for :before_content do %>
-  <%= render GovukComponent::BackLinkComponent.new(
-    text: "Back",
-    href: registration_wizard_show_path(@wizard.previous_step_path)
-  ) %>
-<% end %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Early Headship Coaching Offer</h1>
-
-    <p class="govuk-body">The Early Headship Coaching Offer is a package of structured face-to-face support for new headteachers.</p>
-
-    <h2 class="govuk-heading-m">Who is this for?</h2>
-
-    <p class="govuk-body">You can register for the Early Headship Coaching Offer if you:</p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>have completed an NPQH</li>
-      <li>are studying for an NPQH</li>
-      <li>are about to start an NPQH</li>
-    </ul>
-
-    <h2 class="govuk-heading-m">How is this paid for?</h2>
-
-    <p class="govuk-body">
-      You may be eligible for DfE scholarship funding if you're employed in a state-funded school or a state-funded 16 to 19 educational setting in England upon starting the training.
-    </p>
-
-    <p class="govuk-body">Or you can pay the cost of your Early Headship Coaching Offer another way.</p>
-
-    <p class="govuk-body"><%= govuk_link_to "Read more about the Early Headship Coaching Offer.", "https://www.gov.uk/government/publications/national-professional-qualifications-npqs-reforms/national-professional-qualifications-npqs-reforms#additional-support-offer-for-the-npq-in-headship" %></p>
-
-    <%= govuk_button_link_to "Continue", registration_wizard_show_path(@wizard.next_step_path) %>
-  </div>
-</div>

--- a/app/views/registration_wizard/aso_funding_not_available.html.erb
+++ b/app/views/registration_wizard/aso_funding_not_available.html.erb
@@ -1,30 +1,19 @@
-<% content_for :title do %>
-  DfE scholarship funding not available
+<%=
+  render(
+    'registration_wizard/shared/copy_page',
+    form: @form,
+    wizard: @wizard,
+    ) do
+%>
+  <h1 class="govuk-heading-xl" >DfE scholarship funding is not available</h1>
+
+  <p class="govuk-body">
+    You can still register for the <b>Early Headship Coaching Offer</b>, but you need to pay for it another way.
+  </p>
+
+  <p class="govuk-body">
+    To find out more about your funding options please contact your course provider.
+  </p>
+
+  <%= govuk_button_link_to "Continue", registration_wizard_show_path(@wizard.next_step_path) %>
 <% end %>
-
-<% content_for :before_content do %>
-  <%= render GovukComponent::BackLinkComponent.new(
-    text: "Back",
-    href: registration_wizard_show_path(@wizard.previous_step_path)
-  ) %>
-<% end %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
-      <%= f.govuk_error_summary %>
-
-      <h1 class="govuk-heading-xl" >DfE scholarship funding is not available</h1>
-
-      <p class="govuk-body">
-        You can still register for the <b>Early Headship Coaching Offer</b>, but you need to pay for it another way.
-      </p>
-
-      <p class="govuk-body">
-        To find out more about your funding options please contact your course provider.
-      </p>
-
-      <%= f.govuk_submit %>
-    <% end %>
-  </div>
-</div>

--- a/app/views/registration_wizard/aso_headteacher.html.erb
+++ b/app/views/registration_wizard/aso_headteacher.html.erb
@@ -1,36 +1,7 @@
-<% content_for :title do %>
-  <%= @form.errors.present? ? "Error: " : nil %> Are you a headteacher?
-<% end %>
-
-<% content_for :before_content do %>
-  <%= render GovukComponent::BackLinkComponent.new(
-    text: "Back",
-    href: registration_wizard_show_path(@wizard.previous_step_path)
-  ) %>
-<% end %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
-      <%= f.govuk_error_summary %>
-
-      <%= f.govuk_radio_buttons_fieldset(:aso_headteacher,
-            legend: {
-              text: "Are you a headteacher?",
-              size: "xl",
-              tag: "h1"
-            }
-          ) do %>
-        <% @form.options.each do |struct| %>
-          <%=
-            f.govuk_radio_button :aso_headteacher,
-                                 struct.value,
-                                 link_errors: struct.link_errors
-          %>
-        <% end %>
-      <% end %>
-
-      <%= f.govuk_submit %>
-    <% end %>
-  </div>
-</div>
+<%=
+  render(
+    'registration_wizard/shared/question_page',
+    form: @form,
+    wizard: @wizard,
+  )
+%>

--- a/app/views/registration_wizard/aso_new_headteacher.html.erb
+++ b/app/views/registration_wizard/aso_new_headteacher.html.erb
@@ -1,32 +1,7 @@
-<% content_for :title do %>
-  <%= @form.errors.present? ? "Error: " : nil %> Are you in your first 5 years of a headship?
-<% end %>
-
-<% content_for :before_content do %>
-  <%= render GovukComponent::BackLinkComponent.new(
-    text: "Back",
-    href: registration_wizard_show_path(@wizard.previous_step_path)
-  ) %>
-<% end %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
-      <%= f.govuk_error_summary %>
-
-      <%= f.govuk_radio_buttons_fieldset(:aso_new_headteacher,
-            legend: {
-              text: "Are you in your first 5 years of a headship?",
-              size: "xl",
-              tag: "h1"
-            }
-          ) do %>
-        <% @form.options.each do |struct| %>
-          <%= f.govuk_radio_button :aso_new_headteacher, struct.value, link_errors: struct.link_errors %>
-        <% end %>
-      <% end %>
-
-      <%= f.govuk_submit %>
-    <% end %>
-  </div>
-</div>
+<%=
+  render(
+    'registration_wizard/shared/question_page',
+    form: @form,
+    wizard: @wizard,
+  )
+%>

--- a/app/views/registration_wizard/aso_possible_funding.html.erb
+++ b/app/views/registration_wizard/aso_possible_funding.html.erb
@@ -1,28 +1,19 @@
-<% content_for :title do %>
-  You may qualify for DfE scholarship funding
+<%=
+  render(
+    'registration_wizard/shared/copy_page',
+    form: @form,
+    wizard: @wizard,
+    ) do
+%>
+  <h1 class="govuk-heading-xl">If your provider accepts your application, you’ll qualify for DfE scholarship funding</h1>
+
+  <p class="govuk-body">
+    From the information you have provided, DfE scholarship funding should be available for the Early Headship Coaching Offer.
+  </p>
+
+  <p class="govuk-body">
+    Your training provider will give you more details and confirm if you qualify for funding.
+  </p>
+
+  <%= govuk_button_link_to "Continue", registration_wizard_show_path(@wizard.next_step_path) %>
 <% end %>
-
-<% content_for :before_content do %>
-  <%= render GovukComponent::BackLinkComponent.new(
-    text: "Back",
-    href: registration_wizard_show_path(@wizard.previous_step_path)
-  ) %>
-<% end %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">If your provider accepts your application, you’ll qualify for DfE scholarship funding</h1>
-
-    <p class="govuk-body">
-      From the information you have provided, DfE scholarship funding should be available for the Early Headship Coaching Offer.
-    </p>
-
-    <p class="govuk-body">
-      Your training provider will give you more details and confirm if you qualify for funding.
-    </p>
-
-    <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
-      <%= f.govuk_submit %>
-    <% end %>
-  </div>
-</div>

--- a/app/views/registration_wizard/aso_previously_funded.html.erb
+++ b/app/views/registration_wizard/aso_previously_funded.html.erb
@@ -1,34 +1,27 @@
-<% content_for :title do %>
-  DfE scholarship funding not available
-<% end %>
+<%=
+  render(
+    'registration_wizard/shared/copy_page',
+    form: @form,
+    wizard: @wizard,
+    ) do
+%>
+  <h1 class="govuk-heading-xl">DfE scholarship funding is not available</h1>
 
-<% content_for :before_content do %>
-  <%= render GovukComponent::BackLinkComponent.new(
-    text: "Back",
-    href: registration_wizard_show_path(@wizard.previous_step_path)
-  ) %>
-<% end %>
+  <p class="govuk-body">Our records show that you are already registered to study <b>Early Headship Coaching Offer</b> (previously known as the Additional Support Offer).</p>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">DfE scholarship funding is not available</h1>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>
+      You can only receive scholarship funding to study this offer with one provider. If you do not wish to proceed with your current provider you will need to contact them.
+    </li>
 
-    <p class="govuk-body">Our records show that you are already registered to study <b>Early Headship Coaching Offer</b> (previously known as the Additional Support Offer).</p>
+    <li>
+      If you have previously withdrawn from this offer, then you're not eligible for scholarship funding for the same offer again. If you do not believe you’ve withdrawn from this course please email <%= govuk_mail_to "continuing-professional-development@digital.education.gov.uk", "continuing-professional-development@digital.education.gov.uk" %>
+    </li>
+  </ul>
 
-    <ul class="govuk-list govuk-list--bullet">
-      <li>
-        You can only receive scholarship funding to study this offer with one provider. If you do not wish to proceed with your current provider you will need to contact them.
-      </li>
+  <p class="govuk-body">
+    You can <%= link_to('go back and select an NPQ', registration_wizard_show_path(@wizard.previous_step_path)) %> or continue with your registration for the Early Headship Coaching Offer. You'll need to pay for it another way. Contact your course provider to discuss your funding options.
+  </p>
 
-      <li>
-        If you have previously withdrawn from this offer, then you're not eligible for scholarship funding for the same offer again. If you do not believe you’ve withdrawn from this course please email <%= govuk_mail_to "continuing-professional-development@digital.education.gov.uk", "continuing-professional-development@digital.education.gov.uk" %>
-      </li>
-    </ul>
-
-    <p class="govuk-body">
-      You can <%= link_to('go back and select an NPQ', registration_wizard_show_path(@wizard.previous_step_path)) %> or continue with your registration for the Early Headship Coaching Offer. You'll need to pay for it another way. Contact your course provider to discuss your funding options.
-    </p>
-
-    <%= govuk_button_link_to "Continue", registration_wizard_show_path(@wizard.next_step_path) %>
-  </div>
-</div>
+  <%= govuk_button_link_to "Continue", registration_wizard_show_path(@wizard.next_step_path) %>
+<% end  %>

--- a/app/views/registration_wizard/aso_unavailable.html.erb
+++ b/app/views/registration_wizard/aso_unavailable.html.erb
@@ -1,26 +1,19 @@
-<% content_for :title do %>
-  You cannot register for the Early Headship Coaching Offer
+<%=
+  render(
+    'registration_wizard/shared/copy_page',
+    form: @form,
+    wizard: @wizard,
+    ) do
+%>
+  <h1 class="govuk-heading-xl">You cannot register for the Early Headship Coaching Offer</h1>
+
+  <p class="govuk-body">You do not meet the eligibility criteria for taking the Early Headship Coaching Offer.</p>
+
+  <p class="govuk-body">You can only register if you meet one of the following criteria:</p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li>have completed an NPQH</li>
+    <li>are studying for an NPQH</li>
+    <li>are about to start an NPQH</li>
+  </ul>
 <% end %>
-
-<% content_for :before_content do %>
-  <%= render GovukComponent::BackLinkComponent.new(
-    text: "Back",
-    href: registration_wizard_show_path(@wizard.previous_step_path)
-  ) %>
-<% end %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">You cannot register for the Early Headship Coaching Offer</h1>
-
-    <p class="govuk-body">You do not meet the eligibility criteria for taking the Early Headship Coaching Offer.</p>
-
-    <p class="govuk-body">You can only register if you meet one of the following criteria:</p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>have completed an NPQH</li>
-      <li>are studying for an NPQH</li>
-      <li>are about to start an NPQH</li>
-    </ul>
-  </div>
-</div>

--- a/app/views/registration_wizard/funding_your_aso.html.erb
+++ b/app/views/registration_wizard/funding_your_aso.html.erb
@@ -1,34 +1,7 @@
-<% content_for :title do %>
-  <%= @form.errors.present? ? "Error: " : nil %>Funding
-<% end %>
-
-<% content_for :before_content do %>
-  <%= render GovukComponent::BackLinkComponent.new(
-    text: "Back",
-    href: registration_wizard_show_path(@wizard.previous_step_path)
-  ) %>
-<% end %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
-      <%= f.govuk_error_summary %>
-
-      <%= f.govuk_radio_buttons_fieldset(:aso_funding_choice,
-            legend: {
-              text: "How is the Early Headship Coaching Offer being paid for?",
-              size: "xl",
-              tag: "h1"
-            }
-          ) do %>
-        <% @form.options.each do |struct| %>
-          <%= f.govuk_radio_button :aso_funding_choice,
-            struct.value,
-            link_errors: struct.link_errors %>
-        <% end %>
-      <% end %>
-
-      <%= f.govuk_submit %>
-    <% end %>
-  </div>
-</div>
+<%=
+  render(
+    'registration_wizard/shared/question_page',
+    form: @form,
+    wizard: @wizard,
+  )
+%>

--- a/app/views/registration_wizard/shared/_copy_page.html.erb
+++ b/app/views/registration_wizard/shared/_copy_page.html.erb
@@ -1,0 +1,16 @@
+<% content_for :title do %>
+  <%= t("helpers.title.registration_wizard.#{@wizard.current_step}") %>
+<% end %>
+
+<% content_for :before_content do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: "Back",
+    href: registration_wizard_show_path(@wizard.previous_step_path)
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= yield %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -159,6 +159,7 @@ en:
   helpers:
     legend:
       registration_wizard:
+        aso_headteacher: "Are you a headteacher?"
         kind_of_nursery: "What kind of nursery do you work in?"
         employment_type: "How are you employed?"
         work_setting: "What setting do you work in?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -163,6 +163,7 @@ en:
         aso_funding_not_available: "DfE scholarship funding not available"
         aso_possible_funding: "You may qualify for DfE scholarship funding"
         aso_previously_funded: "DfE scholarship funding not available"
+        aso_unavailable: "You cannot register for the Early Headship Coaching Offer"
     legend:
       registration_wizard:
         aso_headteacher: "Are you a headteacher?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -160,6 +160,7 @@ en:
     title:
       registration_wizard:
         about_ehco: "Early Headship Coaching Offer"
+        aso_funding_not_available: "DfE scholarship funding not available"
     legend:
       registration_wizard:
         aso_headteacher: "Are you a headteacher?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -174,6 +174,7 @@ en:
         funding: "How is your course being paid for?"
         teacher_catchment: "Where do you work?"
         works_in_nursery: "Do you work in a nursery?"
+        aso_funding_choice: "How is the Early Headship Coaching Offer being paid for?"
     hint:
       registration_wizard:
         work_setting_options:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -157,6 +157,9 @@ en:
               taken: This email has already been registered for interest
 
   helpers:
+    title:
+      registration_wizard:
+        about_ehco: "Early Headship Coaching Offer"
     legend:
       registration_wizard:
         aso_headteacher: "Are you a headteacher?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -161,6 +161,7 @@ en:
       registration_wizard:
         about_ehco: "Early Headship Coaching Offer"
         aso_funding_not_available: "DfE scholarship funding not available"
+        aso_possible_funding: "You may qualify for DfE scholarship funding"
     legend:
       registration_wizard:
         aso_headteacher: "Are you a headteacher?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -167,6 +167,7 @@ en:
     legend:
       registration_wizard:
         aso_headteacher: "Are you a headteacher?"
+        aso_new_headteacher: "Are you in your first 5 years of a headship?"
         kind_of_nursery: "What kind of nursery do you work in?"
         employment_type: "How are you employed?"
         work_setting: "What setting do you work in?"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -162,6 +162,7 @@ en:
         about_ehco: "Early Headship Coaching Offer"
         aso_funding_not_available: "DfE scholarship funding not available"
         aso_possible_funding: "You may qualify for DfE scholarship funding"
+        aso_previously_funded: "DfE scholarship funding not available"
     legend:
       registration_wizard:
         aso_headteacher: "Are you a headteacher?"

--- a/spec/features/happy_journeys/non_js/funded_ehco_registration_journey_spec.rb
+++ b/spec/features/happy_journeys/non_js/funded_ehco_registration_journey_spec.rb
@@ -123,7 +123,7 @@ RSpec.feature "Happy journeys", type: :feature do
       page.choose("Yes", visible: :all)
     end
 
-    expect_page_to_have(path: "/registration/aso-possible-funding", submit_form: true) do
+    expect_page_to_have(path: "/registration/aso-possible-funding", click_continue: true) do
       expect(page).to have_selector "h1", text: "If your provider accepts your application, you’ll qualify for DfE scholarship funding"
     end
 

--- a/spec/features/happy_journeys/non_js/other_funded_ehco_registration_journey_spec.rb
+++ b/spec/features/happy_journeys/non_js/other_funded_ehco_registration_journey_spec.rb
@@ -117,7 +117,7 @@ RSpec.feature "Happy journeys", type: :feature do
       page.choose("No", visible: :all)
     end
 
-    expect_page_to_have(path: "/registration/aso-funding-not-available", submit_form: true) do
+    expect_page_to_have(path: "/registration/aso-funding-not-available", click_continue: true) do
       expect(page).to have_selector "h1", text: "DfE scholarship funding is not available"
     end
 

--- a/spec/features/sad_journeys/applying_for_ehco_but_not_new_headteacher_spec.rb
+++ b/spec/features/sad_journeys/applying_for_ehco_but_not_new_headteacher_spec.rb
@@ -127,10 +127,8 @@ RSpec.feature "Happy journeys", type: :feature do
       page.choose "No", visible: :all
     end
 
-    expect_page_to_have(path: "/registration/aso-funding-not-available", submit_form: false) do
+    expect_page_to_have(path: "/registration/aso-funding-not-available", click_continue: true) do
       expect(page).to have_selector "h1", text: "DfE scholarship funding is not available"
-
-      page.click_button("Continue")
     end
 
     expect_page_to_have(path: "/registration/funding-your-aso", submit_form: true) do

--- a/spec/support/helpers/journey_assertion_helper.rb
+++ b/spec/support/helpers/journey_assertion_helper.rb
@@ -6,7 +6,7 @@ module Helpers
       expect_page_to_have(path:, submit_form:, submit_button_text:, axe_check:, &block)
     end
 
-    def expect_page_to_have(path:, submit_form: false, submit_button_text: "Continue", axe_check: true, &block)
+    def expect_page_to_have(path:, submit_form: false, click_continue: false, submit_button_text: "Continue", axe_check: true, &block)
       expect(page.current_path).to eql(path)
 
       if axe_check && Capybara.current_driver != :rack_test
@@ -16,6 +16,7 @@ module Helpers
       block.call if block_given?
 
       page.click_button(submit_button_text) if submit_form
+      page.click_link("Continue") if click_continue
     end
 
     def expect_check_answers_page_to_have_answers(values)


### PR DESCRIPTION
### Context

#512 continued the work of refactoring the question flow to use the new question_page shared templating system to improve code reuse and cut down on repetition.

This PR is aimed at expanding that system to the entire EHCO flow.

### Changes proposed in this pull request

- Move EHCO questions to use the question_page template and use the `Forms::QuestionTypes` classes for their questions.
- Introduce app/views/registration_wizard/shared/_copy_page template for sharing logic between pure copy pages.
- Use copy_page template for all EHCO question free steps.

### Pages updated to use the question_page template

- https://npq-registration-review-app-522.london.cloudapps.digital/registration/aso_headteacher
- https://npq-registration-review-app-522.london.cloudapps.digital/registration/aso_new_headteacher
- https://npq-registration-review-app-522.london.cloudapps.digital/registration/funding_your_aso

### Pages updated to use the new copy_page template

- https://npq-registration-review-app-522.london.cloudapps.digital/registration/about_ehco
- https://npq-registration-review-app-522.london.cloudapps.digital/registration/aso_funding_not_available
- https://npq-registration-review-app-522.london.cloudapps.digital/registration/aso_possible_funding
- https://npq-registration-review-app-522.london.cloudapps.digital/registration/aso_previously_funded
- https://npq-registration-review-app-522.london.cloudapps.digital/registration/aso_unavailable

