### PR TITLE
Move share_provider to question_page system

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ group :development, :test do
   gem "capybara"
   gem "dotenv-rails"
   gem "pry-byebug"
+  gem "pry-rails"
   gem "rspec-rails", "~> 6.0.2"
   gem "rubocop-govuk"
   gem "scss_lint-govuk"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,6 +301,8 @@ GEM
     pry-byebug (3.10.1)
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (5.0.1)
     puma (6.2.2)
       nio4r (~> 2.0)
@@ -542,6 +544,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   pg_search
   pry-byebug
+  pry-rails
   puma (~> 6.2)
   rack-attack
   rails (~> 6.1.7)

--- a/app/lib/forms/question_types/check_box.rb
+++ b/app/lib/forms/question_types/check_box.rb
@@ -1,0 +1,31 @@
+module Forms
+  module QuestionTypes
+    class CheckBox < Base
+      DEFAULT_STYLES = {
+        legend: {
+          size: "xl",
+          tag: "h1",
+        }.freeze,
+      }.freeze
+
+      attr_reader :checked_value, :unchecked_value, :required, :body
+
+      def initialize(*args, checked_value: "1", unchecked_value: "0", required: false, body: nil, **opts)
+        @checked_value = checked_value
+        @unchecked_value = unchecked_value
+        @required = required
+        @body = Array.wrap(body)
+
+        super(*args, **opts)
+      end
+
+      def title_locale_type
+        :legend
+      end
+
+      def style_options
+        DEFAULT_STYLES.deep_merge(@style_options)
+      end
+    end
+  end
+end

--- a/app/lib/forms/question_types/check_box.rb
+++ b/app/lib/forms/question_types/check_box.rb
@@ -6,6 +6,7 @@ module Forms
           size: "xl",
           tag: "h1",
         }.freeze,
+        hint: nil,
       }.freeze
 
       attr_reader :checked_value, :unchecked_value, :required, :body

--- a/app/lib/forms/share_provider.rb
+++ b/app/lib/forms/share_provider.rb
@@ -10,6 +10,14 @@ module Forms
       ]
     end
 
+    def question
+      @question ||= Forms::QuestionTypes::CheckBox.new(
+        name: :can_share_choices,
+        required: true,
+        body: I18n.t("helpers.hint.registration_wizard.can_share_choices"),
+      )
+    end
+
     def next_step
       :check_answers
     end

--- a/app/views/registration_wizard/share_provider.html.erb
+++ b/app/views/registration_wizard/share_provider.html.erb
@@ -1,41 +1,8 @@
-<% content_for :title do %>
-  <%= @form.errors.present? ? "Error: " : nil %>Sharing your NPQ information
-<% end %>
+<%=
+  render(
+    'registration_wizard/shared/question_page',
+    form: @form,
+    wizard: @wizard,
+  )
+%>
 
-<% content_for :before_content do %>
-  <%= render GovukComponent::BackLinkComponent.new(
-    text: "Back",
-    href: registration_wizard_show_path(@wizard.previous_step_path)
-  ) %>
-<% end %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
-      <%= f.govuk_error_summary %>
-
-      <%= f.govuk_check_boxes_fieldset :can_share_choices,
-        multiple: false,
-        legend: {
-          text: "Sharing your NPQ information",
-          size: "xl",
-          tag: "h1"
-        } do %>
-
-      <p class="govuk-body">All the information you enter for your NPQ application will be shared with your training provider - this lets your provider register the details to start your course.</p>
-
-      <p class="govuk-body">If you do not share this, you cannot progress with your NPQ.</p>
-
-      <%= f.govuk_check_box :can_share_choices,
-        "1",
-        "0",
-        multiple: false,
-        required: true,
-        link_errors: true,
-        label: { text: "Yes, I agree my information can be shared" } %>
-      <% end %>
-
-      <%= f.govuk_submit %>
-    <% end %>
-  </div>
-</div>

--- a/app/views/registration_wizard/shared/questions/_check_box.html.erb
+++ b/app/views/registration_wizard/shared/questions/_check_box.html.erb
@@ -1,0 +1,6 @@
+<%= form.govuk_check_boxes_fieldset(question.name, multiple: false, **question.style_options) do %>
+  <% question.body.each do |body_text| %>
+    <p class="govuk-body"><%= body_text %></p>
+  <% end %>
+  <%= form.govuk_check_box question.name, question.checked_value, question.unchecked_value, multiple: false, required: question.required %>
+<% end  %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -248,6 +248,7 @@ en:
     legend:
       registration_wizard:
         aso_headteacher: "Are you a headteacher?"
+        can_share_choices: "Sharing your NPQ information"
         aso_new_headteacher: "Are you in your first 5 years of a headship?"
         employment_type: "How are you employed?"
         work_setting: "What setting do you work in?"
@@ -272,6 +273,9 @@ en:
         course_identifier_options:
           "npq-early-headship-coaching-offer": "Structured support and networking opportunities if you’re a headteacher in your first 5 years of headship."
         npqh_status_title_hint: "To be eligible for the Early headship coaching offer you need to do the Headship NPQ."
+        can_share_choices:
+          - All the information you enter for your NPQ application will be shared with your training provider - this lets your provider register the details to start your course.
+          - If you do not share this, you cannot progress with your NPQ.
     label:
       registration_wizard:
         work_setting_options:
@@ -312,6 +316,9 @@ en:
         employment_role: "What is your role?"
 
         employer_name: "What organisation are you employed by?"
+
+        can_share_choices_options:
+          1: Yes, I agree my information can be shared
 
         aso_funding_choice_options:
           school: "My workplace is covering the cost"

--- a/spec/lib/forms/share_provider_spec.rb
+++ b/spec/lib/forms/share_provider_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe Forms::ShareProvider, type: :model do
+  subject(:model) { described_class.new }
+
+  describe "validations" do
+    it { is_expected.to validate_acceptance_of(:can_share_choices) }
+  end
+
+  describe "#next_step" do
+    subject(:next_step) { model.next_step }
+
+    it { is_expected.to be :check_answers }
+  end
+
+  describe "#previous_step" do
+    subject(:previous_step) { model.previous_step }
+
+    it { is_expected.to be :choose_your_provider }
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-1104

Just another part of the question_page migration

### Changes proposed in this pull request

- Replaced the share_provider view with a common question partial.
- Created new type of question - check box

### Notes:

I was playing with an idea of CheckBoxGroup as well, however it seems there are some significant conceptual differences between a group and a single checkbox and in the end decided to write CheckBox as a standalone type of question rather than a very specific type of CheckBoxGroup.