### PR TITLE
[CPDNPQ-808] Use govuk classes for styling ChooseYourNPQ page

### DIFF
--- a/app/views/registration_wizard/choose_your_npq.html.erb
+++ b/app/views/registration_wizard/choose_your_npq.html.erb
@@ -1,6 +1,12 @@
-<h1 class="govuk-heading-xl"><%= t("helpers.title.registration_wizard.course_identifier") %></h1>
+<h1 class="govuk-heading-xl"><%= t("helpers.title.registration_wizard.choose_your_npq") %></h1>
 
-<p style="margin-bottom: 40px" class="govuk-body">To register for an NPQ and the <a href="https://professional-development-for-teachers-leaders.education.gov.uk/early-headship-coaching-offer" class="govuk-link">early headship coaching offer</a>, submit 2 separate registrations.</p>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body govuk-!-margin-bottom-7">
+      <%= t("helpers.hint.registration_wizard.choose_your_npq_html") %>
+    </p>
+  </div>
+</div>
 
 <%=
   render(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -203,7 +203,7 @@ en:
         aso_possible_funding: "You may qualify for DfE scholarship funding"
         aso_previously_funded: "DfE scholarship funding not available"
         aso_unavailable: "You cannot register for the Early Headship Coaching Offer"
-        course_identifier: "Choose an NPQ"
+        choose_your_npq: "Choose an NPQ"
     legend:
       registration_wizard:
         aso_headteacher: "Are you a headteacher?"
@@ -217,6 +217,7 @@ en:
         aso_funding_choice: "How is the Early Headship Coaching Offer being paid for?"
     hint:
       registration_wizard:
+        choose_your_npq_html: "To register for an NPQ and the <a href=\"https://professional-development-for-teachers-leaders.education.gov.uk/early-headship-coaching-offer\" class=\"govuk-link\">early headship coaching offer</a>, submit 2 separate registrations."
         work_setting_options:
           other: "For example a local authority, at a hospital school or young offender institution"
         employment_role: "For example: Administrator, business manager"


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-808

The styling on this page wasn't correct, the text overflow didn't match up along the page.

### Changes proposed in this pull request

- Wrap hint text at 2/3rds.
- Move text into locales
- Use govuk classes for styling

| Before | After |
| - | - |
| <img width="984" alt="Screenshot 2023-02-27 at 14 37 11" src="https://user-images.githubusercontent.com/1465268/221592784-00bd5366-26aa-4fec-8606-ee0f0898b30a.png"> | <img width="983" alt="Screenshot 2023-02-27 at 14 38 03" src="https://user-images.githubusercontent.com/1465268/221592768-831fd6cf-42fe-44f9-95a0-9a619fe97460.png"> |


