### PR TITLE
Only display users once in the unsynced users list

### DIFF
--- a/app/controllers/admin/unsynced_users_controller.rb
+++ b/app/controllers/admin/unsynced_users_controller.rb
@@ -8,6 +8,6 @@ class Admin::UnsyncedUsersController < AdminController
 private
 
   def scope
-    User.unsynced.joins(:applications).order(created_at: :desc)
+    User.unsynced.joins(:applications).distinct.order(created_at: :desc)
   end
 end

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -333,7 +333,7 @@ RSpec.feature "admin", type: :feature do
     # Unsynced users with applications should appear in the list.
     unsynced_users = create_list(:user, 2)
     unsynced_users.each do |unsynced_user|
-      create(:application, user: unsynced_user)
+      create_list(:application, 2, user: unsynced_user)
     end
 
     page.click_link("Unsynced users")


### PR DESCRIPTION
### Context

Without a distinct users appear twice due to the join

### Changes proposed in this pull request

Apply distinct to the query

