### PR TITLE
Prompt TRA to clear login when application created

### DIFF
--- a/app/controllers/omniauth_controller.rb
+++ b/app/controllers/omniauth_controller.rb
@@ -3,6 +3,9 @@ class OmniauthController < Devise::OmniauthCallbacksController
   before_action :remove_from_get_an_identity_pilot, only: :tra_openid_connect, if: :tra_response_excludes_trn?
 
   def tra_openid_connect
+    # Let user continue using current TRA login
+    session.delete("clear_tra_login")
+
     @user = User.find_or_create_from_provider_data(
       request.env["omniauth.auth"],
       feature_flag_id: session["feature_flag_id"],

--- a/app/lib/forms/confirmation.rb
+++ b/app/lib/forms/confirmation.rb
@@ -14,6 +14,7 @@ module Forms
 
     def after_render
       wizard.store["submitted"] = true
+      wizard.session["clear_tra_login"] = true if wizard.tra_get_an_identity_omniauth_integration_active?
     end
 
     def display_npqh_information?

--- a/lib/omniauth/strategies/tra_openid_connect.rb
+++ b/lib/omniauth/strategies/tra_openid_connect.rb
@@ -27,6 +27,12 @@ module Omniauth
 
       extra { { "raw_info" => raw_info } }
 
+      def authorize_params
+        return super.merge(prompt: :login) if request.session["clear_tra_login"] == true
+
+        super
+      end
+
       def raw_info
         @raw_info ||= access_token.get("connect/userinfo").parsed
       end


### PR DESCRIPTION
### Context

For testing, and shared computers, we want to make sure that if you complete an application people can't re-use your TRA login. 

### Changes proposed in this pull request

Mark session as needing to tell TRA to use a fresh session when NPQ applications completed.

