### PR TITLE
Revert #657 

### DIFF
--- a/.github/workflows/deploy_to_review_app.yml
+++ b/.github/workflows/deploy_to_review_app.yml
@@ -123,7 +123,7 @@ jobs:
             --name import_childminder_agencies
 
       - name: comment on PR
-        uses: unsplash/comment-on-pr@v1.3.1
+        uses: unsplash/comment-on-pr@v1.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Revert "Merge pull request #657 from DFE-Digital/dependabot/github_actions/unsplash/comment-on-pr-1.3.1"

This reverts commit cbad78f3ea668d303d3eb77c334d1e4e3fb3dc93, reversing changes made to f90d7d6aa8f549d425a7d93e935c3c5af2a7a77f.

I need to look into why this was preventing proper commenting. Seems the minor update was not backwards compatible.