### PR TITLE
Send provider UID to sentry on error for debugging purposes

### DIFF
--- a/app/controllers/omniauth_controller.rb
+++ b/app/controllers/omniauth_controller.rb
@@ -6,8 +6,10 @@ class OmniauthController < Devise::OmniauthCallbacksController
     # Let user continue using current TRA login
     session.delete("clear_tra_login")
 
+    provider_data = request.env["omniauth.auth"]
+
     @user = User.find_or_create_from_provider_data(
-      request.env["omniauth.auth"],
+      provider_data,
       feature_flag_id: session["feature_flag_id"],
     )
 
@@ -21,6 +23,10 @@ class OmniauthController < Devise::OmniauthCallbacksController
         "Could not persist user after omniauth callback",
         contexts: {
           "Errors" => @user.errors.to_hash,
+          "Provider" => {
+            provider: provider_data.provider,
+            uid: provider_data.uid,
+          },
         },
       )
 
@@ -84,11 +90,17 @@ private
   end
 
   def remove_from_get_an_identity_pilot
+    provider_data = request.env["omniauth.auth"]
+
     send_error_to_sentry(
       "User removed from Pilot",
       contexts: {
         status: {
           trn_blank: tra_response_excludes_trn?,
+        },
+        "Provider" => {
+          provider: provider_data.provider,
+          uid: provider_data.uid,
         },
       },
     )


### PR DESCRIPTION
### Context

For debugging purposes we need to be able to look up user's encountering errors within the GAI interface

### Changes proposed in this pull request

Add GAI ID to logged information

