### PR TITLE
[CPDNPQ-1088] Update childcare-provider-not-in-engalnd to use copy_page template

### DIFF
--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -307,6 +307,7 @@ private
       your_role
       your_employer
       school_not_in_england
+      childcare_provider_not_in_england
       possible_funding
       ineligible_for_funding
       funding_your_npq

--- a/app/views/registration_wizard/childcare_provider_not_in_england.html.erb
+++ b/app/views/registration_wizard/childcare_provider_not_in_england.html.erb
@@ -1,22 +1,15 @@
-<% content_for :title do %>
-  Nursery must be in England, Guernsey, Jersey or the Isle of Man
+<%=
+  render(
+    'registration_wizard/shared/copy_page',
+    form: @form,
+    wizard: @wizard,
+    ) do
+%>
+  <h1 class="govuk-heading-xl">Nursery must be in England, Guernsey, Jersey or the Isle of Man</h1>
+
+  <p class="govuk-body">The nursery you have selected is not in England, Guernsey, Jersey or the Isle of Man.</p>
+
+  <p class="govuk-body">This NPQ application can only be completed by people working in these locations.</p>
+
+  <p class="govuk-body">If you work in a nursery outside these locations and you want to study for an NPQ, check with your training provider or nursery’s training contact.</p>
 <% end %>
-
-<% content_for :before_content do %>
-  <%= render GovukComponent::BackLinkComponent.new(
-    text: "Back",
-    href: registration_wizard_show_path(@wizard.previous_step_path)
-  ) %>
-<% end %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Nursery must be in England, Guernsey, Jersey or the Isle of Man</h1>
-
-    <p class="govuk-body">The nursery you have selected is not in England, Guernsey, Jersey or the Isle of Man.</p>
-
-    <p class="govuk-body">This NPQ application can only be completed by people working in these locations.</p>
-
-    <p class="govuk-body">If you work in a nursery outside these locations and you want to study for an NPQ, check with your training provider or nursery’s training contact.</p>
-  </div>
-</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -243,6 +243,7 @@ en:
         choose_your_npq: "Choose an NPQ"
         npqh_status: "Eligibility for the Early headship coaching offer"
         change_dqt: "Change your details on the Teaching Regulation Agency records"
+        childcare_provider_not_in_england: "Nursery must be in England, Guernsey, Jersey or the Isle of Man"
     legend:
       registration_wizard:
         aso_headteacher: "Are you a headteacher?"


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-1088

We are standardising on one page format across the app.

### Changes proposed in this pull request

- Forms::ChildcareProviderNotInEngland moved to use copy_page template
