### PR TITLE
expand on how we use your data

### DIFF
--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -89,10 +89,10 @@
       We’ll also look at any feedback you share - for example, through website surveys.
     </p>
 
-    <h3 class="govuk-heading-m">Getting insight to make government policy better</h3>
+    <h3 class="govuk-heading-m">Informing government policy</h3>
 
     <p class="govuk-body">
-      We may use your data to help inform government policy around teacher recruitment and retention.
+      We may use your data to help inform government policy.
     </p>
     
     <h3 class="govuk-heading-m">Identifying you so that you can access DfE services</h3>
@@ -119,7 +119,7 @@
     <h3 class="govuk-heading-m">Inform you about relevant government policies</h3>
     
     <p class="govuk-body">
-      We may contact you to inform you about government policies relevant to you. If you're contacted you can opt out of these communications.
+      We may contact you to inform you about government policies relevant to you. You can opt out of this if you’re contacted.
     </p>
 
     <h2 class="govuk-heading-l">Who we share your data with</h2>

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -84,7 +84,7 @@
     <h3 class="govuk-heading-m">Getting insight to inform government policy</h3>
 
     <p class="govuk-body">
-      Your data contributes to our understanding education, training and care in England, helping us to inform government policy.
+      Your data contributes to our understanding of education, training and care in England, helping us to inform government policy.
     </p>
     
     <h3 class="govuk-heading-m">Identifying you so that you can access DfE services</h3>

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -90,13 +90,12 @@
     <h3 class="govuk-heading-m">Identifying you so that you can access DfE services</h3>
     
     <p class="govuk-body">
-      If we do not already hold your data on our records, we’ll create a professional record for you. 
+      If we do not already hold your data on our records, we’ll add you to our database of educational professionals. 
     </p>
     
     <p class="govuk-body">
       We use this to identify you so that you can access relevant DfE services.  
-    </p>
-    
+    </p>    
 
     <h3 class="govuk-heading-m">Monitoring and evaluating NPQs</h3>
 

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -14,11 +14,11 @@
     <h1 class="govuk-heading-xl">Privacy policy</h1>
 
     <p class="govuk-body">
-      This policy refers to data collected as part of the national professional qualifications programme, run by the Department for Education (DfE).
+      When you register for a national professional qualification (NPQ), the Department for Education (DfE) collects and processes some of your personal data. 
     </p>
 
     <p class="govuk-body">
-      This includes the ‘Register for a national professional qualification’ service.
+      DfE, referred to as ‘we’, ‘us’ and ‘our’ in this policy, is the data controller for your information - as defined by data protection law. 
     </p>
 
     <p class="govuk-body">

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -178,7 +178,7 @@
     <h3 class="govuk-heading-m">Evaluators</h3>
 
     <p class="govuk-body">
-      We use external evaluators to understand the effectiveness of the training you’re receiving from NPQ providers and the impact it’s having on the teacher workforce.
+      We use external evaluators to understand the effectiveness and impact of NPQs.
     </p>
 
     <h2 class="govuk-heading-l">How long we keep your personal data for</h2>

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -22,10 +22,6 @@
     </p>
 
     <p class="govuk-body">
-      DfE is the data controller for your information, as defined by data protection law. This policy refers to ‘us’, ‘we’ and ‘our’. This means DfE.
-    </p>
-
-    <p class="govuk-body">
       Your data is also shared with the following data processors:
     </p>
 

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -81,14 +81,6 @@
       We may contact you about taking part in user research and look at any feedback you share - for example, through website surveys.
     </p>
 
-    <p class="govuk-body">
-      For example, we’ll contact you about taking part in user research.
-    </p>
-
-    <p class="govuk-body">
-      We’ll also look at any feedback you share - for example, through website surveys.
-    </p>
-
     <h3 class="govuk-heading-m">Getting insight to inform government policy</h3>
 
     <p class="govuk-body">

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -75,10 +75,14 @@
       <li>getting in touch if there’s a security issue concerning your data</li>
       </ul>
 
-    <h3 class="govuk-heading-m">Improving government services</h3>
+    <h3 class="govuk-heading-m">Running and improving our services</h3>
 
     <p class="govuk-body">
-      We’ll use your data to help us improve our services.
+      We use your data to run and improve our services.
+    </p>
+    
+     <p class="govuk-body">
+      We may contact you about taking part in user research and look at any feedback you share - for example, through website surveys.
     </p>
 
     <p class="govuk-body">

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -89,10 +89,10 @@
       We’ll also look at any feedback you share - for example, through website surveys.
     </p>
 
-    <h3 class="govuk-heading-m">Informing government policy</h3>
+    <h3 class="govuk-heading-m">Getting insight to inform government policy</h3>
 
     <p class="govuk-body">
-      We may use your data to help inform government policy.
+      Your data contributes to our understanding education, training and care in England, helping us to inform government policy.
     </p>
     
     <h3 class="govuk-heading-m">Identifying you so that you can access DfE services</h3>

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -18,7 +18,11 @@
     </p>
 
     <p class="govuk-body">
-      DfE, referred to as ‘we’, ‘us’ and ‘our’ in this policy, is the data controller for your information - as defined by data protection law. 
+      DfE is the data controller for your information, as defined by data protection law. 
+    </p>
+    
+     <p class="govuk-body">
+      DfE is referred to as ‘we’, ‘us’ and ‘our’ in this privacy policy. 
     </p>
 
     <p class="govuk-body">

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -108,10 +108,10 @@
       They may contact you for research relating to your NPQ. You can opt out of this if you’re contacted.
     </p>
     
-    <h3 class="govuk-heading-m">Inform you about relevant government policies</h3>
+    <h3 class="govuk-heading-m">Inform you of relevant government policies</h3>
     
     <p class="govuk-body">
-      We may contact you to inform you about government policies relevant to you. You can opt out of this if you’re contacted.
+      We may contact you to inform you of government policies which are relevant to you. You can opt out of this if you’re contacted.
     </p>
 
     <h2 class="govuk-heading-l">Who we share your data with</h2>

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -94,6 +94,17 @@
     <p class="govuk-body">
       We may use your data to help inform government policy around teacher recruitment and retention.
     </p>
+    
+    <h3 class="govuk-heading-m">Identifying you so that you can access DfE services</h3>
+    
+    <p class="govuk-body">
+      If we do not already hold your data on our records, we’ll create a professional record for you. 
+    </p>
+    
+    <p class="govuk-body">
+      We use this to identify you so that you can access relevant DfE services.  
+    </p>
+    
 
     <h3 class="govuk-heading-m">Monitoring and evaluating NPQs</h3>
 
@@ -104,7 +115,12 @@
     <p class="govuk-body">
       They may contact you for research relating to your NPQ. You can opt out of this if you’re contacted.
     </p>
-
+    
+    <h3 class="govuk-heading-m">Inform you about relevant government policies</h3>
+    
+    <p class="govuk-body">
+      We may contact you to inform you about government policies relevant to you. If you're contacted you can opt out of these communications.
+    </p>
 
     <h2 class="govuk-heading-l">Who we share your data with</h2>
 

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -22,7 +22,7 @@
     </p>
 
     <p class="govuk-body">
-      Your data is also shared with the following data processors:
+      We share your data with the following data processors:
     </p>
 
     <ul class="govuk-list govuk-list--bullet">

--- a/spec/features/disabled_get_an_identity_integration/privacy_policy_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/privacy_policy_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Privacy Policy", type: :feature do
 
     aggregate_failures do
       expect(page).to have_css("h1", text: "Privacy policy")
-      expect(page).to have_content("This policy refers to data collected as part of the national professional qualifications programme")
+      expect(page).to have_content("When you register for a national professional qualification (NPQ), the Department for Education (DfE) collects and processes some of your personal data.")
     end
   end
 end

--- a/spec/features/privacy_policy_spec.rb
+++ b/spec/features/privacy_policy_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Privacy Policy", type: :feature do
 
     aggregate_failures do
       expect(page).to have_content("Privacy policy")
-      expect(page).to have_content("This policy refers to data collected as part of the national professional qualifications programme")
+      expect(page).to have_content("When you register for a national professional qualification (NPQ), the Department for Education (DfE) collects and processes some of your personal data.")
     end
   end
 end


### PR DESCRIPTION
- Add 2 paras to the 'How we use your data' section to better encompass what we do with peoples data 
- Be clearer about what we mean re. 'informing government policy'
- Include 'run our services' in the 'improve our services' section - i.e. we need your information to make our services work (e.g. sharing information across services etc)
- be more user centred in the opening para - e.g. this is what happens when **you** register for an NPQ

Review the content: https://npq-registration-review-app-589.london.cloudapps.digital/privacy-policy
