### PR TITLE
Format big numbers with commas on the dashboard

### DIFF
--- a/app/components/status_box.html.erb
+++ b/app/components/status_box.html.erb
@@ -4,7 +4,7 @@
       <% if url %>
         <a class="govuk-link govuk-link--no-visited-state big-number-link" href="<%= url %>">
       <% end %>
-        <%= number %> <%= label %>
+        <%= number_with_delimiter(number) %> <%= label %>
         <% if percentage %>
           - <%= percentage %>%
         <% end %>
@@ -20,7 +20,7 @@
         <a class="govuk-link govuk-link--no-visited-state big-number-link" href="<%= url %>">
       <% end %>
       <span class="big-number-number">
-            <%= number %>
+            <%= number_with_delimiter(number) %>
           </span>
 
           <span class="big-number-label">

--- a/app/views/admin/show.html.erb
+++ b/app/views/admin/show.html.erb
@@ -1,8 +1,8 @@
-<%= render "admin/layout", title: "Admin Dashboard" %>
+<%= render "admin/layout", title: "Admin dashboard" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l">Last 7 Days</h1>
+    <h1 class="govuk-heading-l">Last 7 days</h1>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third">
@@ -39,7 +39,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l">All Time</h1>
+    <h1 class="govuk-heading-l">All time</h1>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third">


### PR DESCRIPTION
### Changes proposed in this pull request

- Only capitalise first letter in dashboard sections as per [style guide](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#capitalisation)
- Format dashboard counts with `#number_with_delimiter` so they are [easier to read](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#numbers)

### Preview (with random numbers!)

![Screenshot from 2022-11-28 18-12-52](https://user-images.githubusercontent.com/128088/204351091-8f36b9fb-0abd-4afc-b252-642ca4291e76.png)
e/a-to-z-of-gov-uk-style#numbers)

