### PR TITLE
[CPDNPQ-806] Drops flipper_admin_access column from uses table

### DIFF
--- a/db/migrate/20230331120924_drop_unused_column_flipper_admin_access.rb
+++ b/db/migrate/20230331120924_drop_unused_column_flipper_admin_access.rb
@@ -1,0 +1,5 @@
+class DropUnusedColumnFlipperAdminAccess < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :users, :flipper_admin_access, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_23_184936) do
+ActiveRecord::Schema.define(version: 2023_03_31_120924) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -244,7 +244,6 @@ ActiveRecord::Schema.define(version: 2023_03_23_184936) do
     t.text "national_insurance_number"
     t.boolean "trn_auto_verified", default: false
     t.boolean "admin", default: false
-    t.boolean "flipper_admin_access", default: false
     t.string "feature_flag_id"
     t.string "provider"
     t.string "uid"

--- a/spec/lib/services/handle_submission_for_store_spec.rb
+++ b/spec/lib/services/handle_submission_for_store_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Services::HandleSubmissionForStore do
 
     describe "#call" do
       def stable_as_json(record)
-        record.as_json(except: %i[id created_at updated_at flipper_admin_access])
+        record.as_json(except: %i[id created_at updated_at])
       end
 
       context "when store includes information from the school path" do
@@ -405,7 +405,7 @@ RSpec.describe Services::HandleSubmissionForStore do
 
     describe "#call" do
       def stable_as_json(record)
-        record.as_json(except: %i[id created_at updated_at flipper_admin_access])
+        record.as_json(except: %i[id created_at updated_at])
       end
 
       context "when store includes information from the school path" do

--- a/spec/support/helpers/journey_helper.rb
+++ b/spec/support/helpers/journey_helper.rb
@@ -9,7 +9,7 @@ module Helpers
     end
 
     def retrieve_latest_application_user_data
-      latest_application_user&.as_json(except: %i[id feature_flag_id created_at updated_at flipper_admin_access])
+      latest_application_user&.as_json(except: %i[id feature_flag_id created_at updated_at])
     end
 
     def retrieve_latest_application_data


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-806

This column been replaced with super_admin, it needs removing now that it is not used by any code.

### Changes proposed in this pull request

- Drop flipper_admin_access column and remove references to it within the codebase