### PR TITLE
[CPDNPQ-1080] Use localised course names instead of course.name where possible

### DIFF
--- a/app/helpers/course_helper.rb
+++ b/app/helpers/course_helper.rb
@@ -1,5 +1,5 @@
 module CourseHelper
   def localise_course_name(course)
-    I18n.t(course.identifier, scope: "course.identifier")
+    I18n.t(course.identifier, scope: "course.name")
   end
 end

--- a/app/helpers/course_helper.rb
+++ b/app/helpers/course_helper.rb
@@ -2,4 +2,20 @@ module CourseHelper
   def localise_course_name(course)
     I18n.t(course.identifier, scope: "course.name")
   end
+
+  # Returns either "the #{course_name}" (for EHCO) or "the #{course_name} NPQ" in all other cases
+  # Saves having this logic in a bunch of different templates
+  def localise_sentence_embedded_course_name(course)
+    embed_mode = if course.ehco? || course.aso?
+                   :ehco
+                 else
+                   :default
+                 end
+
+    I18n.t("course.embedded_sentence.#{embed_mode}", course_name: localise_course_name(course))
+  end
+
+  def course_short_code(course)
+    I18n.t(course.identifier, scope: "course.short_code")
+  end
 end

--- a/app/helpers/course_helper.rb
+++ b/app/helpers/course_helper.rb
@@ -1,5 +1,5 @@
 module CourseHelper
   def localise_course_name(course)
-    I18n.t(course.identifier, scope: "helpers.label.registration_wizard.course_identifier_options")
+    I18n.t(course.identifier, scope: "course.identifier")
   end
 end

--- a/app/jobs/application_submission_job.rb
+++ b/app/jobs/application_submission_job.rb
@@ -1,4 +1,6 @@
 class ApplicationSubmissionJob < ApplicationJob
+  include CourseHelper
+
   queue_as :default
 
   def perform(user:)
@@ -15,7 +17,7 @@ class ApplicationSubmissionJob < ApplicationJob
         to: user.email,
         full_name: user.full_name,
         provider_name: application.lead_provider.name,
-        course_name: application.course.name,
+        course_name: localise_course_name(application.course),
       ).deliver_now
     end
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -3,6 +3,7 @@ class Course < ApplicationRecord
   scope :ehco, -> { where(identifier: "npq-early-headship-coaching-offer") }
   scope :npqeyl, -> { where(identifier: "npq-early-years-leadership") }
   scope :npqltd, -> { where(identifier: "npq-leading-teaching-development") }
+  scope :npqh, -> { where(identifier: "npq-headship") }
 
   def supports_targeted_delivery_funding?
     !ehco? && !aso?

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -152,7 +152,7 @@ class RegistrationWizard
     end
 
     array << OpenStruct.new(key: "Course",
-                            value: I18n.t(query_store.course.identifier, scope: "course.identifier"),
+                            value: I18n.t(query_store.course.identifier, scope: "course.name"),
                             change_step: :choose_your_npq)
 
     unless eligible_for_funding?

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -152,7 +152,7 @@ class RegistrationWizard
     end
 
     array << OpenStruct.new(key: "Course",
-                            value: I18n.t(query_store.course.identifier, scope: "helpers.label.registration_wizard.course_identifier_options"),
+                            value: I18n.t(query_store.course.identifier, scope: "course.identifier"),
                             change_step: :choose_your_npq)
 
     unless eligible_for_funding?

--- a/app/views/admin/unsynced_applications/index.html.erb
+++ b/app/views/admin/unsynced_applications/index.html.erb
@@ -22,7 +22,7 @@
             @applications.each do |app|
               body.row do |row|
                 row.cell(text: govuk_link_to(app.user.email, admin_application_path(app)))
-                row.cell(text: app.course.name)
+                row.cell(text: localise_course_name(app.course))
                 row.cell(text: app.lead_provider.name)
                 row.cell(text: app.school_urn)
                 row.cell(text: app.created_at.to_date.to_formatted_s(:govuk))

--- a/app/views/admin/users/_applications.html.erb
+++ b/app/views/admin/users/_applications.html.erb
@@ -13,7 +13,7 @@
   <tbody class="govuk-table__body">
   <% applications.each do |app| %>
     <tr class="govuk-table__row">
-      <td class="govuk-table__cell"><%= app.course.name %></td>
+      <td class="govuk-table__cell"><%= localise_course_name(app.course) %></td>
       <td class="govuk-table__cell"><%= app.lead_provider.name %></td>
       <td class="govuk-table__cell"><%= app.school_urn %></td>
       <td class="govuk-table__cell"><%= boolean_red_green_tag(app.eligible_for_funding) %></td>

--- a/app/views/registration_wizard/aso_funding_not_available.html.erb
+++ b/app/views/registration_wizard/aso_funding_not_available.html.erb
@@ -8,7 +8,7 @@
   <h1 class="govuk-heading-xl" >DfE scholarship funding is not available</h1>
 
   <p class="govuk-body">
-    You can still register for the Early headship coaching offer, but you need to pay for it another way.
+    You can still register for <%= localise_sentence_embedded_course_name(Course.ehco.first) %>, but you need to pay for it another way.
   </p>
 
   <p class="govuk-body">

--- a/app/views/registration_wizard/aso_possible_funding.html.erb
+++ b/app/views/registration_wizard/aso_possible_funding.html.erb
@@ -8,7 +8,7 @@
   <h1 class="govuk-heading-xl">If your provider accepts your application, you’ll qualify for DfE scholarship funding</h1>
 
   <p class="govuk-body">
-    From the information you have provided, DfE scholarship funding should be available for the Early headship coaching offer.
+    From the information you have provided, DfE scholarship funding should be available for <%= localise_sentence_embedded_course_name(Course.ehco.first) %>.
   </p>
 
   <p class="govuk-body">

--- a/app/views/registration_wizard/aso_previously_funded.html.erb
+++ b/app/views/registration_wizard/aso_previously_funded.html.erb
@@ -7,7 +7,7 @@
 %>
   <h1 class="govuk-heading-xl">DfE scholarship funding is not available</h1>
 
-  <p class="govuk-body">Our records show that you are already registered to study <b>Early headship coaching offer</b> (previously known as the Additional Support Offer).</p>
+  <p class="govuk-body">Our records show that you are already registered to study <%= localise_sentence_embedded_course_name(Course.ehco.first) %> (previously known as <%= localise_sentence_embedded_course_name(Course.aso.first) %>).</p>
 
   <ul class="govuk-list govuk-list--bullet">
     <li>
@@ -20,7 +20,7 @@
   </ul>
 
   <p class="govuk-body">
-    You can <%= link_to('go back and select an NPQ', registration_wizard_show_path(@wizard.previous_step_path)) %> or continue with your registration for the Early headship coaching offer. You'll need to pay for it another way. Contact your course provider to discuss your funding options.
+    You can <%= link_to('go back and select an NPQ', registration_wizard_show_path(@wizard.previous_step_path)) %> or continue with your registration for <%= localise_sentence_embedded_course_name(Course.ehco.first) %>. You'll need to pay for it another way. Contact your course provider to discuss your funding options.
   </p>
 
   <%= govuk_button_link_to "Continue", registration_wizard_show_path(@wizard.next_step_path) %>

--- a/app/views/registration_wizard/aso_unavailable.html.erb
+++ b/app/views/registration_wizard/aso_unavailable.html.erb
@@ -5,9 +5,16 @@
     wizard: @wizard,
     ) do
 %>
-  <h1 class="govuk-heading-xl">You cannot register for the Early headship coaching offer</h1>
+  <%
+    ehco = Course.ehco.first
+    ehco_course_name_string = localise_sentence_embedded_course_name(ehco)
+    npqh = Course.npqh.first
+    npqh_course_name_string = localise_sentence_embedded_course_name(npqh)
+  %>
 
-  <p class="govuk-body">To be eligible for the Early headship coaching offer you need to do the Headship NPQ.</p>
+  <h1 class="govuk-heading-xl">You cannot register for <%= ehco_course_name_string %>.</h1>
 
-  <p class="govuk-body">Go back if you want to <%= govuk_link_to("register for the Headship NPQ", registration_wizard_show_path(:choose_your_npq)) %>.</p>
+  <p class="govuk-body">To be eligible for <%= ehco_course_name_string %> you need to do <%= npqh_course_name_string %>.</p>
+
+  <p class="govuk-body">Go back if you want to <%= govuk_link_to("register for #{npqh_course_name_string}", registration_wizard_show_path(:choose_your_npq)) %>.</p>
 <% end %>

--- a/app/views/registration_wizard/choose_your_provider.html.erb
+++ b/app/views/registration_wizard/choose_your_provider.html.erb
@@ -24,7 +24,7 @@
 
         <% if @form.course %>
           <p class="govuk-body">
-            These are the training providers who provide <b><%= @form.course.name %></b>. Providers may have different entry requirements.
+            These are the training providers who provide <b><%= localise_course_name(@form.course) %></b>. Providers may have different entry requirements.
           </p>
         <% end %>
 

--- a/app/views/registration_wizard/choose_your_provider.html.erb
+++ b/app/views/registration_wizard/choose_your_provider.html.erb
@@ -24,7 +24,7 @@
 
         <% if @form.course %>
           <p class="govuk-body">
-            These are the training providers who provide <b><%= localise_course_name(@form.course) %></b>. Providers may have different entry requirements.
+            These are the training providers who provide <%= localise_sentence_embedded_course_name(@form.course) %>. Providers may have different entry requirements.
           </p>
         <% end %>
 

--- a/app/views/registration_wizard/closed.html.erb
+++ b/app/views/registration_wizard/closed.html.erb
@@ -12,7 +12,7 @@
 
     <ul class="govuk-list govuk-list--bullet">
       <li>to study for an NPQ</li>
-      <li>for the Additional Support Offer for new headteachers</li>
+      <li>for <%= localise_sentence_embedded_course_name(Course.ehco.first) %> for new headteachers</li>
     </ul>
 
     <p class="govuk-body">For more information you can read guidance on the <%= govuk_link_to "NPQ reforms.", "https://www.gov.uk/government/publications/national-professional-qualifications-npqs-reforms/national-professional-qualifications-npqs-reforms" %></p>

--- a/app/views/registration_wizard/confirmation.html.erb
+++ b/app/views/registration_wizard/confirmation.html.erb
@@ -9,7 +9,7 @@
         text: "Your initial registration is complete"
       },
       body: {
-        text: "You’ve registered for an <strong>#{localise_course_name(@form.course)}</strong> with <strong>#{@form.lead_provider.name}</strong>".html_safe,
+        text: "You’ve registered for <strong>#{localise_sentence_embedded_course_name(@form.course)}</strong> with <strong>#{@form.lead_provider.name}</strong>".html_safe,
         classes: ["govuk-!-font-size-19"]
       }
     ) %>
@@ -21,22 +21,26 @@
     <p class="govuk-body">They’ll contact you to outline the next steps, including how to apply.</p>
 
     <% if @form.display_npqh_information?  %>
-      <h2 class="govuk-heading-m">Early headship coaching offer</h2>
+      <% ehco_course = Course.ehco.first %>
 
-      <p class="govuk-body">The Early headship coaching offer is a package of structured face-to-face support for new headteachers.</p>
+      <h2 class="govuk-heading-m"><%= localise_course_name(ehco_course) %></h2>
+
+      <p class="govuk-body">The <%= localise_course_name(ehco_course) %> is a package of structured face-to-face support for new headteachers.</p>
 
       <p class="govuk-body">You may be eligible for DfE scholarship funding if you are in the first 5 years of a headship and:</p>
 
       <ul class="govuk-list govuk-list--bullet">
-        <li>have completed an NPQH</li>
-        <li>are studying for an NPQH</li>
-        <li>are about to start an NPOH</li>
+        <% npqh_name = course_short_code(Course.npqh.first) %>
+
+        <li>have completed an <%= npqh_name %></li>
+        <li>are studying for an <%= npqh_name %></li>
+        <li>are about to start an <%= npqh_name %></li>
       </ul>
 
       <p class="govuk-body">If eligible, your training provider will share further details with you.</p>
 
       <p class="govuk-body">
-        <%= govuk_link_to "Read more about the Early headship coaching offer", @form.ehco_more_information_url %>
+        <%= govuk_link_to "Read more about #{localise_sentence_embedded_course_name(ehco_course)}", @form.ehco_more_information_url %>
       </p>
     <% end %>
 

--- a/app/views/registration_wizard/confirmation.html.erb
+++ b/app/views/registration_wizard/confirmation.html.erb
@@ -9,7 +9,7 @@
         text: "Your initial registration is complete"
       },
       body: {
-        text: "You’ve registered for an <strong>#{@form.course.name}</strong> with <strong>#{@form.lead_provider.name}</strong>".html_safe,
+        text: "You’ve registered for an <strong>#{localise_course_name(@form.course)}</strong> with <strong>#{@form.lead_provider.name}</strong>".html_safe,
         classes: ["govuk-!-font-size-19"]
       }
     ) %>

--- a/app/views/registration_wizard/confirmation.html.erb
+++ b/app/views/registration_wizard/confirmation.html.erb
@@ -30,11 +30,11 @@
       <p class="govuk-body">You may be eligible for DfE scholarship funding if you are in the first 5 years of a headship and:</p>
 
       <ul class="govuk-list govuk-list--bullet">
-        <% npqh_name = course_short_code(Course.npqh.first) %>
+        <% npqh_name = localise_sentence_embedded_course_name(Course.npqh.first) %>
 
-        <li>have completed an <%= npqh_name %></li>
-        <li>are studying for an <%= npqh_name %></li>
-        <li>are about to start an <%= npqh_name %></li>
+        <li>have completed <%= npqh_name %></li>
+        <li>are studying for <%= npqh_name %></li>
+        <li>are about to start <%= npqh_name %></li>
       </ul>
 
       <p class="govuk-body">If eligible, your training provider will share further details with you.</p>

--- a/app/views/registration_wizard/ineligible_for_funding.erb
+++ b/app/views/registration_wizard/ineligible_for_funding.erb
@@ -11,7 +11,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render "registration_wizard/ineligible_for_funding/#{@form.ineligible_template}", course_name: @form.course.name %>
+    <%=
+      render(
+        "registration_wizard/ineligible_for_funding/#{@form.ineligible_template}",
+        course_name: localise_course_name(@form.course),
+      )
+    %>
 
     <%= govuk_button_link_to "Continue", registration_wizard_show_path(@wizard.next_step_path) %>
   </div>

--- a/app/views/registration_wizard/ineligible_for_funding.erb
+++ b/app/views/registration_wizard/ineligible_for_funding.erb
@@ -14,7 +14,7 @@
     <%=
       render(
         "registration_wizard/ineligible_for_funding/#{@form.ineligible_template}",
-        course_name: localise_course_name(@form.course),
+        course: @form.course,
       )
     %>
 

--- a/app/views/registration_wizard/ineligible_for_funding/early_years/_not_applying_for_NPQEY.html.erb
+++ b/app/views/registration_wizard/ineligible_for_funding/early_years/_not_applying_for_NPQEY.html.erb
@@ -4,7 +4,7 @@
 
 <h1 class="govuk-heading-xl">DfE scholarship funding is not available</h1>
 
-<p class="govuk-body">To be eligible for scholarship funding for the <b><%= course_name %></b> you must work in one of these settings in England:</p>
+<p class="govuk-body">To be eligible for scholarship funding for <%= localise_sentence_embedded_course_name(course) %> you must work in one of these settings in England:</p>
 
 <ul class="govuk-list govuk-list--bullet">
   <li>state-funded schools</li>
@@ -15,7 +15,9 @@
   <li>young offenders institutions</li>
 </ul>
 
+<% npqeyl = Course.npqeyl.first %>
+
 <div class="govuk-inset-text">
-  From the answers you have given us you should be eligible for scholarship funding for the NPQ Early Years Leadership (NPQEYL). You can <%= link_to('go back and select the NPQEYL', registration_wizard_show_path(@wizard.previous_step_path)) %> or continue with your registration for NPQ for <%= course_name %>.
+  From the answers you have given us you should be eligible for scholarship funding for <%= localise_sentence_embedded_course_name(npqeyl) %>. You can <%= link_to("go back and select the #{course_short_code(npqeyl)}", registration_wizard_show_path(@wizard.previous_step_path)) %> or continue with your registration for NPQ for <%= localise_sentence_embedded_course_name(course) %>.
 </div>
 

--- a/app/views/registration_wizard/ineligible_for_funding/early_years/_not_applying_for_NPQEY.html.erb
+++ b/app/views/registration_wizard/ineligible_for_funding/early_years/_not_applying_for_NPQEY.html.erb
@@ -18,6 +18,6 @@
 <% npqeyl = Course.npqeyl.first %>
 
 <div class="govuk-inset-text">
-  From the answers you have given us you should be eligible for scholarship funding for <%= localise_sentence_embedded_course_name(npqeyl) %>. You can <%= link_to("go back and select the #{course_short_code(npqeyl)}", registration_wizard_show_path(@wizard.previous_step_path)) %> or continue with your registration for NPQ for <%= localise_sentence_embedded_course_name(course) %>.
+  From the answers you have given us you should be eligible for scholarship funding for <%= localise_sentence_embedded_course_name(npqeyl) %> (<%= course_short_code(npqeyl) %>). You can <%= link_to("go back and select the #{course_short_code(npqeyl)}", registration_wizard_show_path(@wizard.previous_step_path)) %> or continue with your registration for NPQ for <%= localise_sentence_embedded_course_name(course) %>.
 </div>
 

--- a/app/views/registration_wizard/ineligible_for_funding/early_years/_outside_catchment_or_not_on_early_years_register.html.erb
+++ b/app/views/registration_wizard/ineligible_for_funding/early_years/_outside_catchment_or_not_on_early_years_register.html.erb
@@ -4,11 +4,11 @@
 
 <h1 class="govuk-heading-xl">DfE scholarship funding is not available</h1>
 
-<p class="govuk-body">To be eligible for scholarship funding for the <b><%= course_name %></b> you must:</p>
+<p class="govuk-body">To be eligible for scholarship funding for <%= localise_sentence_embedded_course_name(course) %> you must:</p>
 
 <ul class="govuk-list govuk-list--bullet">
   <li>Work in England</li>
   <li>Be registered with Ofsted on the Early Years Register or the Childcare Register, or be registered with a Childminder Agency (CMA)</li>
 </ul>
 
-<p class="govuk-body">You can still register for <%= course_name %>, but you need to pay for it another way. Contact your course provider to discuss your funding options.</p>
+<p class="govuk-body">You can still register for <%= localise_sentence_embedded_course_name(course) %>, but you need to pay for it another way. Contact your course provider to discuss your funding options.</p>

--- a/app/views/registration_wizard/ineligible_for_funding/lead_mentor/_not_applying_for_NPQLTD.html.erb
+++ b/app/views/registration_wizard/ineligible_for_funding/lead_mentor/_not_applying_for_NPQLTD.html.erb
@@ -4,7 +4,7 @@
 
 <h1 class="govuk-heading-xl">DfE scholarship funding is not available</h1>
 
-<p class="govuk-body">To be eligible for scholarship funding for the <b><%= course_name %></b> you must work in one of these settings in England:</p>
+<p class="govuk-body">To be eligible for scholarship funding for <%= localise_sentence_embedded_course_name(course) %> you must work in one of these settings in England:</p>
 
 <ul class="govuk-list govuk-list--bullet">
   <li>state-funded schools</li>
@@ -15,4 +15,6 @@
   <li>young offender institutions</li>
 </ul>
 
-<p class="govuk-body">From the answers you have given us you should be eligible for scholarship funding for the NPQ Leading Teacher Development (NPQLTD). you can go back and select the NPQLTD or continue with your registration for <b><%= course_name %></b>.</p>
+<% npqltd = Course.npqltd.first %>
+
+<p class="govuk-body">From the answers you have given us you should be eligible for scholarship funding for <%= localise_sentence_embedded_course_name(npqltd) %> you can go back and select the <%= course_short_code(npqltd) %> or continue with your registration for <%= localise_sentence_embedded_course_name(course) %>.</p>

--- a/app/views/registration_wizard/ineligible_for_funding/lead_mentor/_not_applying_for_NPQLTD.html.erb
+++ b/app/views/registration_wizard/ineligible_for_funding/lead_mentor/_not_applying_for_NPQLTD.html.erb
@@ -17,4 +17,4 @@
 
 <% npqltd = Course.npqltd.first %>
 
-<p class="govuk-body">From the answers you have given us you should be eligible for scholarship funding for <%= localise_sentence_embedded_course_name(npqltd) %> you can go back and select the <%= course_short_code(npqltd) %> or continue with your registration for <%= localise_sentence_embedded_course_name(course) %>.</p>
+<p class="govuk-body">From the answers you have given us you should be eligible for scholarship funding for <%= localise_sentence_embedded_course_name(npqltd) %> (<%= course_short_code(npqltd) %>) you can go back and select the <%= course_short_code(npqltd) %> or continue with your registration for <%= localise_sentence_embedded_course_name(course) %>.</p>

--- a/app/views/registration_wizard/ineligible_for_funding/school/_has_already_been_funded.html.erb
+++ b/app/views/registration_wizard/ineligible_for_funding/school/_has_already_been_funded.html.erb
@@ -4,7 +4,7 @@
 
 <h1 class="govuk-heading-xl">DfE scholarship funding is not available</h1>
 
-<p class="govuk-body">Our records show that you are already registered to study <b><%= course_name %></b>.</p>
+<p class="govuk-body">Our records show that you are already registered to study <%= localise_sentence_embedded_course_name(course) %>.</p>
 
 <ul class="govuk-list govuk-list--bullet">
   <li>
@@ -17,5 +17,5 @@
 </ul>
 
 <p class="govuk-body">
-  You can <%= link_to('go back and select a different NPQ', registration_wizard_show_path(@wizard.previous_step_path)) %> or continue with your registration for the <%= course_name %>. You'll need to pay for it another way. Contact your course provider to discuss your funding options.
+  You can <%= link_to('go back and select a different NPQ', registration_wizard_show_path(@wizard.previous_step_path)) %> or continue with your registration for <%= localise_sentence_embedded_course_name(course) %>. You'll need to pay for it another way. Contact your course provider to discuss your funding options.
 </p>

--- a/app/views/registration_wizard/ineligible_for_funding/school/_outside_catchment_or_ineligible_establishment.html.erb
+++ b/app/views/registration_wizard/ineligible_for_funding/school/_outside_catchment_or_ineligible_establishment.html.erb
@@ -4,7 +4,7 @@
 
 <h1 class="govuk-heading-xl">DfE scholarship funding is not available</h1>
 
-<p class="govuk-body">To be eligible for scholarship funding for the <%= course_name %> you must work in one of these settings in England:</p>
+<p class="govuk-body">To be eligible for scholarship funding for <%= localise_sentence_embedded_course_name(course) %> you must work in one of these settings in England:</p>
 
 <ul class="govuk-list govuk-list--bullet">
   <li>state-funded schools</li>
@@ -15,4 +15,4 @@
   <li>young offenders institutions</li>
 </ul>
 
-<p class="govuk-body">You can still register for <%= course_name %>, but you need to pay for it another way. Contact your course provider to discuss your funding options.</p>
+<p class="govuk-body">You can still register for <%= localise_sentence_embedded_course_name(course) %>, but you need to pay for it another way. Contact your course provider to discuss your funding options.</p>

--- a/app/views/registration_wizard/possible_funding.html.erb
+++ b/app/views/registration_wizard/possible_funding.html.erb
@@ -11,7 +11,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render "registration_wizard/possible_funding/#{@form.message_template}", course_name: @form.course.name %>
+    <%= render "registration_wizard/possible_funding/#{@form.message_template}", course_name: localise_course_name(@form.course) %>
 
     <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
       <%= f.govuk_submit %>

--- a/app/views/registration_wizard/possible_funding.html.erb
+++ b/app/views/registration_wizard/possible_funding.html.erb
@@ -11,7 +11,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render "registration_wizard/possible_funding/#{@form.message_template}", course_name: localise_course_name(@form.course) %>
+    <%=
+      render(
+        "registration_wizard/possible_funding/#{@form.message_template}",
+        course: @form.course
+      )
+    %>
 
     <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
       <%= f.govuk_submit %>

--- a/app/views/registration_wizard/possible_funding/_lead_mentor.html.erb
+++ b/app/views/registration_wizard/possible_funding/_lead_mentor.html.erb
@@ -1,7 +1,7 @@
 <h1 class="govuk-heading-xl">If your provider accepts your application, you’ll qualify for DfE funding</h1>
 
 <p class="govuk-body">
-  From the information you have provided, DfE scholarship funding should be available for the <strong><%= course_name %>.</strong>
+  From the information you have provided, DfE scholarship funding should be available for <%= localise_sentence_embedded_course_name(course) %>.
 </p>
 
 <p class="govuk-body">

--- a/app/views/registration_wizard/possible_funding/_lead_mentor.html.erb
+++ b/app/views/registration_wizard/possible_funding/_lead_mentor.html.erb
@@ -1,7 +1,7 @@
 <h1 class="govuk-heading-xl">If your provider accepts your application, you’ll qualify for DfE funding</h1>
 
 <p class="govuk-body">
-  From the information you have provided, DfE scholarship funding should be available for the <strong>NPQ for Leading Teacher Development (NPQLTD).</strong>
+  From the information you have provided, DfE scholarship funding should be available for the <strong><%= course_name %>.</strong>
 </p>
 
 <p class="govuk-body">

--- a/app/views/registration_wizard/possible_funding/_private_childcare_provider.html.erb
+++ b/app/views/registration_wizard/possible_funding/_private_childcare_provider.html.erb
@@ -1,7 +1,7 @@
 <h1 class="govuk-heading-xl">If your provider accepts your application, you’ll qualify for DfE funding</h1>
 
 <p class="govuk-body">
-  From the information you have provided, DfE scholarship funding should be available for the <b><%= course_name %></b>.
+  From the information you have provided, DfE scholarship funding should be available for <%= localise_sentence_embedded_course_name(course) %>.
 </p>
 
 <p class="govuk-body">

--- a/app/views/registration_wizard/start.html.erb
+++ b/app/views/registration_wizard/start.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Register for a national professional qualification (NPQ)</h1>
 
-    <p class="govuk-body">Use this service to register for an NPQ or the early headship coaching offer.</p>
+    <p class="govuk-body">Use this service to register for an NPQ or <%= localise_sentence_embedded_course_name(Course.ehco.first) %>.</p>
 
     <p class="govuk-body">You also need to apply separately with your training provider. They’ll contact you once you’ve registered.</p>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -235,7 +235,7 @@ en:
         message: "Message"
 
   course:
-    identifier: &course_identifiers
+    name: &course_names
       "npq-leading-teaching": "Leading teaching"
       "npq-leading-behaviour-culture": "Leading behaviour and culture"
       "npq-leading-teaching-development": "Leading teacher development"
@@ -312,7 +312,7 @@ en:
           private_nursery: "Private nursery"
           another_early_years_setting: "Another early years setting"
 
-        course_identifier_options: *course_identifiers
+        course_identifier_options: *course_names
 
         employment_type_options:
           local_authority_virtual_school: "In a virtual school (local authority run organisations that support the education of children in care)"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -235,6 +235,20 @@ en:
         message: "Message"
 
   course:
+    embedded_sentence:
+      default: "the %{course_name} NPQ"
+      ehco: "the %{course_name}"
+    short_code:
+      "npq-leading-teaching": "NPQLT"
+      "npq-leading-behaviour-culture": "NPQLBC"
+      "npq-leading-teaching-development": "NPQLTD"
+      "npq-senior-leadership": "NPQSL"
+      "npq-headship": "NPQH"
+      "npq-executive-leadership": "NPQEL"
+      "npq-additional-support-offer": "ASO"
+      "npq-early-headship-coaching-offer": "EHCO"
+      "npq-early-years-leadership": "NPQEYL"
+      "npq-leading-literacy": "NPQLL"
     name: &course_names
       "npq-leading-teaching": "Leading teaching"
       "npq-leading-behaviour-culture": "Leading behaviour and culture"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -234,6 +234,19 @@ en:
         status_comment: "Status Comment"
         message: "Message"
 
+  course:
+    identifier: &course_identifiers
+      "npq-leading-teaching": "Leading teaching"
+      "npq-leading-behaviour-culture": "Leading behaviour and culture"
+      "npq-leading-teaching-development": "Leading teacher development"
+      "npq-senior-leadership": "Senior leadership"
+      "npq-headship": "Headship"
+      "npq-executive-leadership": "Executive leadership"
+      "npq-additional-support-offer": "Additional Support Offer"
+      "npq-early-headship-coaching-offer": "Early headship coaching offer"
+      "npq-early-years-leadership": "Early years leadership"
+      "npq-leading-literacy": "Leading literacy"
+
   helpers:
     title:
       registration_wizard:
@@ -299,17 +312,7 @@ en:
           private_nursery: "Private nursery"
           another_early_years_setting: "Another early years setting"
 
-        course_identifier_options:
-          "npq-leading-teaching": "Leading teaching"
-          "npq-leading-behaviour-culture": "Leading behaviour and culture"
-          "npq-leading-teaching-development": "Leading teacher development"
-          "npq-senior-leadership": "Senior leadership"
-          "npq-headship": "Headship"
-          "npq-executive-leadership": "Executive leadership"
-          "npq-additional-support-offer": "Additional Support Offer"
-          "npq-early-headship-coaching-offer": "Early headship coaching offer"
-          "npq-early-years-leadership": "Early years leadership"
-          "npq-leading-literacy": "Leading literacy"
+        course_identifier_options: *course_identifiers
 
         employment_type_options:
           local_authority_virtual_school: "In a virtual school (local authority run organisations that support the education of children in care)"

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/js/while_working_at_private_childcare_privider_but_not_a_nursery_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/js/while_working_at_private_childcare_privider_but_not_a_nursery_spec.rb
@@ -98,7 +98,7 @@ RSpec.feature "Happy journeys", type: :feature do
     ineligible_courses_list = Forms::ChooseYourNpq.new.options.map(&:value)
 
     ineligible_courses = ineligible_courses_list.map { |name|
-      I18n.t("course.identifier.#{name}")
+      I18n.t("course.name.#{name}")
     } - eyl_course
 
     ineligible_courses.each do |course|

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/js/while_working_at_private_childcare_privider_but_not_a_nursery_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/js/while_working_at_private_childcare_privider_but_not_a_nursery_spec.rb
@@ -98,8 +98,7 @@ RSpec.feature "Happy journeys", type: :feature do
     ineligible_courses_list = Forms::ChooseYourNpq.new.options.map(&:value)
 
     ineligible_courses = ineligible_courses_list.map { |name|
-      I18n
-        .t("helpers.label.registration_wizard.course_identifier_options.#{name}")
+      I18n.t("course.identifier.#{name}")
     } - eyl_course
 
     ineligible_courses.each do |course|

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/js/while_working_at_private_nursery_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/js/while_working_at_private_nursery_spec.rb
@@ -95,8 +95,7 @@ RSpec.feature "Happy journeys", type: :feature do
     ineligible_courses_list = Forms::ChooseYourNpq.new.options.map(&:value)
 
     ineligible_courses = ineligible_courses_list.map { |name|
-      I18n
-        .t("helpers.label.registration_wizard.course_identifier_options.#{name}")
+      I18n.t("course.identifier.#{name}")
     } - eyl_course
 
     ineligible_courses.each do |course|

--- a/spec/features/disabled_get_an_identity_integration/happy_journeys/js/while_working_at_private_nursery_spec.rb
+++ b/spec/features/disabled_get_an_identity_integration/happy_journeys/js/while_working_at_private_nursery_spec.rb
@@ -95,7 +95,7 @@ RSpec.feature "Happy journeys", type: :feature do
     ineligible_courses_list = Forms::ChooseYourNpq.new.options.map(&:value)
 
     ineligible_courses = ineligible_courses_list.map { |name|
-      I18n.t("course.identifier.#{name}")
+      I18n.t("course.name.#{name}")
     } - eyl_course
 
     ineligible_courses.each do |course|

--- a/spec/features/happy_journeys/js/while_working_at_private_childcare_privider_but_not_a_nursery_spec.rb
+++ b/spec/features/happy_journeys/js/while_working_at_private_childcare_privider_but_not_a_nursery_spec.rb
@@ -74,7 +74,7 @@ RSpec.feature "Happy journeys", type: :feature do
     ineligible_courses_list = Forms::ChooseYourNpq.new.options.map(&:value)
 
     ineligible_courses = ineligible_courses_list.map { |name|
-      I18n.t("course.identifier.#{name}")
+      I18n.t("course.name.#{name}")
     } - eyl_course
 
     ineligible_courses.each do |course|

--- a/spec/features/happy_journeys/js/while_working_at_private_childcare_privider_but_not_a_nursery_spec.rb
+++ b/spec/features/happy_journeys/js/while_working_at_private_childcare_privider_but_not_a_nursery_spec.rb
@@ -74,8 +74,7 @@ RSpec.feature "Happy journeys", type: :feature do
     ineligible_courses_list = Forms::ChooseYourNpq.new.options.map(&:value)
 
     ineligible_courses = ineligible_courses_list.map { |name|
-      I18n
-        .t("helpers.label.registration_wizard.course_identifier_options.#{name}")
+      I18n.t("course.identifier.#{name}")
     } - eyl_course
 
     ineligible_courses.each do |course|

--- a/spec/features/happy_journeys/js/while_working_at_private_nursery_spec.rb
+++ b/spec/features/happy_journeys/js/while_working_at_private_nursery_spec.rb
@@ -72,8 +72,7 @@ RSpec.feature "Happy journeys", type: :feature do
     ineligible_courses_list = Forms::ChooseYourNpq.new.options.map(&:value)
 
     ineligible_courses = ineligible_courses_list.map { |name|
-      I18n
-        .t("helpers.label.registration_wizard.course_identifier_options.#{name}")
+      I18n.t("course.identifier.#{name}")
     } - eyl_course
 
     ineligible_courses.each do |course|

--- a/spec/features/happy_journeys/js/while_working_at_private_nursery_spec.rb
+++ b/spec/features/happy_journeys/js/while_working_at_private_nursery_spec.rb
@@ -72,7 +72,7 @@ RSpec.feature "Happy journeys", type: :feature do
     ineligible_courses_list = Forms::ChooseYourNpq.new.options.map(&:value)
 
     ineligible_courses = ineligible_courses_list.map { |name|
-      I18n.t("course.identifier.#{name}")
+      I18n.t("course.name.#{name}")
     } - eyl_course
 
     ineligible_courses.each do |course|

--- a/spec/features/journeys/happy_paths/when_choose_lead_mentor_course_spec.rb
+++ b/spec/features/journeys/happy_paths/when_choose_lead_mentor_course_spec.rb
@@ -77,7 +77,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
     expect_page_to_have(path: "/registration/possible-funding", submit_form: true) do
       expect(page).to have_text("If your provider accepts your application, you’ll qualify for DfE funding")
-      expect(page).to have_text("From the information you have provided, DfE scholarship funding should be available for the NPQ for Leading Teacher Development (NPQLTD).")
+      expect(page).to have_text("From the information you have provided, DfE scholarship funding should be available for the Leading teacher development.")
     end
 
     expect_page_to_have(path: "/registration/choose-your-provider", submit_form: true) do

--- a/spec/features/journeys/happy_paths/when_choose_lead_mentor_course_spec.rb
+++ b/spec/features/journeys/happy_paths/when_choose_lead_mentor_course_spec.rb
@@ -77,7 +77,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
     expect_page_to_have(path: "/registration/possible-funding", submit_form: true) do
       expect(page).to have_text("If your provider accepts your application, you’ll qualify for DfE funding")
-      expect(page).to have_text("From the information you have provided, DfE scholarship funding should be available for the Leading teacher development.")
+      expect(page).to have_text("From the information you have provided, DfE scholarship funding should be available for the Leading teacher development NPQ.")
     end
 
     expect_page_to_have(path: "/registration/choose-your-provider", submit_form: true) do

--- a/spec/jobs/application_submission_job_spec.rb
+++ b/spec/jobs/application_submission_job_spec.rb
@@ -36,12 +36,17 @@ RSpec.describe ApplicationSubmissionJob do
       expect(Services::Ecf::EcfUserCreator).to receive(:new).and_return(user_creator_double)
       expect(Services::Ecf::NpqProfileCreator).to receive(:new).and_return(profile_creator_double)
 
+      localised_course_name = I18n.t(
+        application.course.identifier,
+        scope: "helpers.label.registration_wizard.course_identifier_options"
+      )
+
       allow(ApplicationSubmissionMailer).to receive(:application_submitted_mail).and_call_original
       expect(ApplicationSubmissionMailer).to receive(:application_submitted_mail).with(
         to: user.email,
         full_name: user.full_name,
         provider_name: application.lead_provider.name,
-        course_name: application.course.name,
+        course_name: localised_course_name,
       )
 
       subject.perform_now

--- a/spec/jobs/application_submission_job_spec.rb
+++ b/spec/jobs/application_submission_job_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe ApplicationSubmissionJob do
       expect(Services::Ecf::EcfUserCreator).to receive(:new).and_return(user_creator_double)
       expect(Services::Ecf::NpqProfileCreator).to receive(:new).and_return(profile_creator_double)
 
-      localised_course_name = I18n.t(application.course.identifier, scope: "course.identifier")
+      localised_course_name = I18n.t(application.course.identifier, scope: "course.name")
 
       allow(ApplicationSubmissionMailer).to receive(:application_submitted_mail).and_call_original
       expect(ApplicationSubmissionMailer).to receive(:application_submitted_mail).with(

--- a/spec/jobs/application_submission_job_spec.rb
+++ b/spec/jobs/application_submission_job_spec.rb
@@ -36,10 +36,7 @@ RSpec.describe ApplicationSubmissionJob do
       expect(Services::Ecf::EcfUserCreator).to receive(:new).and_return(user_creator_double)
       expect(Services::Ecf::NpqProfileCreator).to receive(:new).and_return(profile_creator_double)
 
-      localised_course_name = I18n.t(
-        application.course.identifier,
-        scope: "helpers.label.registration_wizard.course_identifier_options"
-      )
+      localised_course_name = I18n.t(application.course.identifier, scope: "course.identifier")
 
       allow(ApplicationSubmissionMailer).to receive(:application_submitted_mail).and_call_original
       expect(ApplicationSubmissionMailer).to receive(:application_submitted_mail).with(

--- a/spec/lib/services/funding_eligibility_spec.rb
+++ b/spec/lib/services/funding_eligibility_spec.rb
@@ -197,7 +197,7 @@ RSpec.describe Services::FundingEligibility do
         Course.all.reject(&:npqltd?).each do |course|
           let(:course) { course }
 
-          it "is not eligible for #{course.name}" do
+          it "is not eligible for #{course.identifier}" do
             expect(subject).not_to be_funded
             expect(subject.funding_eligiblity_status_code).to eq :not_lead_mentor_course
           end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-1080

`course.name` contains old versions of NPQ names, we should be moving towards only using the localised strings everywhere.

These names are used in most locations around the app, this cleans up remaining uses of the old names.

### Changes proposed in this pull request

- Use new course names on /registration/ineligible-for-funding
- Use new course names on /registration/choose-your-provider
- Use new course names on /registration/possible-funding
- Use new course names on /registration/confirmation
- Use new course names in application submitted emails 
  Note that though we are sending the new course name this isn't actually used in the template.
- Use new course names on /admin/users
- Use new course names on /admin/unsynced_applications

| Old | New|
| - | - | 
| NPQ for Leading Teaching (NPQLT) | Leading teaching |
| NPQ for Leading Behaviour and Culture (NPQLBC) | Leading behaviour and culture |
| NPQ for Leading Teacher Development (NPQLTD) | Leading teacher development |
| NPQ for Senior Leadership (NPQSL) | Senior leadership |
| NPQ for Headship (NPQH) | Headship |
| NPQ for Executive Leadership (NPQEL) | Executive leadership |
| Additional Support Offer for new headteachers | Additional Support Offer |
| Early Headship Coaching Offer | Early headship coaching offer |
| NPQ for Early Years Leadership (NPQEYL) | Early years leadership |
| NPQ for Leading Literacy (NPQLL) | Leading literacy |

| Before | After| 
| - | - |
| <img width="632" alt="choose-your-provider" src="https://github.com/DFE-Digital/npq-registration/assets/1465268/ec2ae073-e696-4ef0-8a44-6a70367557ac"> | <img width="617" alt="choose-your-provider" src="https://github.com/DFE-Digital/npq-registration/assets/1465268/92a6cf67-5d19-455f-9a76-05527fba6523"> |
| <img width="647" alt="confirmation" src="https://github.com/DFE-Digital/npq-registration/assets/1465268/ffd77b40-f27f-4c36-aec8-370e9fec8c8c"> | <img width="661" alt="confirmation" src="https://github.com/DFE-Digital/npq-registration/assets/1465268/371a9822-ff4d-419b-8dbd-d5132ce4fb78"> |
| <img width="656" alt="ineligible-for-funding" src="https://github.com/DFE-Digital/npq-registration/assets/1465268/12e6d851-3671-475c-9297-4911325de800"> | <img width="661" alt="ineligible-for-funding" src="https://github.com/DFE-Digital/npq-registration/assets/1465268/b65f92a3-bfe8-4583-927d-bd7e0f6d707f"> |
| <img width="699" alt="possible-funding" src="https://github.com/DFE-Digital/npq-registration/assets/1465268/33c22d0e-c251-43bc-911a-18373fd34c9e"> | <img width="652" alt="possible-funding" src="https://github.com/DFE-Digital/npq-registration/assets/1465268/cd34f1b3-d3f9-46ed-8153-f0f39436d277"> |


