### PR TITLE
Make sure users returning from GAI are in the GAI pilot

### DIFF
--- a/app/controllers/omniauth_controller.rb
+++ b/app/controllers/omniauth_controller.rb
@@ -9,6 +9,7 @@ class OmniauthController < Devise::OmniauthCallbacksController
     )
 
     if @user.persisted?
+      Services::Feature.enroll_user_in_get_an_identity_pilot(@user)
       session["user_id"] = @user.id
 
       sign_in_and_redirect @user

--- a/app/lib/services/feature.rb
+++ b/app/lib/services/feature.rb
@@ -24,6 +24,10 @@ module Services
           !Flipper.enabled?(Services::Feature::REMOVE_USER_FROM_GAI_PILOT_KEY, user)
       end
 
+      def enroll_user_in_get_an_identity_pilot(user)
+        Flipper.enable_actor(Services::Feature::GAI_INTEGRATION_KEY, user)
+      end
+
       def remove_user_from_get_an_identity_pilot(user)
         Flipper.enable_actor(Services::Feature::REMOVE_USER_FROM_GAI_PILOT_KEY, user)
       end


### PR DESCRIPTION
### Context

There’s an odd interaction at the moment.

If you’re not logged into an account when you return from the GAI flow it’ll create one for you in the database. It’ll then copy your feature flag ID from your session into that new user record so your flags remain consistent.

However, if you’re already logged in you’ll be using the feature flag ID off of your user record for determining whether you're in the pilot. If you then go through the GAI flow but register with a different email address it’ll create a new user in the database and it’ll get a new feature flag ID rather than having it copied over (because we don't want two users with the same flag ID). 

This can then mean that you’re on an account that isn’t in the pilot. This has happened during testing so we know it isn't just theoretical.

### Changes proposed in this pull request

Automatically enroll anyone who returns from the get an identity flow in the get an identity pilot.
