### PR TITLE
DontHaveTeacherReferenceNumber page to use new shared CopyPage template

### DIFF
--- a/app/views/registration_wizard/dont_have_teacher_reference_number.html.erb
+++ b/app/views/registration_wizard/dont_have_teacher_reference_number.html.erb
@@ -1,100 +1,94 @@
-<% content_for :title do %>
-  Get a Teacher Reference Number (TRN) to register for an NPQ
+<%=
+  render(
+    'registration_wizard/shared/copy_page',
+    form: @form,
+    wizard: @wizard,
+    ) do
+%>
+
+  <h1 class="govuk-heading-xl">Get a Teacher Reference Number (TRN)</h1>
+
+  <h2 class="govuk-heading-m">Why do I need this?</h2>
+
+  <p class="govuk-body">
+    Everyone needs a <%= govuk_link_to "TRN (opens in a new tab)", "https://www.gov.uk/guidance/teacher-reference-number-trn", target: :_blank, rel: "noopener noreferrer" %>
+    to register for an NPQ. You do not need to be a teacher to get a TRN.
+  </p>
+
+  <h2 class="govuk-heading-m">Request a TRN by email</h2>
+
+  <p class="govuk-body">
+    If you’ve never been given a TRN, email the Teaching Regulation Agency at <%= govuk_mail_to "qts.enquiries@education.gov.uk", "qts.enquiries@education.gov.uk" %>.
+    The team aim to respond to valid email requests within 5 working days.
+  </p>
+
+  <p class="govuk-body">
+    You’ll need to provide contact details and proof of ID to receive a TRN.
+  </p>
+
+  <p class="govuk-body">
+    Use the free Galaxkey secure email platform to ensure your identification documents are protected. Full instructions can be found below.
+  </p>
+
+  <h2 class="govuk-heading-m">Register to send a secure email</h2>
+
+  <p class="govuk-body">
+    To send a secure email to the department, please go to the Galaxkey site:
+    <%= govuk_link_to "https://manager.galaxkey.com/services/registerme (opens in a new tab)", "https://manager.galaxkey.com/services/registerme",  target: :_blank, rel: "noopener noreferrer" %>
+  </p>
+
+  <p class="govuk-body">
+    Enter the email address that you wish to sign up with and complete the registration process.
+  </p>
+
+  <p class="govuk-body">
+    You’ll be sent an email to activate your account once you have completed this step. You can then send secure emails to the Teaching Regulation Agency using Galaxkey.
+  </p>
+
+  <h2 class="govuk-heading-m">Send your ID documents securely</h2>
+
+  <p class="govuk-body">
+    Follow these steps to send your documents through Galaxkey:
+  </p>
+
+  <ol class="govuk-list govuk-list--number">
+    <li>Select ‘Compose’ to create a new secure email.</li>
+    <li>Enter ’qts.enquiries@education.gov.uk’ as the recipient.</li>
+    <li>Enter ‘Undertaking an NPQ, do not have a TRN and require a number to be issued’ as the subject line.</li>
+    <li>
+      Include the following information in your email:
+      <ul class="govuk-list govuk-list--bullet">
+        <li>your full legal name</li>
+        <li>your date of birth</li>
+        <li>an email address for the team to reply to</li>
+      </ul>
+    </li>
+    <li>Attach a scanned copy or photo of one of the following types of ID:
+      <ul class="govuk-list govuk-list--bullet">
+        <li>passport</li>
+        <li>driving license (full or provisional)</li>
+        <li>certificate of residence</li>
+        <li>birth certificate</li>
+      </ul>
+    </li>
+  </ol>
+
+  <p class="govuk-body">
+    Follow the guidance on screen to make sure you send the correct file size.
+  </p>
+
+  <p class="govuk-body">
+    Find information about how the Teaching Regulation Agency processes your data on the
+    <%= govuk_link_to "teacher self-service site (opens in a new tab)", "https://www.gov.uk/guidance/teacher-self-service-portal", target: :_blank, rel: "noopener noreferrer" %>.
+  </p>
+
+  <h2 class="govuk-heading-m">What happens next</h2>
+
+  <p class="govuk-body">
+    The Teaching Regulation Agency will use the information you send to create a permanent record and your TRN.
+  </p>
+
+  <p class="govuk-body">
+    Your ID documents will be deleted once your request is processed.
+  </p>
 <% end %>
-
-<% content_for :before_content do %>
-  <%= render GovukComponent::BackLinkComponent.new(
-    text: "Back",
-    href: registration_wizard_show_path(@wizard.previous_step_path)
-  ) %>
-<% end %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Get a Teacher Reference Number (TRN)</h1>
-
-    <h2 class="govuk-heading-m">Why do I need this?</h2>
-
-    <p class="govuk-body">
-      Everyone needs a <%= govuk_link_to "TRN (opens in a new tab)", "https://www.gov.uk/guidance/teacher-reference-number-trn", target: :_blank, rel: "noopener noreferrer" %>
-      to register for an NPQ. You do not need to be a teacher to get a TRN.
-    </p>
-
-    <h2 class="govuk-heading-m">Request a TRN by email</h2>
-
-    <p class="govuk-body">
-      If you’ve never been given a TRN, email the Teaching Regulation Agency at <%= govuk_mail_to "qts.enquiries@education.gov.uk", "qts.enquiries@education.gov.uk" %>.
-      The team aim to respond to valid email requests within 5 working days.
-    </p>
-
-    <p class="govuk-body">
-      You’ll need to provide contact details and proof of ID to receive a TRN.
-    </p>
-
-    <p class="govuk-body">
-      Use the free Galaxkey secure email platform to ensure your identification documents are protected. Full instructions can be found below.
-    </p>
-
-    <h2 class="govuk-heading-m">Register to send a secure email</h2>
-
-    <p class="govuk-body">
-      To send a secure email to the department, please go to the Galaxkey site:
-      <%= govuk_link_to "https://manager.galaxkey.com/services/registerme (opens in a new tab)", "https://manager.galaxkey.com/services/registerme",  target: :_blank, rel: "noopener noreferrer" %>
-    </p>
-
-    <p class="govuk-body">
-      Enter the email address that you wish to sign up with and complete the registration process.
-    </p>
-
-    <p class="govuk-body">
-      You’ll be sent an email to activate your account once you have completed this step. You can then send secure emails to the Teaching Regulation Agency using Galaxkey.
-    </p>
-
-    <h2 class="govuk-heading-m">Send your ID documents securely</h2>
-
-    <p class="govuk-body">
-      Follow these steps to send your documents through Galaxkey:
-    </p>
-
-    <ol class="govuk-list govuk-list--number">
-      <li>Select ‘Compose’ to create a new secure email.</li>
-      <li>Enter ’qts.enquiries@education.gov.uk’ as the recipient.</li>
-      <li>Enter ‘Undertaking an NPQ, do not have a TRN and require a number to be issued’ as the subject line.</li>
-      <li>
-        Include the following information in your email:
-        <ul class="govuk-list govuk-list--bullet">
-          <li>your full legal name</li>
-          <li>your date of birth</li>
-          <li>an email address for the team to reply to</li>
-        </ul>
-      </li>
-      <li>Attach a scanned copy or photo of one of the following types of ID:
-        <ul class="govuk-list govuk-list--bullet">
-          <li>passport</li>
-          <li>driving license (full or provisional)</li>
-          <li>certificate of residence</li>
-          <li>birth certificate</li>
-        </ul>
-      </li>
-    </ol>
-
-    <p class="govuk-body">
-      Follow the guidance on screen to make sure you send the correct file size.
-    </p>
-
-    <p class="govuk-body">
-      Find information about how the Teaching Regulation Agency processes your data on the
-      <%= govuk_link_to "teacher self-service site (opens in a new tab)", "https://www.gov.uk/guidance/teacher-self-service-portal", target: :_blank, rel: "noopener noreferrer" %>.
-    </p>
-
-    <h2 class="govuk-heading-m">What happens next</h2>
-
-    <p class="govuk-body">
-      The Teaching Regulation Agency will use the information you send to create a permanent record and your TRN.
-    </p>
-
-    <p class="govuk-body">
-      Your ID documents will be deleted once your request is processed.
-    </p>
-  </div>
-</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -245,6 +245,7 @@ en:
         change_dqt: "Change your details on the Teaching Regulation Agency records"
         childcare_provider_not_in_england: "Nursery must be in England, Guernsey, Jersey or the Isle of Man"
         check_answers: "Check your answers and confirm"
+        dont_have_teacher_reference_number: "Get a Teacher Reference Number (TRN)"
     legend:
       registration_wizard:
         aso_headteacher: "Are you a headteacher?"


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-1122

### Changes proposed in this pull request
- Forms::DontHaveTeacherReferenceNumber moved to use copy_page template
