### PR TITLE
Improve seeds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ end
 
 group :development do
   gem "brakeman"
+  gem "faker"
   gem "i18n-debug"
   gem "listen", ">= 3.0.5", "< 3.9"
   gem "web-console", ">= 3.3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,8 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
+    faker (3.1.1)
+      i18n (>= 1.8.11, < 2)
     faraday (1.10.0)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
@@ -512,6 +514,7 @@ DEPENDENCIES
   dotenv-rails
   email_validator
   factory_bot_rails
+  faker
   flipper (~> 0.28.0)
   flipper-active_record (~> 0.28.0)
   flipper-ui (~> 0.28.0)

--- a/app/lib/forms/sign_in.rb
+++ b/app/lib/forms/sign_in.rb
@@ -21,6 +21,8 @@ module Forms
     end
 
     def after_save
+      return if skip_sending_otp
+
       user = User.find_by(email:)
 
       if user
@@ -29,6 +31,10 @@ module Forms
         user.update!(otp_hash: code, otp_expires_at: 15.minutes.from_now)
         ConfirmEmailMailer.confirmation_code_mail(to: email, code:).deliver_now
       end
+    end
+
+    def skip_sending_otp
+      Rails.env.development? && @email == "admin@example.com"
     end
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,5 @@
+require "faker"
+
 def seed_courses!
   Services::Courses::DefinitionLoader.call
 end
@@ -15,3 +17,50 @@ end
 seed_courses!
 seed_lead_providers!
 seed_itt_providers!
+
+# Create admin user
+User.create!(
+  email: "admin@example.com",
+  ecf_id: nil,
+  trn: nil,
+  full_name: "example admin",
+  otp_hash: "000000",
+  otp_expires_at: "3000-01-01 00:00:00.000000000 +0000",
+  date_of_birth: nil,
+  trn_verified: false,
+  active_alert: false,
+  national_insurance_number: nil,
+  trn_auto_verified: false,
+  admin: true,
+  flipper_admin_access: true,
+  feature_flag_id: SecureRandom.uuid,
+  provider: nil,
+  uid: nil,
+  raw_tra_provider_data: nil,
+  get_an_identity_id_synced_to_ecf: false,
+)
+
+# Create childcare providers
+# 10.times do
+#   PrivateChildcareProvider.create!(
+#     provider_urn: "EY#{Faker::Number.number(digits: 5)}",
+#     provider_name: Faker::Educator.secondary_school,
+#     registered_person_urn: Faker::Number.number(digits: 7),
+#     registered_person_name: Faker::Educator.university,
+#     registration_date: "04/01/1995",
+#     provider_status: "Active",
+#     address_1: Faker::Address.secondary_address,
+#     address_2: Faker::Address.street_address,
+#     address_3: nil,
+#     town: Faker::Address.city,
+#     postcode: Faker::Address.postcode,
+#     postcode_without_spaces: Faker::Address.postcode.delete(" "),
+#     region: Faker::Address.state,
+#     local_authority: Faker::Address.city,
+#     ofsted_region: nil,
+#     early_years_individual_registers: %w[CCR VCR EYR].sample,
+#     provider_early_years_register_flag: false,
+#     provider_compulsory_childcare_register_flag: false,
+#     places: 30,
+#   )
+# end


### PR DESCRIPTION
### Context

Its very annoying having to log in to the admin panel without an admin user so this creates an admin user plus `PrivateChildcareProvider` users. There are lots other things we can add to seeds but this provides benefit with getting easy access to the backend through the `admin@example.com` user which will only work in development at the moment. 

### Changes proposed in this pull request

[What has been changed?]
