### PR TITLE
[CPDNPQ-655] Record logs to the DB of sync requests to the ECF DB

### DIFF
--- a/app/lib/services/ecf/ecf_user_creator.rb
+++ b/app/lib/services/ecf/ecf_user_creator.rb
@@ -9,8 +9,26 @@ module Services
 
       def call
         remote = EcfApi::User.new(email: user.email, full_name: user.full_name)
+
+        # JsonApiClient::Resource uses errors for flow control, so failed saves
+        # will divert to the rescue block below
+        # I'd prefer to use the return value of save, but that's not possible
         remote.save
         user.update!(ecf_id: remote.id)
+
+        EcfSyncRequestLog.create(
+          sync_type: :user_creation,
+          syncable: user,
+          status: :success,
+        )
+      rescue StandardError => e
+        EcfSyncRequestLog.create(
+          sync_type: :user_creation,
+          syncable: user,
+          status: :failed,
+          error_messages: ["#{e.class} - #{e.message}"],
+          response_body: e.env["response_body"],
+        )
       end
     end
   end

--- a/app/lib/services/ecf/ecf_user_creator.rb
+++ b/app/lib/services/ecf/ecf_user_creator.rb
@@ -29,6 +29,10 @@ module Services
           error_messages: ["#{e.class} - #{e.message}"],
           response_body: e.env["response_body"],
         )
+        Sentry.with_scope do |scope|
+          scope.set_context("User", { id: user.id })
+          Sentry.capture_exception(e)
+        end
       end
     end
   end

--- a/app/lib/services/ecf/npq_profile_creator.rb
+++ b/app/lib/services/ecf/npq_profile_creator.rb
@@ -38,10 +38,28 @@ module Services
           },
         )
 
+        # JsonApiClient::Resource uses errors for flow control, so failed saves
+        # will divert to the rescue block below
+        # I'd prefer to use the return value of save, but that's not possible
         profile.save
+
         application.update!(
           ecf_id: profile.id,
           teacher_catchment_synced_to_ecf: true,
+        )
+
+        EcfSyncRequestLog.create(
+          sync_type: :application_creation,
+          syncable: application,
+          status: :success,
+        )
+      rescue StandardError => e
+        EcfSyncRequestLog.create(
+          sync_type: :application_creation,
+          syncable: application,
+          status: :failed,
+          error_messages: ["#{e.class} - #{e.message}"],
+          response_body: e.env["response_body"],
         )
       end
 

--- a/app/lib/services/ecf/npq_profile_creator.rb
+++ b/app/lib/services/ecf/npq_profile_creator.rb
@@ -61,6 +61,10 @@ module Services
           error_messages: ["#{e.class} - #{e.message}"],
           response_body: e.env["response_body"],
         )
+        Sentry.with_scope do |scope|
+          scope.set_context("Application", { id: application.id })
+          Sentry.capture_exception(e)
+        end
       end
 
     private

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -5,6 +5,8 @@ class Application < ApplicationRecord
   belongs_to :school, foreign_key: "school_urn", primary_key: "urn", optional: true
   belongs_to :private_childcare_provider, foreign_key: "private_childcare_provider_urn", primary_key: "provider_urn", optional: true
 
+  has_many :ecf_sync_request_logs, as: :syncable, dependent: :destroy
+
   scope :unsynced, -> { where(ecf_id: nil) }
 
   enum kind_of_nursery: {

--- a/app/models/ecf_sync_request_log.rb
+++ b/app/models/ecf_sync_request_log.rb
@@ -1,0 +1,16 @@
+class EcfSyncRequestLog < ApplicationRecord
+  belongs_to :syncable, polymorphic: true
+
+  validates :syncable, presence: true
+  validates :status, presence: true
+  validates :sync_type, presence: true
+
+  enum status: {
+    success: "success",
+    failed: "failed",
+  }
+  enum sync_type: {
+    user_creation: "user_creation",
+    application_creation: "application_creation",
+  }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   devise :omniauthable, omniauth_providers: [:tra_openid_connect]
 
   has_many :applications, dependent: :destroy
+  has_many :ecf_sync_request_logs, as: :syncable, dependent: :destroy
 
   validates :email, uniqueness: true
 

--- a/db/migrate/20221213151804_create_ecf_sync_request_logs.rb
+++ b/db/migrate/20221213151804_create_ecf_sync_request_logs.rb
@@ -1,0 +1,16 @@
+class CreateEcfSyncRequestLogs < ActiveRecord::Migration[6.1]
+  def change
+    create_table :ecf_sync_request_logs do |t|
+      t.integer :syncable_id, null: false
+      t.string :syncable_type, null: false
+      t.string :status, null: false
+      t.string :sync_type, null: false
+      t.jsonb :error_messages, default: []
+      t.jsonb :response_body
+
+      t.index(%i[syncable_id syncable_type])
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_30_142333) do
+ActiveRecord::Schema.define(version: 2022_12_13_151804) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -75,6 +75,18 @@ ActiveRecord::Schema.define(version: 2022_11_30_142333) do
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
+  end
+
+  create_table "ecf_sync_request_logs", force: :cascade do |t|
+    t.integer "syncable_id", null: false
+    t.string "syncable_type", null: false
+    t.string "status", null: false
+    t.string "sync_type", null: false
+    t.jsonb "error_messages", default: []
+    t.jsonb "response_body"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["syncable_id", "syncable_type"], name: "index_ecf_sync_request_logs_on_syncable_id_and_syncable_type"
   end
 
   create_table "flipper_features", force: :cascade do |t|

--- a/spec/lib/services/ecf/ecf_user_creator_spec.rb
+++ b/spec/lib/services/ecf/ecf_user_creator_spec.rb
@@ -18,15 +18,6 @@ RSpec.describe Services::Ecf::EcfUserCreator do
       }.to_json
     end
 
-    let(:response_body) do
-      {
-        data: {
-          type: "user",
-          id: "123",
-        },
-      }.to_json
-    end
-
     before do
       stub_request(:post, "https://ecf-app.gov.uk/api/v1/users")
         .with(
@@ -38,18 +29,121 @@ RSpec.describe Services::Ecf::EcfUserCreator do
           },
         )
         .to_return(
-          status: 201,
-          body: response_body,
+          status: response_code,
+          body: response_body.to_json,
           headers: {
             "Content-Type" => "application/vnd.api+json",
           },
         )
     end
 
-    it "sets user.ecf_id with returned guid" do
-      subject.call
-      user.reload
-      expect(user.ecf_id).to eql("123")
+    context "when authorized" do
+      let(:response_code) { 201 }
+      let(:response_body) do
+        {
+          data: {
+            type: "user",
+            id: "123",
+          },
+        }
+      end
+
+      it "sets user.ecf_id with returned guid" do
+        expect {
+          subject.call
+        }.to change(user, :ecf_id).to("123")
+      end
+
+      it "creates a EcfSyncRequestLog with status :success" do
+        expect {
+          subject.call
+        }.to change(EcfSyncRequestLog, :count).by(1)
+
+        expect(
+          EcfSyncRequestLog.last.slice(:syncable, :status, :error_messages, :response_body, :sync_type),
+        ).to match(
+          "syncable" => user,
+          "status" => "success",
+          "error_messages" => [],
+          "response_body" => nil,
+          "sync_type" => "user_creation",
+        )
+      end
+
+      context "when save fails" do
+        let(:error_array) do
+          [
+            {
+              "title" => "Invalid action",
+              "detail" => "Validation failed: Email Enter an email address in the correct format, like name@example.com",
+            },
+          ]
+        end
+
+        let(:response_body) do
+          {
+            "errors": error_array,
+          }
+        end
+
+        let(:response_code) { 400 }
+
+        it "does not set application.ecf_id " do
+          expect {
+            subject.call
+          }.to_not change(user, :ecf_id)
+        end
+
+        it "creates a EcfSyncRequestLog with status :failed" do
+          expect {
+            subject.call
+          }.to change(EcfSyncRequestLog, :count).by(1)
+
+          expect(
+            EcfSyncRequestLog.last.slice(:syncable, :status, :error_messages, :response_body, :sync_type),
+          ).to match(
+            "syncable" => user,
+            "status" => "failed",
+            "error_messages" => [
+              "JsonApiClient::Errors::ClientError - Invalid action",
+            ],
+            "response_body" => response_body,
+            "sync_type" => "user_creation",
+          )
+        end
+      end
+    end
+
+    context "when unauthorized" do
+      let(:response_code) { 401 }
+
+      let(:response_body) do
+        {
+          "error" => "HTTP Token: Access denied",
+        }
+      end
+
+      it "does not set application.ecf_id " do
+        expect {
+          subject.call
+        }.to_not change(user, :ecf_id)
+      end
+
+      it "creates a EcfSyncRequestLog with status :failed" do
+        expect {
+          subject.call
+        }.to change(EcfSyncRequestLog, :count).by(1)
+
+        expect(
+          EcfSyncRequestLog.last.slice(:syncable, :status, :error_messages, :response_body, :sync_type),
+        ).to match(
+          "syncable" => user,
+          "status" => "failed",
+          "error_messages" => ["JsonApiClient::Errors::NotAuthorized - JsonApiClient::Errors::NotAuthorized"],
+          "response_body" => response_body,
+          "sync_type" => "user_creation",
+        )
+      end
     end
   end
 end

--- a/spec/lib/services/ecf/npq_profile_creator_spec.rb
+++ b/spec/lib/services/ecf/npq_profile_creator_spec.rb
@@ -117,17 +117,127 @@ RSpec.describe Services::Ecf::NpqProfileCreator do
           },
         )
         .to_return(
-          status: 200,
-          body: response_body,
+          status: response_code,
+          body: response_body.to_json,
           headers: {
             "Content-Type" => "application/vnd.api+json",
           },
         )
     end
 
-    it "sets application.ecf_id with returned guid" do
-      subject.call
-      expect(application.ecf_id).to eql("789")
+    context "when authorized" do
+      let(:response_code) { 200 }
+
+      let(:response_body) do
+        {
+          data: {
+            type: "npq_profiles",
+            id: "789",
+          },
+        }
+      end
+
+      it "sets application.ecf_id with returned guid" do
+        expect {
+          subject.call
+        }.to change(application, :ecf_id).to("789")
+      end
+
+      it "creates a EcfSyncRequestLog with status :success" do
+        expect {
+          subject.call
+        }.to change(EcfSyncRequestLog, :count).by(1)
+
+        expect(
+          EcfSyncRequestLog.last.slice(:syncable, :status, :error_messages, :response_body, :sync_type),
+        ).to match(
+          "syncable" => application,
+          "status" => "success",
+          "error_messages" => [],
+          "response_body" => nil,
+          "sync_type" => "application_creation",
+        )
+      end
+
+      context "when save fails" do
+        let(:error_array) do
+          [
+            {
+              "title": "Participant identity blank",
+              "detail": "must exist",
+            },
+            {
+              "title": "NPQ lead provider blank",
+              "detail": "must exist",
+            },
+            {
+              "title": "NPQ course blank",
+              "detail": "must exist",
+            },
+          ]
+        end
+        let(:response_body) do
+          {
+            "errors": error_array,
+          }
+        end
+
+        let(:response_code) { 400 }
+
+        it "does not set application.ecf_id " do
+          expect {
+            subject.call
+          }.to_not change(application, :ecf_id)
+        end
+
+        it "creates a EcfSyncRequestLog with status :failed" do
+          expect {
+            subject.call
+          }.to change(EcfSyncRequestLog, :count).by(1)
+
+          expect(
+            EcfSyncRequestLog.last.slice(:syncable, :status, :error_messages, :response_body, :sync_type),
+          ).to match(
+            "syncable" => application,
+            "status" => "failed",
+            "error_messages" => ["JsonApiClient::Errors::ClientError - Participant identity blank; NPQ lead provider blank; NPQ course blank"],
+            "response_body" => response_body,
+            "sync_type" => "application_creation",
+          )
+        end
+      end
+    end
+
+    context "when unauthorized" do
+      let(:response_code) { 401 }
+
+      let(:response_body) do
+        {
+          "error" => "HTTP Token: Access denied",
+        }
+      end
+
+      it "does not set application.ecf_id " do
+        expect {
+          subject.call
+        }.to_not change(application, :ecf_id)
+      end
+
+      it "creates a EcfSyncRequestLog with status :failed" do
+        expect {
+          subject.call
+        }.to change(EcfSyncRequestLog, :count).by(1)
+
+        expect(
+          EcfSyncRequestLog.last.slice(:syncable, :status, :error_messages, :response_body, :sync_type),
+        ).to match(
+          "syncable" => application,
+          "status" => "failed",
+          "error_messages" => ["JsonApiClient::Errors::NotAuthorized - JsonApiClient::Errors::NotAuthorized"],
+          "response_body" => response_body,
+          "sync_type" => "application_creation",
+        )
+      end
     end
   end
 end

--- a/spec/models/ecf_sync_request_log_spec.rb
+++ b/spec/models/ecf_sync_request_log_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe EcfSyncRequestLog, type: :model do
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:syncable) }
+    it { is_expected.to validate_presence_of(:status) }
+    it { is_expected.to validate_presence_of(:sync_type) }
+  end
+end


### PR DESCRIPTION
### Context

We are building out a set of tools in the admin interface for making sure users are properly synced to the ECF DB. Right now there isn't explicit logging of the results of syncing, making it harder to see when and why a sync attempt failed.

### Changes proposed in this pull request

- Add in DB logging for sync requests

