### PR TITLE
Expect works_in_nursery to be nil not false

### DIFF
--- a/spec/features/happy_journeys/non_js/previously_received_targeted_delivery_funding_spec.rb
+++ b/spec/features/happy_journeys/non_js/previously_received_targeted_delivery_funding_spec.rb
@@ -171,7 +171,7 @@ RSpec.feature "Happy journeys", type: :feature do
       "teacher_catchment_synced_to_ecf" => false,
       "ukprn" => nil,
       "works_in_childcare" => false,
-      "works_in_nursery" => false,
+      "works_in_nursery" => nil,
       "works_in_school" => true,
       "work_setting" => "a_school",
       "raw_application_data" => {


### PR DESCRIPTION
### Context

All the other mentions are now `nil` and the field no longer appears to be used.

For reference, all the assertions in the test prior to this change:

```bash
$ ag --nofilename works_in_nursery spec/ | strip-blank-lines | trim | sort | uniq -c
      1 "works_in_nursery" => false,
     50 "works_in_nursery" => nil,
```

