### PR TITLE
Edit start page in line with prototype

### DIFF
--- a/app/views/registration_wizard/start.html.erb
+++ b/app/views/registration_wizard/start.html.erb
@@ -8,11 +8,18 @@
 
     <h2 class="govuk-heading-m">Before you start</h2>
 
-    <p class="govuk-body"><a href="https://professional-development-for-teachers-leaders.education.gov.uk/" class="govuk-link">Choose an NPQ and provider</a>.</p>
+     <p>You need to know:</p>
 
-    <p class="govuk-body">If you work in early years or childcare, <%= govuk_link_to("check if your workplace is registered with Ofsted", "https://reports.ofsted.gov.uk/childcare") %> and get their Ofsted unique reference number (URN) if they have one.</p>
+     <ul class="govuk-list govuk-list--bullet">
+       <li>which NPQ you want to do</li>
+       <li>who your provider is</li>
+     </ul>
 
-    <p class="govuk-body"><%= govuk_link_to("Check if you have a teacher reference number (TRN)", "https://find-a-lost-trn.education.gov.uk/start") %>. If you’re not a teacher you can still register, but you’ll need to request a TRN. We’ll show you how to do this.</p>
+     <p>If you have not chosen yet, <a href="https://professional-development-for-teachers-leaders.education.gov.uk">find out about NPQs and providers</a>.</p>
+
+     <p class="govuk-body">If you work in early years or childcare, <%= govuk_link_to("check if your workplace is registered with Ofsted", "https://reports.ofsted.gov.uk/childcare") %> and get their Ofsted unique reference number (URN) if they have one.</p>
+
+     <p class="govuk-body"><%= govuk_link_to("Check if you have a teacher reference number (TRN)", "https://find-a-lost-trn.education.gov.uk/start") %>. If you’re not a teacher you can still register, but you’ll need to request a TRN. We’ll show you how to do this.</p>
 
     <%= render GovukComponent::StartButtonComponent.new(
       text: "Start now",

--- a/app/views/registration_wizard/start.html.erb
+++ b/app/views/registration_wizard/start.html.erb
@@ -8,14 +8,14 @@
 
     <h2 class="govuk-heading-m">Before you start</h2>
 
-     <p>You need to know:</p>
+     <p class="govuk-body">You need to know:</p>
 
      <ul class="govuk-list govuk-list--bullet">
        <li>which NPQ you want to do</li>
        <li>who your provider is</li>
      </ul>
 
-     <p>If you have not chosen yet, <a href="https://professional-development-for-teachers-leaders.education.gov.uk">find out about NPQs and providers</a>.</p>
+     <p class="govuk-body">If you have not chosen yet, <a href="https://professional-development-for-teachers-leaders.education.gov.uk">find out about NPQs and providers</a>.</p>
 
      <p class="govuk-body">If you work in early years or childcare, <%= govuk_link_to("check if your workplace is registered with Ofsted", "https://reports.ofsted.gov.uk/childcare") %> and get their Ofsted unique reference number (URN) if they have one.</p>
 


### PR DESCRIPTION
In user research, a user clicked on the 'choose an NPQ and provider' link when she had already chosen an NPQ and provider. 

Hypothesis:

Editing the link text and placement may help prevent people clicking the link when they don't need to. 

| Before  | After |
| ------------- |:-------------:|
| <img width="521" alt="Screenshot 2023-01-23 at 16 21 18" src="https://user-images.githubusercontent.com/56349171/214092384-639d6cc7-83cf-4ef7-b7be-cdd3bdda8430.png">     | <img width="561" alt="Screenshot 2023-01-23 at 16 21 45" src="https://user-images.githubusercontent.com/56349171/214092498-9fdb9b75-4efc-44ef-9081-ba99e024e281.png">     |


