### PR TITLE
Use proper job names in Github Actions

### DIFF
--- a/.github/workflows/deploy_to_dev.yml
+++ b/.github/workflows/deploy_to_dev.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   deploy:
+    name: Deploy to Dev
+
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout Code

--- a/.github/workflows/deploy_to_production.yml
+++ b/.github/workflows/deploy_to_production.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   deploy:
+    name: Deploy to Production
+
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout Code

--- a/.github/workflows/deploy_to_review_app.yml
+++ b/.github/workflows/deploy_to_review_app.yml
@@ -1,4 +1,4 @@
-name: Push PR to Review App
+name: Create Review App
 
 on:
   pull_request:
@@ -9,6 +9,8 @@ on:
 
 jobs:
   deploy:
+    name: Deploy to Review App
+
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/deploy_to_sandbox.yml
+++ b/.github/workflows/deploy_to_sandbox.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   deploy:
+    name: Deploy to Sandbox
+
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout Code

--- a/.github/workflows/destroy_review_app.yml
+++ b/.github/workflows/destroy_review_app.yml
@@ -1,11 +1,14 @@
 name: Destroy Review App
+
 on:
   pull_request:
     branches: [ main ]
     types: [ closed ]
 
 jobs:
-  deploy:
+  destroy:
+    name: Destroy Review App
+
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/export_dashboard_report.yml
+++ b/.github/workflows/export_dashboard_report.yml
@@ -6,7 +6,9 @@ on:
     - cron:  '10 * * * *'
 
 jobs:
-  deploy:
+  export:
+    name: Export dashboard report to BigQuery
+
     runs-on: ubuntu-20.04
     container: google/cloud-sdk:latest
     steps:

--- a/.github/workflows/generate_dashboard_report.yml
+++ b/.github/workflows/generate_dashboard_report.yml
@@ -1,4 +1,4 @@
-name: Generate dashboard report
+name: Generate Dashboard Report
 
 on:
   workflow_dispatch:
@@ -6,7 +6,9 @@ on:
     - cron:  '0 * * * *'
 
 jobs:
-  deploy:
+  generate:
+    name: Generate Dashboard Report
+
     runs-on: ubuntu-20.04
     steps:
       - name: Install CloudFoundry CLI

--- a/.github/workflows/get_an_identity_data_sync_all.yml
+++ b/.github/workflows/get_an_identity_data_sync_all.yml
@@ -3,7 +3,9 @@ name: Resync User data for all GAI users
 on: workflow_dispatch
 
 jobs:
-  deploy:
+  sync:
+    name: Resync User data for all GAI users
+
     runs-on: ubuntu-20.04
     steps:
       - name: Install CloudFoundry CLI

--- a/.github/workflows/get_an_identity_data_sync_unsynced.yml
+++ b/.github/workflows/get_an_identity_data_sync_unsynced.yml
@@ -3,7 +3,9 @@ name: Resync User data for all unsynced GAI users
 on: workflow_dispatch
 
 jobs:
-  deploy:
+  sync:
+    name: Resync User data for all unsynced GAI users
+
     runs-on: ubuntu-20.04
     steps:
       - name: Install CloudFoundry CLI

--- a/.github/workflows/get_an_identity_data_sync_user.yml
+++ b/.github/workflows/get_an_identity_data_sync_user.yml
@@ -8,7 +8,9 @@ on:
         required: true
 
 jobs:
-  deploy:
+  sync:
+    name: Resync User data for specific GAI user
+
     runs-on: ubuntu-20.04
     steps:
       - name: Install CloudFoundry CLI

--- a/.github/workflows/schedule_sweep_stale_sessions.yml
+++ b/.github/workflows/schedule_sweep_stale_sessions.yml
@@ -5,7 +5,9 @@ on:
     - cron:  '30 3 * * *'
 
 jobs:
-  deploy:
+  sweep:
+    name: Sweep stale sessions
+
     runs-on: ubuntu-20.04
     steps:
       - name: Install CloudFoundry CLI

--- a/.github/workflows/update_all_schools.yml
+++ b/.github/workflows/update_all_schools.yml
@@ -3,7 +3,9 @@ name: Sync School Data (All Schools)
 on: workflow_dispatch
 
 jobs:
-  deploy:
+  update:
+    name: Sync School Data (All Schools)
+
     runs-on: ubuntu-20.04
     steps:
       - name: Install CloudFoundry CLI

--- a/.github/workflows/update_all_schools_test_run.yml
+++ b/.github/workflows/update_all_schools_test_run.yml
@@ -3,7 +3,9 @@ name: Sync School Data (All Schools - Test Run)
 on: workflow_dispatch
 
 jobs:
-  deploy:
+  update:
+    name: Sync School Data (All Schools - Test Run)
+
     runs-on: ubuntu-20.04
     steps:
       - name: Install CloudFoundry CLI

--- a/.github/workflows/update_course_definitions.yml
+++ b/.github/workflows/update_course_definitions.yml
@@ -3,7 +3,9 @@ name: Update Course Definitions
 on: workflow_dispatch
 
 jobs:
-  deploy:
+  update:
+    name: Update Course Definitions
+
     runs-on: ubuntu-20.04
     steps:
       - name: Install CloudFoundry CLI

--- a/.github/workflows/update_schools.yml
+++ b/.github/workflows/update_schools.yml
@@ -5,7 +5,9 @@ on:
     - cron:  '0 5 * * *'
 
 jobs:
-  deploy:
+  update:
+    name: Sync School Data (Changed Schools Only)
+
     runs-on: ubuntu-20.04
     steps:
       - name: Install CloudFoundry CLI


### PR DESCRIPTION
### Context

Almost every job in the repo had the name "deploy". Most of them aren't deployments.

### Changes proposed in this pull request

Updates all job ids to be appropriate to the job and gives them proper names.