### PR TITLE
[CPDNPQ-723] Only allow targeted delivery funding once

### DIFF
--- a/app/lib/services/eligibility/targeted_delivery_funding.rb
+++ b/app/lib/services/eligibility/targeted_delivery_funding.rb
@@ -1,5 +1,8 @@
 module Services
   module Eligibility
+    # Note that this doesn't take into account any details about the user or application. This is
+    # just for determinging course+institution eligibility. Further checks related to do with the user
+    # are performed after this service is called.
     class TargetedDeliveryFunding
       attr_reader :institution, :course
 

--- a/app/lib/services/eligibility/targeted_delivery_funding.rb
+++ b/app/lib/services/eligibility/targeted_delivery_funding.rb
@@ -1,7 +1,7 @@
 module Services
   module Eligibility
     # Note that this doesn't take into account any details about the user or application. This is
-    # just for determinging course+institution eligibility. Further checks related to do with the user
+    # just for determining course+institution eligibility. Further checks related to do with the user
     # are performed after this service is called.
     class TargetedDeliveryFunding
       attr_reader :institution, :course

--- a/app/lib/services/funding_eligibility.rb
+++ b/app/lib/services/funding_eligibility.rb
@@ -64,8 +64,8 @@ module Services
     end
 
     def eligible_for_targeted_delivery_funding?
-      !previously_received_targeted_funding_support? &&
-        course_and_institution_eligible_for_targeted_delivery_funding?
+      course_and_institution_eligible_for_targeted_delivery_funding? &&
+        !previously_received_targeted_funding_support? # Check last as it involves an API call
     end
 
     def ineligible_institution_type?

--- a/app/lib/services/funding_eligibility.rb
+++ b/app/lib/services/funding_eligibility.rb
@@ -19,7 +19,7 @@ module Services
     NOT_ON_EARLY_YEARS_REGISTER = :not_on_early_years_register
     EARLY_YEARS_INVALID_NPQ = :early_years_invalid_npq
 
-    attr_reader :institution, :course
+    attr_reader :institution, :course, :trn
 
     def initialize(institution:, course:, inside_catchment:, trn:, new_headteacher: false)
       @institution = institution
@@ -133,7 +133,7 @@ module Services
     end
 
     def ecf_api_funding_lookup
-      @ecf_api_funding_lookup = EcfApi::NpqFunding.with_params(npq_course_identifier: course.identifier).find(@trn)
+      @ecf_api_funding_lookup = EcfApi::NpqFunding.with_params(npq_course_identifier: course.identifier).find(trn)
     end
 
     def previously_funded?

--- a/app/lib/services/handle_submission_for_store.rb
+++ b/app/lib/services/handle_submission_for_store.rb
@@ -188,16 +188,14 @@ module Services
       eligible_for_funding?
     end
 
-    delegate :ineligible_institution_type?,
+    def targeted_delivery_funding_eligibility
+      eligible_for_targeted_delivery_funding?
+    end
+
+    delegate :eligible_for_targeted_delivery_funding?,
+             :ineligible_institution_type?,
              :funding_eligiblity_status_code,
              to: :funding_eligibility_service
-
-    def targeted_delivery_funding_eligibility
-      @targeted_delivery_funding_eligibility ||= Services::Eligibility::TargetedDeliveryFunding.new(
-        institution: institution_from_store,
-        course:,
-      ).call
-    end
 
     def new_headteacher?
       %w[yes_in_first_two_years yes_in_first_five_years yes_when_course_starts].include?(headteacher_status)

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/js/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/js/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
@@ -144,7 +144,7 @@ RSpec.feature "Happy journeys", type: :feature do
       )
       .to_return(
         status: 200,
-        body: previously_funded_response(false),
+        body: ecf_funding_lookup_response(previously_funded: false),
         headers: {
           "Content-Type" => "application/vnd.api+json",
         },

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/js/when_previously_funded_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/js/when_previously_funded_spec.rb
@@ -106,7 +106,7 @@ RSpec.feature "Happy journeys", type: :feature do
         )
         .to_return(
           status: 200,
-          body: previously_funded_response(true),
+          body: ecf_funding_lookup_response(previously_funded: true),
           headers: {
             "Content-Type" => "application/vnd.api+json",
           },

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/js/while_working_at_public_nursery_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/js/while_working_at_public_nursery_spec.rb
@@ -98,7 +98,7 @@ RSpec.feature "Happy journeys", type: :feature do
       )
       .to_return(
         status: 200,
-        body: previously_funded_response(false),
+        body: ecf_funding_lookup_response(previously_funded: false),
         headers: {
           "Content-Type" => "application/vnd.api+json",
         },

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/non_js/able_to_receive_targeted_delivery_funding_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/non_js/able_to_receive_targeted_delivery_funding_spec.rb
@@ -103,7 +103,7 @@ RSpec.feature "Happy journeys", type: :feature do
       )
       .to_return(
         status: 200,
-        body: previously_funded_response(false),
+        body: ecf_funding_lookup_response(previously_funded: false),
         headers: {
           "Content-Type" => "application/vnd.api+json",
         },
@@ -122,7 +122,7 @@ RSpec.feature "Happy journeys", type: :feature do
       )
       .to_return(
         status: 200,
-        body: previously_funded_response(false),
+        body: ecf_funding_lookup_response(previously_funded: false),
         headers: {
           "Content-Type" => "application/vnd.api+json",
         },

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/non_js/via_using_old_name_and_not_headship_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/non_js/via_using_old_name_and_not_headship_spec.rb
@@ -111,7 +111,7 @@ RSpec.feature "Happy journeys", type: :feature do
       )
       .to_return(
         status: 200,
-        body: previously_funded_response(false),
+        body: ecf_funding_lookup_response(previously_funded: false),
         headers: {
           "Content-Type" => "application/vnd.api+json",
         },
@@ -130,7 +130,7 @@ RSpec.feature "Happy journeys", type: :feature do
       )
       .to_return(
         status: 200,
-        body: previously_funded_response(false),
+        body: ecf_funding_lookup_response(previously_funded: false),
         headers: {
           "Content-Type" => "application/vnd.api+json",
         },

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/non_js/via_using_same_name_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/non_js/via_using_same_name_spec.rb
@@ -93,7 +93,7 @@ RSpec.feature "Happy journeys", type: :feature do
       )
       .to_return(
         status: 200,
-        body: previously_funded_response(false),
+        body: ecf_funding_lookup_response(previously_funded: false),
         headers: {
           "Content-Type" => "application/vnd.api+json",
         },

--- a/spec/features/happy_journeys/js/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
+++ b/spec/features/happy_journeys/js/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
@@ -108,7 +108,7 @@ RSpec.feature "Happy journeys", type: :feature do
       )
       .to_return(
         status: 200,
-        body: previously_funded_response(false),
+        body: ecf_funding_lookup_response(previously_funded: false),
         headers: {
           "Content-Type" => "application/vnd.api+json",
         },

--- a/spec/features/happy_journeys/js/when_previously_funded_spec.rb
+++ b/spec/features/happy_journeys/js/when_previously_funded_spec.rb
@@ -82,7 +82,7 @@ RSpec.feature "Happy journeys", type: :feature do
         )
         .to_return(
           status: 200,
-          body: previously_funded_response(true),
+          body: ecf_funding_lookup_response(previously_funded: true),
           headers: {
             "Content-Type" => "application/vnd.api+json",
           },

--- a/spec/features/happy_journeys/js/while_working_at_public_nursery_spec.rb
+++ b/spec/features/happy_journeys/js/while_working_at_public_nursery_spec.rb
@@ -73,7 +73,7 @@ RSpec.feature "Happy journeys", type: :feature do
       )
       .to_return(
         status: 200,
-        body: previously_funded_response(false),
+        body: ecf_funding_lookup_response(previously_funded: false),
         headers: {
           "Content-Type" => "application/vnd.api+json",
         },

--- a/spec/features/happy_journeys/non_js/via_using_old_name_and_not_headship_spec.rb
+++ b/spec/features/happy_journeys/non_js/via_using_old_name_and_not_headship_spec.rb
@@ -78,7 +78,7 @@ RSpec.feature "Happy journeys", type: :feature do
       )
       .to_return(
         status: 200,
-        body: previously_funded_response(false),
+        body: ecf_funding_lookup_response(previously_funded: false),
         headers: {
           "Content-Type" => "application/vnd.api+json",
         },
@@ -97,7 +97,7 @@ RSpec.feature "Happy journeys", type: :feature do
       )
       .to_return(
         status: 200,
-        body: previously_funded_response(false),
+        body: ecf_funding_lookup_response(previously_funded: false),
         headers: {
           "Content-Type" => "application/vnd.api+json",
         },

--- a/spec/features/happy_journeys/non_js/via_using_same_name_spec.rb
+++ b/spec/features/happy_journeys/non_js/via_using_same_name_spec.rb
@@ -70,7 +70,7 @@ RSpec.feature "Happy journeys", type: :feature do
       )
       .to_return(
         status: 200,
-        body: previously_funded_response(false),
+        body: ecf_funding_lookup_response(previously_funded: false),
         headers: {
           "Content-Type" => "application/vnd.api+json",
         },

--- a/spec/lib/forms/check_answers_spec.rb
+++ b/spec/lib/forms/check_answers_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Forms::CheckAnswers do
         )
         .to_return(
           status: 200,
-          body: previously_funded_response(false),
+          body: ecf_funding_lookup_response(previously_funded: false),
           headers: {
             "Content-Type" => "application/vnd.api+json",
           },

--- a/spec/lib/forms/choose_your_npq_spec.rb
+++ b/spec/lib/forms/choose_your_npq_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Forms::ChooseYourNpq, type: :model do
             )
             .to_return(
               status: 200,
-              body: previously_funded_response(false),
+              body: ecf_funding_lookup_response(previously_funded: false),
               headers: {
                 "Content-Type" => "application/vnd.api+json",
               },
@@ -105,7 +105,7 @@ RSpec.describe Forms::ChooseYourNpq, type: :model do
             )
             .to_return(
               status: 200,
-              body: previously_funded_response(false),
+              body: ecf_funding_lookup_response(previously_funded: false),
               headers: {
                 "Content-Type" => "application/vnd.api+json",
               },

--- a/spec/lib/services/funding_eligibility_spec.rb
+++ b/spec/lib/services/funding_eligibility_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Services::FundingEligibility do
     stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/#{trn}?npq_course_identifier=#{course_identifier}")
       .to_return(
         status: 200,
-        body: previously_funded_response(previously_funded),
+        body: ecf_funding_lookup_response(previously_funded:),
         headers: {
           "Content-Type" => "application/vnd.api+json",
         },

--- a/spec/lib/services/handle_submission_for_store_spec.rb
+++ b/spec/lib/services/handle_submission_for_store_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Services::HandleSubmissionForStore do
         )
         .to_return(
           status: 200,
-          body: previously_funded_response(false),
+          body: ecf_funding_lookup_response(previously_funded: false),
           headers: {
             "Content-Type" => "application/vnd.api+json",
           },
@@ -354,7 +354,7 @@ RSpec.describe Services::HandleSubmissionForStore do
               )
               .to_return(
                 status: 200,
-                body: previously_funded_response(false),
+                body: ecf_funding_lookup_response(previously_funded: false),
                 headers: {
                   "Content-Type" => "application/vnd.api+json",
                 },
@@ -409,7 +409,7 @@ RSpec.describe Services::HandleSubmissionForStore do
         )
         .to_return(
           status: 200,
-          body: previously_funded_response(false),
+          body: ecf_funding_lookup_response(previously_funded: false),
           headers: {
             "Content-Type" => "application/vnd.api+json",
           },
@@ -695,7 +695,7 @@ RSpec.describe Services::HandleSubmissionForStore do
               )
               .to_return(
                 status: 200,
-                body: previously_funded_response(false),
+                body: ecf_funding_lookup_response(previously_funded: false),
                 headers: {
                   "Content-Type" => "application/vnd.api+json",
                 },

--- a/spec/models/registration_wizard_spec.rb
+++ b/spec/models/registration_wizard_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe RegistrationWizard do
         )
        .to_return(
          status: 200,
-         body: previously_funded_response(false),
+         body: ecf_funding_lookup_response(previously_funded: false),
          headers: {
            "Content-Type" => "application/vnd.api+json",
          },

--- a/spec/support/api_responses.rb
+++ b/spec/support/api_responses.rb
@@ -25,8 +25,9 @@ def participant_validator_response(trn: "1234567", active_alert: false)
   }.to_json
 end
 
-def previously_funded_response(previously_funded)
+def ecf_funding_lookup_response(previously_funded:, previously_received_targeted_funding_support: false)
   {
     previously_funded:,
+    previously_received_targeted_funding_support:,
   }.to_json
 end

--- a/spec/support/shared_contexts/stub_course_ecf_to_identifier_mappings.rb
+++ b/spec/support/shared_contexts/stub_course_ecf_to_identifier_mappings.rb
@@ -9,7 +9,7 @@ RSpec.shared_context("stub course ecf to identifier mappings") do
         )
         .to_return(
           status: 200,
-          body: previously_funded_response(false),
+          body: ecf_funding_lookup_response(previously_funded: false),
           headers: {
             "Content-Type" => "application/vnd.api+json",
           },


### PR DESCRIPTION
### Context

https://dfedigital.atlassian.net/browse/CPDNPQ-723

### Changes proposed in this pull request

`targeted_delivery_funding_eligibility` is now filtered through a check to the ECF DB for whether the user has already been received targeted delivery funding for the course they have selected on an accepted application. If they have, they won't be funded.

I've moved the check for this into Services::FundingEligibility to make sure we don't make multiple queries to the ECF API.
