### PR TITLE
Remove the unique index from `User#ecf_id`

### DIFF
--- a/db/migrate/20221118124435_drop_unique_index_from_users_ecf_id.rb
+++ b/db/migrate/20221118124435_drop_unique_index_from_users_ecf_id.rb
@@ -1,0 +1,6 @@
+class DropUniqueIndexFromUsersEcfId < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :users, :ecf_id, unique: true
+    add_index :users, :ecf_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_20_102023) do
+ActiveRecord::Schema.define(version: 2022_11_18_124435) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -217,7 +217,7 @@ ActiveRecord::Schema.define(version: 2022_10_20_102023) do
     t.string "provider"
     t.string "uid"
     t.jsonb "raw_tra_provider_data"
-    t.index ["ecf_id"], name: "index_users_on_ecf_id", unique: true
+    t.index ["ecf_id"], name: "index_users_on_ecf_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["provider"], name: "index_users_on_provider"
     t.index ["uid"], name: "index_users_on_uid", unique: true


### PR DESCRIPTION
## Context

I don't think this column needs to be unique. It tells us which user in the ECF application this record belongs to, but ECF users can have multiple email addresses (via their participant identities).

It causes problems when a person applies more than once with different email addresses. When submitting the NPQ application to ECF we hit an error caused the unique index on `users.ecf_id`, which was assigned to their original user record when they completed their first application.

The current solution is to manually 'move' the applications to their original user account and re-trigger the submission manually.

### Pros

* users don't need to worry about which of their email addresses they use when applying for an NPQ
* it simplifies our submission process and avoids any manual intervention

#### Cons

* we'll end up with some users in the NPQ database that share an `ecf_id`