### PR TITLE
Add code to support DNS management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,10 @@ yarn-debug.log*
 /coverage
 
 .DS_Store
+
+# Terraform files
+.terraform
+terraform/application/vendor
+terraform/domains/environment_domains/vendor
+terraform.tfstate*
+bin/terrafile

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+terraform 1.5.1

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,10 @@
+TERRAFILE_VERSION=0.8
+ARM_TEMPLATE_TAG=1.1.6
+RG_TAGS={"Product" : "Teacher services cloud"}
+REGION=UK South
+SERVICE_NAME=npq-registration
+SERVICE_SHORT=cpdnpq
+
 .PHONY: build-local-image docker-compose-build
 build-local-image:
 	docker buildx build -t dfedigital/govuk-rails-boilerplate:builder-local \
@@ -11,3 +18,68 @@ build-local-image:
 
 docker-compose-build:
 	docker-compose build --build-arg BUNDLE_FLAGS='--jobs=4 --no-binstubs --no-cache' --parallel
+
+production:
+	$(if $(or ${SKIP_CONFIRM}, ${CONFIRM_PRODUCTION}), , $(error Missing CONFIRM_PRODUCTION=yes))
+	$(eval include global_config/production.sh)
+
+domains:
+	$(eval include global_config/domains.sh)
+
+domains-composed-variables:
+	$(eval RESOURCE_GROUP_NAME=${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}domains-rg)
+	$(eval KEYVAULT_NAMES=["${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}domains-kv"])
+	$(eval STORAGE_ACCOUNT_NAME=${AZURE_RESOURCE_PREFIX}${SERVICE_SHORT}domainstf)
+
+bin/terrafile: ## Install terrafile to manage terraform modules
+	curl -sL https://github.com/coretech/terrafile/releases/download/v${TERRAFILE_VERSION}/terrafile_${TERRAFILE_VERSION}_$$(uname)_x86_64.tar.gz \
+		| tar xz -C ./bin terrafile
+
+set-azure-account:
+	[ "${SKIP_AZURE_LOGIN}" != "true" ] && az account set -s ${AZURE_SUBSCRIPTION} || true
+
+set-what-if:
+	$(eval WHAT_IF=--what-if)
+
+arm-deployment: set-azure-account
+	$(if ${KEYVAULT_NAMES}, $(eval KV_ARG='keyVaultNames=${KEYVAULT_NAMES}'),)
+
+	az deployment sub create --name "resourcedeploy-tsc-$(shell date +%Y%m%d%H%M%S)" \
+		-l "${REGION}" --template-uri "https://raw.githubusercontent.com/DFE-Digital/tra-shared-services/${ARM_TEMPLATE_TAG}/azure/resourcedeploy.json" \
+		--parameters "resourceGroupName=${RESOURCE_GROUP_NAME}" 'tags=${RG_TAGS}' \
+			"tfStorageAccountName=${STORAGE_ACCOUNT_NAME}" "tfStorageContainerName=terraform-state" \
+			${KV_ARG} \
+			"enableKVPurgeProtection=${KV_PURGE_PROTECTION}" \
+			${WHAT_IF}
+
+deploy-domain-arm-resources: domains-composed-variables arm-deployment
+
+validate-domain-arm-resources: set-what-if domain-composed-variables arm-deployment
+
+domains-infra-init: bin/terrafile domains-composed-variables domains set-azure-account
+	./bin/terrafile -p terraform/domains/infrastructure/vendor/modules -f terraform/domains/infrastructure/config/zones_Terrafile
+
+	terraform -chdir=terraform/domains/infrastructure init -reconfigure -upgrade \
+		-backend-config=resource_group_name=${RESOURCE_GROUP_NAME} \
+		-backend-config=storage_account_name=${STORAGE_ACCOUNT_NAME} \
+		-backend-config=key=domains_infrastructure.tfstate
+
+domains-infra-plan: domains domains-infra-init
+	terraform -chdir=terraform/domains/infrastructure plan -var-file config/zones.tfvars.json
+
+domains-infra-apply: domains domains-infra-init
+	terraform -chdir=terraform/domains/infrastructure apply -var-file config/zones.tfvars.json ${AUTO_APPROVE}
+
+domains-init: bin/terrafile domains-composed-variables domains set-azure-account
+	./bin/terrafile -p terraform/domains/environment_domains/vendor/modules -f terraform/domains/environment_domains/config/${CONFIG}_Terrafile
+
+	terraform -chdir=terraform/domains/environment_domains init -upgrade -reconfigure \
+		-backend-config=resource_group_name=${RESOURCE_GROUP_NAME} \
+		-backend-config=storage_account_name=${STORAGE_ACCOUNT_NAME} \
+		-backend-config=key=${ENVIRONMENT}.tfstate
+
+domains-plan: domains-init
+	terraform -chdir=terraform/domains/environment_domains plan -var-file config/${CONFIG}.tfvars.json
+
+domains-apply: domains-init
+	terraform -chdir=terraform/domains/environment_domains apply -var-file config/${CONFIG}.tfvars.json ${AUTO_APPROVE}

--- a/global_config/domains.sh
+++ b/global_config/domains.sh
@@ -1,0 +1,2 @@
+AZURE_SUBSCRIPTION=s189-teacher-services-cloud-production
+AZURE_RESOURCE_PREFIX=s189p01

--- a/global_config/production.sh
+++ b/global_config/production.sh
@@ -1,0 +1,5 @@
+CONFIG=production
+ENVIRONMENT=production
+CONFIG_SHORT=pd
+AZURE_SUBSCRIPTION=s189-teacher-services-cloud-production
+AZURE_RESOURCE_PREFIX=s189p01

--- a/terraform/domains/environment_domains/.terraform.lock.hcl
+++ b/terraform/domains/environment_domains/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "3.62.1"
+  constraints = "3.62.1"
+  hashes = [
+    "h1:DjR9eGTQPL9YX1fF539MPOrKYLrEmBgrGSBYDJo2iNE=",
+    "zh:0fa21ac98474f3a2aeab1191628735ddf1fdb0767f935e8b0f7e259a335773cd",
+    "zh:45ca710ffc39d194e0a29ca6983117a180302f3e1babb425257a23a1f38bb974",
+    "zh:481fd2ace1cf52ebae940ec8c66d025d2582af3aaf67340b6afbfa7a19b86864",
+    "zh:4fd32a7442f052fdf48ce6379f001581312a3ca7a10da837ee1c4e46c2f882dc",
+    "zh:507fff425b941a0fd53a57a4b79763183d37fac7ba3d4aa46a74dadf13ee5ced",
+    "zh:a09964b92e227cbceec7bf62e92bb71638b74738e465e5dafd75899a3c098eab",
+    "zh:a64ac7583675b0e704c6d6d1de31595e99ac7c270fd3e180d5f50d3f81f18801",
+    "zh:b20f4dbbd39aab6a3833541704771794790485ce62a85730f1cd671cf064ea8a",
+    "zh:d03b5c537e40fae12a9dd7750f0e29820b54f58efb1be1c7005ffb0ad70c6876",
+    "zh:ed19a03b3da4dfc000d278ffe986c5b3ab7114ccbe1d59e8bd474f065cfad377",
+    "zh:f53bb11e7be3d109f8763cb90910d79044693be35968c06eb31aa48f5375db31",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terraform/domains/environment_domains/config/production.tfvars.json
+++ b/terraform/domains/environment_domains/config/production.tfvars.json
@@ -1,0 +1,23 @@
+{
+  "hosted_zone": {
+    "register-national-professional-qualifications.education.gov.uk": {
+      "front_door_name": "s189p01-cpdnpqdomains-fd",
+      "resource_group_name": "s189p01-cpdnpqdomains-rg",
+      "domains": [
+        "apex"
+      ],
+      "cached_paths": [
+        "/packs/*"
+      ],
+      "environment_short": "pd",
+      "origin_hostname": "npq-registration-prod.london.cloudapps.digital",
+      "null_host_header": true,
+      "cnames": {
+        "_14c49b3a20d4ad049e0708795e1f8ca4": {
+          "target": "_9156bba248c12a46b784f7312750bd29.gwpjclltnz.acm-validations.aws.",
+          "ttl": 86400
+        }
+      }
+    }
+  }
+}

--- a/terraform/domains/environment_domains/config/production_Terrafile
+++ b/terraform/domains/environment_domains/config/production_Terrafile
@@ -1,0 +1,3 @@
+domains:
+    source:  "https://github.com/DFE-Digital/terraform-modules"
+    version: "stable"

--- a/terraform/domains/environment_domains/main.tf
+++ b/terraform/domains/environment_domains/main.tf
@@ -1,0 +1,19 @@
+# Used to create domains to be managed by front door.
+module "domains" {
+  for_each            = var.hosted_zone
+  source              = "./vendor/modules/domains//domains/environment_domains"
+  zone                = each.key
+  front_door_name     = each.value.front_door_name
+  resource_group_name = each.value.resource_group_name
+  domains             = each.value.domains
+  environment         = each.value.environment_short
+  host_name           = each.value.origin_hostname
+  null_host_header    = try(each.value.null_host_header, false)
+  cached_paths        = try(each.value.cached_paths, [])
+}
+
+# Takes values from hosted_zone.domain_name.cnames (or txt_records, a-records). Use for domains which are not associated with front door.
+module "dns_records" {
+  source      = "./vendor/modules/domains//dns/records"
+  hosted_zone = var.hosted_zone
+}

--- a/terraform/domains/environment_domains/terraform.tf
+++ b/terraform/domains/environment_domains/terraform.tf
@@ -1,0 +1,19 @@
+terraform {
+
+  required_version = "= 1.5.1"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "3.62.1"
+    }
+  }
+  backend "azurerm" {
+    container_name = "terraform-state"
+  }
+}
+
+provider "azurerm" {
+  features {}
+
+  skip_provider_registration = true
+}

--- a/terraform/domains/environment_domains/variables.tf
+++ b/terraform/domains/environment_domains/variables.tf
@@ -1,0 +1,4 @@
+variable "hosted_zone" {
+  type    = map(any)
+  default = {}
+}

--- a/terraform/domains/infrastructure/.terraform.lock.hcl
+++ b/terraform/domains/infrastructure/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "3.62.1"
+  constraints = "3.62.1"
+  hashes = [
+    "h1:DjR9eGTQPL9YX1fF539MPOrKYLrEmBgrGSBYDJo2iNE=",
+    "zh:0fa21ac98474f3a2aeab1191628735ddf1fdb0767f935e8b0f7e259a335773cd",
+    "zh:45ca710ffc39d194e0a29ca6983117a180302f3e1babb425257a23a1f38bb974",
+    "zh:481fd2ace1cf52ebae940ec8c66d025d2582af3aaf67340b6afbfa7a19b86864",
+    "zh:4fd32a7442f052fdf48ce6379f001581312a3ca7a10da837ee1c4e46c2f882dc",
+    "zh:507fff425b941a0fd53a57a4b79763183d37fac7ba3d4aa46a74dadf13ee5ced",
+    "zh:a09964b92e227cbceec7bf62e92bb71638b74738e465e5dafd75899a3c098eab",
+    "zh:a64ac7583675b0e704c6d6d1de31595e99ac7c270fd3e180d5f50d3f81f18801",
+    "zh:b20f4dbbd39aab6a3833541704771794790485ce62a85730f1cd671cf064ea8a",
+    "zh:d03b5c537e40fae12a9dd7750f0e29820b54f58efb1be1c7005ffb0ad70c6876",
+    "zh:ed19a03b3da4dfc000d278ffe986c5b3ab7114ccbe1d59e8bd474f065cfad377",
+    "zh:f53bb11e7be3d109f8763cb90910d79044693be35968c06eb31aa48f5375db31",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terraform/domains/infrastructure/config/zones.tfvars.json
+++ b/terraform/domains/infrastructure/config/zones.tfvars.json
@@ -1,0 +1,15 @@
+{
+    "hosted_zone": {
+      "register-national-professional-qualifications.education.gov.uk": {
+        "caa_records": {},
+        "txt_records": {
+          "_dmarc": {
+            "value": "v=DMARC1;p=quarantine;sp=quarantine;pct=100;fo=1;rua=mailto:dmarc-rua@dmarc.service.gov.uk,mailto:dmarc-rua@education.gov.uk;ruf=mailto:DMARC.Forensic@education.gov.uk"
+          }
+        },
+        "resource_group_name": "s189p01-cpdnpqdomains-rg",
+        "front_door_name": "s189p01-cpdnpqdomains-fd"
+      }
+    },
+    "deploy_default_records": false
+  }

--- a/terraform/domains/infrastructure/config/zones_Terrafile
+++ b/terraform/domains/infrastructure/config/zones_Terrafile
@@ -1,0 +1,3 @@
+domains:
+    source:  "https://github.com/DFE-Digital/terraform-modules"
+    version: "testing"

--- a/terraform/domains/infrastructure/main.tf
+++ b/terraform/domains/infrastructure/main.tf
@@ -1,0 +1,5 @@
+module "domains_infrastructure" {
+  source                 = "./vendor/modules/domains//domains/infrastructure"
+  hosted_zone            = var.hosted_zone
+  deploy_default_records = var.deploy_default_records
+}

--- a/terraform/domains/infrastructure/terraform.tf
+++ b/terraform/domains/infrastructure/terraform.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = "= 1.5.1"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "3.62.1"
+    }
+  }
+  backend "azurerm" {
+    container_name = "terraform-state"
+  }
+}
+
+provider "azurerm" {
+  features {}
+
+  skip_provider_registration = true
+}

--- a/terraform/domains/infrastructure/variables.tf
+++ b/terraform/domains/infrastructure/variables.tf
@@ -1,0 +1,7 @@
+variable "hosted_zone" {
+  type = map(any)
+}
+
+variable "deploy_default_records" {
+  default = true
+}


### PR DESCRIPTION
### Context

Ticket: https://trello.com/c/i1HAQLBe

Manage the services domain from within the services code and move it from AWS Route 53 to Azure DNS and Front Door.

### Changes proposed in this pull request

Add relevant code to allow the manual deployment of the DNS infrastructure and configuration using `Makefile` commands.

### Testing
On MacOS:

Follow - https://vninja.net/2020/02/06/macos-custom-dns-resolvers

cd /etc
sudo mkdir resolver
cd resolver
sudo touch register-national-professional-qualifications.education.gov.uk

sudo vi register-national-professional-qualifications.education.gov.uk

Add the following lines and save:

```
domain register-national-professional-qualifications.education.gov.uk
search register-national-professional-qualifications.education.gov.uk
nameserver 13.107.236.4
nameserver 150.171.21.4
nameserver 204.14.183.4
nameserver 208.84.5.4
```

Save the file:
esc :wq!

Check the file:
cat register-national-professional-qualifications.education.gov.uk

sudo killall -HUP mDNSResponder

Visit the domain and confirm the certificate is DigiCert which is generated by front door.