### PR TITLE
Use beginning of day for dashboard calculations

### DIFF
--- a/app/lib/services/admin/dashboard_stats.rb
+++ b/app/lib/services/admin/dashboard_stats.rb
@@ -4,7 +4,7 @@ module Services
       attr_reader :start_time
 
       def initialize(start_time: nil)
-        @start_time = start_time
+        @start_time = start_time&.at_beginning_of_day
       end
 
       def applications_created

--- a/spec/lib/services/admin/dashboard_stats_spec.rb
+++ b/spec/lib/services/admin/dashboard_stats_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Services::Admin::DashboardStats do
-  let(:start_time) { 7.days.ago }
+  let(:start_time) { 7.days.ago.at_beginning_of_day }
 
   let(:get_an_identity_applications_created_before_start_time) { 3 }
   let(:non_get_an_identity_applications_created_before_start_time) { 4 }


### PR DESCRIPTION
### Context

Noticed that figures oscillated through the day due to timing of when previous applications were made.

### Changes proposed in this pull request

Fix the "last 7 days" cut off to midnight.
