### PR TITLE
Populate IDs from Get and Identity

### DIFF
--- a/app/lib/services/importers/populate_get_identity_id.rb
+++ b/app/lib/services/importers/populate_get_identity_id.rb
@@ -3,9 +3,16 @@ module Services
     class PopulateGetIdentityId
       def import(rows)
         rows.each do |row|
-          user = Application.find(row.fetch(:id)).user
-          user.update!(uid: row.fetch(:user_id))
-          Rails.logger.info("User #{user.id} has been updated with get_identity_id #{row.fetch(:user_id)}")
+          user = Application.find_by!(ecf_id: row.fetch(:id)).user
+          if user.uid.blank?
+            user.update!(uid: row.fetch(:user_id))
+            Rails.logger.info("User #{user.id} has been updated with get_identity_id #{row.fetch(:user_id)}")
+          else
+            Rails.logger.info("User #{user.id} already has an uid.")
+            if user.uid != row.fetch(:user_id)
+              Rails.logger.error(("User #{user.id} already has a different uid? #{user.uid} vs #{row.fetch(:user_id)}"))
+            end
+          end
         end
       end
     end

--- a/lib/tasks/one_off/populate_get_identity.rake
+++ b/lib/tasks/one_off/populate_get_identity.rake
@@ -27,15 +27,14 @@ namespace :get_identity_id do
       rows << row
       attrs = row.to_h
 
-      application_id = attrs.fetch(:user_id)
-      application = Application.find_by(id: application_id)
+      application_id = attrs.fetch(:id)
+      application = Application.find_by(ecf_id: application_id)
       Rails.logger.error("Application #{application_id} not found") if application.nil?
 
       if application
         user = application.user
 
         Rails.logger.error("User not found") if user.nil?
-        Rails.logger.error("User #{user.id} has no ECF ID") if user && user.ecf_id.nil?
         Rails.logger.error("User #{user.id} with existing GIA? same -> (#{user.uid != attrs.fetch(:user_id)})") if user && user.uid.present?
 
         Rails.logger.info(".")

--- a/spec/lib/services/importers/populate_get_identity_id_spec.rb
+++ b/spec/lib/services/importers/populate_get_identity_id_spec.rb
@@ -4,9 +4,9 @@ require "tempfile"
 RSpec.describe Services::Importers::PopulateGetIdentityId do
   it "Updates the get_identity_id for the user" do
     user = create(:user)
-    application = create(:application, user:)
+    create(:application, user:, ecf_id: "the-id-in-ecf")
 
-    described_class.new.import([{ id: application.id, user_id: "get-an-id-" }])
+    described_class.new.import([{ id: "the-id-in-ecf", user_id: "get-an-id-" }])
 
     expect(user.reload.uid).to eq("get-an-id-")
   end
@@ -15,10 +15,13 @@ RSpec.describe Services::Importers::PopulateGetIdentityId do
     user1 = create(:user)
     user2 = create(:user)
 
-    application1 = create(:application, user: user1)
-    application2 = create(:application, user: user2)
+    create(:application, user: user1, ecf_id: "the-id-in-ecf-1")
+    create(:application, user: user2, ecf_id: "the-id-in-ecf-2")
 
-    described_class.new.import([{ id: application1.id, user_id: "get-an-id-1" }, { id: application2.id, user_id: "get-an-id-2" }])
+    described_class.new.import([
+      { id: "the-id-in-ecf-1", user_id: "get-an-id-1" },
+      { id: "the-id-in-ecf-2", user_id: "get-an-id-2" },
+    ])
 
     expect(user1.reload.uid).to eq("get-an-id-1")
     expect(user2.reload.uid).to eq("get-an-id-2")
@@ -32,11 +35,11 @@ RSpec.describe Services::Importers::PopulateGetIdentityId do
 
   it "Logs the uid to the Rails logger" do
     user = create(:user)
-    application = create(:application, user:)
+    create(:application, user:, ecf_id: "the-id-in-ecf")
     logger = instance_spy(Logger)
     allow(Rails).to receive(:logger).and_return(logger)
 
-    described_class.new.import([{ id: application.id, user_id: "get-an-id-" }])
+    described_class.new.import([{ id: "the-id-in-ecf", user_id: "get-an-id-" }])
 
     expect(logger).to have_received(:info).with("User #{user.id} has been updated with get_identity_id get-an-id-")
   end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-1269

A subset of the NPQ users do not have an identity id stored, as the identity id
services was active after NPQ service started.

We have requested the GetAnIdentity team to populate the IDs of Users in NPQ
that don't have an identity ID. We have received a file with the result of the import
and on this PR we are populating the data via a rake task.

The way to use it is the following:

1. Select the rows that we aim to import from the result file (from the Get An Identity Service). The
Script only look for two fields: `ID` and `USER_ID`. It ignores the other columns of the file 
because they are informative about the result of the operation (some rows need to be manually checked)
2. Run the `rake` task with: 

```shell
bundle exec rake get_identity_id:import[<<path-to-file>>]
```
The script will inform via `Rails.logger` about progress and errors

### Technical notes

1. I am not pushing the CSV into the repo because it contains sensitive data
2. This approach enables running the rake task with multiple files (in batches) as the data is continually improved
3. I am not creating jobs within the script as I am assuming a quick execution of the rake task and we have major control, but this needs to be checked with the other devs.