### PR TITLE
CPDNPQ-1188: Update only synced application with ecf

### DIFF
--- a/app/lib/services/ecf/ecf_application_synchronization.rb
+++ b/app/lib/services/ecf/ecf_application_synchronization.rb
@@ -36,8 +36,12 @@ module Services
             lead_provider_approval_status = record.lead_provider_approval_status
             participant_outcome_state = record.participant_outcome_state
 
-            application = Application.find_by!(ecf_id: id)
-            application.update!(lead_provider_approval_status:, participant_outcome_state:)
+            application = Application.find_by(ecf_id: id)
+            if application.present?
+              application.update!(lead_provider_approval_status:, participant_outcome_state:)
+            else
+              Rails.logger.info("Application #{id} is not synced yet")
+            end
           end
         else
           raise "Failed to update application: #{response.message}"

--- a/app/lib/services/ecf/ecf_application_synchronization.rb
+++ b/app/lib/services/ecf/ecf_application_synchronization.rb
@@ -40,7 +40,7 @@ module Services
             if application.present?
               application.update!(lead_provider_approval_status:, participant_outcome_state:)
             else
-              Rails.logger.info("Application #{id} is not synced yet")
+              Rails.logger.info("Application where ecf_id=#{id} is not synced yet")
             end
           end
         else


### PR DESCRIPTION
### Context
update only synced applications with ecf

### Ticket/PR: 
https://github.com/DFE-Digital/npq-registration/pull/819

### Changes proposed in this pull request

We are not raising an exception, we will be updating any ID's that are present in the npq space.

```
For example, application A and B got updated in the ECF. But in the NPQ, we have only application A and application B has not synced yet.

It should update only application A since it is synced with Ecf.
```
