### PR TITLE
Install ca-certificates before adding keys when running export dashboard report

### DIFF
--- a/.github/workflows/export_dashboard_report.yml
+++ b/.github/workflows/export_dashboard_report.yml
@@ -18,10 +18,12 @@ jobs:
       - name: Install CloudFoundry CLI
         shell: bash
         run: |
+          apt-get update
+          apt-get install -y ca-certificates wget
           wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | apt-key add -
           echo "deb https://packages.cloudfoundry.org/debian stable main" | tee /etc/apt/sources.list.d/cloudfoundry-cli.list
           apt-get update
-          apt-get install -y wget postgresql-client cf7-cli
+          apt-get install -y postgresql-client cf7-cli
 
       - name: Install conduit plugin
         shell: bash


### PR DESCRIPTION
So my previous attempt #634 wasn't quite right 🤦🏽‍♂️ 

The export dashboard report job failed for various reasons including:

```
gpg: no valid OpenPGP data found.
```

It seems that installing the `ca-certificates` helps.

This approach [definitely works](https://github.com/DFE-Digital/npq-registration/actions/runs/3839356212/jobs/6537007682) and has been tested.

