### PR TITLE
[CPDNPQ-788] [CPDNPQ-910] Update ECF with user details in ApplicationSubmissionJob even when not creating a new user

### DIFF
--- a/app/jobs/application_submission_job.rb
+++ b/app/jobs/application_submission_job.rb
@@ -2,14 +2,10 @@ class ApplicationSubmissionJob < ApplicationJob
   queue_as :default
 
   def perform(user:)
-    unless user.synced_to_ecf?
-      ecf_user = ecf_user_for(user:)
-
-      if ecf_user
-        user.update!(ecf_id: ecf_user.id)
-      else
-        Services::Ecf::EcfUserCreator.new(user:).call
-      end
+    if user.synced_to_ecf?
+      update_ecf_user_details(user:)
+    else
+      create_link_to_ecf_user(user:)
     end
 
     user.applications.includes(:lead_provider, :course).where(ecf_id: nil).each do |application|
@@ -26,7 +22,37 @@ class ApplicationSubmissionJob < ApplicationJob
 
 private
 
-  def ecf_user_for(user:)
+  def create_link_to_ecf_user(user:)
+    ecf_user = find_ecf_user_by_email(user:)
+
+    if ecf_user
+      user.update!(ecf_id: ecf_user.id)
+      # Now make sure the user we found is fully up to date
+      update_ecf_user_details(user:)
+    else
+      Services::Ecf::EcfUserCreator.new(user:).call
+    end
+  end
+
+  def update_ecf_user_details(user:)
+    user.ecf_user.update(
+      email: user.email,
+      full_name: user.full_name,
+      get_an_identity_id: user.get_an_identity_id,
+    )
+    # Record that the GAI ID has been synced
+    user.update(get_an_identity_id_synced_to_ecf: true) if user.get_an_identity_id.present?
+  rescue => e
+    Sentry.with_scope do |scope|
+      scope.set_context("User", { id: user.id, ecf_id: user.ecf_id })
+      Sentry.capture_exception(e)
+
+      # We aren't re-raising the error here, updating the user failing
+      # should not halt application submission
+    end
+  end
+
+  def find_ecf_user_by_email(user:)
     Services::Ecf::EcfUserFinder.new(user:).call
   rescue StandardError => e
     env = e.try(:env) || {}

--- a/app/jobs/application_submission_job.rb
+++ b/app/jobs/application_submission_job.rb
@@ -35,14 +35,18 @@ private
   end
 
   def update_ecf_user_details(user:)
+    # rubocop:disable Rails/SaveBang
+    # This is not necessary
     user.ecf_user.update(
       email: user.email,
       full_name: user.full_name,
       get_an_identity_id: user.get_an_identity_id,
     )
+    # rubocop:enable Rails/SaveBang
+
     # Record that the GAI ID has been synced
-    user.update(get_an_identity_id_synced_to_ecf: true) if user.get_an_identity_id.present?
-  rescue => e
+    user.update_column(:get_an_identity_id_synced_to_ecf, true) if user.get_an_identity_id.present?
+  rescue StandardError => e
     Sentry.with_scope do |scope|
       scope.set_context("User", { id: user.id, ecf_id: user.ecf_id })
       Sentry.capture_exception(e)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,6 +8,15 @@ FactoryBot.define do
     trait :with_ecf_id do
       ecf_id { SecureRandom.uuid }
     end
+
+    trait :with_get_an_identity_id do
+      transient do
+        get_an_identity_id { SecureRandom.uuid }
+      end
+
+      uid { uid }
+      provider { "tra_openid_connect" }
+    end
   end
 
   factory :admin, class: "User" do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
         get_an_identity_id { SecureRandom.uuid }
       end
 
-      uid { uid }
+      uid { get_an_identity_id }
       provider { "tra_openid_connect" }
     end
   end

--- a/spec/jobs/application_submission_job_spec.rb
+++ b/spec/jobs/application_submission_job_spec.rb
@@ -59,10 +59,10 @@ RSpec.describe ApplicationSubmissionJob do
         expect(Services::Ecf::NpqProfileCreator).to receive(:new).with(application:).and_return(profile_creator_double)
         expect(EcfApi::Npq::User).to receive(:find).and_return([ecf_user])
         expect(ecf_user).to receive(:update).with({
-                                                    email: user.email,
-                                                    full_name: user.full_name,
-                                                    get_an_identity_id: user.get_an_identity_id
-                                                  })
+          email: user.email,
+          full_name: user.full_name,
+          get_an_identity_id: user.get_an_identity_id,
+        })
 
         subject.perform_now
 
@@ -84,10 +84,10 @@ RSpec.describe ApplicationSubmissionJob do
         expect(Services::Ecf::NpqProfileCreator).to receive(:new).with(application:).and_return(profile_creator_double)
         expect(EcfApi::Npq::User).to receive(:find).and_return([ecf_user])
         expect(ecf_user).to receive(:update).with({
-                                                    email: user.email,
-                                                    full_name: user.full_name,
-                                                    get_an_identity_id: user.get_an_identity_id
-                                                  })
+          email: user.email,
+          full_name: user.full_name,
+          get_an_identity_id: user.get_an_identity_id,
+        })
 
         subject.perform_now
 
@@ -113,7 +113,7 @@ RSpec.describe ApplicationSubmissionJob do
         expect(ecf_user).to receive(:update).with({
           email: user.email,
           full_name: user.full_name,
-          get_an_identity_id: user.get_an_identity_id
+          get_an_identity_id: user.get_an_identity_id,
         })
 
         subject.perform_now

--- a/spec/jobs/application_submission_job_spec.rb
+++ b/spec/jobs/application_submission_job_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ApplicationSubmissionJob do
 
   describe "#perform" do
     let(:application) { create(:application, user:, school:) }
-    let(:user) { create(:user) }
+    let(:user) { create(:user, :with_get_an_identity_id) }
     let(:school) { create(:school) }
 
     before do
@@ -53,9 +53,16 @@ RSpec.describe ApplicationSubmissionJob do
       it "calls correct servivces" do
         instance_double(Services::Ecf::EcfUserCreator)
         profile_creator_double = instance_double(Services::Ecf::NpqProfileCreator, call: nil)
+        ecf_user = instance_double(EcfApi::Npq::User)
 
         expect(Services::Ecf::EcfUserCreator).not_to receive(:new)
         expect(Services::Ecf::NpqProfileCreator).to receive(:new).with(application:).and_return(profile_creator_double)
+        expect(EcfApi::Npq::User).to receive(:find).and_return([ecf_user])
+        expect(ecf_user).to receive(:update).with({
+                                                    email: user.email,
+                                                    full_name: user.full_name,
+                                                    get_an_identity_id: user.get_an_identity_id
+                                                  })
 
         subject.perform_now
 
@@ -70,10 +77,17 @@ RSpec.describe ApplicationSubmissionJob do
       it "calls correct services" do
         user_finder_double = instance_double(Services::Ecf::EcfUserFinder, call: ecf_user)
         profile_creator_double = instance_double(Services::Ecf::NpqProfileCreator, call: nil)
+        ecf_user = instance_double(EcfApi::Npq::User)
 
         expect(Services::Ecf::EcfUserFinder).to receive(:new).with(user:).and_return(user_finder_double)
         expect(Services::Ecf::EcfUserCreator).not_to receive(:new)
         expect(Services::Ecf::NpqProfileCreator).to receive(:new).with(application:).and_return(profile_creator_double)
+        expect(EcfApi::Npq::User).to receive(:find).and_return([ecf_user])
+        expect(ecf_user).to receive(:update).with({
+                                                    email: user.email,
+                                                    full_name: user.full_name,
+                                                    get_an_identity_id: user.get_an_identity_id
+                                                  })
 
         subject.perform_now
 
@@ -91,9 +105,16 @@ RSpec.describe ApplicationSubmissionJob do
       it "calls correct servivces" do
         instance_double(Services::Ecf::EcfUserCreator)
         instance_double(Services::Ecf::NpqProfileCreator, call: nil)
+        ecf_user = instance_double(EcfApi::Npq::User)
 
         expect(Services::Ecf::EcfUserCreator).not_to receive(:new)
         expect(Services::Ecf::NpqProfileCreator).not_to receive(:new)
+        expect(EcfApi::Npq::User).to receive(:find).and_return([ecf_user])
+        expect(ecf_user).to receive(:update).with({
+          email: user.email,
+          full_name: user.full_name,
+          get_an_identity_id: user.get_an_identity_id
+        })
 
         subject.perform_now
       end

--- a/spec/lib/services/admin/dashboard_stats_spec.rb
+++ b/spec/lib/services/admin/dashboard_stats_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Services::Admin::DashboardStats do
       :application,
       get_an_identity_applications_created_before_start_time,
       created_at: start_time - 1.day,
-      user: create(:user, provider: :tra_openid_connect),
+      user: create(:user, :with_get_an_identity_id),
     )
 
     create_list(
@@ -44,7 +44,7 @@ RSpec.describe Services::Admin::DashboardStats do
       :application,
       get_an_identity_applications_created_since_start_time,
       created_at: start_time + 1.day,
-      user: create(:user, provider: :tra_openid_connect),
+      user: create(:user, :with_get_an_identity_id),
     )
 
     create_list(


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-910
Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-788

CPDNPQ-910 relates to a bug where pre-existing users that have acquired a get_an_identity_id would not have this new ID sync to the ECF database.

CPDNPQ-788 relates to an issue where once created new user information (email/full_name) would not be synced to the ECF database.

### Changes proposed in this pull request

This PR updates the ApplicationSubmissionJob so that a user's information (get_an_identity_id, full_name, email) is always synced across to the ECF database.

- Update ECF with new user details on application submission for:
  - Already synced and linked users
  - Newly linked users where the ECF user already exists
