### PR TITLE
[CPDNPQ-883] Integrate new previously funded API to send GAI to ECF for previously funded checks

### DIFF
--- a/app/lib/ecf_api/npq/previous_funding.rb
+++ b/app/lib/ecf_api/npq/previous_funding.rb
@@ -6,6 +6,17 @@ module EcfApi
       def self.table_name
         "previous_funding"
       end
+
+      # Abstracted so we can decide whether or not to send trn/get_an_identity_id
+      def self.find_for(npq_course_identifier:, trn:, get_an_identity_id:)
+        params = {
+          npq_course_identifier: npq_course_identifier,
+        }
+        params[:trn] = trn if trn.present?
+        params[:get_an_identity_id] = get_an_identity_id if get_an_identity_id.present?
+
+        with_params(params).find
+      end
     end
   end
 end

--- a/app/lib/ecf_api/npq/previous_funding.rb
+++ b/app/lib/ecf_api/npq/previous_funding.rb
@@ -10,7 +10,7 @@ module EcfApi
       # Abstracted so we can decide whether or not to send trn/get_an_identity_id
       def self.find_for(npq_course_identifier:, trn:, get_an_identity_id:)
         params = {
-          npq_course_identifier: npq_course_identifier,
+          npq_course_identifier:,
         }
         params[:trn] = trn if trn.present?
         params[:get_an_identity_id] = get_an_identity_id if get_an_identity_id.present?

--- a/app/lib/ecf_api/npq/previous_funding.rb
+++ b/app/lib/ecf_api/npq/previous_funding.rb
@@ -1,0 +1,11 @@
+module EcfApi
+  module Npq
+    class PreviousFunding < Base
+      self.parser = RawParser
+
+      def self.table_name
+        "previous_funding"
+      end
+    end
+  end
+end

--- a/app/lib/forms/aso_new_headteacher.rb
+++ b/app/lib/forms/aso_new_headteacher.rb
@@ -50,6 +50,7 @@ module Forms
         inside_catchment: inside_catchment?,
         new_headteacher: new_headteacher?,
         trn:,
+        get_an_identity_id:,
       ).funding_eligiblity_status_code
     end
 
@@ -57,6 +58,7 @@ module Forms
              :course,
              :inside_catchment?,
              :trn,
+             :get_an_identity_id,
              to: :query_store
 
     def new_headteacher?

--- a/app/lib/forms/choose_your_npq.rb
+++ b/app/lib/forms/choose_your_npq.rb
@@ -124,6 +124,7 @@ module Forms
         inside_catchment: inside_catchment?,
         new_headteacher: new_headteacher?,
         trn: wizard.query_store.trn,
+        get_an_identity_id: wizard.query_store.get_an_identity_id,
       ).funded?
     end
 
@@ -136,6 +137,7 @@ module Forms
         inside_catchment: inside_catchment?,
         new_headteacher: new_headteacher?,
         trn: wizard.query_store.trn,
+        get_an_identity_id: wizard.query_store.get_an_identity_id,
       )
     end
 

--- a/app/lib/forms/choose_your_provider.rb
+++ b/app/lib/forms/choose_your_provider.rb
@@ -58,6 +58,7 @@ module Forms
         inside_catchment: inside_catchment?,
         new_headteacher: new_headteacher?,
         trn:,
+        get_an_identity_id:,
       ).funded?
     end
 
@@ -74,6 +75,7 @@ module Forms
              :inside_catchment?,
              :new_headteacher?,
              :trn,
+             :get_an_identity_id,
              to: :query_store
 
     def validate_lead_provider_exists

--- a/app/lib/forms/ineligible_for_funding.rb
+++ b/app/lib/forms/ineligible_for_funding.rb
@@ -49,6 +49,7 @@ module Forms
         inside_catchment: inside_catchment?,
         new_headteacher: new_headteacher?,
         trn: wizard.query_store.trn,
+        get_an_identity_id: wizard.query_store.get_an_identity_id,
       ).funding_eligiblity_status_code
     end
 

--- a/app/lib/services/funding_eligibility.rb
+++ b/app/lib/services/funding_eligibility.rb
@@ -22,12 +22,19 @@ module Services
     # Lead Mentor
     NOT_LEAD_MENTOR_COURSE = :not_lead_mentor_course
 
-    attr_reader :institution, :course, :trn, :approved_itt_provider, :lead_mentor, :employment_role
+    attr_reader :institution,
+                :course,
+                :trn,
+                :approved_itt_provider,
+                :lead_mentor,
+                :employment_role,
+                :get_an_identity_id
 
     def initialize(institution:,
                    course:,
                    inside_catchment:,
                    trn:,
+                   get_an_identity_id:,
                    approved_itt_provider: false,
                    lead_mentor: false,
                    new_headteacher: false,
@@ -38,6 +45,7 @@ module Services
       @new_headteacher = new_headteacher
       @approved_itt_provider = approved_itt_provider
       @lead_mentor = lead_mentor
+      @get_an_identity_id = get_an_identity_id
       @trn = trn
       @employment_role = employment_role
     end
@@ -165,10 +173,11 @@ module Services
     end
 
     def ecf_api_funding_lookup
-      @ecf_api_funding_lookup = EcfApi::Npq::PreviousFunding.with_params(
+      @ecf_api_funding_lookup = EcfApi::Npq::PreviousFunding.find_for(
         trn: trn,
+        get_an_identity_id:,
         npq_course_identifier: course.identifier,
-      ).find
+      )
     end
 
     def previously_funded?

--- a/app/lib/services/funding_eligibility.rb
+++ b/app/lib/services/funding_eligibility.rb
@@ -174,7 +174,7 @@ module Services
 
     def ecf_api_funding_lookup
       @ecf_api_funding_lookup = EcfApi::Npq::PreviousFunding.find_for(
-        trn: trn,
+        trn:,
         get_an_identity_id:,
         npq_course_identifier: course.identifier,
       )

--- a/app/lib/services/funding_eligibility.rb
+++ b/app/lib/services/funding_eligibility.rb
@@ -165,7 +165,10 @@ module Services
     end
 
     def ecf_api_funding_lookup
-      @ecf_api_funding_lookup = EcfApi::NpqFunding.with_params(npq_course_identifier: course.identifier).find(trn)
+      @ecf_api_funding_lookup = EcfApi::Npq::PreviousFunding.with_params(
+        trn: trn,
+        npq_course_identifier: course.identifier,
+      ).find
     end
 
     def previously_funded?

--- a/app/lib/services/handle_submission_for_store.rb
+++ b/app/lib/services/handle_submission_for_store.rb
@@ -188,6 +188,7 @@ module Services
         inside_catchment: inside_catchment?,
         new_headteacher: new_headteacher?,
         trn: query_store.trn,
+        get_an_identity_id: query_store.get_an_identity_id,
       )
     end
 

--- a/app/lib/services/query_store.rb
+++ b/app/lib/services/query_store.rb
@@ -17,6 +17,10 @@ class Services::QueryStore
     ::IttProvider.currently_approved.find_by(legal_name: itt_provider).present?
   end
 
+  def get_an_identity_id
+    current_user.get_an_identity_id
+  end
+
   def trn
     # If the GAI flow was used then the updated TRN is already on the user record,
     # other wise it will have been entered into the store by the user and should be retrieved from there.

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -233,6 +233,7 @@ private
       inside_catchment: inside_catchment?,
       new_headteacher: new_headteacher?,
       trn: query_store.trn,
+      get_an_identity_id: query_store.get_an_identity_id,
     )
   end
 

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -187,14 +187,16 @@ RSpec.feature "admin", type: :feature do
     page.click_link("Users")
     expect(page.current_path).to eql(admin_users_path)
 
+    display_users = User.all
+
     # Test application pagination
-    users[0..2].each do |user|
+    display_users[0..2].each do |user|
       expect(page).to have_content(user.email)
     end
 
     page.find("[aria-label=next]").click
 
-    users[3..].each do |user|
+    display_users[3..].each do |user|
       expect(page).to have_content(user.email)
     end
 

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/js/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/js/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
@@ -136,19 +136,11 @@ RSpec.feature "Happy journeys", type: :feature do
       page.find("#school-picker__option--0").click
     end
 
-    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=npq-senior-leadership")
-      .with(
-        headers: {
-          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
-        },
-      )
-      .to_return(
-        status: 200,
-        body: ecf_funding_lookup_response(previously_funded: false),
-        headers: {
-          "Content-Type" => "application/vnd.api+json",
-        },
-      )
+    mock_previous_funding_api_request(
+      course_identifier: "npq-senior-leadership",
+      trn: "1234567",
+      response: ecf_funding_lookup_response(previously_funded: false)
+    )
 
     expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do
       expect(page).to have_text("Which NPQ do you want to do?")

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/js/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/js/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
@@ -139,7 +139,7 @@ RSpec.feature "Happy journeys", type: :feature do
     mock_previous_funding_api_request(
       course_identifier: "npq-senior-leadership",
       trn: "1234567",
-      response: ecf_funding_lookup_response(previously_funded: false)
+      response: ecf_funding_lookup_response(previously_funded: false),
     )
 
     expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/js/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/js/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
@@ -7,7 +7,10 @@ RSpec.feature "Happy journeys", type: :feature do
 
   include_context "retrieve latest application data"
   include_context "Disable Get An Identity integration"
-  include_context "Stub previously funding check for all courses"
+  include_context "Stub previously funding check for all courses" do
+    let(:api_call_get_an_identity_id) { nil }
+    let(:api_call_trn) { "1234567" }
+  end
 
   scenario "registration journey changing do you work in childcare from yes to no" do
     stub_participant_validation_request

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/js/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/js/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
   include_context "retrieve latest application data"
   include_context "Disable Get An Identity integration"
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
 
   scenario "registration journey changing do you work in childcare from yes to no" do
     stub_participant_validation_request

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/js/changing_from_outside_of_catchment_area_to_inside_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/js/changing_from_outside_of_catchment_area_to_inside_spec.rb
@@ -7,7 +7,10 @@ RSpec.feature "Happy journeys", type: :feature do
 
   include_context "retrieve latest application data"
   include_context "Disable Get An Identity integration"
-  include_context "Stub previously funding check for all courses"
+  include_context "Stub previously funding check for all courses" do
+    let(:api_call_get_an_identity_id) { nil }
+    let(:api_call_trn) { "1234567" }
+  end
 
   scenario "registration journey changing from outside of catchment area to inside" do
     stub_participant_validation_request(nino: "")

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/js/changing_from_outside_of_catchment_area_to_inside_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/js/changing_from_outside_of_catchment_area_to_inside_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
   include_context "retrieve latest application data"
   include_context "Disable Get An Identity integration"
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
 
   scenario "registration journey changing from outside of catchment area to inside" do
     stub_participant_validation_request(nino: "")

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/js/changing_npq_to_one_leadprovider_no_longer_supports_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/js/changing_npq_to_one_leadprovider_no_longer_supports_spec.rb
@@ -7,7 +7,10 @@ RSpec.feature "Happy journeys", type: :feature do
 
   include_context "retrieve latest application data"
   include_context "Disable Get An Identity integration"
-  include_context "Stub previously funding check for all courses"
+  include_context "Stub previously funding check for all courses" do
+    let(:api_call_get_an_identity_id) { nil }
+    let(:api_call_trn) { "1234567" }
+  end
 
   scenario "registration journey changing NPQ to one LeadProvider no longer supports" do
     stub_participant_validation_request

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/js/changing_npq_to_one_leadprovider_no_longer_supports_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/js/changing_npq_to_one_leadprovider_no_longer_supports_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
   include_context "retrieve latest application data"
   include_context "Disable Get An Identity integration"
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
 
   scenario "registration journey changing NPQ to one LeadProvider no longer supports" do
     stub_participant_validation_request

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/js/via_using_old_name_and_not_headship_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/js/via_using_old_name_and_not_headship_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
   include_context "retrieve latest application data"
   include_context "Disable Get An Identity integration"
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
 
   scenario "registration journey via using old name and not headship" do
     stub_participant_validation_request

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/js/via_using_old_name_and_not_headship_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/js/via_using_old_name_and_not_headship_spec.rb
@@ -7,7 +7,10 @@ RSpec.feature "Happy journeys", type: :feature do
 
   include_context "retrieve latest application data"
   include_context "Disable Get An Identity integration"
-  include_context "Stub previously funding check for all courses"
+  include_context "Stub previously funding check for all courses" do
+    let(:api_call_get_an_identity_id) { nil }
+    let(:api_call_trn) { "1234567" }
+  end
 
   scenario "registration journey via using old name and not headship" do
     stub_participant_validation_request

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/js/via_using_same_name_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/js/via_using_same_name_spec.rb
@@ -7,7 +7,10 @@ RSpec.feature "Happy journeys", type: :feature do
 
   include_context "retrieve latest application data"
   include_context "Disable Get An Identity integration"
-  include_context "Stub previously funding check for all courses"
+  include_context "Stub previously funding check for all courses" do
+    let(:api_call_get_an_identity_id) { nil }
+    let(:api_call_trn) { "1234567" }
+  end
 
   scenario "registration journey via using same name" do
     stub_participant_validation_request

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/js/via_using_same_name_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/js/via_using_same_name_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
   include_context "retrieve latest application data"
   include_context "Disable Get An Identity integration"
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
 
   scenario "registration journey via using same name" do
     stub_participant_validation_request

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/js/when_previously_funded_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/js/when_previously_funded_spec.rb
@@ -99,7 +99,7 @@ RSpec.feature "Happy journeys", type: :feature do
       mock_previous_funding_api_request(
         course_identifier: identifier,
         trn: "1234567",
-        response: ecf_funding_lookup_response(previously_funded: true)
+        response: ecf_funding_lookup_response(previously_funded: true),
       )
     end
 

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/js/when_previously_funded_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/js/when_previously_funded_spec.rb
@@ -93,19 +93,11 @@ RSpec.feature "Happy journeys", type: :feature do
     end
 
     %w[npq-early-headship-coaching-offer npq-early-years-leadership].each do |identifier|
-      stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=#{identifier}")
-        .with(
-          headers: {
-            "Authorization" => "Bearer ECFAPPBEARERTOKEN",
-          },
-        )
-        .to_return(
-          status: 200,
-          body: ecf_funding_lookup_response(previously_funded: true),
-          headers: {
-            "Content-Type" => "application/vnd.api+json",
-          },
-        )
+      mock_previous_funding_api_request(
+        course_identifier: identifier,
+        trn: "1234567",
+        response: ecf_funding_lookup_response(previously_funded: true)
+      )
     end
 
     expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/js/when_previously_funded_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/js/when_previously_funded_spec.rb
@@ -7,7 +7,10 @@ RSpec.feature "Happy journeys", type: :feature do
 
   include_context "retrieve latest application data"
   include_context "Disable Get An Identity integration"
-  include_context "Stub previously funding check for all courses"
+  include_context "Stub previously funding check for all courses" do
+    let(:api_call_get_an_identity_id) { nil }
+    let(:api_call_trn) { "1234567" }
+  end
 
   scenario "registration journey when previously funded" do
     stub_participant_validation_request

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/js/when_previously_funded_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/js/when_previously_funded_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
   include_context "retrieve latest application data"
   include_context "Disable Get An Identity integration"
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
 
   scenario "registration journey when previously funded" do
     stub_participant_validation_request

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/js/while_working_at_private_childcare_privider_but_not_a_nursery_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/js/while_working_at_private_childcare_privider_but_not_a_nursery_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
   include_context "retrieve latest application data"
   include_context "Disable Get An Identity integration"
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
 
   scenario "registration journey while working at private childcare provider but not a nursery" do
     stub_participant_validation_request

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/js/while_working_at_private_childcare_privider_but_not_a_nursery_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/js/while_working_at_private_childcare_privider_but_not_a_nursery_spec.rb
@@ -7,7 +7,10 @@ RSpec.feature "Happy journeys", type: :feature do
 
   include_context "retrieve latest application data"
   include_context "Disable Get An Identity integration"
-  include_context "Stub previously funding check for all courses"
+  include_context "Stub previously funding check for all courses" do
+    let(:api_call_get_an_identity_id) { nil }
+    let(:api_call_trn) { "1234567" }
+  end
 
   scenario "registration journey while working at private childcare provider but not a nursery" do
     stub_participant_validation_request

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/js/while_working_at_private_nursery_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/js/while_working_at_private_nursery_spec.rb
@@ -7,7 +7,10 @@ RSpec.feature "Happy journeys", type: :feature do
 
   include_context "retrieve latest application data"
   include_context "Disable Get An Identity integration"
-  include_context "Stub previously funding check for all courses"
+  include_context "Stub previously funding check for all courses" do
+    let(:api_call_get_an_identity_id) { nil }
+    let(:api_call_trn) { "1234567" }
+  end
 
   scenario "registration journey while working at private nursery" do
     stub_participant_validation_request

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/js/while_working_at_private_nursery_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/js/while_working_at_private_nursery_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
   include_context "retrieve latest application data"
   include_context "Disable Get An Identity integration"
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
 
   scenario "registration journey while working at private nursery" do
     stub_participant_validation_request

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/js/while_working_at_public_nursery_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/js/while_working_at_public_nursery_spec.rb
@@ -85,19 +85,11 @@ RSpec.feature "Happy journeys", type: :feature do
       page.find("#nursery-picker__option--0").click
     end
 
-    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=npq-senior-leadership")
-      .with(
-        headers: {
-          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
-        },
-      )
-      .to_return(
-        status: 200,
-        body: ecf_funding_lookup_response(previously_funded: false),
-        headers: {
-          "Content-Type" => "application/vnd.api+json",
-        },
-      )
+    mock_previous_funding_api_request(
+      course_identifier: "npq-senior-leadership",
+      trn: "1234567",
+      response: ecf_funding_lookup_response(previously_funded: false)
+    )
 
     expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do
       expect(page).to have_text("Which NPQ do you want to do?")

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/js/while_working_at_public_nursery_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/js/while_working_at_public_nursery_spec.rb
@@ -88,7 +88,7 @@ RSpec.feature "Happy journeys", type: :feature do
     mock_previous_funding_api_request(
       course_identifier: "npq-senior-leadership",
       trn: "1234567",
-      response: ecf_funding_lookup_response(previously_funded: false)
+      response: ecf_funding_lookup_response(previously_funded: false),
     )
 
     expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/non_js/able_to_receive_targeted_delivery_funding_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/non_js/able_to_receive_targeted_delivery_funding_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
   include_context "retrieve latest application data"
   include_context "Disable Get An Identity integration"
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
 
   around do |example|
     Capybara.current_driver = :rack_test

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/non_js/able_to_receive_targeted_delivery_funding_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/non_js/able_to_receive_targeted_delivery_funding_spec.rb
@@ -101,7 +101,7 @@ RSpec.feature "Happy journeys", type: :feature do
     mock_previous_funding_api_request(
       course_identifier: "npq-senior-leadership",
       trn: "RP12%2F345",
-      response: ecf_funding_lookup_response(previously_funded: false)
+      response: ecf_funding_lookup_response(previously_funded: false),
     )
 
     expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do
@@ -112,7 +112,7 @@ RSpec.feature "Happy journeys", type: :feature do
     mock_previous_funding_api_request(
       course_identifier: "npq-headship",
       trn: "1234567",
-      response: ecf_funding_lookup_response(previously_funded: false)
+      response: ecf_funding_lookup_response(previously_funded: false),
     )
 
     expect_page_to_have(path: "/registration/possible-funding", submit_form: false) do

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/non_js/able_to_receive_targeted_delivery_funding_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/non_js/able_to_receive_targeted_delivery_funding_spec.rb
@@ -7,7 +7,10 @@ RSpec.feature "Happy journeys", type: :feature do
 
   include_context "retrieve latest application data"
   include_context "Disable Get An Identity integration"
-  include_context "Stub previously funding check for all courses"
+  include_context "Stub previously funding check for all courses" do
+    let(:api_call_get_an_identity_id) { nil }
+    let(:api_call_trn) { "1234567" }
+  end
 
   around do |example|
     Capybara.current_driver = :rack_test

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/non_js/able_to_receive_targeted_delivery_funding_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/non_js/able_to_receive_targeted_delivery_funding_spec.rb
@@ -95,38 +95,22 @@ RSpec.feature "Happy journeys", type: :feature do
       page.choose "open manchester school"
     end
 
-    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/RP12%2F345?npq_course_identifier=npq-senior-leadership")
-      .with(
-        headers: {
-          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
-        },
-      )
-      .to_return(
-        status: 200,
-        body: ecf_funding_lookup_response(previously_funded: false),
-        headers: {
-          "Content-Type" => "application/vnd.api+json",
-        },
-      )
+    mock_previous_funding_api_request(
+      course_identifier: "npq-senior-leadership",
+      trn: "RP12%2F345",
+      response: ecf_funding_lookup_response(previously_funded: false)
+    )
 
     expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do
       expect(page).to have_text("Which NPQ do you want to do?")
       page.choose("Senior leadership")
     end
 
-    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=npq-headship")
-      .with(
-        headers: {
-          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
-        },
-      )
-      .to_return(
-        status: 200,
-        body: ecf_funding_lookup_response(previously_funded: false),
-        headers: {
-          "Content-Type" => "application/vnd.api+json",
-        },
-      )
+    mock_previous_funding_api_request(
+      course_identifier: "npq-headship",
+      trn: "1234567",
+      response: ecf_funding_lookup_response(previously_funded: false)
+    )
 
     expect_page_to_have(path: "/registration/possible-funding", submit_form: false) do
       expect(page).to have_text("If your provider accepts your application, you’ll qualify for DfE funding")

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/non_js/funded_ehco_registration_journey_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/non_js/funded_ehco_registration_journey_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
   include_context "retrieve latest application data"
   include_context "Disable Get An Identity integration"
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
 
   around do |example|
     Capybara.current_driver = :rack_test

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/non_js/funded_ehco_registration_journey_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/non_js/funded_ehco_registration_journey_spec.rb
@@ -7,7 +7,10 @@ RSpec.feature "Happy journeys", type: :feature do
 
   include_context "retrieve latest application data"
   include_context "Disable Get An Identity integration"
-  include_context "Stub previously funding check for all courses"
+  include_context "Stub previously funding check for all courses" do
+    let(:api_call_get_an_identity_id) { nil }
+    let(:api_call_trn) { "1234567" }
+  end
 
   around do |example|
     Capybara.current_driver = :rack_test

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/non_js/other_funded_ehco_registration_journey_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/non_js/other_funded_ehco_registration_journey_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyHelper
   include Helpers::JourneyAssertionHelper
 
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
   include_context "Disable Get An Identity integration"
 
   around do |example|

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/non_js/other_funded_ehco_registration_journey_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/non_js/other_funded_ehco_registration_journey_spec.rb
@@ -4,7 +4,11 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyHelper
   include Helpers::JourneyAssertionHelper
 
-  include_context "Stub previously funding check for all courses"
+  include_context "Stub previously funding check for all courses" do
+    let(:api_call_get_an_identity_id) { nil }
+    let(:api_call_trn) { "1234567" }
+  end
+
   include_context "Disable Get An Identity integration"
 
   around do |example|

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/non_js/via_using_old_name_and_not_headship_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/non_js/via_using_old_name_and_not_headship_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyHelper
   include Helpers::JourneyAssertionHelper
 
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
   include_context "Disable Get An Identity integration"
 
   around do |example|

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/non_js/via_using_old_name_and_not_headship_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/non_js/via_using_old_name_and_not_headship_spec.rb
@@ -3,8 +3,11 @@ require "rails_helper"
 RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyHelper
   include Helpers::JourneyAssertionHelper
+  include_context "Stub previously funding check for all courses" do
+    let(:api_call_get_an_identity_id) { nil }
+    let(:api_call_trn) { "1234567" }
+  end
 
-  include_context "Stub previously funding check for all courses"
   include_context "Disable Get An Identity integration"
 
   around do |example|

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/non_js/via_using_old_name_and_not_headship_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/non_js/via_using_old_name_and_not_headship_spec.rb
@@ -103,38 +103,22 @@ RSpec.feature "Happy journeys", type: :feature do
       page.choose "open manchester school"
     end
 
-    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/RP12%2F345?npq_course_identifier=npq-senior-leadership")
-      .with(
-        headers: {
-          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
-        },
-      )
-      .to_return(
-        status: 200,
-        body: ecf_funding_lookup_response(previously_funded: false),
-        headers: {
-          "Content-Type" => "application/vnd.api+json",
-        },
-      )
+    mock_previous_funding_api_request(
+      course_identifier: "npq-senior-leadership",
+      trn: "RP12%2F345",
+      response: ecf_funding_lookup_response(previously_funded: false)
+    )
 
     expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do
       expect(page).to have_text("Which NPQ do you want to do?")
       page.choose("Senior leadership")
     end
 
-    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=npq-headship")
-      .with(
-        headers: {
-          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
-        },
-      )
-      .to_return(
-        status: 200,
-        body: ecf_funding_lookup_response(previously_funded: false),
-        headers: {
-          "Content-Type" => "application/vnd.api+json",
-        },
-      )
+    mock_previous_funding_api_request(
+      course_identifier: "npq-headship",
+      trn: "1234567",
+      response: ecf_funding_lookup_response(previously_funded: false)
+    )
 
     expect_page_to_have(path: "/registration/possible-funding", submit_form: true) do
       expect(page).to have_text("If your provider accepts your application, you’ll qualify for DfE funding")

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/non_js/via_using_old_name_and_not_headship_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/non_js/via_using_old_name_and_not_headship_spec.rb
@@ -109,7 +109,7 @@ RSpec.feature "Happy journeys", type: :feature do
     mock_previous_funding_api_request(
       course_identifier: "npq-senior-leadership",
       trn: "RP12%2F345",
-      response: ecf_funding_lookup_response(previously_funded: false)
+      response: ecf_funding_lookup_response(previously_funded: false),
     )
 
     expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do
@@ -120,7 +120,7 @@ RSpec.feature "Happy journeys", type: :feature do
     mock_previous_funding_api_request(
       course_identifier: "npq-headship",
       trn: "1234567",
-      response: ecf_funding_lookup_response(previously_funded: false)
+      response: ecf_funding_lookup_response(previously_funded: false),
     )
 
     expect_page_to_have(path: "/registration/possible-funding", submit_form: true) do

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/non_js/via_using_same_name_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/non_js/via_using_same_name_spec.rb
@@ -88,7 +88,7 @@ RSpec.feature "Happy journeys", type: :feature do
     mock_previous_funding_api_request(
       course_identifier: "npq-headship",
       trn: "1234567",
-      response: ecf_funding_lookup_response(previously_funded: false)
+      response: ecf_funding_lookup_response(previously_funded: false),
     )
 
     expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/non_js/via_using_same_name_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/non_js/via_using_same_name_spec.rb
@@ -85,19 +85,11 @@ RSpec.feature "Happy journeys", type: :feature do
       page.choose "open manchester school"
     end
 
-    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=npq-headship")
-      .with(
-        headers: {
-          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
-        },
-      )
-      .to_return(
-        status: 200,
-        body: ecf_funding_lookup_response(previously_funded: false),
-        headers: {
-          "Content-Type" => "application/vnd.api+json",
-        },
-      )
+    mock_previous_funding_api_request(
+      course_identifier: "npq-headship",
+      trn: "1234567",
+      response: ecf_funding_lookup_response(previously_funded: false)
+    )
 
     expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do
       expect(page).to have_text("Which NPQ do you want to do?")

--- a/spec/features/disabled_get_an_identity_integration/sad_journeys/applying_for_ehco_but_not_new_headteacher_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/sad_journeys/applying_for_ehco_but_not_new_headteacher_spec.rb
@@ -7,7 +7,10 @@ RSpec.feature "Happy journeys", type: :feature do
 
   include_context "retrieve latest application data"
   include_context "Disable Get An Identity integration"
-  include_context "Stub previously funding check for all courses"
+  include_context "Stub previously funding check for all courses" do
+    let(:api_call_get_an_identity_id) { nil }
+    let(:api_call_trn) { "1234567" }
+  end
 
   scenario "applying for EHCO but not new headteacher" do
     stub_participant_validation_request

--- a/spec/features/disabled_get_an_identity_integration/sad_journeys/applying_for_ehco_but_not_new_headteacher_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/sad_journeys/applying_for_ehco_but_not_new_headteacher_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
   include_context "retrieve latest application data"
   include_context "Disable Get An Identity integration"
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
 
   scenario "applying for EHCO but not new headteacher" do
     stub_participant_validation_request

--- a/spec/features/disabled_get_an_identity_integration/sad_journeys/dqt_mismatch_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/sad_journeys/dqt_mismatch_spec.rb
@@ -6,7 +6,10 @@ RSpec.feature "Happy journeys", type: :feature do
 
   include_context "retrieve latest application data"
   include_context "Disable Get An Identity integration"
-  include_context "Stub previously funding check for all courses"
+  include_context "Stub previously funding check for all courses" do
+    let(:api_call_get_an_identity_id) { nil }
+    let(:api_call_trn) { "1234567" }
+  end
 
   scenario "DQT mismatch" do
     navigate_to_page(path: "/", submit_form: false, axe_check: false) do

--- a/spec/features/disabled_get_an_identity_integration/sad_journeys/dqt_mismatch_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/sad_journeys/dqt_mismatch_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
   include_context "retrieve latest application data"
   include_context "Disable Get An Identity integration"
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
 
   scenario "DQT mismatch" do
     navigate_to_page(path: "/", submit_form: false, axe_check: false) do

--- a/spec/features/disabled_get_an_identity_integration/sad_journeys/school_not_in_england_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/sad_journeys/school_not_in_england_spec.rb
@@ -7,7 +7,10 @@ RSpec.feature "Happy journeys", type: :feature do
 
   include_context "retrieve latest application data"
   include_context "Disable Get An Identity integration"
-  include_context "Stub previously funding check for all courses"
+  include_context "Stub previously funding check for all courses" do
+    let(:api_call_get_an_identity_id) { nil }
+    let(:api_call_trn) { "1234567" }
+  end
 
   scenario "school not in england" do
     stub_participant_validation_request

--- a/spec/features/disabled_get_an_identity_integration/sad_journeys/school_not_in_england_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/sad_journeys/school_not_in_england_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
   include_context "retrieve latest application data"
   include_context "Disable Get An Identity integration"
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
 
   scenario "school not in england" do
     stub_participant_validation_request

--- a/spec/features/disabled_get_an_identity_integration/sad_journeys/works_in_childcare_but_not_in_england_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/sad_journeys/works_in_childcare_but_not_in_england_spec.rb
@@ -7,7 +7,10 @@ RSpec.feature "Happy journeys", type: :feature do
 
   include_context "retrieve latest application data"
   include_context "Disable Get An Identity integration"
-  include_context "Stub previously funding check for all courses"
+  include_context "Stub previously funding check for all courses" do
+    let(:api_call_get_an_identity_id) { nil }
+    let(:api_call_trn) { "1234567" }
+  end
 
   scenario "works in childcare but not in england" do
     stub_participant_validation_request(nino: "")

--- a/spec/features/disabled_get_an_identity_integration/sad_journeys/works_in_childcare_but_not_in_england_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/sad_journeys/works_in_childcare_but_not_in_england_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
   include_context "retrieve latest application data"
   include_context "Disable Get An Identity integration"
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
 
   scenario "works in childcare but not in england" do
     stub_participant_validation_request(nino: "")

--- a/spec/features/happy_journeys/js/basic_registration_journey_spec.rb
+++ b/spec/features/happy_journeys/js/basic_registration_journey_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
   include_context "Enable Get An Identity integration"
 
   scenario "registration journey" do

--- a/spec/features/happy_journeys/js/basic_registration_journey_spec.rb
+++ b/spec/features/happy_journeys/js/basic_registration_journey_spec.rb
@@ -5,7 +5,10 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "Stub previously funding check for all courses"
+  include_context "Stub previously funding check for all courses" do
+    let(:api_call_get_an_identity_id) { user_uid }
+    let(:api_call_trn) { user_trn }
+  end
   include_context "Enable Get An Identity integration"
 
   scenario "registration journey" do

--- a/spec/features/happy_journeys/js/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
+++ b/spec/features/happy_journeys/js/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
@@ -103,7 +103,7 @@ RSpec.feature "Happy journeys", type: :feature do
       course_identifier: "npq-senior-leadership",
       get_an_identity_id: user_uid,
       trn: "1234567",
-      response: ecf_funding_lookup_response(previously_funded: false)
+      response: ecf_funding_lookup_response(previously_funded: false),
     )
 
     expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do

--- a/spec/features/happy_journeys/js/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
+++ b/spec/features/happy_journeys/js/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
@@ -99,19 +99,11 @@ RSpec.feature "Happy journeys", type: :feature do
       page.find("#school-picker__option--0").click
     end
 
-    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=npq-senior-leadership")
-      .with(
-        headers: {
-          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
-        },
-      )
-      .to_return(
-        status: 200,
-        body: ecf_funding_lookup_response(previously_funded: false),
-        headers: {
-          "Content-Type" => "application/vnd.api+json",
-        },
-      )
+    mock_previous_funding_api_request(
+      course_identifier: "npq-senior-leadership",
+      trn: "1234567",
+      response: ecf_funding_lookup_response(previously_funded: false)
+    )
 
     expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do
       expect(page).to have_text("Which NPQ do you want to do?")

--- a/spec/features/happy_journeys/js/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
+++ b/spec/features/happy_journeys/js/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
@@ -101,6 +101,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
     mock_previous_funding_api_request(
       course_identifier: "npq-senior-leadership",
+      get_an_identity_id: user_uid,
       trn: "1234567",
       response: ecf_funding_lookup_response(previously_funded: false)
     )

--- a/spec/features/happy_journeys/js/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
+++ b/spec/features/happy_journeys/js/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
   include_context "Enable Get An Identity integration"
 
   scenario "registration journey changing do you work in childcare from yes to no" do

--- a/spec/features/happy_journeys/js/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
+++ b/spec/features/happy_journeys/js/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
@@ -5,7 +5,10 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "Stub previously funding check for all courses"
+  include_context "Stub previously funding check for all courses" do
+    let(:api_call_get_an_identity_id) { user_uid }
+    let(:api_call_trn) { user_trn }
+  end
   include_context "Enable Get An Identity integration"
 
   scenario "registration journey changing do you work in childcare from yes to no" do

--- a/spec/features/happy_journeys/js/changing_from_outside_of_catchment_area_to_inside_spec.rb
+++ b/spec/features/happy_journeys/js/changing_from_outside_of_catchment_area_to_inside_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
   include_context "Enable Get An Identity integration"
 
   scenario "registration journey changing from outside of catchment area to inside" do

--- a/spec/features/happy_journeys/js/changing_from_outside_of_catchment_area_to_inside_spec.rb
+++ b/spec/features/happy_journeys/js/changing_from_outside_of_catchment_area_to_inside_spec.rb
@@ -5,7 +5,10 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "Stub previously funding check for all courses"
+  include_context "Stub previously funding check for all courses" do
+    let(:api_call_get_an_identity_id) { user_uid }
+    let(:api_call_trn) { user_trn }
+  end
   include_context "Enable Get An Identity integration"
 
   scenario "registration journey changing from outside of catchment area to inside" do

--- a/spec/features/happy_journeys/js/changing_npq_to_one_leadprovider_no_longer_supports_spec.rb
+++ b/spec/features/happy_journeys/js/changing_npq_to_one_leadprovider_no_longer_supports_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
   include_context "Enable Get An Identity integration"
 
   scenario "registration journey changing NPQ to one LeadProvider no longer supports" do

--- a/spec/features/happy_journeys/js/changing_npq_to_one_leadprovider_no_longer_supports_spec.rb
+++ b/spec/features/happy_journeys/js/changing_npq_to_one_leadprovider_no_longer_supports_spec.rb
@@ -5,7 +5,10 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "Stub previously funding check for all courses"
+  include_context "Stub previously funding check for all courses" do
+    let(:api_call_get_an_identity_id) { user_uid }
+    let(:api_call_trn) { user_trn }
+  end
   include_context "Enable Get An Identity integration"
 
   scenario "registration journey changing NPQ to one LeadProvider no longer supports" do

--- a/spec/features/happy_journeys/js/entering_different_email_in_get_an_identity_and_outside_pilot_spec.rb
+++ b/spec/features/happy_journeys/js/entering_different_email_in_get_an_identity_and_outside_pilot_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
   include_context "Enable Get An Identity integration"
 
   # This controls what is returned from the Get An Identity API

--- a/spec/features/happy_journeys/js/entering_different_email_in_get_an_identity_and_outside_pilot_spec.rb
+++ b/spec/features/happy_journeys/js/entering_different_email_in_get_an_identity_and_outside_pilot_spec.rb
@@ -5,7 +5,10 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "Stub previously funding check for all courses"
+  include_context "Stub previously funding check for all courses" do
+    let(:api_call_get_an_identity_id) { nil }
+    let(:api_call_trn) { "1234567" }
+  end
   include_context "Enable Get An Identity integration"
 
   # This controls what is returned from the Get An Identity API

--- a/spec/features/happy_journeys/js/via_using_old_name_and_not_headship_spec.rb
+++ b/spec/features/happy_journeys/js/via_using_old_name_and_not_headship_spec.rb
@@ -5,7 +5,10 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "Stub previously funding check for all courses"
+  include_context "Stub previously funding check for all courses" do
+    let(:api_call_get_an_identity_id) { user_uid }
+    let(:api_call_trn) { user_trn }
+  end
   include_context "Enable Get An Identity integration"
 
   scenario "registration journey via using old name and not headship" do

--- a/spec/features/happy_journeys/js/via_using_old_name_and_not_headship_spec.rb
+++ b/spec/features/happy_journeys/js/via_using_old_name_and_not_headship_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
   include_context "Enable Get An Identity integration"
 
   scenario "registration journey via using old name and not headship" do

--- a/spec/features/happy_journeys/js/when_choose_lead_mentor_course_spec.rb
+++ b/spec/features/happy_journeys/js/when_choose_lead_mentor_course_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
   include_context "Enable Get An Identity integration"
 
   scenario "registration journey when choosing lead mentor journey and approved ITT provider" do

--- a/spec/features/happy_journeys/js/when_choose_lead_mentor_course_spec.rb
+++ b/spec/features/happy_journeys/js/when_choose_lead_mentor_course_spec.rb
@@ -5,7 +5,10 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "Stub previously funding check for all courses"
+  include_context "Stub previously funding check for all courses" do
+    let(:api_call_get_an_identity_id) { user_uid }
+    let(:api_call_trn) { user_trn }
+  end
   include_context "Enable Get An Identity integration"
 
   scenario "registration journey when choosing lead mentor journey and approved ITT provider" do

--- a/spec/features/happy_journeys/js/when_get_an_identity_returns_no_trn_spec.rb
+++ b/spec/features/happy_journeys/js/when_get_an_identity_returns_no_trn_spec.rb
@@ -5,14 +5,20 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "Stub previously funding check for all courses"
+  include_context "Stub previously funding check for all courses" do
+    # In this situation we fallback to a non-pilot set of checks
+    let(:api_call_get_an_identity_id) { nil }
+    let(:api_call_trn) { manually_entered_trn }
+  end
   include_context "Enable Get An Identity integration"
 
   # This controls what is returned from the Get An Identity API
   let(:user_trn) { "" }
 
+  let(:manually_entered_trn) { "3651763" }
+
   scenario "registration journey when get an identity returns no TRN" do
-    stub_participant_validation_request
+    stub_participant_validation_request(trn: manually_entered_trn, response: { trn: manually_entered_trn })
 
     navigate_to_page(path: "/", submit_form: false, axe_check: false) do
       expect(page).to have_text("Before you start")
@@ -67,7 +73,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect_page_to_have(path: "/registration/qualified-teacher-check", submit_form: true) do
       expect(page).to have_text("Check your details")
 
-      page.fill_in "Teacher reference number (TRN)", with: "1234567"
+      page.fill_in "Teacher reference number (TRN)", with: manually_entered_trn
       page.fill_in "Full name", with: "John Doe"
       page.fill_in "Day", with: "13"
       page.fill_in "Month", with: "12"
@@ -135,7 +141,7 @@ RSpec.feature "Happy journeys", type: :feature do
       expect_check_answers_page_to_have_answers(
         {
           "Full name" => "John Doe",
-          "TRN" => "1234567",
+          "TRN" => manually_entered_trn,
           "Date of birth" => "13 December 1980",
           "National Insurance number" => "AB123456C",
           "Email" => "user@example.com",
@@ -159,7 +165,7 @@ RSpec.feature "Happy journeys", type: :feature do
     User.last.tap do |user|
       expect(user.email).to eql("user@example.com")
       expect(user.full_name).to eql("John Doe")
-      expect(user.trn).to eql("1234567")
+      expect(user.trn).to eql(manually_entered_trn)
       expect(user.trn_verified).to be_truthy
       expect(user.trn_auto_verified).to be_truthy
       expect(user.date_of_birth).to eql(Date.new(1980, 12, 13))
@@ -197,7 +203,7 @@ RSpec.feature "Happy journeys", type: :feature do
       "otp_hash" => nil,
       "provider" => nil,
       "raw_tra_provider_data" => nil,
-      "trn" => "1234567",
+      "trn" => manually_entered_trn,
       "trn_auto_verified" => true,
       "trn_verified" => true,
       "uid" => nil,
@@ -246,11 +252,11 @@ RSpec.feature "Happy journeys", type: :feature do
         "national_insurance_number" => "AB123456C",
         "teacher_catchment" => "england",
         "teacher_catchment_country" => nil,
-        "trn" => "1234567",
+        "trn" => manually_entered_trn,
         "trn_auto_verified" => true,
         "trn_knowledge" => "yes",
         "trn_verified" => true,
-        "verified_trn" => "1234567",
+        "verified_trn" => manually_entered_trn,
         "works_in_school" => "yes",
         "works_in_childcare" => "no",
         "work_setting" => "a_school",

--- a/spec/features/happy_journeys/js/when_get_an_identity_returns_no_trn_spec.rb
+++ b/spec/features/happy_journeys/js/when_get_an_identity_returns_no_trn_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
   include_context "Enable Get An Identity integration"
 
   # This controls what is returned from the Get An Identity API

--- a/spec/features/happy_journeys/js/when_previously_funded_spec.rb
+++ b/spec/features/happy_journeys/js/when_previously_funded_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
   include_context "Enable Get An Identity integration"
 
   scenario "registration journey when previously funded" do

--- a/spec/features/happy_journeys/js/when_previously_funded_spec.rb
+++ b/spec/features/happy_journeys/js/when_previously_funded_spec.rb
@@ -69,19 +69,11 @@ RSpec.feature "Happy journeys", type: :feature do
     end
 
     %w[npq-early-headship-coaching-offer npq-early-years-leadership].each do |identifier|
-      stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=#{identifier}")
-        .with(
-          headers: {
-            "Authorization" => "Bearer ECFAPPBEARERTOKEN",
-          },
-        )
-        .to_return(
-          status: 200,
-          body: ecf_funding_lookup_response(previously_funded: true),
-          headers: {
-            "Content-Type" => "application/vnd.api+json",
-          },
-        )
+      mock_previous_funding_api_request(
+        course_identifier: identifier,
+        trn: "1234567",
+        response: ecf_funding_lookup_response(previously_funded: true)
+      )
     end
 
     expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do

--- a/spec/features/happy_journeys/js/when_previously_funded_spec.rb
+++ b/spec/features/happy_journeys/js/when_previously_funded_spec.rb
@@ -75,7 +75,8 @@ RSpec.feature "Happy journeys", type: :feature do
       mock_previous_funding_api_request(
         course_identifier: identifier,
         trn: "1234567",
-        response: ecf_funding_lookup_response(previously_funded: true)
+        get_an_identity_id: user_uid,
+        response: ecf_funding_lookup_response(previously_funded: true),
       )
     end
 

--- a/spec/features/happy_journeys/js/when_previously_funded_spec.rb
+++ b/spec/features/happy_journeys/js/when_previously_funded_spec.rb
@@ -5,7 +5,10 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "Stub previously funding check for all courses"
+  include_context "Stub previously funding check for all courses" do
+    let(:api_call_get_an_identity_id) { user_uid }
+    let(:api_call_trn) { user_trn }
+  end
   include_context "Enable Get An Identity integration"
 
   scenario "registration journey when previously funded" do

--- a/spec/features/happy_journeys/js/while_working_at_private_childcare_privider_but_not_a_nursery_spec.rb
+++ b/spec/features/happy_journeys/js/while_working_at_private_childcare_privider_but_not_a_nursery_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
   include_context "Enable Get An Identity integration"
 
   scenario "registration journey while working at private childcare provider but not a nursery" do

--- a/spec/features/happy_journeys/js/while_working_at_private_childcare_privider_but_not_a_nursery_spec.rb
+++ b/spec/features/happy_journeys/js/while_working_at_private_childcare_privider_but_not_a_nursery_spec.rb
@@ -5,7 +5,10 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "Stub previously funding check for all courses"
+  include_context "Stub previously funding check for all courses" do
+    let(:api_call_get_an_identity_id) { user_uid }
+    let(:api_call_trn) { user_trn }
+  end
   include_context "Enable Get An Identity integration"
 
   scenario "registration journey while working at private childcare provider but not a nursery" do

--- a/spec/features/happy_journeys/js/while_working_at_private_nursery_spec.rb
+++ b/spec/features/happy_journeys/js/while_working_at_private_nursery_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
   include_context "Enable Get An Identity integration"
 
   scenario "registration journey while working at private nursery" do

--- a/spec/features/happy_journeys/js/while_working_at_private_nursery_spec.rb
+++ b/spec/features/happy_journeys/js/while_working_at_private_nursery_spec.rb
@@ -5,7 +5,10 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "Stub previously funding check for all courses"
+  include_context "Stub previously funding check for all courses" do
+    let(:api_call_get_an_identity_id) { user_uid }
+    let(:api_call_trn) { user_trn }
+  end
   include_context "Enable Get An Identity integration"
 
   scenario "registration journey while working at private nursery" do

--- a/spec/features/happy_journeys/js/while_working_at_public_nursery_spec.rb
+++ b/spec/features/happy_journeys/js/while_working_at_public_nursery_spec.rb
@@ -60,19 +60,11 @@ RSpec.feature "Happy journeys", type: :feature do
       page.find("#nursery-picker__option--0").click
     end
 
-    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=npq-senior-leadership")
-      .with(
-        headers: {
-          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
-        },
-      )
-      .to_return(
-        status: 200,
-        body: ecf_funding_lookup_response(previously_funded: false),
-        headers: {
-          "Content-Type" => "application/vnd.api+json",
-        },
-      )
+    mock_previous_funding_api_request(
+      course_identifier: "npq-senior-leadership",
+      trn: "1234567",
+      response: ecf_funding_lookup_response(previously_funded: false)
+    )
 
     expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do
       expect(page).to have_text("Which NPQ do you want to do?")

--- a/spec/features/happy_journeys/js/while_working_at_public_nursery_spec.rb
+++ b/spec/features/happy_journeys/js/while_working_at_public_nursery_spec.rb
@@ -62,6 +62,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
     mock_previous_funding_api_request(
       course_identifier: "npq-senior-leadership",
+      get_an_identity_id: user_uid,
       trn: "1234567",
       response: ecf_funding_lookup_response(previously_funded: false)
     )

--- a/spec/features/happy_journeys/js/while_working_at_public_nursery_spec.rb
+++ b/spec/features/happy_journeys/js/while_working_at_public_nursery_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
   include_context "retrieve latest application data"
   include_context "Enable Get An Identity integration"
+
   scenario "registration journey while working at public nursery" do
     stub_participant_validation_request
 
@@ -64,7 +65,7 @@ RSpec.feature "Happy journeys", type: :feature do
       course_identifier: "npq-senior-leadership",
       get_an_identity_id: user_uid,
       trn: "1234567",
-      response: ecf_funding_lookup_response(previously_funded: false)
+      response: ecf_funding_lookup_response(previously_funded: false),
     )
 
     expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do

--- a/spec/features/happy_journeys/non_js/able_to_receive_targeted_delivery_funding_spec.rb
+++ b/spec/features/happy_journeys/non_js/able_to_receive_targeted_delivery_funding_spec.rb
@@ -5,7 +5,10 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "Stub previously funding check for all courses"
+  include_context "Stub previously funding check for all courses" do
+    let(:api_call_get_an_identity_id) { user_uid }
+    let(:api_call_trn) { user_trn }
+  end
   include_context "Enable Get An Identity integration"
 
   around do |example|

--- a/spec/features/happy_journeys/non_js/able_to_receive_targeted_delivery_funding_spec.rb
+++ b/spec/features/happy_journeys/non_js/able_to_receive_targeted_delivery_funding_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
   include_context "Enable Get An Identity integration"
 
   around do |example|

--- a/spec/features/happy_journeys/non_js/able_to_receive_targeted_delivery_funding_spec.rb
+++ b/spec/features/happy_journeys/non_js/able_to_receive_targeted_delivery_funding_spec.rb
@@ -71,38 +71,22 @@ RSpec.feature "Happy journeys", type: :feature do
       page.choose "open manchester school"
     end
 
-    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/RP12%2F345?npq_course_identifier=npq-senior-leadership")
-      .with(
-        headers: {
-          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
-        },
-      )
-      .to_return(
-        status: 200,
-        body: ecf_funding_lookup_response(previously_funded: false),
-        headers: {
-          "Content-Type" => "application/vnd.api+json",
-        },
-      )
+    mock_previous_funding_api_request(
+      course_identifier: "npq-senior-leadership",
+      trn: "RP12%2F345",
+      response: ecf_funding_lookup_response(previously_funded: false)
+    )
 
     expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do
       expect(page).to have_text("Which NPQ do you want to do?")
       page.choose("Senior leadership")
     end
 
-    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=npq-headship")
-      .with(
-        headers: {
-          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
-        },
-      )
-      .to_return(
-        status: 200,
-        body: ecf_funding_lookup_response(previously_funded: false),
-        headers: {
-          "Content-Type" => "application/vnd.api+json",
-        },
-      )
+    mock_previous_funding_api_request(
+      course_identifier: "npq-headship",
+      trn: "1234567",
+      response: ecf_funding_lookup_response(previously_funded: false)
+    )
 
     expect_page_to_have(path: "/registration/possible-funding", submit_form: false) do
       expect(page).to have_text("If your provider accepts your application, you’ll qualify for DfE funding")

--- a/spec/features/happy_journeys/non_js/able_to_receive_targeted_delivery_funding_spec.rb
+++ b/spec/features/happy_journeys/non_js/able_to_receive_targeted_delivery_funding_spec.rb
@@ -77,7 +77,7 @@ RSpec.feature "Happy journeys", type: :feature do
     mock_previous_funding_api_request(
       course_identifier: "npq-senior-leadership",
       trn: "RP12%2F345",
-      response: ecf_funding_lookup_response(previously_funded: false)
+      response: ecf_funding_lookup_response(previously_funded: false),
     )
 
     expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do
@@ -88,7 +88,7 @@ RSpec.feature "Happy journeys", type: :feature do
     mock_previous_funding_api_request(
       course_identifier: "npq-headship",
       trn: "1234567",
-      response: ecf_funding_lookup_response(previously_funded: false)
+      response: ecf_funding_lookup_response(previously_funded: false),
     )
 
     expect_page_to_have(path: "/registration/possible-funding", submit_form: false) do

--- a/spec/features/happy_journeys/non_js/funded_ehco_registration_journey_spec.rb
+++ b/spec/features/happy_journeys/non_js/funded_ehco_registration_journey_spec.rb
@@ -5,7 +5,10 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "Stub previously funding check for all courses"
+  include_context "Stub previously funding check for all courses" do
+    let(:api_call_get_an_identity_id) { user_uid }
+    let(:api_call_trn) { user_trn }
+  end
   include_context "Enable Get An Identity integration"
 
   around do |example|

--- a/spec/features/happy_journeys/non_js/funded_ehco_registration_journey_spec.rb
+++ b/spec/features/happy_journeys/non_js/funded_ehco_registration_journey_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
   include_context "Enable Get An Identity integration"
 
   around do |example|

--- a/spec/features/happy_journeys/non_js/other_funded_ehco_registration_journey_spec.rb
+++ b/spec/features/happy_journeys/non_js/other_funded_ehco_registration_journey_spec.rb
@@ -4,7 +4,10 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyHelper
   include Helpers::JourneyAssertionHelper
 
-  include_context "Stub previously funding check for all courses"
+  include_context "Stub previously funding check for all courses" do
+    let(:api_call_get_an_identity_id) { user_uid }
+    let(:api_call_trn) { user_trn }
+  end
   include_context "Enable Get An Identity integration"
 
   around do |example|

--- a/spec/features/happy_journeys/non_js/other_funded_ehco_registration_journey_spec.rb
+++ b/spec/features/happy_journeys/non_js/other_funded_ehco_registration_journey_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyHelper
   include Helpers::JourneyAssertionHelper
 
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
   include_context "Enable Get An Identity integration"
 
   around do |example|

--- a/spec/features/happy_journeys/non_js/previously_received_targeted_delivery_funding_spec.rb
+++ b/spec/features/happy_journeys/non_js/previously_received_targeted_delivery_funding_spec.rb
@@ -5,7 +5,6 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "Stub previously funding check for all courses"
   include_context "Enable Get An Identity integration"
 
   around do |example|
@@ -73,11 +72,12 @@ RSpec.feature "Happy journeys", type: :feature do
 
     mock_previous_funding_api_request(
       course_identifier: "npq-senior-leadership",
-      trn: "1234567",
+      trn: user_trn,
+      get_an_identity_id: user_uid,
       response: ecf_funding_lookup_response(
         previously_funded: false,
         previously_received_targeted_funding_support: true,
-      )
+      ),
     )
 
     expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do

--- a/spec/features/happy_journeys/non_js/previously_received_targeted_delivery_funding_spec.rb
+++ b/spec/features/happy_journeys/non_js/previously_received_targeted_delivery_funding_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
   include_context "Enable Get An Identity integration"
 
   around do |example|

--- a/spec/features/happy_journeys/non_js/previously_received_targeted_delivery_funding_spec.rb
+++ b/spec/features/happy_journeys/non_js/previously_received_targeted_delivery_funding_spec.rb
@@ -71,22 +71,14 @@ RSpec.feature "Happy journeys", type: :feature do
       page.choose "open manchester school"
     end
 
-    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=npq-senior-leadership")
-      .with(
-        headers: {
-          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
-        },
+    mock_previous_funding_api_request(
+      course_identifier: "npq-senior-leadership",
+      trn: "1234567",
+      response: ecf_funding_lookup_response(
+        previously_funded: false,
+        previously_received_targeted_funding_support: true,
       )
-      .to_return(
-        status: 200,
-        body: ecf_funding_lookup_response(
-          previously_funded: false,
-          previously_received_targeted_funding_support: true,
-        ),
-        headers: {
-          "Content-Type" => "application/vnd.api+json",
-        },
-      )
+    )
 
     expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do
       expect(page).to have_text("Which NPQ do you want to do?")

--- a/spec/features/happy_journeys/non_js/via_using_old_name_and_not_headship_spec.rb
+++ b/spec/features/happy_journeys/non_js/via_using_old_name_and_not_headship_spec.rb
@@ -76,7 +76,7 @@ RSpec.feature "Happy journeys", type: :feature do
     mock_previous_funding_api_request(
       course_identifier: "npq-senior-leadership",
       trn: "RP12%2F345",
-      response: ecf_funding_lookup_response(previously_funded: false)
+      response: ecf_funding_lookup_response(previously_funded: false),
     )
 
     expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do
@@ -87,7 +87,7 @@ RSpec.feature "Happy journeys", type: :feature do
     mock_previous_funding_api_request(
       course_identifier: "npq-headship",
       trn: "1234567",
-      response: ecf_funding_lookup_response(previously_funded: false)
+      response: ecf_funding_lookup_response(previously_funded: false),
     )
 
     expect_page_to_have(path: "/registration/possible-funding", submit_form: true) do

--- a/spec/features/happy_journeys/non_js/via_using_old_name_and_not_headship_spec.rb
+++ b/spec/features/happy_journeys/non_js/via_using_old_name_and_not_headship_spec.rb
@@ -4,7 +4,10 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyHelper
   include Helpers::JourneyAssertionHelper
 
-  include_context "Stub previously funding check for all courses"
+  include_context "Stub previously funding check for all courses" do
+    let(:api_call_get_an_identity_id) { user_uid }
+    let(:api_call_trn) { user_trn }
+  end
   include_context "Enable Get An Identity integration"
 
   around do |example|

--- a/spec/features/happy_journeys/non_js/via_using_old_name_and_not_headship_spec.rb
+++ b/spec/features/happy_journeys/non_js/via_using_old_name_and_not_headship_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyHelper
   include Helpers::JourneyAssertionHelper
 
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
   include_context "Enable Get An Identity integration"
 
   around do |example|

--- a/spec/features/happy_journeys/non_js/via_using_old_name_and_not_headship_spec.rb
+++ b/spec/features/happy_journeys/non_js/via_using_old_name_and_not_headship_spec.rb
@@ -70,38 +70,22 @@ RSpec.feature "Happy journeys", type: :feature do
       page.choose "open manchester school"
     end
 
-    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/RP12%2F345?npq_course_identifier=npq-senior-leadership")
-      .with(
-        headers: {
-          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
-        },
-      )
-      .to_return(
-        status: 200,
-        body: ecf_funding_lookup_response(previously_funded: false),
-        headers: {
-          "Content-Type" => "application/vnd.api+json",
-        },
-      )
+    mock_previous_funding_api_request(
+      course_identifier: "npq-senior-leadership",
+      trn: "RP12%2F345",
+      response: ecf_funding_lookup_response(previously_funded: false)
+    )
 
     expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do
       expect(page).to have_text("Which NPQ do you want to do?")
       page.choose("Senior leadership")
     end
 
-    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=npq-headship")
-      .with(
-        headers: {
-          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
-        },
-      )
-      .to_return(
-        status: 200,
-        body: ecf_funding_lookup_response(previously_funded: false),
-        headers: {
-          "Content-Type" => "application/vnd.api+json",
-        },
-      )
+    mock_previous_funding_api_request(
+      course_identifier: "npq-headship",
+      trn: "1234567",
+      response: ecf_funding_lookup_response(previously_funded: false)
+    )
 
     expect_page_to_have(path: "/registration/possible-funding", submit_form: true) do
       expect(page).to have_text("If your provider accepts your application, you’ll qualify for DfE funding")

--- a/spec/features/happy_journeys/non_js/via_using_same_name_spec.rb
+++ b/spec/features/happy_journeys/non_js/via_using_same_name_spec.rb
@@ -62,19 +62,11 @@ RSpec.feature "Happy journeys", type: :feature do
       page.choose "open manchester school"
     end
 
-    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=npq-headship")
-      .with(
-        headers: {
-          "Authorization" => "Bearer ECFAPPBEARERTOKEN",
-        },
-      )
-      .to_return(
-        status: 200,
-        body: ecf_funding_lookup_response(previously_funded: false),
-        headers: {
-          "Content-Type" => "application/vnd.api+json",
-        },
-      )
+    mock_previous_funding_api_request(
+      course_identifier: "npq-headship",
+      trn: "1234567",
+      response: ecf_funding_lookup_response(previously_funded: false)
+    )
 
     expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do
       expect(page).to have_text("Which NPQ do you want to do?")

--- a/spec/features/happy_journeys/non_js/via_using_same_name_spec.rb
+++ b/spec/features/happy_journeys/non_js/via_using_same_name_spec.rb
@@ -64,6 +64,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
     mock_previous_funding_api_request(
       course_identifier: "npq-headship",
+      get_an_identity_id: user_uid,
       trn: "1234567",
       response: ecf_funding_lookup_response(previously_funded: false)
     )

--- a/spec/features/happy_journeys/non_js/via_using_same_name_spec.rb
+++ b/spec/features/happy_journeys/non_js/via_using_same_name_spec.rb
@@ -66,7 +66,7 @@ RSpec.feature "Happy journeys", type: :feature do
       course_identifier: "npq-headship",
       get_an_identity_id: user_uid,
       trn: "1234567",
-      response: ecf_funding_lookup_response(previously_funded: false)
+      response: ecf_funding_lookup_response(previously_funded: false),
     )
 
     expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do

--- a/spec/features/sad_journeys/applying_for_ehco_but_not_new_headteacher_spec.rb
+++ b/spec/features/sad_journeys/applying_for_ehco_but_not_new_headteacher_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
   include_context "Enable Get An Identity integration"
 
   scenario "applying for EHCO but not new headteacher" do

--- a/spec/features/sad_journeys/applying_for_ehco_but_not_new_headteacher_spec.rb
+++ b/spec/features/sad_journeys/applying_for_ehco_but_not_new_headteacher_spec.rb
@@ -5,7 +5,10 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "Stub previously funding check for all courses"
+  include_context "Stub previously funding check for all courses" do
+    let(:api_call_get_an_identity_id) { user_uid }
+    let(:api_call_trn) { user_trn }
+  end
   include_context "Enable Get An Identity integration"
 
   scenario "applying for EHCO but not new headteacher" do

--- a/spec/features/sad_journeys/lead_mentor_journey_with_incorrect_course_spec.rb
+++ b/spec/features/sad_journeys/lead_mentor_journey_with_incorrect_course_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Sad journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
   include_context "Enable Get An Identity integration"
 
   scenario "registration journey when choosing lead mentor journey and approved ITT provider but picking the wrong course" do

--- a/spec/features/sad_journeys/lead_mentor_journey_with_incorrect_course_spec.rb
+++ b/spec/features/sad_journeys/lead_mentor_journey_with_incorrect_course_spec.rb
@@ -5,7 +5,10 @@ RSpec.feature "Sad journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "Stub previously funding check for all courses"
+  include_context "Stub previously funding check for all courses" do
+    let(:api_call_get_an_identity_id) { user_uid }
+    let(:api_call_trn) { user_trn }
+  end
   include_context "Enable Get An Identity integration"
 
   scenario "registration journey when choosing lead mentor journey and approved ITT provider but picking the wrong course" do

--- a/spec/features/sad_journeys/school_not_in_england_spec.rb
+++ b/spec/features/sad_journeys/school_not_in_england_spec.rb
@@ -5,7 +5,10 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "Stub previously funding check for all courses"
+  include_context "Stub previously funding check for all courses" do
+    let(:api_call_get_an_identity_id) { user_uid }
+    let(:api_call_trn) { user_trn }
+  end
   include_context "Enable Get An Identity integration"
 
   scenario "school not in england" do

--- a/spec/features/sad_journeys/school_not_in_england_spec.rb
+++ b/spec/features/sad_journeys/school_not_in_england_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
   include_context "Enable Get An Identity integration"
 
   scenario "school not in england" do

--- a/spec/features/sad_journeys/works_in_childcare_but_not_in_england_spec.rb
+++ b/spec/features/sad_journeys/works_in_childcare_but_not_in_england_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "stub course ecf to identifier mappings"
+  include_context "Stub previously funding check for all courses"
   include_context "Enable Get An Identity integration"
 
   scenario "works in childcare but not in england" do

--- a/spec/features/sad_journeys/works_in_childcare_but_not_in_england_spec.rb
+++ b/spec/features/sad_journeys/works_in_childcare_but_not_in_england_spec.rb
@@ -5,7 +5,10 @@ RSpec.feature "Happy journeys", type: :feature do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"
-  include_context "Stub previously funding check for all courses"
+  include_context "Stub previously funding check for all courses" do
+    let(:api_call_get_an_identity_id) { user_uid }
+    let(:api_call_trn) { user_trn }
+  end
   include_context "Enable Get An Identity integration"
 
   scenario "works in childcare but not in england" do

--- a/spec/lib/forms/check_answers_spec.rb
+++ b/spec/lib/forms/check_answers_spec.rb
@@ -25,19 +25,11 @@ RSpec.describe Forms::CheckAnswers do
 
   describe "#after_save" do
     before do
-      stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=#{course.identifier}")
-        .with(
-          headers: {
-            "Authorization" => "Bearer ECFAPPBEARERTOKEN",
-          },
-        )
-        .to_return(
-          status: 200,
-          body: ecf_funding_lookup_response(previously_funded: false),
-          headers: {
-            "Content-Type" => "application/vnd.api+json",
-          },
-        )
+      mock_previous_funding_api_request(
+        course_identifier: course.identifier,
+        trn: "1234567",
+        response: ecf_funding_lookup_response(previously_funded: false)
+      )
     end
 
     context "when TRA feature flag is enabled" do

--- a/spec/lib/forms/check_answers_spec.rb
+++ b/spec/lib/forms/check_answers_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Forms::CheckAnswers do
       mock_previous_funding_api_request(
         course_identifier: course.identifier,
         trn: "1234567",
-        response: ecf_funding_lookup_response(previously_funded: false)
+        response: ecf_funding_lookup_response(previously_funded: false),
       )
     end
 

--- a/spec/lib/forms/choose_your_npq_spec.rb
+++ b/spec/lib/forms/choose_your_npq_spec.rb
@@ -84,13 +84,13 @@ RSpec.describe Forms::ChooseYourNpq, type: :model do
           mock_previous_funding_api_request(
             course_identifier: "npq-headship",
             trn: "1234567",
-            response: ecf_funding_lookup_response(previously_funded: false)
+            response: ecf_funding_lookup_response(previously_funded: false),
           )
 
           mock_previous_funding_api_request(
             course_identifier: "npq-leading-teaching",
             trn: "1234567",
-            response: ecf_funding_lookup_response(previously_funded: false)
+            response: ecf_funding_lookup_response(previously_funded: false),
           )
         end
 

--- a/spec/lib/forms/choose_your_npq_spec.rb
+++ b/spec/lib/forms/choose_your_npq_spec.rb
@@ -81,33 +81,17 @@ RSpec.describe Forms::ChooseYourNpq, type: :model do
             request:, current_user: create(:user)
           )
 
-          stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=npq-headship")
-            .with(
-              headers: {
-                "Authorization" => "Bearer ECFAPPBEARERTOKEN",
-              },
-            )
-            .to_return(
-              status: 200,
-              body: ecf_funding_lookup_response(previously_funded: false),
-              headers: {
-                "Content-Type" => "application/vnd.api+json",
-              },
-            )
+          mock_previous_funding_api_request(
+            course_identifier: "npq-headship",
+            trn: "1234567",
+            response: ecf_funding_lookup_response(previously_funded: false)
+          )
 
-          stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=npq-leading-teaching")
-            .with(
-              headers: {
-                "Authorization" => "Bearer ECFAPPBEARERTOKEN",
-              },
-            )
-            .to_return(
-              status: 200,
-              body: ecf_funding_lookup_response(previously_funded: false),
-              headers: {
-                "Content-Type" => "application/vnd.api+json",
-              },
-            )
+          mock_previous_funding_api_request(
+            course_identifier: "npq-leading-teaching",
+            trn: "1234567",
+            response: ecf_funding_lookup_response(previously_funded: false)
+          )
         end
 
         context "when lead provider is valid for new course" do

--- a/spec/lib/services/funding_eligibility_spec.rb
+++ b/spec/lib/services/funding_eligibility_spec.rb
@@ -20,14 +20,11 @@ RSpec.describe Services::FundingEligibility do
   end
 
   before do
-    stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/#{trn}?npq_course_identifier=#{course_identifier}")
-      .to_return(
-        status: 200,
-        body: ecf_funding_lookup_response(previously_funded:),
-        headers: {
-          "Content-Type" => "application/vnd.api+json",
-        },
-      )
+    mock_previous_funding_api_request(
+      course_identifier: course_identifier,
+      trn: trn,
+      response: ecf_funding_lookup_response(previously_funded:)
+    )
   end
 
   describe ".funded? && .funding_eligiblity_status_code" do

--- a/spec/lib/services/funding_eligibility_spec.rb
+++ b/spec/lib/services/funding_eligibility_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Services::FundingEligibility do
                   get_an_identity_id:,
                   trn:,
                   approved_itt_provider:,
-                  lead_mentor:
+                  lead_mentor:,
                 )
               end
 
@@ -138,7 +138,7 @@ RSpec.describe Services::FundingEligibility do
                   get_an_identity_id:,
                   trn:,
                   approved_itt_provider:,
-                  lead_mentor:
+                  lead_mentor:,
                 )
               end
 

--- a/spec/lib/services/funding_eligibility_spec.rb
+++ b/spec/lib/services/funding_eligibility_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Services::FundingEligibility do
   let(:course) { Course.all.find { |c| !c.aso? } }
   let(:inside_catchment) { true }
   let(:trn) { "1234567" }
+  let(:get_an_identity_id) { SecureRandom.uuid }
   let(:previously_funded) { false }
   let(:course_identifier) { course.identifier }
   let(:eyl_funding_eligible) { false }
@@ -15,15 +16,17 @@ RSpec.describe Services::FundingEligibility do
                         course:,
                         inside_catchment:,
                         trn:,
+                        get_an_identity_id:,
                         approved_itt_provider:,
                         lead_mentor:)
   end
 
   before do
     mock_previous_funding_api_request(
-      course_identifier: course_identifier,
-      trn: trn,
-      response: ecf_funding_lookup_response(previously_funded:)
+      course_identifier:,
+      get_an_identity_id:,
+      trn:,
+      response: ecf_funding_lookup_response(previously_funded:),
     )
   end
 
@@ -77,6 +80,7 @@ RSpec.describe Services::FundingEligibility do
                   course:,
                   inside_catchment:,
                   new_headteacher: true,
+                  get_an_identity_id:,
                   trn:,
                 )
               end
@@ -129,6 +133,7 @@ RSpec.describe Services::FundingEligibility do
                   course:,
                   inside_catchment:,
                   new_headteacher: true,
+                  get_an_identity_id:,
                   trn:,
                 )
               end

--- a/spec/lib/services/funding_eligibility_spec.rb
+++ b/spec/lib/services/funding_eligibility_spec.rb
@@ -82,6 +82,8 @@ RSpec.describe Services::FundingEligibility do
                   new_headteacher: true,
                   get_an_identity_id:,
                   trn:,
+                  approved_itt_provider:,
+                  lead_mentor:
                 )
               end
 
@@ -135,6 +137,8 @@ RSpec.describe Services::FundingEligibility do
                   new_headteacher: true,
                   get_an_identity_id:,
                   trn:,
+                  approved_itt_provider:,
+                  lead_mentor:
                 )
               end
 

--- a/spec/lib/services/handle_submission_for_store_spec.rb
+++ b/spec/lib/services/handle_submission_for_store_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Services::HandleSubmissionForStore do
       mock_previous_funding_api_request(
         course_identifier: course.identifier,
         trn: "12345",
-        response: ecf_funding_lookup_response(previously_funded: false)
+        response: ecf_funding_lookup_response(previously_funded: false),
       )
     end
 
@@ -347,7 +347,7 @@ RSpec.describe Services::HandleSubmissionForStore do
             mock_previous_funding_api_request(
               course_identifier: "npq-early-headship-coaching-offer",
               trn: "12345",
-              response: ecf_funding_lookup_response(previously_funded: false)
+              response: ecf_funding_lookup_response(previously_funded: false),
             )
           end
 
@@ -393,7 +393,7 @@ RSpec.describe Services::HandleSubmissionForStore do
       mock_previous_funding_api_request(
         course_identifier: course.identifier,
         trn: "0012345",
-        response: ecf_funding_lookup_response(previously_funded: false)
+        response: ecf_funding_lookup_response(previously_funded: false),
       )
     end
 
@@ -678,7 +678,7 @@ RSpec.describe Services::HandleSubmissionForStore do
             mock_previous_funding_api_request(
               course_identifier: "npq-early-headship-coaching-offer",
               trn: "12345",
-              response: ecf_funding_lookup_response(previously_funded: false)
+              response: ecf_funding_lookup_response(previously_funded: false),
             )
           end
 

--- a/spec/lib/services/handle_submission_for_store_spec.rb
+++ b/spec/lib/services/handle_submission_for_store_spec.rb
@@ -35,19 +35,11 @@ RSpec.describe Services::HandleSubmissionForStore do
     end
 
     before do
-      stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/12345?npq_course_identifier=#{course.identifier}")
-        .with(
-          headers: {
-            "Authorization" => "Bearer ECFAPPBEARERTOKEN",
-          },
-        )
-        .to_return(
-          status: 200,
-          body: ecf_funding_lookup_response(previously_funded: false),
-          headers: {
-            "Content-Type" => "application/vnd.api+json",
-          },
-        )
+      mock_previous_funding_api_request(
+        course_identifier: course.identifier,
+        trn: "12345",
+        response: ecf_funding_lookup_response(previously_funded: false)
+      )
     end
 
     subject { described_class.new(store:) }
@@ -352,19 +344,11 @@ RSpec.describe Services::HandleSubmissionForStore do
           end
 
           before do
-            stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/12345?npq_course_identifier=npq-early-headship-coaching-offer")
-              .with(
-                headers: {
-                  "Authorization" => "Bearer ECFAPPBEARERTOKEN",
-                },
-              )
-              .to_return(
-                status: 200,
-                body: ecf_funding_lookup_response(previously_funded: false),
-                headers: {
-                  "Content-Type" => "application/vnd.api+json",
-                },
-              )
+            mock_previous_funding_api_request(
+              course_identifier: "npq-early-headship-coaching-offer",
+              trn: "12345",
+              response: ecf_funding_lookup_response(previously_funded: false)
+            )
           end
 
           it "returns headteacher_status as yes_over_five_years" do
@@ -406,19 +390,11 @@ RSpec.describe Services::HandleSubmissionForStore do
     end
 
     before do
-      stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/0012345?npq_course_identifier=#{course.identifier}")
-        .with(
-          headers: {
-            "Authorization" => "Bearer ECFAPPBEARERTOKEN",
-          },
-        )
-        .to_return(
-          status: 200,
-          body: ecf_funding_lookup_response(previously_funded: false),
-          headers: {
-            "Content-Type" => "application/vnd.api+json",
-          },
-        )
+      mock_previous_funding_api_request(
+        course_identifier: course.identifier,
+        trn: "0012345",
+        response: ecf_funding_lookup_response(previously_funded: false)
+      )
     end
 
     subject { described_class.new(store:) }
@@ -699,19 +675,11 @@ RSpec.describe Services::HandleSubmissionForStore do
           end
 
           before do
-            stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/12345?npq_course_identifier=npq-early-headship-coaching-offer")
-              .with(
-                headers: {
-                  "Authorization" => "Bearer ECFAPPBEARERTOKEN",
-                },
-              )
-              .to_return(
-                status: 200,
-                body: ecf_funding_lookup_response(previously_funded: false),
-                headers: {
-                  "Content-Type" => "application/vnd.api+json",
-                },
-              )
+            mock_previous_funding_api_request(
+              course_identifier: "npq-early-headship-coaching-offer",
+              trn: "12345",
+              response: ecf_funding_lookup_response(previously_funded: false)
+            )
           end
 
           it "returns headteacher_status as yes_over_five_years" do

--- a/spec/models/registration_wizard_spec.rb
+++ b/spec/models/registration_wizard_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe RegistrationWizard do
       mock_previous_funding_api_request(
         course_identifier: "npq-additional-support-offer",
         trn: "1234567",
-        response: ecf_funding_lookup_response(previously_funded: false)
+        response: ecf_funding_lookup_response(previously_funded: false),
       )
     end
 

--- a/spec/models/registration_wizard_spec.rb
+++ b/spec/models/registration_wizard_spec.rb
@@ -39,19 +39,11 @@ RSpec.describe RegistrationWizard do
     let(:school) { create(:school, establishment_type_code: "1") }
 
     before do
-      stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=npq-additional-support-offer")
-        .with(
-          headers: {
-            "Authorization" => "Bearer ECFAPPBEARERTOKEN",
-          },
-        )
-       .to_return(
-         status: 200,
-         body: ecf_funding_lookup_response(previously_funded: false),
-         headers: {
-           "Content-Type" => "application/vnd.api+json",
-         },
-       )
+      mock_previous_funding_api_request(
+        course_identifier: "npq-additional-support-offer",
+        trn: "1234567",
+        response: ecf_funding_lookup_response(previously_funded: false)
+      )
     end
 
     context "when ASO is selected course and is eligible for funding" do

--- a/spec/support/helpers/api_mocking.rb
+++ b/spec/support/helpers/api_mocking.rb
@@ -1,0 +1,15 @@
+def mock_previous_funding_api_request(course_identifier:, trn:, response:)
+  stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/#{trn}?npq_course_identifier=#{course_identifier}")
+    .with(
+      headers: {
+        "Authorization" => "Bearer ECFAPPBEARERTOKEN",
+      },
+      )
+    .to_return(
+      status: 200,
+      body: response,
+      headers: {
+        "Content-Type" => "application/vnd.api+json",
+      },
+    )
+end

--- a/spec/support/helpers/api_mocking.rb
+++ b/spec/support/helpers/api_mocking.rb
@@ -1,11 +1,11 @@
-def mock_previous_funding_api_request(course_identifier:, trn: nil, get_an_identity_id: nil, response:)
+def mock_previous_funding_api_request(course_identifier:, response:, trn: nil, get_an_identity_id: nil)
   base_url = "https://ecf-app.gov.uk/api/v1/npq/previous_funding"
 
   query_params = {
     npq_course_identifier: course_identifier,
-    trn:,
-    get_an_identity_id:
-  }.compact
+  }
+  query_params[:trn] = trn if trn.present?
+  query_params[:get_an_identity_id] = get_an_identity_id if get_an_identity_id.present?
 
   query_string = CGI.unescape(query_params.to_query)
   url = "#{base_url}?#{query_string}"

--- a/spec/support/helpers/api_mocking.rb
+++ b/spec/support/helpers/api_mocking.rb
@@ -1,10 +1,19 @@
 def mock_previous_funding_api_request(course_identifier:, trn:, response:)
-  stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/#{trn}?npq_course_identifier=#{course_identifier}")
+  base_url = "https://ecf-app.gov.uk/api/v1/npq-funding/#{trn}"
+
+  query_params = {
+    npq_course_identifier: course_identifier,
+  }
+
+  query_string = CGI.unescape(query_params.to_query)
+  url = "#{base_url}?#{query_string}"
+
+  stub_request(:get, url)
     .with(
       headers: {
         "Authorization" => "Bearer ECFAPPBEARERTOKEN",
       },
-      )
+    )
     .to_return(
       status: 200,
       body: response,

--- a/spec/support/helpers/api_mocking.rb
+++ b/spec/support/helpers/api_mocking.rb
@@ -1,9 +1,11 @@
-def mock_previous_funding_api_request(course_identifier:, trn:, response:)
-  base_url = "https://ecf-app.gov.uk/api/v1/npq-funding/#{trn}"
+def mock_previous_funding_api_request(course_identifier:, trn: nil, get_an_identity_id: nil, response:)
+  base_url = "https://ecf-app.gov.uk/api/v1/npq/previous_funding"
 
   query_params = {
     npq_course_identifier: course_identifier,
-  }
+    trn:,
+    get_an_identity_id:
+  }.compact
 
   query_string = CGI.unescape(query_params.to_query)
   url = "#{base_url}?#{query_string}"

--- a/spec/support/shared_contexts/stub_course_ecf_to_identifier_mappings.rb
+++ b/spec/support/shared_contexts/stub_course_ecf_to_identifier_mappings.rb
@@ -1,19 +1,11 @@
 RSpec.shared_context("stub course ecf to identifier mappings") do
   before do
     Course.pluck(:identifier).each do |course_identifier|
-      stub_request(:get, "https://ecf-app.gov.uk/api/v1/npq-funding/1234567?npq_course_identifier=#{course_identifier}")
-        .with(
-          headers: {
-            "Authorization" => "Bearer ECFAPPBEARERTOKEN",
-          },
-        )
-        .to_return(
-          status: 200,
-          body: ecf_funding_lookup_response(previously_funded: false),
-          headers: {
-            "Content-Type" => "application/vnd.api+json",
-          },
-        )
+      mock_previous_funding_api_request(
+        course_identifier: course_identifier,
+        trn: "1234567",
+        response: ecf_funding_lookup_response(previously_funded: false)
+      )
     end
   end
 end

--- a/spec/support/shared_contexts/stub_previously_funding_check_for_all_courses.rb
+++ b/spec/support/shared_contexts/stub_previously_funding_check_for_all_courses.rb
@@ -1,4 +1,4 @@
-RSpec.shared_context("stub course ecf to identifier mappings") do
+RSpec.shared_context("Stub previously funding check for all courses") do
   before do
     Course.pluck(:identifier).each do |course_identifier|
       mock_previous_funding_api_request(

--- a/spec/support/shared_contexts/stub_previously_funding_check_for_all_courses.rb
+++ b/spec/support/shared_contexts/stub_previously_funding_check_for_all_courses.rb
@@ -1,10 +1,14 @@
 RSpec.shared_context("Stub previously funding check for all courses") do
+  let(:api_call_get_an_identity_id) { raise NotImplementedError }
+  let(:api_call_trn) { raise NotImplementedError }
+
   before do
     Course.pluck(:identifier).each do |course_identifier|
       mock_previous_funding_api_request(
-        course_identifier: course_identifier,
-        trn: "1234567",
-        response: ecf_funding_lookup_response(previously_funded: false)
+        course_identifier:,
+        trn: api_call_trn,
+        get_an_identity_id: api_call_get_an_identity_id,
+        response: ecf_funding_lookup_response(previously_funded: false),
       )
     end
   end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-883

We need to prepare for a system where the Get an Identity service does not have to send us TRNs for every user. To support this the ECF app now has an API for checking previous funding that doesn't require a TRN. We need to integrate with that and send TRNs/Get an Identity IDs when available to support the differing availability of each. 

### Changes proposed in this pull request

