### PR TITLE
Add github action to run courses:update in all envs

### DIFF
--- a/.github/workflows/update_course_definitions.yml
+++ b/.github/workflows/update_course_definitions.yml
@@ -1,0 +1,79 @@
+name: Update Course Definitions
+
+on: workflow_dispatch
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Install CloudFoundry CLI
+        shell: bash
+        run: |
+          wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
+          echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+          sudo apt-get update
+          sudo apt-get install cf7-cli
+
+      - name: Schedule school sync for dev
+        shell: bash
+        env:
+          PAAS_ORGANISATION: dfe
+          # This is a shared PAAS space
+          PAAS_SPACE: earlycareers-framework-dev
+          ENV_STUB: dev
+          APP_NAME: npq-registration
+          CF_USERNAME: ${{ secrets.GOVPAAS_DEV_USERNAME }}
+          CF_PASSWORD: ${{ secrets.GOVPAAS_DEV_PASSWORD }}
+        run: |
+          cf api https://api.london.cloud.service.gov.uk
+          cf auth
+          cf target -o "${{ env.PAAS_ORGANISATION }}" -s "${{ env.PAAS_SPACE }}"
+          cf run-task "${{ env.APP_NAME }}"-"${{ env.ENV_STUB }}" --command "cd /app && /usr/local/bundle/bin/bundle exec rails courses:update" --process worker --name schedule_course_definition_update
+
+      - name: Schedule school sync for staging
+        shell: bash
+        env:
+          PAAS_ORGANISATION: dfe
+          # This is a shared PAAS space
+          PAAS_SPACE: early-careers-framework-staging
+          ENV_STUB: staging
+          APP_NAME: npq-registration
+          CF_USERNAME: ${{ secrets.GOVPAAS_STAG_USERNAME }}
+          CF_PASSWORD: ${{ secrets.GOVPAAS_STAG_PASSWORD }}
+        run: |
+          cf api https://api.london.cloud.service.gov.uk
+          cf auth
+          cf target -o "${{ env.PAAS_ORGANISATION }}" -s "${{ env.PAAS_SPACE }}"
+          cf run-task "${{ env.APP_NAME }}"-"${{ env.ENV_STUB }}" --command "cd /app && /usr/local/bundle/bin/bundle exec rails courses:update" --process worker --name schedule_course_definition_update
+
+      - name: Schedule school sync for sandbox
+        shell: bash
+        env:
+          PAAS_ORGANISATION: dfe
+          # This is a shared PAAS space
+          PAAS_SPACE: early-careers-framework-sandbox
+          ENV_STUB: sandbox
+          APP_NAME: npq-registration
+          CF_USERNAME: ${{ secrets.GOVPAAS_STAG_USERNAME }}
+          CF_PASSWORD: ${{ secrets.GOVPAAS_STAG_PASSWORD }}
+        run: |
+          cf api https://api.london.cloud.service.gov.uk
+          cf auth
+          cf target -o "${{ env.PAAS_ORGANISATION }}" -s "${{ env.PAAS_SPACE }}"
+          cf run-task "${{ env.APP_NAME }}"-"${{ env.ENV_STUB }}" --command "cd /app && /usr/local/bundle/bin/bundle exec rails courses:update" --process worker --name schedule_course_definition_update
+
+      - name: Schedule school sync for prod
+        shell: bash
+        env:
+          PAAS_ORGANISATION: dfe
+          # This is a shared PAAS space
+          PAAS_SPACE: early-careers-framework-prod
+          ENV_STUB: prod
+          APP_NAME: npq-registration
+          CF_USERNAME: ${{ secrets.GOVPAAS_PROD_USERNAME }}
+          CF_PASSWORD: ${{ secrets.GOVPAAS_PROD_PASSWORD }}
+        run: |
+          cf api https://api.london.cloud.service.gov.uk
+          cf auth
+          cf target -o "${{ env.PAAS_ORGANISATION }}" -s "${{ env.PAAS_SPACE }}"
+          cf run-task "${{ env.APP_NAME }}"-"${{ env.ENV_STUB }}" --command "cd /app && /usr/local/bundle/bin/bundle exec rails courses:update" --process worker --name schedule_course_definition_update


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-808

Currently you have to log into the server to run these tasks. We should be working to avoid entering the console as much as possible and providing structured interfaces for interacting with data.

### Changes proposed in this pull request

Adds a Github action to trigger a rake task on each environment that will update course definitions.
