### PR TITLE
Registration: remove duplicated header when TRN details not found

### DIFF
--- a/app/views/registration_wizard/dqt_mismatch.html.erb
+++ b/app/views/registration_wizard/dqt_mismatch.html.erb
@@ -24,8 +24,6 @@
 
   <h2 class="govuk-heading-m">Check your details and try again</h2>
 
-  <h2 class="govuk-heading-m">Check your details and try again</h2>
-
   <%= render GovukComponent::SummaryListComponent.new do |summary_list| %>
     <% summary_list.with_row do |row|
          row.with_key { "Teacher reference number (TRN)" }


### PR DESCRIPTION
### Context

When working on [CPDNPQ-1230](https://dfedigital.atlassian.net/browse/CPDNPQ-1230) I noticed that on the registration page we have a duplicated heading. This PR fixes it.

### Before

<img width="522" alt="image" src="https://github.com/DFE-Digital/npq-registration/assets/227328/8a0d6e9a-5a30-44b0-8ba8-3351351cd195">

### After

<img width="510" alt="image" src="https://github.com/DFE-Digital/npq-registration/assets/227328/21f3f43e-efcd-4132-827d-c7234f6a5ace">