### PR TITLE
Raise GAI error if changes fail to persist

### DIFF
--- a/app/controllers/omniauth_controller.rb
+++ b/app/controllers/omniauth_controller.rb
@@ -13,7 +13,9 @@ class OmniauthController < Devise::OmniauthCallbacksController
       feature_flag_id: session["feature_flag_id"],
     )
 
-    if @user.persisted?
+    # @user.persisted? checks that it exists and has been persisted to the database
+    # @user.save checks that any changes made to an existing record have been persisted to that persisted record
+    if @user.persisted? && @user.save
       Services::Feature.enroll_user_in_get_an_identity_pilot(@user)
       session["user_id"] = @user.id
 


### PR DESCRIPTION
### Context

This change will detect issues preventing user records from updating. An example is this:

1. A user registered before the GAI pilot with email “mail@example.com”, this creates user A with email “mail@example.com” and no GAI ID.
2. After the pilot they registered via the GAI service with email “user@example.com”. This creates user B with the email “user@example.com” and a GAI ID.
3. The user then returns later to register again, entering user@example.com into GAI and logging into the GAI account with the ID corresponding to user B in our DB.
4. The user changes their email to “mail@example.com” in the GAI interface and proceeds back to NPQ.
5. The NPQ app tries to change the email on User B to “mail@example.com”. An error is encountered due to the uniqueness validation.

Currently this leads to errors later on in the process because .persisted? was true and the app assumed everything was okay as the save failed silently.

### Changes proposed in this pull request

This change makes it so that there is a final check that data is persisted before proceeding, if the changes to the existing app have not been persisted it will raise an error and not let the user proceed.
