### PR TITLE
Downcase all emails from the TraOpenidConnect provider

### DIFF
--- a/lib/omniauth/strategies/tra_openid_connect.rb
+++ b/lib/omniauth/strategies/tra_openid_connect.rb
@@ -18,7 +18,7 @@ module Omniauth
       info do
         {
           date_of_birth: parsed_date_of_birth,
-          email: raw_info["email"],
+          email: raw_info["email"].downcase,
           email_verified: parsed_email_verified,
           name: raw_info["name"],
           trn: raw_info["trn"],


### PR DESCRIPTION
### Context

Emails are stored in the database as downcased strings, this downcasing occurs after validation. Emails coming back from the TRA are not downcased meaning that a find_or_initialize_by using this data without downcasing would lead to a new record with the non-downcased string being created. When this goes to be persisted it would trigger a validation error.

### Changes proposed in this pull request

- Downcase all emails coming from the TRA integration.


