### PR TITLE
Add redirect button to confirmation page

### DIFF
--- a/app/views/accounts/user_registrations/show.html.erb
+++ b/app/views/accounts/user_registrations/show.html.erb
@@ -1,7 +1,18 @@
+<% if params[:success] == "true" %>
+  <%= render GovukComponent::NotificationBannerComponent.new(
+    success: true,
+    title_text: "Success"
+  ) do %>
+    <h3 class="govuk-notification-banner__heading">
+      Registration successfully submitted
+    </h3>
+    <p class="govuk-body">Check the details of your registration and see next steps below.</p>
+  <% end %>
+<% end %>
 <% content_for :before_content do %>
   <%= render GovukComponent::BackLinkComponent.new(
     text: "Back",
-    href: url_for(:back)
+    href: account_path
   ) %>
 <% end %>
 

--- a/app/views/registration_wizard/confirmation.html.erb
+++ b/app/views/registration_wizard/confirmation.html.erb
@@ -16,6 +16,10 @@
 
     <p class="govuk-body">They’ll contact you to outline the next steps, including how to apply.</p>
 
+    <a href="<%= accounts_user_registration_path(current_user.applications.last, success: true) %>" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
+      Continue
+    </a>
+
     <% if @form.display_npqh_information?  %>
       <% ehco_course = Course.ehco.first %>
 

--- a/spec/features/journeys/happy_paths/when_choose_lead_mentor_course_spec.rb
+++ b/spec/features/journeys/happy_paths/when_choose_lead_mentor_course_spec.rb
@@ -91,6 +91,13 @@ RSpec.feature "Happy journeys", type: :feature do
       expect(page).to have_text("You’ve registered for the Leading teacher development NPQ with Church of England")
     end
 
+    page.click_link("Continue")
+
+    expect_page_to_have(path: "/accounts/user_registrations/#{Application.last.id}?success=true", submit_form: false) do
+      expect(page).to have_text("Registration successfully submitted")
+      expect(page).to have_text("Leading teacher development NPQ registration details")
+    end
+
     expect(User.count).to be(1)
 
     User.last.tap do |user|


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-1095

### Changes proposed in this pull request

The success banner depends on the URL param which is not ideal, but there is no straightforward way to do it via redirection at the moment.

