### PR TITLE
link to PDTL site from home page

### DIFF
--- a/app/views/pages/_choose_an_npq_and_provider_content.erb
+++ b/app/views/pages/_choose_an_npq_and_provider_content.erb
@@ -6,24 +6,9 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Choose an NPQ and provider</h1>
 
-    <p class="govuk-body">Visit <a href="https://professional-development-for-teachers-leaders.education.gov.uk/">Professional development for teachers and leaders</a> to see what NPQs are available.</p>
+    <p class="govuk-body">Visit <a href="https://professional-development-for-teachers-leaders.education.gov.uk/">Professional development for teachers and leaders</a> to explore NPQs and providers.</p>
 
-    <p class="govuk-body">Your employer can help you choose an NPQ that’s suitable for you. They may also have a recommended provider for your training.</p>
-
-    <p class="govuk-body">Providers include:</p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li><a class="govuk-link" href="https://www.ambition.org.uk/blog/how-new-npqs-will-make-professional-development-work-your-school/">Ambition Institute</a></li>
-      <li><a class="govuk-link" href="https://www.outstandingleaders.org/npq">Best Practice Network (home of Outstanding Leaders Partnership)</a></li>
-      <li><a class="govuk-link" href="https://www.cefel.org.uk/npq/">Church of England</a></li>
-      <li><a class="govuk-link" href="https://www.educationdevelopmenttrust.com/npqs">Education Development Trust</a></li>
-      <li><a class="govuk-link" href="http://www.llse.org.uk/">LLSE</a></li>
-      <li><a class="govuk-link" href="https://tdtrust.org/npqs/">Teacher Development Trust</a></li>
-      <li><a class="govuk-link" href="http://www.teachfirst.org.uk/npqs">Teach First</a></li>
-      <li><a class="govuk-link" href="https://www.ucl.ac.uk/ioe/departments-and-centres/centres/ucl-centre-educational-leadership/national-professional-qualification-programmes">UCL Institute of Education</a></li>
-    </ul>
-
-    <p class="govuk-body">Not every provider will necessarily offer every NPQ. Talk to your employer or check with individual providers for advice.</p>
+    <p class="govuk-body">If you’re employed, speak to your manager for support. They may have a recommended provider for your training.</p>
 
   </div>
 </div>

--- a/app/views/pages/_choose_an_npq_and_provider_content.erb
+++ b/app/views/pages/_choose_an_npq_and_provider_content.erb
@@ -18,7 +18,6 @@
       <li><a class="govuk-link" href="https://www.cefel.org.uk/npq/">Church of England</a></li>
       <li><a class="govuk-link" href="https://www.educationdevelopmenttrust.com/npqs">Education Development Trust</a></li>
       <li><a class="govuk-link" href="http://www.llse.org.uk/">LLSE</a></li>
-      <li><a class="govuk-link" href="https://niot.org.uk/">National Institute of Teaching</a></li>
       <li><a class="govuk-link" href="https://tdtrust.org/npqs/">Teacher Development Trust</a></li>
       <li><a class="govuk-link" href="http://www.teachfirst.org.uk/npqs">Teach First</a></li>
       <li><a class="govuk-link" href="https://www.ucl.ac.uk/ioe/departments-and-centres/centres/ucl-centre-educational-leadership/national-professional-qualification-programmes">UCL Institute of Education</a></li>

--- a/app/views/registration_wizard/start.html.erb
+++ b/app/views/registration_wizard/start.html.erb
@@ -8,7 +8,7 @@
 
     <h2 class="govuk-heading-m">Before you start</h2>
 
-    <p class="govuk-body"><%= govuk_link_to("Choose an NPQ and provider", root_path) %>.</p>
+    <p class="govuk-body"><a href="https://professional-development-for-teachers-leaders.education.gov.uk/" class="govuk-link">Choose an NPQ and provider</a>.</p>
 
     <p class="govuk-body">If you work in early years or childcare, <%= govuk_link_to("check if your workplace is registered with Ofsted", "https://reports.ofsted.gov.uk/childcare") %> and get their Ofsted unique reference number (URN) if they have one.</p>
 

--- a/app/views/registration_wizard/start.html.erb
+++ b/app/views/registration_wizard/start.html.erb
@@ -8,7 +8,7 @@
 
     <h2 class="govuk-heading-m">Before you start</h2>
 
-    <p class="govuk-body"><%= govuk_link_to("Choose an NPQ and provider", choose_an_npq_and_provider_path) %>.</p>
+    <p class="govuk-body"><a href="https://professional-development-for-teachers-leaders.education.gov.uk/" class="govuk-link">Choose an NPQ and provider</a>.</p>
 
     <p class="govuk-body">If you work in early years or childcare, <%= govuk_link_to("check if your workplace is registered with Ofsted", "https://reports.ofsted.gov.uk/childcare") %> and get their Ofsted unique reference number (URN) if they have one.</p>
 

--- a/app/views/registration_wizard/start.html.erb
+++ b/app/views/registration_wizard/start.html.erb
@@ -8,7 +8,7 @@
 
     <h2 class="govuk-heading-m">Before you start</h2>
 
-    <p class="govuk-body"><a href="https://professional-development-for-teachers-leaders.education.gov.uk/" class="govuk-link">Choose an NPQ and provider</a>.</p>
+    <p class="govuk-body"><%= govuk_link_to("Choose an NPQ and provider", root_path) %>.</p>
 
     <p class="govuk-body">If you work in early years or childcare, <%= govuk_link_to("check if your workplace is registered with Ofsted", "https://reports.ofsted.gov.uk/childcare") %> and get their Ofsted unique reference number (URN) if they have one.</p>
 


### PR DESCRIPTION
## What

Update this link destination. 

<img width="877" alt="Screenshot 2022-12-28 at 12 57 16" src="https://user-images.githubusercontent.com/56349171/209815824-2e784453-459f-444a-8494-5ed6236cf39c.png">

| Current destination | Proposed destination |
| ------------- |:-------------:|
| <img width="602" alt="Screenshot 2022-12-28 at 12 57 42" src="https://user-images.githubusercontent.com/56349171/209815858-9ba9e762-e9c7-4d0f-b9f2-a2dc98398bcd.png">      | <img width="854" alt="Screenshot 2022-12-28 at 13 01 56" src="https://user-images.githubusercontent.com/56349171/209816367-74c3bcd1-168a-4378-b7ca-569542c520d1.png">     |

## Why?

The 'Choose an NPQ and provider' page duplicates content on the PDTL site. The PDTL now lists providers. 

## Other issues 

The 'Choose and NPQ and provider' page also shows if you answer 'No' to the question 'Have you already chosen an NPQ and provider?' 

<img width="657" alt="Screenshot 2022-12-28 at 14 39 11" src="https://user-images.githubusercontent.com/56349171/209828549-10d329f3-d48c-44a5-8a02-c8b8edb38304.png">

I've proposed removing the provider list on this page for now, to avoid duplication with the PDTL site.

| Current content | Proposed content |
| ------------- |:-------------:|
| <img width="613" alt="Screenshot 2022-12-28 at 14 40 20" src="https://user-images.githubusercontent.com/56349171/209828686-97cd8e81-df35-4379-babb-ce84c703a28e.png">      | <img width="669" alt="Screenshot 2022-12-28 at 14 41 37" src="https://user-images.githubusercontent.com/56349171/209828841-ede65d19-5d48-485e-8a47-e0a179f82fbc.png">     |

## Next steps 

We should review whether the 'Choose an NPQ and provider' page and the question 'Have you already chosen an NPQ and provider?' is needed at all. 

We do already inform people that you need to choose an NPQ and provider on the start page. 

Is there evidence to suggest that people come to the NPQ service without already knowing their NPQ and provider?
