### PR TITLE
Revert "Bump google-github-actions/setup-gcloud from 0 to 1"

### DIFF
--- a/.github/workflows/export_dashboard_report.yml
+++ b/.github/workflows/export_dashboard_report.yml
@@ -11,7 +11,7 @@ jobs:
     container: google/cloud-sdk:latest
     steps:
       - name: Auth with gcloud
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v0
         with:
           service_account_key: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_BASE64 }}
 


### PR DESCRIPTION
Reverts DFE-Digital/npq-registration#659

This PR also needs a corresponding change to the 'Export results to BigQuery action', the scheduled action has [started failing](https://github.com/DFE-Digital/npq-registration/actions/workflows/export_dashboard_report.yml).