### PR TITLE
Question page as a view component

### DIFF
--- a/app/lib/forms/confirm_email.rb
+++ b/app/lib/forms/confirm_email.rb
@@ -11,6 +11,18 @@ module Forms
       ]
     end
 
+    def question
+      @question ||= QuestionTypes::TextField.new(
+        name: :confirmation_code,
+        form: self,
+        header: "Confirm your email address",
+        style_options: {
+          width: 10,
+          label: { text: "Enter your code" },
+        },
+      )
+    end
+
     def next_step
       if changing_answer?
         :check_answers

--- a/app/lib/forms/question_types/base.html.erb
+++ b/app/lib/forms/question_types/base.html.erb
@@ -1,0 +1,30 @@
+<% content_for :title do %>
+  <%= form.errors.present? ? "Error: " : nil %>
+  <%= t("helpers.#{form.question.title_locale_type}.registration_wizard.#{form.question.name}") %>
+<% end %>
+
+<% content_for :before_content do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: "Back",
+    href: registration_wizard_show_path(form.wizard.previous_step_path)
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: form, url: helpers.registration_wizard_form_url(form), scope: 'registration_wizard', method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+      <% if header.present? %>
+        <h1 class="govuk-heading-xl"><%= header %></h1>
+      <% end %>
+
+      <%= yield f %>
+
+      <%= after_question %>
+
+      <%= f.govuk_submit %>
+    <% end %>
+  </div>
+</div>
+
+

--- a/app/lib/forms/question_types/base.rb
+++ b/app/lib/forms/question_types/base.rb
@@ -1,12 +1,22 @@
 module Forms
   module QuestionTypes
-    class Base
-      attr_reader :name, :options
+    class Base < ViewComponent::Base
+      include ActiveModel::Attributes
+      include ActiveModel::AttributeAssignment
 
-      def initialize(name:, options: [], style_options: {})
-        @name = name
-        @options = options
-        @style_options = style_options # Freeform optional parameters that can differ for each subclass
+      self.default_form_builder = GOVUKDesignSystemFormBuilder::FormBuilder
+
+      renders_one :after_question
+
+      attribute :name
+      attribute :header
+      attribute :options, default: -> { {} } # TODO: options should be moved to appropriate subclass!
+      attribute :form
+      attribute :style_options, default: -> { {} }
+
+      def initialize(**attrs)
+        super
+        assign_attributes(**attrs)
       end
 
       # For determining which partial to use
@@ -20,6 +30,14 @@ module Forms
       # This is only used for the title population in _question_page.html.erb.
       def title_locale_type
         :label
+      end
+
+      def style_options
+        default_styles.deep_merge(super)
+      end
+
+      def default_styles
+        {}
       end
     end
   end

--- a/app/lib/forms/question_types/check_box.rb
+++ b/app/lib/forms/question_types/check_box.rb
@@ -1,14 +1,6 @@
 module Forms
   module QuestionTypes
     class CheckBox < Base
-      DEFAULT_STYLES = {
-        legend: {
-          size: "xl",
-          tag: "h1",
-        }.freeze,
-        hint: nil,
-      }.freeze
-
       attr_reader :checked_value, :unchecked_value, :required, :body
 
       def initialize(*args, checked_value: "1", unchecked_value: "0", required: false, body: nil, **opts)
@@ -24,8 +16,14 @@ module Forms
         :legend
       end
 
-      def style_options
-        DEFAULT_STYLES.deep_merge(@style_options)
+      def default_styles
+        {
+          legend: {
+            size: "xl",
+            tag: "h1",
+          },
+          hint: nil,
+        }
       end
     end
   end

--- a/app/lib/forms/question_types/radio_button_group.rb
+++ b/app/lib/forms/question_types/radio_button_group.rb
@@ -6,9 +6,9 @@ module Forms
       end
 
       def fieldset_legend_attributes
-        return {} if @style_options.empty?
+        return {} if style_options.empty?
 
-        @style_options.dig(:fieldset, :legend)
+        style_options.dig(:fieldset, :legend)
       end
     end
   end

--- a/app/lib/forms/question_types/text_field.html.erb
+++ b/app/lib/forms/question_types/text_field.html.erb
@@ -1,0 +1,8 @@
+<% super do |f| %>
+  <%=
+    f.govuk_text_field(
+      name,
+      **style_options
+    )
+  %>
+<% end %>

--- a/app/lib/forms/question_types/text_field.rb
+++ b/app/lib/forms/question_types/text_field.rb
@@ -1,6 +1,18 @@
 module Forms
   module QuestionTypes
     class TextField < Base
+      # TODO: Move this onto Base?
+      def default_styles
+        {
+          width: "full",
+          label: header.present? ? {} : { size: "xl", tag: "h1" },
+        }
+      end
+
+      # TODO: Would be great to use same translation patterns for all the questions to configure govuk components
+      def title_locale_type
+        :title
+      end
     end
   end
 end

--- a/app/views/registration_wizard/confirm_email.html.erb
+++ b/app/views/registration_wizard/confirm_email.html.erb
@@ -1,30 +1,7 @@
-<% content_for :title do %>
-  <%= @form.errors.present? ? "Error: " : nil %>Confirm your email address
+<%= render @form.question do |component| %>
+  <% component.with_after_question do %>
+    <p class="govuk-body">
+      <%= govuk_link_to "I have not received an email", registration_wizard_show_path(step: "resend-code") %>
+    </p>
+  <% end %>
 <% end %>
-
-<% content_for :before_content do %>
-  <%= render GovukComponent::BackLinkComponent.new(
-    text: "Back",
-    href: registration_wizard_show_path(@wizard.previous_step_path)
-  ) %>
-<% end %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
-      <%= f.govuk_error_summary %>
-
-      <h1 class="govuk-heading-xl">Confirm your email address</h1>
-
-      <%= f.govuk_text_field :confirmation_code,
-        width: 10,
-        label: { text: "Enter your code" } %>
-
-      <p class="govuk-body">
-        <%= govuk_link_to "I have not received an email", registration_wizard_show_path(step: "resend-code") %>
-      </p>
-
-      <%= f.govuk_submit %>
-    <% end %>
-  </div>
-</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -245,6 +245,7 @@ en:
         change_dqt: "Change your details on the Teaching Regulation Agency records"
         childcare_provider_not_in_england: "Nursery must be in England, Guernsey, Jersey or the Isle of Man"
         check_answers: "Check your answers and confirm"
+        confirmation_code: Confirm your email address
     legend:
       registration_wizard:
         aso_headteacher: "Are you a headteacher?"


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-1109

### Changes proposed in this pull request

Apart from the refactor onto a question page, this PR also converts QuestionType objects into a standalone ViewComponents. Transofrmation is seamlessly invisible and QuestionType objects can still be used both via a question-page partial or be rendered explicitly as `render form.question`.

View components adds a bit of more power to previously plain object as we can now define various slots in our question pages as we won't be able to replace all the pages with a plain objects without defining a completely new DSL to mimic html - for example, in this PR we need to add an additional link below the text box.

Ideally, we would come up with some universal configuration option for all the question pages. Naturally some of the pages will have their own additional attributes, which is why I also introduced `ActiveModel::Attributes` to QuestionType - this way we can avoid the long list of keyword arguments and overriding initialise function.
