### PR TITLE
Run apt-get update before installing cf7-cli

### DIFF
--- a/.github/workflows/export_dashboard_report.yml
+++ b/.github/workflows/export_dashboard_report.yml
@@ -18,11 +18,10 @@ jobs:
       - name: Install CloudFoundry CLI
         shell: bash
         run: |
-          apt-get update
-          apt-get install -y wget postgresql-client
           wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | apt-key add -
           echo "deb https://packages.cloudfoundry.org/debian stable main" | tee /etc/apt/sources.list.d/cloudfoundry-cli.list
-          apt-get install cf7-cli
+          apt-get update
+          apt-get install -y wget postgresql-client cf7-cli
 
       - name: Install conduit plugin
         shell: bash


### PR DESCRIPTION
### Context

We need to re-run `apt-get update` after adding a new source too other wise it won't find packages from the new repo.
