### PR TITLE
Add employment_type to BigQuery upload

### DIFF
--- a/app/lib/services/report.rb
+++ b/app/lib/services/report.rb
@@ -35,6 +35,7 @@ module Services
         school_postcode
         course_name
         provider_name
+        employment_type
       ]
     end
 
@@ -65,6 +66,7 @@ module Services
           a.school&.postcode,
           a.course.name,
           a.lead_provider.name,
+          a.employment_type,
         ]
       end
     end

--- a/spec/lib/services/report_spec.rb
+++ b/spec/lib/services/report_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe Services::Report do
         school_postcode
         course_name
         provider_name
+        employment_type
       ]
 
       csv_headers = CSV.parse(subject.call).first


### PR DESCRIPTION
### Context

We need this to be able to isolate non-school records in queries.

The corresponding column is ready and waiting in BigQuery:

![image](https://user-images.githubusercontent.com/128088/233073432-3f1d57ca-ab65-47a9-94dd-9df10c518dfa.png)

