### PR TITLE
Stop sending preferred_name scope

### DIFF
--- a/lib/omniauth/strategies/tra_openid_connect.rb
+++ b/lib/omniauth/strategies/tra_openid_connect.rb
@@ -11,7 +11,7 @@ module Omniauth
              }
       option :pkce, true
       option :scope,
-             %i[email openid preferred_name profile trn].join(" ") # This is a space separated string, comma separated will fail
+             %i[email openid profile trn].join(" ") # This is a space separated string, comma separated will fail
 
       uid { raw_info["sub"] }
 


### PR DESCRIPTION
This scope has stopped being recognised, we need to remove that so that the app starts working again.