### PR TITLE
Remove amazon voucher incentive

### DIFF
--- a/app/views/registration_wizard/confirmation.html.erb
+++ b/app/views/registration_wizard/confirmation.html.erb
@@ -41,7 +41,7 @@
     <% end %>
 
     <div class="govuk-inset-text">
-      <%= govuk_link_to "Tell us about your experience", "https://docs.google.com/forms/d/e/1FAIpQLScAD7XvFlHl8LzfSyxstYErWMiFPXGamrA_qBhBJTGXuP9efw/viewform?usp=sf_link", target: "_blank", rel: "noreferrer noopener" %> of registering for an NPQ. Your views help us improve. 
+      <%= govuk_link_to "Tell us about your experience", "https://docs.google.com/forms/d/e/1FAIpQLScAD7XvFlHl8LzfSyxstYErWMiFPXGamrA_qBhBJTGXuP9efw/viewform?usp=sf_link", target: "_blank", rel: "noreferrer noopener" %> of registering for an NPQ. Your views help us improve this service. 
     </div>
   </div>
 </div>

--- a/app/views/registration_wizard/confirmation.html.erb
+++ b/app/views/registration_wizard/confirmation.html.erb
@@ -41,7 +41,7 @@
     <% end %>
 
     <div class="govuk-inset-text">
-      <%= govuk_link_to "Tell us about your experience", "https://docs.google.com/forms/d/e/1FAIpQLScAD7XvFlHl8LzfSyxstYErWMiFPXGamrA_qBhBJTGXuP9efw/viewform?usp=sf_link", target: "_blank", rel: "noreferrer noopener" %> of registering for an NPQ for the possibility to be called for further research. If you are chosen and participate you will receive a £40 Amazon voucher.
+      <%= govuk_link_to "Tell us about your experience", "https://docs.google.com/forms/d/e/1FAIpQLScAD7XvFlHl8LzfSyxstYErWMiFPXGamrA_qBhBJTGXuP9efw/viewform?usp=sf_link", target: "_blank", rel: "noreferrer noopener" %> of registering for an NPQ. Your views help us improve. 
     </div>
   </div>
 </div>


### PR DESCRIPTION
We're no longer running UR sessions. 

Make copy more general about giving us feedback, rather than about getting called for research. 

This includes removing any reference to an incentive. 
