### PR TITLE
Increase worker memory to 2G

### DIFF
--- a/config/manifests/prod-manifest.yml
+++ b/config/manifests/prod-manifest.yml
@@ -11,6 +11,7 @@ applications:
     instances: 2
   - type: worker
     disk_quota: 2G
+    memory: 2G
     health-check-type: process
     instances: 2
     command: bundle exec rake jobs:work


### PR DESCRIPTION
### Context

We had some 'out of memory' crashes in prod. It looked like the Dashboard job might've been hungrier than expected. Boosting to 2G is a short term fix, we really should ensure the heavy lifting jobs are more efficient in the long run.

