### PR TITLE
Use new NPQ API for syncing users

### DIFF
--- a/app/lib/ecf_api/npq/base.rb
+++ b/app/lib/ecf_api/npq/base.rb
@@ -1,0 +1,7 @@
+module EcfApi
+  module Npq
+    class Base < ::EcfApi::Base
+      self.site = "#{ENV['ECF_APP_BASE_URL']}/api/v1/npq"
+    end
+  end
+end

--- a/app/lib/ecf_api/npq/user.rb
+++ b/app/lib/ecf_api/npq/user.rb
@@ -1,0 +1,7 @@
+module EcfApi
+  module Npq
+    class User < Base
+      has_many :npq_profiles
+    end
+  end
+end

--- a/app/lib/services/ecf/ecf_user_creator.rb
+++ b/app/lib/services/ecf/ecf_user_creator.rb
@@ -8,7 +8,11 @@ module Services
       end
 
       def call
-        remote = EcfApi::User.new(email: user.email, full_name: user.full_name)
+        remote = EcfApi::Npq::User.new(
+          email: user.email,
+          get_an_identity_id: user.get_an_identity_id,
+          full_name: user.full_name,
+        )
 
         # JsonApiClient::Resource uses errors for flow control, so failed saves
         # will divert to the rescue block below

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,6 +55,14 @@ class User < ApplicationRecord
     user_from_provider_data.tap(&:save)
   end
 
+  def get_an_identity_provider?
+    provider == "tra_openid_connect"
+  end
+
+  def get_an_identity_id
+    uid if get_an_identity_provider?
+  end
+
   def null_user?
     false
   end
@@ -74,10 +82,6 @@ class User < ApplicationRecord
     Delayed::Job.where(job_name_query)
                 .where(user_id_query)
                 .order(run_at: :asc)
-  end
-
-  def in_get_an_identity_pilot?
-    provider == "tra_openid_connect"
   end
 
   # Whether this user has admin access to the feature flagging interface

--- a/app/views/admin/applications/_application_details.html.erb
+++ b/app/views/admin/applications/_application_details.html.erb
@@ -26,7 +26,7 @@
 
     sl.row do |row|
       row.key(text: 'In Get an Identity Pilot?')
-      row.value(text: boolean_red_green_tag(application.user.in_get_an_identity_pilot?))
+      row.value(text: boolean_red_green_tag(application.user.get_an_identity_provider?))
       row.action
     end
 

--- a/app/views/admin/applications/index.html.erb
+++ b/app/views/admin/applications/index.html.erb
@@ -36,7 +36,7 @@
             <td class="govuk-table__cell"><%= app.lead_provider.name %></td>
             <td class="govuk-table__cell"><%= app.school_urn %></td>
             <td class="govuk-table__cell"><%= boolean_red_green_tag(app.eligible_for_funding) %></td>
-            <td class="govuk-table__cell"><%= boolean_red_green_tag(app.user.in_get_an_identity_pilot?) %></td>
+            <td class="govuk-table__cell"><%= boolean_red_green_tag(app.user.get_an_identity_provider?) %></td>
             <td class="govuk-table__cell"><%= govuk_link_to("View", admin_application_path(app)) %></td>
           </tr>
         <% end %>

--- a/app/views/admin/unsynced_users/index.html.erb
+++ b/app/views/admin/unsynced_users/index.html.erb
@@ -22,7 +22,7 @@
               body.row do |row|
                 row.cell(text: user.full_name.presence || "-")
                 row.cell(text: govuk_link_to(user.email.presence || "No Email Found", admin_user_path(user)))
-                row.cell(text: boolean_red_green_tag(user.in_get_an_identity_pilot?))
+                row.cell(text: boolean_red_green_tag(user.get_an_identity_provider?))
                 row.cell(text: user.created_at.to_date.to_formatted_s(:govuk))
                 row.cell(text: govuk_link_to("View", admin_user_path(user)))
               end

--- a/app/views/admin/users/_user_details.html.erb
+++ b/app/views/admin/users/_user_details.html.erb
@@ -17,7 +17,7 @@
 
     sl.row do |row|
       row.key(text: 'In Get an Identity Pilot?')
-      row.value(text: boolean_red_green_tag(user.in_get_an_identity_pilot?))
+      row.value(text: boolean_red_green_tag(user.get_an_identity_provider?))
     end
 
     sl.row do |row|

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -33,7 +33,7 @@
             body.row do |row|
               row.cell(text: user.full_name.presence || "-")
               row.cell(text: govuk_link_to(user.email.presence || "No Email Found", admin_user_path(user)))
-              row.cell(text: boolean_red_green_tag(user.in_get_an_identity_pilot?))
+              row.cell(text: boolean_red_green_tag(user.get_an_identity_provider?))
               row.cell(text: user.created_at.to_date.to_formatted_s(:govuk))
               row.cell(text: govuk_link_to("View", admin_user_path(user)))
             end

--- a/spec/lib/services/ecf/ecf_user_creator_spec.rb
+++ b/spec/lib/services/ecf/ecf_user_creator_spec.rb
@@ -1,7 +1,15 @@
 require "rails_helper"
 
 RSpec.describe Services::Ecf::EcfUserCreator do
-  let(:user) { User.create!(email: "john.doe@example.com", full_name: "John Doe") }
+  let(:get_an_identity_id) { SecureRandom.uuid }
+  let(:user) do
+    User.create!(
+      email: "john.doe@example.com",
+      full_name: "John Doe",
+      uid: get_an_identity_id,
+      provider: :tra_openid_connect,
+    )
+  end
 
   subject { described_class.new(user:) }
 
@@ -12,6 +20,7 @@ RSpec.describe Services::Ecf::EcfUserCreator do
           type: "users",
           attributes: {
             email: "john.doe@example.com",
+            get_an_identity_id:,
             full_name: "John Doe",
           },
         },
@@ -19,7 +28,7 @@ RSpec.describe Services::Ecf::EcfUserCreator do
     end
 
     before do
-      stub_request(:post, "https://ecf-app.gov.uk/api/v1/users")
+      stub_request(:post, "https://ecf-app.gov.uk/api/v1/npq/users")
         .with(
           body: request_body,
           headers: {


### PR DESCRIPTION
### Context

- Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-713

We need to sync GAI IDs across to the ECF DB during user creation. https://github.com/DFE-Digital/early-careers-framework/pull/2919 has added in a new API that replaces the old one, accepting the same params as the previous API along with get_an_identity_id.

### Changes proposed in this pull request

Use the above mentioned new API when syncing users, sending a get_an_identity_id when available.

### Guidance to review

Flows we need to test: 
- Regular flow where you return from the Get an Identity interface with a TRN. This will leave your NPQ user account with a get an identity ID which should then get synced when you complete your application.
- Alterntive flow where you return from the Get an Identity interface without a TRN. This leaves your NPQ user account without a GAI ID, which should *still* have your account synced when you complete your application. Only this time without an ID.
