### PR TITLE
Update EHCO hint text in line with prototype

### DIFF
--- a/config/initializers/courses.rb
+++ b/config/initializers/courses.rb
@@ -78,7 +78,7 @@ module Courses
       name: "Early Headship Coaching Offer",
       ecf_id: "0222d1a8-a8e1-42e3-a040-2c585f6c194a",
       identifier: "npq-early-headship-coaching-offer",
-      description: "A package of structured face-to-face support for new headteachers.",
+      description: "Structured support and networking opportunities if you’re a headteacher in your first 5 years of headship.",
       display: true,
       default_cohort: 2022,
     },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -226,7 +226,7 @@ en:
         funding_options:
           another: "For example, I am sharing the costs with my workplace"
         course_identifier_options:
-          "npq-early-headship-coaching-offer": "A package of structured face-to-face support for new headteachers."
+          "npq-early-headship-coaching-offer": "Structured support and networking opportunities if you’re a headteacher in your first 5 years of headship."
     label:
       registration_wizard:
         work_setting_options:


### PR DESCRIPTION
Following merging this ticket: https://dfedigital.atlassian.net/jira/software/projects/CPDNPQ/boards/137?assignee=637b9f9cf6c85b343c082909&selectedIssue=CPDNPQ-808

I've noticed that the hint text isn't as intended.

![Screenshot 2023-02-27 at 11 23 38](https://user-images.githubusercontent.com/56349171/221551411-e5ad9cbe-dc61-4935-901a-5882af21ee11.png)

This hint text should be the same as in the prototype:

![Screenshot 2023-02-27 at 11 24 00](https://user-images.githubusercontent.com/56349171/221551480-6200bbdd-33c9-4216-852e-bedda629b274.png)
