### PR TITLE
Enable Codespaces for NPQ

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,1 @@
+FROM mcr.microsoft.com/vscode/devcontainers/base:ubuntu-22.04

--- a/.devcontainer/boot.sh
+++ b/.devcontainer/boot.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+echo "Setting SSH password for vscode user..."
+sudo usermod --password $(echo vscode | openssl passwd -1 -stdin) vscode
+
+echo "Updating RubyGems..."
+gem update --system
+
+echo "Installing dependencies..."
+bundle install
+yarn install
+
+echo "Copying database.yml..."
+cp config/database.yml.example config/database.yml
+
+echo "Creating database..."
+bin/rails db:create db:schema:load db:migrate db:seed
+
+echo "Done!"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,47 @@
+{
+	"name": "Register for a national professional qualification",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "app",
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+	"features": {
+		"ghcr.io/devcontainers/features/sshd:1": {},
+		"ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
+			"packages": "libpq-dev, libvips"
+		},
+		"ghcr.io/devcontainers/features/git:1": {
+			"version": "latest"
+		},
+		"ghcr.io/devcontainers/features/ruby:1": {
+			"version": "3.1.2"
+		},
+		"ghcr.io/devcontainers/features/node:1": {
+			"version": 16
+		},
+		"ghcr.io/devcontainers/features/common-utils:1": {
+			"username": "vscode",
+			"uid": 1000,
+			"gid": 1000,
+			"installZsh": true,
+			"installOhMyZsh": true,
+			"configureZshAsDefaultShell": true,
+			"upgradePackages": true
+		}
+	},
+
+	"extensions": [
+		"rebornix.Ruby"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// This can be used to network with other containers or the host.
+	"forwardPorts": [2222],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": ".devcontainer/boot.sh"
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3'
+
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - ../..:/workspaces:cached
+    command: sleep infinity
+  postgres:
+    image: postgres:15-alpine
+    restart: unless-stopped
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_DB: postgres
+      POSTGRES_PASSWORD: postgres
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    volumes:
+      - redis-data:/data
+
+volumes:
+  postgres-data:
+  redis-data:

--- a/README.md
+++ b/README.md
@@ -3,20 +3,28 @@
 
 # npq-registration (National professional qualification)
 
-## Prerequisites
+## Setting up the app
 
-- Ruby 3.1.2
-- PostgreSQL
-- NodeJS 16.19.1
-- Yarn 1.12.x
+### Local development
 
-## Setting up the app in development
+1. Install the prerequisites:
+  - Ruby 3.1.2
+  - PostgreSQL
+  - NodeJS 16.19.1
+  - Yarn 1.12.x
+2. Run `bundle install` to install the gem dependencies
+3. Run `yarn` to install node dependencies
+4. Run `bin/rails db:setup` to set up the database development and test schemas, and seed with test data
+5. Run `bundle exec rails server` to launch the app on http://localhost:3000
+6. Run `./bin/webpack-dev-server` in a separate shell for faster compilation of assets
 
-1. Run `bundle install` to install the gem dependencies
-2. Run `yarn` to install node dependencies
-3. Run `bin/rails db:setup` to set up the database development and test schemas, and seed with test data
-4. Run `bundle exec rails server` to launch the app on http://localhost:3000
-5. Run `./bin/webpack-dev-server` in a separate shell for faster compilation of assets
+### Codespaces
+
+1. Click the green 'Code' button on the repository home page and click 'Create a Codespace'
+2. Run `bundle exec rails server` in the terminal window at the bottom of VS Code
+
+If you're unfamiliar with what Codespaces are or how they work [read the official guiude](https://docs.github.com/en/codespaces/overview). If you
+don't have access to them you can request it in `#digital-tools-support` on DfE Slack.
 
 ## Importing schools
 


### PR DESCRIPTION
Enabled Codespaces for the app.

This should let content/interaction designers run the application without having to go through the process of getting Ruby, Node, PostgreSQL etc running locally. I've tested it and it works with a single click. Managed to get this going while on a call!

Code/approach borrowed from [this starter repo](https://github.com/luizkowalski/devcontainer-rails).

![image](https://user-images.githubusercontent.com/128088/223760943-f456a975-67cc-48f5-849c-52b284da7cf5.png)
