### PR TITLE
Copy feature flags to all users on login

### DIFF
--- a/app/lib/forms/confirm_email.rb
+++ b/app/lib/forms/confirm_email.rb
@@ -24,11 +24,13 @@ module Forms
     end
 
     def after_save
-      user = User.find_or_create_by!(email: wizard.store["email"]) do |new_user|
-        # Transfer feature flag from NullUser to User when created, if the user
-        # already exists then the user will revert to their original set of flags.
-        new_user.feature_flag_id = wizard.session["feature_flag_id"]
-      end
+      user = User.find_or_create_by!(email: wizard.store["email"])
+
+      # Set the feature flag ID on the logged in user to match the session's existing ID.
+      # This way the user has a smooth journey through the app and isn't suddenly swapped
+      # from one A/B tested feature to another.
+      user.update!(feature_flag_id: wizard.session["feature_flag_id"])
+
       # TODO: protect against session fixation
       wizard.session["user_id"] = user.id
       wizard.store["confirmed_email"] = user.email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,8 +19,7 @@ class User < ApplicationRecord
   def self.find_or_create_from_tra_data_on_uid(provider_data, feature_flag_id:)
     user_from_provider_data = find_or_initialize_by(provider: provider_data.provider, uid: provider_data.uid)
 
-    # Only set this if the user doesn't already have a feature flag profile
-    user_from_provider_data.feature_flag_id ||= feature_flag_id
+    user_from_provider_data.feature_flag_id = feature_flag_id
 
     trn = provider_data.info.trn
 
@@ -39,8 +38,7 @@ class User < ApplicationRecord
   def self.find_or_create_from_tra_data_on_unclaimed_email(provider_data, feature_flag_id:)
     user_from_provider_data = find_or_initialize_by(provider: nil, uid: nil, email: provider_data.info.email)
 
-    # Only set this if the user doesn't already have a feature flag profile
-    user_from_provider_data.feature_flag_id ||= feature_flag_id
+    user_from_provider_data.feature_flag_id = feature_flag_id
 
     trn = provider_data.info.trn
 

--- a/spec/features/happy_journeys/js/entering_different_email_in_get_an_identity_and_outside_pilot_spec.rb
+++ b/spec/features/happy_journeys/js/entering_different_email_in_get_an_identity_and_outside_pilot_spec.rb
@@ -1,0 +1,290 @@
+require "rails_helper"
+
+RSpec.feature "Happy journeys", type: :feature do
+  include Helpers::JourneyHelper
+  include Helpers::JourneyAssertionHelper
+
+  include_context "retrieve latest application data"
+  include_context "stub course ecf to identifier mappings"
+  include_context "Enable Get An Identity integration"
+
+  # This controls what is returned from the Get An Identity API
+  let(:user_trn) { "" }
+
+  let(:non_pilot_user_email) { "mail@example.com" }
+
+  before do
+    # create the user that the user will log in as in the non-pilot journey
+    create(:user, email: non_pilot_user_email, trn: nil)
+  end
+
+  # This spec was created to replicate a bug that’s triggered 80 times over about 3 months and leads to a full error page
+  # for users who encounter it. This flow seems like such an extreme edge-case that it can’t be the only trigger for this bug.
+  #
+  # 1. Go through the GAI flow without a verified TRN, return and be removed from the pilot as no TRN is returned.
+  # 2. Go through the non-GAI flow until you reach the email input, enter a different email to the one you used on GAI
+  #    for a user that already exists that doesn’t have a TRN on the record. You will be logged in as this user.
+  # 3. Enter your TRN on the TRN step, it is required and you cannot proceed without one.
+  # 4. Proceed and complete the Choose your NPQ page.
+  # 5. Encounter a 500 error.
+  #
+  # You encounter a 500 error here because after the Choose your NPQ page a funding eligibility check is performed.
+  # This check requires your TRN.
+  #
+  # Since your email was already on a user record when you entered it on the email input page you were logged in as
+  # that user but importantly that user did not have your feature flag ID copied across
+  # (since it’s only copied for new users) and so your feature flags reset to the flags for that user.
+  # This user’s flags more than likely would leave you as a part of the pilot.
+  #
+  # Because you were still considered a part of the pilot during the eligibility check the TRN for the user would be
+  # looked up on the user record in the wrong place looking where it would be for GAI users instead of for non-GAI users.
+  # Then it tries to use nil when constructing the URL and fails.
+  # The solution I found was to just copy feature flags during log in for new and existing uses.
+  # This overall is a better approach IMO because it’s not a great idea to have any user suddenly jump from one set of flags to another.
+  #
+  # The solution was to copy the feature flags from the session ID to the user even if it isn't a new user being created.
+  scenario "registration journey when entering an email for a user record without a TRN after being removed from the pilot" do
+    stub_participant_validation_request
+
+    navigate_to_page(path: "/", submit_form: false, axe_check: false) do
+      expect(page).to have_text("Before you start")
+      page.click_link("Start now")
+    end
+
+    expect_page_to_have(path: "/registration/teacher-reference-number", submit_form: true) do
+      page.choose("Yes", visible: :all)
+    end
+
+    expect(page).not_to have_content("Do you have a TRN?")
+
+    expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
+      expect(page).to have_text("Have you already chosen an NPQ and provider?")
+      page.choose("Yes", visible: :all)
+    end
+
+    # TODO: aria-expanded
+    expect_page_to_have(path: "/registration/teacher-catchment", axe_check: false, submit_form: true) do
+      page.choose("England", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/work-setting", submit_form: true) do
+      page.choose("A school", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/teacher-reference-number", submit_form: true) do
+      page.choose("Yes", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/contact-details", submit_form: true) do
+      expect(page).to have_text("What’s your email address?")
+
+      page.fill_in "What’s your email address?", with: non_pilot_user_email
+    end
+
+    expect_page_to_have(path: "/registration/confirm-email", submit_form: true) do
+      expect(page).to have_text("Confirm your email address")
+      expect(page).to have_text(non_pilot_user_email)
+      page.fill_in "Enter your code", with: "000000"
+      page.click_button("Continue")
+
+      expect(page).to have_text("Confirm your email address")
+      expect(page).to have_text("Code is not correct")
+
+      code = ActionMailer::Base.deliveries.last[:personalisation].unparsed_value[:code]
+
+      page.fill_in "Enter your code", with: code
+      page.click_button("Continue")
+    end
+
+    expect_page_to_have(path: "/registration/qualified-teacher-check", submit_form: true) do
+      expect(page).to have_text("Check your details")
+
+      page.fill_in "Teacher reference number (TRN)", with: "1234567"
+      page.fill_in "Full name", with: "John Doe"
+      page.fill_in "Day", with: "13"
+      page.fill_in "Month", with: "12"
+      page.fill_in "Year", with: "1980"
+      page.fill_in "National Insurance number", with: "AB123456C"
+    end
+
+    School.create!(urn: 100_000, name: "open manchester school", address_1: "street 1", town: "manchester", establishment_status_code: "1")
+    School.create!(urn: 100_001, name: "closed manchester school", address_1: "street 2", town: "manchester", establishment_status_code: "2")
+    School.create!(urn: 100_002, name: "open newcastle school", address_1: "street 3", town: "newcastle", establishment_status_code: "1")
+
+    expect_page_to_have(path: "/registration/find-school", submit_form: true) do
+      page.fill_in "Where is your workplace located?", with: "manchester"
+    end
+
+    expect_page_to_have(path: "/registration/choose-school", submit_form: true) do
+      expect(page).to have_text("Search for schools or 16 to 19 educational settings located in manchester. If you work for a trust, enter one of their schools.")
+
+      within ".npq-js-reveal" do
+        page.fill_in "What’s the name of your workplace?", with: "open"
+      end
+
+      expect(page).to have_content("open manchester school")
+
+      page.find("#school-picker__option--0").click
+      page.click_button("Continue")
+    end
+
+    expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do
+      expect(page).to have_text("What are you applying for?")
+      page.choose("NPQ for Headship (NPQH)", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
+      expect(page).to have_text("DfE scholarship funding is not available")
+      expect(page).to have_text("To be eligible for scholarship funding for")
+      expect(page).to have_text("state-funded schools")
+      expect(page).to have_text("state-funded 16 to 19 organisations")
+      expect(page).to have_text("independent special schools")
+      expect(page).to have_text("virtual schools")
+      expect(page).to have_text("hospital schools")
+      expect(page).to have_text("young offenders institutions")
+
+      page.click_link("Continue")
+    end
+
+    expect_page_to_have(path: "/registration/funding-your-npq", submit_form: true) do
+      expect(page).to have_text("How is your course being paid for?")
+      page.choose "My trust is paying", visible: :all
+    end
+
+    expect_page_to_have(path: "/registration/choose-your-provider", submit_form: true) do
+      expect(page).to have_text("Select your provider")
+      page.choose("Teach First", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/share-provider", submit_form: true) do
+      expect(page).to have_text("Sharing your NPQ information")
+      page.check("Yes, I agree my information can be shared", visible: :all)
+    end
+
+    allow(ApplicationSubmissionJob).to receive(:perform_later).with(anything)
+
+    expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
+      expect_check_answers_page_to_have_answers(
+        {
+          "Full name" => "John Doe",
+          "TRN" => "1234567",
+          "Date of birth" => "13 December 1980",
+          "National Insurance number" => "AB123456C",
+          "Email" => non_pilot_user_email,
+          "Course" => "NPQ for Headship (NPQH)",
+          "Lead provider" => "Teach First",
+          "Workplace" => "open manchester school",
+          "How is your NPQ being paid for?" => "My trust is paying",
+          "What setting do you work in?" => "A school",
+          "Where do you work?" => "England",
+        },
+      )
+    end
+
+    expect_page_to_have(path: "/registration/confirmation", submit_form: false) do
+      expect(page).to have_text("Your initial registration is complete")
+      expect(page).to have_text("The Early Headship Coaching Offer is a package of structured face-to-face support for new headteachers.")
+    end
+
+    expect(User.count).to eql(1)
+
+    User.last.tap do |user|
+      expect(user.email).to eql(non_pilot_user_email)
+      expect(user.full_name).to eql("John Doe")
+      expect(user.trn).to eql("1234567")
+      expect(user.trn_verified).to be_truthy
+      expect(user.trn_auto_verified).to be_truthy
+      expect(user.date_of_birth).to eql(Date.new(1980, 12, 13))
+      expect(user.national_insurance_number).to be_blank
+      expect(user.applications.count).to eql(1)
+
+      user.applications.first.tap do |application|
+        expect(application.eligible_for_funding).to be_falsey
+        expect(application.funding_choice).to eql("trust")
+      end
+    end
+
+    navigate_to_page(path: "/account", axe_check: false, submit_form: false) do
+      expect(page).to have_text("Teach First")
+      expect(page).to have_text("NPQ for Headship (NPQH)")
+    end
+
+    visit "/registration/share-provider"
+
+    expect_page_to_have(path: "/", axe_check: false, submit_form: false) do
+      expect(page).to have_content("Before you start")
+    end
+
+    expect(retrieve_latest_application_user_data).to eq(
+      "active_alert" => false,
+      "admin" => false,
+      "date_of_birth" => "1980-12-13",
+      "ecf_id" => nil,
+      "email" => non_pilot_user_email,
+      "flipper_admin_access" => false,
+      "full_name" => "John Doe",
+      "national_insurance_number" => nil,
+      "otp_expires_at" => nil,
+      "otp_hash" => nil,
+      "provider" => nil,
+      "raw_tra_provider_data" => nil,
+      "trn" => "1234567",
+      "trn_auto_verified" => true,
+      "trn_verified" => true,
+      "uid" => nil,
+    )
+
+    expect(retrieve_latest_application_data).to eq(
+      "cohort" => 2022,
+      "course_id" => Course.find_by_code(code: :NPQH).id,
+      "ecf_id" => nil,
+      "eligible_for_funding" => false,
+      "employer_name" => nil,
+      "employment_type" => nil,
+      "employment_role" => nil,
+      "funding_choice" => "trust",
+      "funding_eligiblity_status_code" => "ineligible_establishment_type",
+      "kind_of_nursery" => nil,
+      "headteacher_status" => nil,
+      "lead_provider_id" => LeadProvider.find_by(name: "Teach First").id,
+      "private_childcare_provider_urn" => nil,
+      "school_urn" => "100000",
+      "targeted_delivery_funding_eligibility" => false,
+      "targeted_support_funding_eligibility" => false,
+      "teacher_catchment" => "england",
+      "teacher_catchment_country" => nil,
+      "teacher_catchment_synced_to_ecf" => false,
+      "ukprn" => nil,
+      "works_in_childcare" => false,
+      "works_in_school" => true,
+      "works_in_nursery" => nil,
+      "work_setting" => "a_school",
+      "raw_application_data" => {
+        "active_alert" => false,
+        "can_share_choices" => "1",
+        "chosen_provider" => "yes",
+        "confirmed_email" => non_pilot_user_email,
+        "course_id" => Course.find_by_code(code: :NPQH).id.to_s,
+        "date_of_birth" => "1980-12-13",
+        "email" => non_pilot_user_email,
+        "full_name" => "John Doe",
+        "funding" => "trust",
+        "institution_identifier" => "School-100000",
+        "institution_location" => "manchester",
+        "institution_name" => "",
+        "lead_provider_id" => "9",
+        "national_insurance_number" => "AB123456C",
+        "teacher_catchment" => "england",
+        "teacher_catchment_country" => nil,
+        "trn" => "1234567",
+        "trn_auto_verified" => true,
+        "trn_knowledge" => "yes",
+        "trn_verified" => true,
+        "verified_trn" => "1234567",
+        "works_in_school" => "yes",
+        "works_in_childcare" => "no",
+        "work_setting" => "a_school",
+      },
+    )
+  end
+end


### PR DESCRIPTION
## Background 

The spec in this PR was created to replicate a bug that’s triggered 80 times over about 3 months ([viewable on Sentry here](https://sentry.io/organizations/dfe-teacher-services/issues/3792837223/?)) and leads to a full error page for users who encounter it that blocks progress. This flow seems like such an extreme edge-case that I'm not convinced that this is the trigger that lead to all 80 of those errors, but it is definitely *a* path to it triggering, so closing it is a positive change.

## Recreation steps

1. Go through the GAI flow without a verified TRN, return and be removed from the pilot as no TRN is returned.
2. Go through the non-GAI flow until you reach the email input, enter a different email to the one you used on GAI for a user that already exists that doesn’t have a TRN on the record. You will be logged in as this user.
3. Enter your TRN on the TRN step, it is required and you cannot proceed without one.
4. Proceed and complete the Choose your NPQ page.
5. Encounter a 500 error.

You encounter a 500 error here because after the Choose your NPQ page a funding eligibility check is performed. This check requires your TRN.

Since your email was already on a user record when you entered it on the email input page you were logged in as that user but importantly that user did not have your feature flag ID copied across (since it’s only copied for new users) and so your feature flags reset to the flags for that user. This user’s flags more than likely would leave you as a part of the pilot. 

Because you were still considered a part of the pilot during the eligibility check the TRN for the user would be looked up on the user record in the wrong place looking where it would be for GAI users instead of for non-GAI users. Then it tries to use nil when constructing the URL and fails. 

## Fix 

The solution I found was to just copy feature flags during log in for new and existing uses. This overall is a better approach IMO because it’s not a great idea to have any user suddenly jump from one set of flags to another. The solution was to copy the feature flags from the session ID to the user even if it isn't a new user being created.

Alongside changing the feature flag ID copying for the non-pilot journey I have updated it during the Get an Identity journey too. This way no matter what you'll always end up maintaining the feature flag state that you began your journey in, even if you have previously gone through the journey differently. The possible combinations of going from one set of flags to another is essentially untestable and will lead to a large amount of edge cases.