### PR TITLE
Update IneligibleForFunding Page to Use New Shared CopyPage Template

### DIFF
--- a/app/views/registration_wizard/ineligible_for_funding.erb
+++ b/app/views/registration_wizard/ineligible_for_funding.erb
@@ -1,23 +1,13 @@
-<% content_for :title do %>
-  DfE scholarship funding is not available
+<%=
+  render(
+    'registration_wizard/shared/copy_page',
+    form: @form,
+    wizard: @wizard,
+    ) do
+%>
+
+  <%= render "registration_wizard/ineligible_for_funding/#{@form.ineligible_template}", course: @form.course %>
+
+  <%= govuk_button_link_to "Continue", registration_wizard_show_path(@wizard.next_step_path) %>
+
 <% end %>
-
-<% content_for :before_content do %>
-  <%= render GovukComponent::BackLinkComponent.new(
-    text: "Back",
-    href: registration_wizard_show_path(@wizard.previous_step_path)
-  ) %>
-<% end %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%=
-      render(
-        "registration_wizard/ineligible_for_funding/#{@form.ineligible_template}",
-        course: @form.course,
-      )
-    %>
-
-    <%= govuk_button_link_to "Continue", registration_wizard_show_path(@wizard.next_step_path) %>
-  </div>
-</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -256,6 +256,7 @@ en:
         check_answers: "Check your answers and confirm"
         possible_funding: "You may qualify for DfE scholarship funding"
         school_not_in_england: "School or college must be in England, Guernsey, Jersey or the Isle of Man"
+        ineligible_for_funding: "DfE scholarship funding is not available"
     legend:
       registration_wizard:
         aso_headteacher: "Are you a headteacher?"


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-1124

### Changes proposed in this pull request
- Forms::IneligibleForFunding moved to use copy_page template