### PR TITLE
Run update before trying to install any packages

### DIFF
--- a/.github/workflows/export_dashboard_report.yml
+++ b/.github/workflows/export_dashboard_report.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Install CloudFoundry CLI
         shell: bash
         run: |
+          apt-get update
           apt-get install -y wget postgresql-client
           wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | apt-key add -
           echo "deb https://packages.cloudfoundry.org/debian stable main" | tee /etc/apt/sources.list.d/cloudfoundry-cli.list
-          apt-get update
           apt-get install cf7-cli
 
       - name: Install conduit plugin


### PR DESCRIPTION
### Context and changes

When we try to install postgresql-client without having run `apt-get update` first we try to pull an old version that's no longer in the repository, and get the following error:

```
E: Failed to fetch http://deb.debian.org/debian/pool/main/p/postgresql-13/postgresql-client-13_13.8-0%2bdeb11u1_amd64.deb
```

Running apt-get update first should resolve it and pull the latest available one.
