### PR TITLE
CPDNPQ-1094 Implement Logic in API Accommodating GAI Name Changes

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,7 +40,7 @@ class User < ApplicationRecord
       trn:,
       trn_lookup_status: provider_data.info.trn_lookup_status,
       trn_verified: trn.present?,
-      full_name: provider_data.info.name,
+      full_name: provider_data.info.preferred_name || provider_data.info.name,
       raw_tra_provider_data: provider_data,
       updated_from_tra_at: Time.zone.now,
     )
@@ -62,7 +62,7 @@ class User < ApplicationRecord
       trn:,
       trn_lookup_status: provider_data.info.trn_lookup_status,
       trn_verified: trn.present?,
-      full_name: provider_data.info.name,
+      full_name: provider_data.info.preferred_name || provider_data.info.name,
       raw_tra_provider_data: provider_data,
       updated_from_tra_at: Time.zone.now,
     )

--- a/lib/omniauth/strategies/tra_openid_connect.rb
+++ b/lib/omniauth/strategies/tra_openid_connect.rb
@@ -11,7 +11,7 @@ module Omniauth
              }
       option :pkce, true
       option :scope,
-             %i[email openid profile trn].join(" ") # This is a space separated string, comma separated will fail
+             %i[email openid preferred_name profile trn].join(" ") # This is a space separated string, comma separated will fail
 
       uid { raw_info["sub"] }
 
@@ -21,6 +21,7 @@ module Omniauth
           email: raw_info["email"].downcase,
           email_verified: parsed_email_verified,
           name: raw_info["name"],
+          preferred_name: raw_info["preferred_name"],
           trn: raw_info["trn"],
           trn_lookup_status: raw_info["trn_lookup_status"],
         }

--- a/spec/support/shared_contexts/stub_gai_oauth.rb
+++ b/spec/support/shared_contexts/stub_gai_oauth.rb
@@ -1,7 +1,8 @@
 RSpec.shared_context("Stub Get An Identity Omniauth Responses") do
   let(:user_first_name) { "John" }
   let(:user_last_name) { "Doe" }
-  let(:user_full_name) { "#{user_first_name} #{user_last_name}" }
+  let(:user_preferred_name) { "#{user_first_name} #{user_last_name}" }
+  let(:user_full_name) { user_preferred_name || "#{user_first_name} #{user_last_name}" }
   let(:user_email) { "user@example.com" }
   let(:user_uid) { SecureRandom.uuid }
   let(:user_date_of_birth) { "1980-12-13" }
@@ -20,6 +21,7 @@ RSpec.shared_context("Stub Get An Identity Omniauth Responses") do
         "email_verified" => true,
         "trn" => user_trn,
         "name" => user_full_name,
+        "preferred_name" => user_preferred_name,
         "trn_lookup_status" => "Found",
       },
       "credentials" => {
@@ -33,6 +35,7 @@ RSpec.shared_context("Stub Get An Identity Omniauth Responses") do
           "email" => user_email,
           "email_verified" => "True",
           "name" => user_full_name,
+          "preferred_name" => user_preferred_name,
           "birthdate" => user_date_of_birth,
           "trn" => user_trn,
           "given_name" => user_first_name,


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-1094

### Changes proposed in this pull request
- The oauth scopes sent to GAI via the tra_openid_connect provider now sends preferred_name as a scope.
- full_name in the NPQ database is set to preferred name if present when saving data from the GAI oauth response If it is not present, full_name is stored instead.