### PR TITLE
CPDNPQ-1201: Display funding eligibility in the journey of not other your-employment

### DIFF
--- a/app/lib/forms/choose_your_npq.rb
+++ b/app/lib/forms/choose_your_npq.rb
@@ -71,7 +71,7 @@ module Forms
       elsif wizard.query_store.works_in_other?
         if lead_mentor?
           :ineligible_for_funding
-        elsif wizard.query_store.employment_type_other?
+        elsif wizard.query_store.employment_type_other? || wizard.query_store.employment_type_not_other?
           :possible_funding
         else
           :choose_your_provider

--- a/app/lib/forms/possible_funding.rb
+++ b/app/lib/forms/possible_funding.rb
@@ -25,7 +25,7 @@ module Forms
     def message_template
       return "private_childcare_provider" if institution.is_a?(PrivateChildcareProvider)
       return "lead_mentor" if Course.npqltd.include?(course)
-      return "funding_eligibility_unclear" if works_in_other? && employment_type_other?
+      return "funding_eligibility_unclear" if works_in_other? && (employment_type_other? || employment_type_not_other?)
 
       if targeted_delivery_funding_eligibility?
         "eligible_for_scholarship_funding"
@@ -42,6 +42,10 @@ module Forms
 
     def employment_type_other?
       wizard.query_store.employment_type_other?
+    end
+
+    def employment_type_not_other?
+      wizard.query_store.employment_type_not_other?
     end
 
     def targeted_delivery_funding_eligibility?

--- a/app/lib/services/query_store.rb
+++ b/app/lib/services/query_store.rb
@@ -69,6 +69,10 @@ class Services::QueryStore
     store["employment_type"] == "other"
   end
 
+  def employment_type_not_other?
+    %w[lead_mentor_for_accredited_itt_provider local_authority_supply_teacher hospital_school local_authority_virtual_school young_offender_institution].include? store["employment_type"]
+  end
+
   def works_in_school?
     store["works_in_school"] == "yes"
   end


### PR DESCRIPTION
### Context

Display funding eligibility in the journey of not other your-employment
### Ticket

https://dfedigital.atlassian.net/browse/CPDNPQ-1201

### Changes proposed in this pull request

Add new functionality to `your-employment` page for selecting other than `other` with country `england` option to follow the missing journey edge-cases of funding eligibility.