### PR TITLE
[CPDNPQ-1092] Add teacher reference number question back in

### DIFF
--- a/app/helpers/forms/flow_helper.rb
+++ b/app/helpers/forms/flow_helper.rb
@@ -1,7 +1,7 @@
 module Forms::FlowHelper
   def after_login_next_step
     if Services::Feature.trn_required? && query_store.current_user.trn.blank?
-      :qualified_teacher_check
+      :teacher_reference_number
     else
       :provider_check
     end

--- a/app/helpers/forms/flow_helper.rb
+++ b/app/helpers/forms/flow_helper.rb
@@ -1,5 +1,5 @@
 module Forms::FlowHelper
-  def after_login_next_step
+  def first_questionnaire_step
     if Services::Feature.trn_required? && query_store.current_user.trn.blank?
       :teacher_reference_number
     else

--- a/app/lib/forms/dont_have_teacher_reference_number.rb
+++ b/app/lib/forms/dont_have_teacher_reference_number.rb
@@ -1,0 +1,7 @@
+module Forms
+  class DontHaveTeacherReferenceNumber < Base
+    def previous_step
+      :teacher_reference_number
+    end
+  end
+end

--- a/app/lib/forms/get_an_identity_callback.rb
+++ b/app/lib/forms/get_an_identity_callback.rb
@@ -5,7 +5,7 @@ module Forms
     end
 
     def next_step
-      after_login_next_step
+      first_questionnaire_step
     end
 
     def previous_step

--- a/app/lib/forms/start.rb
+++ b/app/lib/forms/start.rb
@@ -6,7 +6,7 @@ module Forms
 
     def next_step
       if query_store.current_user.present?
-        after_login_next_step
+        first_questionnaire_step
       else
         # This shouldn't really be reached, in this situation the user should have been
         # presented the omniauth kickoff button on the start back. This is here as a fallback

--- a/app/lib/forms/teacher_reference_number.rb
+++ b/app/lib/forms/teacher_reference_number.rb
@@ -1,0 +1,51 @@
+module Forms
+  class TeacherReferenceNumber < Base
+    VALID_TRN_KNOWLEDGE_OPTIONS = %w[yes no-dont-have].freeze
+
+    attr_accessor :trn_knowledge
+
+    validates :trn_knowledge, presence: true, inclusion: { in: VALID_TRN_KNOWLEDGE_OPTIONS }
+
+    def self.permitted_params
+      %i[
+        trn_knowledge
+      ]
+    end
+
+    # Required since this is the first question
+    # If it wasn't overridden it would check if any previous questions were answered
+    # and since there aren't any it would assume the user was trying to skip questions
+    # and redirect them to the start page
+    def requirements_met?
+      true
+    end
+
+    def next_step
+      case trn_knowledge
+      when "yes"
+        :qualified_teacher_check
+      when "no-dont-have"
+        :dont_have_teacher_reference_number
+      end
+    end
+
+    def previous_step
+      :start
+    end
+
+    def question
+      Forms::QuestionTypes::RadioButtonGroup.new(
+        name: :trn_knowledge,
+        options:,
+        style_options: { fieldset: { legend: { size: "m", tag: "h1" } } },
+      )
+    end
+
+    def options
+      [
+        build_option_struct(value: :yes, link_errors: true),
+        build_option_struct(value: :"no-dont-have"),
+      ]
+    end
+  end
+end

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -267,6 +267,8 @@ private
       choose_an_npq_and_provider
       change_dqt
       get_an_identity_callback
+      teacher_reference_number
+      dont_have_teacher_reference_number
       qualified_teacher_check
       not_sure_updated_name
       dqt_mismatch

--- a/app/views/registration_wizard/dont_have_teacher_reference_number.html.erb
+++ b/app/views/registration_wizard/dont_have_teacher_reference_number.html.erb
@@ -1,0 +1,93 @@
+<%=
+  render(
+    'registration_wizard/shared/copy_page',
+    form: @form,
+    wizard: @wizard,
+    ) do
+%>
+  <h1 class="govuk-heading-xl">Get a Teacher Reference Number (TRN)</h1>
+
+  <h2 class="govuk-heading-m">Why do I need this?</h2>
+
+  <p class="govuk-body">
+    Everyone needs a <%= govuk_link_to "TRN (opens in a new tab)", "https://www.gov.uk/guidance/teacher-reference-number-trn", target: :_blank, rel: "noopener noreferrer" %>
+    to register for an NPQ. You do not need to be a teacher to get a TRN.
+  </p>
+
+  <h2 class="govuk-heading-m">Request a TRN by email</h2>
+
+  <p class="govuk-body">
+    If you’ve never been given a TRN, email the Teaching Regulation Agency at <%= govuk_mail_to "qts.enquiries@education.gov.uk", "qts.enquiries@education.gov.uk" %>.
+    The team aim to respond to valid email requests within 5 working days.
+  </p>
+
+  <p class="govuk-body">
+    You’ll need to provide contact details and proof of ID to receive a TRN.
+  </p>
+
+  <p class="govuk-body">
+    Use the free Galaxkey secure email platform to ensure your identification documents are protected. Full instructions can be found below.
+  </p>
+
+  <h2 class="govuk-heading-m">Register to send a secure email</h2>
+
+  <p class="govuk-body">
+    To send a secure email to the department, please go to the Galaxkey site:
+    <%= govuk_link_to "https://manager.galaxkey.com/services/registerme (opens in a new tab)", "https://manager.galaxkey.com/services/registerme",  target: :_blank, rel: "noopener noreferrer" %>
+  </p>
+
+  <p class="govuk-body">
+    Enter the email address that you wish to sign up with and complete the registration process.
+  </p>
+
+  <p class="govuk-body">
+    You’ll be sent an email to activate your account once you have completed this step. You can then send secure emails to the Teaching Regulation Agency using Galaxkey.
+  </p>
+
+  <h2 class="govuk-heading-m">Send your ID documents securely</h2>
+
+  <p class="govuk-body">
+    Follow these steps to send your documents through Galaxkey:
+  </p>
+
+  <ol class="govuk-list govuk-list--number">
+    <li>Select ‘Compose’ to create a new secure email.</li>
+    <li>Enter ’qts.enquiries@education.gov.uk’ as the recipient.</li>
+    <li>Enter ‘Undertaking an NPQ, do not have a TRN and require a number to be issued’ as the subject line.</li>
+    <li>
+      Include the following information in your email:
+      <ul class="govuk-list govuk-list--bullet">
+        <li>your full legal name</li>
+        <li>your date of birth</li>
+        <li>an email address for the team to reply to</li>
+      </ul>
+    </li>
+    <li>Attach a scanned copy or photo of one of the following types of ID:
+      <ul class="govuk-list govuk-list--bullet">
+        <li>passport</li>
+        <li>driving license (full or provisional)</li>
+        <li>certificate of residence</li>
+        <li>birth certificate</li>
+      </ul>
+    </li>
+  </ol>
+
+  <p class="govuk-body">
+    Follow the guidance on screen to make sure you send the correct file size.
+  </p>
+
+  <p class="govuk-body">
+    Find information about how the Teaching Regulation Agency processes your data on the
+    <%= govuk_link_to "teacher self-service site (opens in a new tab)", "https://www.gov.uk/guidance/teacher-self-service-portal", target: :_blank, rel: "noopener noreferrer" %>.
+  </p>
+
+  <h2 class="govuk-heading-m">What happens next</h2>
+
+  <p class="govuk-body">
+    The Teaching Regulation Agency will use the information you send to create a permanent record and your TRN.
+  </p>
+
+  <p class="govuk-body">
+    Your ID documents will be deleted once your request is processed.
+  </p>
+<% end %>

--- a/app/views/registration_wizard/teacher_reference_number.html.erb
+++ b/app/views/registration_wizard/teacher_reference_number.html.erb
@@ -1,0 +1,19 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t('helpers.title.registration_wizard.teacher_reference_number') %></h1>
+
+    <p class="govuk-body">You’ll need a teacher reference number (TRN) to register for an NPQ, even if you are not a teacher. We use your TRN to check you’re eligible to study for an NPQ.</p>
+
+    <p class="govuk-body">You may not have a TRN if you are working in early years, further education or qualified as a teacher outside England.</p>
+
+    <p class="govuk-body">You can use the <%= govuk_link_to 'Find a lost TRN service (opens in a new tab)', 'https://find-a-lost-trn.education.gov.uk/start', target: :_blank %> if you do not know your TRN, or want to check if you have one.</p>
+  </div>
+</div>
+
+<%=
+  render(
+    'registration_wizard/shared/question_page',
+    form: @form,
+    wizard: @wizard,
+  )
+%>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -258,6 +258,8 @@ en:
         school_not_in_england: "School or college must be in England, Guernsey, Jersey or the Isle of Man"
         ineligible_for_funding: "DfE scholarship funding is not available"
         dqt_mismatch: "We cannot find your details"
+        teacher_reference_number: "You need a teacher reference number to register for an NPQ"
+        dont_have_teacher_reference_number: "Get a Teacher Reference Number (TRN) to register for an NPQ"
     legend:
       registration_wizard:
         aso_headteacher: "Are you a headteacher?"
@@ -272,6 +274,7 @@ en:
         aso_funding_choice: "How is the Early headship coaching offer being paid for?"
         itt_provider: "Enter the name of the ITT provider you are working with"
         npqh_status: "What stage are you at with the Headship NPQ?"
+        trn_knowledge: "Do you have a TRN?"
     hint:
       registration_wizard:
         choose_your_npq_html: "To register for an NPQ and the <a href=\"https://professional-development-for-teachers-leaders.education.gov.uk/early-headship-coaching-offer\" class=\"govuk-link\">Early headship coaching offer</a>, submit 2 separate registrations."
@@ -366,6 +369,10 @@ en:
         aso_new_headteacher_options:
           "yes": "Yes"
           "no": "No"
+
+        trn_knowledge_options:
+          "yes": "Yes"
+          "no-dont-have": "No, I need help getting one"
 
         choose_childcare_provider: "What’s the name of your workplace?"
         choose_childcare_provider_search: "Workplace not shown above"

--- a/spec/features/journeys/happy_paths/when_get_an_identity_returns_no_trn_spec.rb
+++ b/spec/features/journeys/happy_paths/when_get_an_identity_returns_no_trn_spec.rb
@@ -34,6 +34,20 @@ RSpec.feature "Happy journeys", type: :feature do
 
     expect(page).not_to have_content("Before you start")
 
+    expect_page_to_have(path: "/registration/teacher-reference-number", submit_form: true) do
+      page.choose("No, I need help getting one", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/dont-have-teacher-reference-number", submit_form: false) do
+      expect(page).to have_text("Get a Teacher Reference Number (TRN)")
+
+      page.click_link("Back")
+    end
+
+    expect_page_to_have(path: "/registration/teacher-reference-number", submit_form: true) do
+      page.choose("Yes", visible: :all)
+    end
+
     expect_page_to_have(path: "/registration/qualified-teacher-check", submit_form: true) do
       expect(page).to have_text("Check your details")
 
@@ -214,6 +228,7 @@ RSpec.feature "Happy journeys", type: :feature do
         "teacher_catchment_country" => nil,
         "trn" => manually_entered_trn,
         "trn_auto_verified" => true,
+        "trn_knowledge" => "yes",
         "trn_verified" => true,
         "trn_lookup_status" => "Found",
         "verified_trn" => manually_entered_trn,


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-1092

Faisal highlighted that the flow isn't fully clear without this and Jackie and Diana agreed. 

### Changes proposed in this pull request

This PR adds the TRN question back in after the GAI flow and before the qualified_teacher_check question.
