### PR TITLE
Add an unsynced user list to the admin section

### DIFF
--- a/app/controllers/admin/unsynced_applications_controller.rb
+++ b/app/controllers/admin/unsynced_applications_controller.rb
@@ -1,0 +1,17 @@
+class Admin::UnsyncedApplicationsController < AdminController
+  include Pagy::Backend
+
+  def index
+    @pagy, @applications = pagy(scope)
+  end
+
+  def show
+    @application = Application.unsynced.includes(:user).find(params[:id])
+  end
+
+private
+
+  def scope
+    Application.unsynced.joins(:user).eager_load(:user, :course, :lead_provider)
+  end
+end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -5,6 +5,8 @@ class Application < ApplicationRecord
   belongs_to :school, foreign_key: "school_urn", primary_key: "urn", optional: true
   belongs_to :private_childcare_provider, foreign_key: "private_childcare_provider_urn", primary_key: "provider_urn", optional: true
 
+  scope :unsynced, -> { where(ecf_id: nil) }
+
   enum kind_of_nursery: {
     local_authority_maintained_nursery: "local_authority_maintained_nursery",
     preschool_class_as_part_of_school: "preschool_class_as_part_of_school",

--- a/app/views/admin/_application_details.html.erb
+++ b/app/views/admin/_application_details.html.erb
@@ -1,0 +1,114 @@
+<%=
+  govuk_summary_list do |sl|
+    sl.row do |row|
+      row.key(text: 'Application ECF ID')
+      row.value(text: @application.ecf_id || govuk_tag(text: "Missing", colour: "red"))
+    end
+
+    sl.row do |row|
+      row.key(text: 'User ECF ID')
+      row.value(text: @application.user.ecf_id || govuk_tag(text: "Missing", colour: "red"))
+    end
+
+    sl.row do |row|
+      row.key(text: 'User Identity Provider')
+      row.value(text: application.user.provider ? t("omniauth_providers.#{application.user.provider}") : "-")
+    end
+
+    sl.row do |row|
+      row.key(text: 'User Identity UID')
+      row.value(text: application.user.uid || '-')
+    end
+
+    sl.row do |row|
+      row.key(text: 'In Get an Identity Pilot?')
+      row.value(text: boolean_red_green_tag(application.user.in_get_an_identity_pilot?))
+    end
+
+    sl.row do |row|
+      row.key(text: 'Email')
+      row.value(text: application.user.email)
+    end
+
+    sl.row do |row|
+      row.key(text: 'Name')
+      row.value(text: application.user.full_name)
+    end
+
+    sl.row do |row|
+      row.key(text: 'TRN')
+      row.value(text: application.user.trn)
+    end
+
+    sl.row do |row|
+      row.key(text: 'TRN validated')
+      row.value(text: application.user.trn_verified.to_s)
+    end
+
+    sl.row do |row|
+      row.key(text: 'TRN auto validated')
+      row.value(text: application.user.trn_auto_verified.to_s)
+    end
+
+    sl.row do |row|
+      row.key(text: 'Course')
+      row.value(text: application.course.name)
+    end
+
+    sl.row do |row|
+      row.key(text: 'Lead provider')
+      row.value(text: application.lead_provider.name)
+    end
+
+    sl.row do |row|
+      row.key(text: 'School URN')
+      row.value(text: application.school_urn)
+    end
+
+    sl.row do |row|
+      row.key(text: 'School UKPRN')
+      row.value(text: application.ukprn)
+    end
+
+    sl.row do |row|
+      row.key(text: 'Private Childcare Provider URN')
+      row.value(text: application.private_childcare_provider_urn)
+    end
+
+    sl.row do |row|
+      row.key(text: 'Headteacher')
+      row.value(text: application.headteacher_status)
+    end
+
+    sl.row do |row|
+      row.key(text: 'Funding eligibility')
+      row.value(text: boolean_red_green_tag(application.eligible_for_funding))
+    end
+
+    sl.row do |row|
+      row.key(text: 'Funding eligibility status code')
+      row.value(text: application.funding_eligiblity_status_code)
+    end
+
+    sl.row do |row|
+      row.key(text: "Targeted delivery funding eligibility")
+      row.value { boolean_red_green_tag(application.targeted_delivery_funding_eligibility) }
+    end
+
+    sl.row do |row|
+      row.key(text: 'Funding choice')
+      row.value(text: application.funding_choice)
+    end
+
+    sl.row do |row|
+      row.key(text: "Created at")
+      row.value { l application.created_at, format: :admin }
+    end
+
+    sl.row do |row|
+      row.key(text: "Cohort")
+      row.value(text: application.cohort.to_s)
+      :wa
+    end
+  end
+%>

--- a/app/views/admin/_layout.html.erb
+++ b/app/views/admin/_layout.html.erb
@@ -9,6 +9,10 @@
     <%= t(".applications") %>
   <% end %>
 
+  <%= component.nav_item(path: admin_unsynced_applications_path) do %>
+    <%= t(".unsynced_applications") %>
+  <% end %>
+
   <% if current_user.flipper_access? %>
     <%= component.nav_item(path: "/admin/feature_flags") do %>
       <%= t(".feature_flags") %>

--- a/app/views/admin/unsynced_applications/index.html.erb
+++ b/app/views/admin/unsynced_applications/index.html.erb
@@ -1,0 +1,39 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render "admin/layout", title: "Unsynced applications" %>
+
+    <% if @applications.blank? %>
+
+      <p class="govuk-body">All applications have been successfuly linked with an ECF user.</p>
+
+    <% else %>
+      <%=
+        govuk_table do |table|
+          table.head do |head|
+            head.row do |row|
+              row.cell(header: true, text: "Email")
+              row.cell(header: true, text: "Course")
+              row.cell(header: true, text: "Lead provider")
+              row.cell(header: true, text: "School")
+              row.cell(header: true, text: "Applied on")
+            end
+          end
+
+          table.body do |body|
+            @applications.each do |app|
+              body.row do |row|
+                row.cell(text: govuk_link_to(app.user.email, admin_unsynced_application_path(app)))
+                row.cell(text: app.course.name)
+                row.cell(text: app.lead_provider.name)
+                row.cell(text: app.school_urn)
+                row.cell(text: app.created_at.to_date.to_formatted_s(:govuk))
+              end
+            end
+          end
+        end
+      %>
+    <% end %>
+
+    <%== pagy_govuk_nav(@pagy) %>
+  </div>
+</div>

--- a/app/views/admin/unsynced_applications/show.html.erb
+++ b/app/views/admin/unsynced_applications/show.html.erb
@@ -1,13 +1,13 @@
 <% content_for :before_content do %>
   <%= render GovukComponent::BackLinkComponent.new(
     text: "Back",
-    href: admin_applications_path
+    href: admin_unsynced_applications_path
   ) %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-xl">Application</h1>
+    <h1 class="govuk-heading-xl">Unsynced application</h1>
 
     <%= render partial: "admin/application_details", locals: { application: @application } %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -164,6 +164,7 @@ en:
       title: "Admin"
       dashboard: "Dashboard"
       applications: "Applications"
+      unsynced_applications: "Unsynced applications"
       feature_flags: "Feature Flags"
 
   helpers:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :applications, only: %i[index show]
+    resources :unsynced_applications, only: %i[index show], path: "unsynced-applications"
 
     constraints RouteConstraints::HasFlipperAccess do
       mount Flipper::UI.app(Flipper) => "/feature_flags"

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -1,4 +1,11 @@
 require "rails_helper"
 
 RSpec.describe Application do
+  describe "scopes" do
+    describe ".unsynced" do
+      it "returns records where ecf_id is null" do
+        expect(described_class.unsynced.to_sql).to match(%("ecf_id" IS NULL))
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Jira Ticket

https://dfedigital.atlassian.net/browse/CPDNPQ-656

### Context and changes

Unsynced users are users who have completed their application but we failed to link their record with an ECF user. This usually happens because they've used more than one email address and we already have their `ecf_id` on record.


| List of unsynced applications | Viewing an unsynced application |
| ----------- | ----------------- |
| ![image](https://user-images.githubusercontent.com/128088/202751318-5c62be6c-dfa8-488d-9f06-f0e7d44e730e.png) | ![image](https://user-images.githubusercontent.com/128088/202751193-e3c5107c-cba3-458e-8efe-fb7253433940.png) |

