### PR TITLE
Move docker build and push to its own action

### DIFF
--- a/.github/actions/build-and-push-docker-image/action.yml
+++ b/.github/actions/build-and-push-docker-image/action.yml
@@ -1,0 +1,58 @@
+name: Build and push Docker image
+description: Builds a Docker image and pushes it to Dockerhub and GitHub container registry
+
+inputs:
+  dockerhub-username:
+    description: CPD dockerhub account username
+    required: true
+  dockerhub-password:
+    description: CPD dockerhub account password
+    required: true
+  account:
+    description: DockerHub account, the part of the org/app:tag before the colon
+    required: true
+  tag:
+    description: Tag for the Docker image
+    required: true
+  github-token:
+    description: GitHub access token
+    required: true
+
+outputs:
+  docker_image_id:
+    description: The Docker image ID returned by the build step
+    value: ${{ steps.docker_build_push.outputs.digest }}
+
+runs:
+  using: composite
+
+  steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ inputs.dockerhub-username }}
+        password: ${{ inputs.dockerhub-password }}
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ inputs.github-token }}
+
+    - name: Build and push docker image
+      uses: docker/build-push-action@v3
+      id: docker_build_push
+      with:
+        context: .
+        build-args: |
+          BUILDKIT_INLINE_CACHE=1
+          GIT_COMMIT_SHA=${{ github.sha }}
+        push: true
+        tags: |
+          ${{ inputs.account }}:${{ inputs.tag }}
+          ghcr.io/dfe-digital/npq-registration:${{ github.event.pull_request.head.sha }}
+        provenance: false

--- a/.github/workflows/deploy_to_dev.yml
+++ b/.github/workflows/deploy_to_dev.yml
@@ -15,9 +15,6 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
       - name: Install CloudFoundry CLI
         shell: bash
         run: |
@@ -26,23 +23,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install cf7-cli
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
+      - name: Build and push Docker image
+        id: docker_build
+        uses: ./.github/actions/build-and-push-docker-image
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_DEV_PASSWORD }}
-
-      - name: Build and push docker image
-        uses: docker/build-push-action@v3
-        id: docker_build_push
-        with:
-          context: .
-          build-args: |
-            BUILDKIT_INLINE_CACHE=1
-            GIT_COMMIT_SHA=${{ github.sha }}
-          push: true
-          tags: dfedigital/early-careers-framework-dev:npq-registration-dev
-          provenance: false
+          dockerhub-username: ${{ secrets.DOCKER_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKER_DEV_PASSWORD }}
+          tag: npq-registration-dev
+          account: dfedigital/early-careers-framework-dev
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy to Gov.uk PaaS
         id: deploy-to-paas
@@ -63,7 +52,7 @@ jobs:
           cf target -o "${{ env.PAAS_ORGANISATION }}" -s "${{ env.PAAS_SPACE }}"
           cf push "${{ env.APP_NAME }}"-"${{ env.ENV_STUB }}" \
             --manifest ./config/manifests/"${{ env.ENV_STUB }}"-manifest.yml \
-            --var DOCKER_IMAGE_ID="${{ steps.docker_build_push.outputs.digest }}" \
+            --var DOCKER_IMAGE_ID="${{ steps.docker_build.outputs.docker_image_id }}" \
             --var SECRET_KEY_BASE="${{ secrets.RAILS_SECRET_KEY_BASE_DEV }}" \
             --var GOVUK_NOTIFY_API_KEY="${{ secrets.GOVUK_NOTIFY_API_KEY_DEV }}" \
             --var TRA_OIDC_DOMAIN="${{ secrets.TRA_OIDC_DOMAIN_DEV }}" \

--- a/.github/workflows/deploy_to_production.yml
+++ b/.github/workflows/deploy_to_production.yml
@@ -15,9 +15,6 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
       - name: Install CloudFoundry CLI
         shell: bash
         run: |
@@ -26,23 +23,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install cf7-cli
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
+      - name: Build and push Docker image
+        id: docker_build
+        uses: ./.github/actions/build-and-push-docker-image
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_DEV_PASSWORD }}
-
-      - name: Build and push docker image
-        uses: docker/build-push-action@v3
-        id: docker_build_push
-        with:
-          context: .
-          build-args: |
-            BUILDKIT_INLINE_CACHE=1
-            GIT_COMMIT_SHA=${{ github.sha }}
-          push: true
-          tags: dfedigital/early-careers-framework-prod:npq-registration-prod
-          provenance: false
+          dockerhub-username: ${{ secrets.DOCKER_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKER_DEV_PASSWORD }}
+          tag: npq-registration-prod
+          account: dfedigital/early-careers-framework-prod
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy to Gov.uk PaaS
         id: deploy-to-paas
@@ -63,7 +52,7 @@ jobs:
           cf target -o "${{ env.PAAS_ORGANISATION }}" -s "${{ env.PAAS_SPACE }}"
           cf push "${{ env.APP_NAME }}"-"${{ env.ENV_STUB }}" \
             --manifest ./config/manifests/"${{ env.ENV_STUB }}"-manifest.yml \
-            --var DOCKER_IMAGE_ID="${{ steps.docker_build_push.outputs.digest }}" \
+            --var DOCKER_IMAGE_ID="${{ steps.docker_build.outputs.docker_image_id }}" \
             --var SECRET_KEY_BASE="${{ secrets.RAILS_SECRET_KEY_BASE_PROD }}" \
             --var GOVUK_NOTIFY_API_KEY="${{ secrets.GOVUK_NOTIFY_API_KEY_PROD }}" \
             --var TRA_OIDC_DOMAIN="${{ secrets.TRA_OIDC_DOMAIN_PROD }}" \

--- a/.github/workflows/deploy_to_review_app.yml
+++ b/.github/workflows/deploy_to_review_app.yml
@@ -17,9 +17,6 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
       - name: Install CloudFoundry CLI
         shell: bash
         run: |
@@ -28,23 +25,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install cf7-cli
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
+      - name: Build and push Docker image
+        id: docker_build
+        uses: ./.github/actions/build-and-push-docker-image
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_DEV_PASSWORD }}
-
-      - name: Build and push docker image
-        uses: docker/build-push-action@v3
-        id: docker_build_push
-        with:
-          context: .
-          build-args: |
-            BUILDKIT_INLINE_CACHE=1
-            GIT_COMMIT_SHA=${{ github.sha }}
-          push: true
-          tags: dfedigital/early-careers-framework-dev:npq-registration-review-app-${{ github.event.number }}
-          provenance: false
+          dockerhub-username: ${{ secrets.DOCKER_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKER_DEV_PASSWORD }}
+          tag: npq-registration-review-app-${{ github.event.number }}
+          account: dfedigital/early-careers-framework-dev
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy to Gov.uk PaaS
         id: deploy-to-paas
@@ -66,7 +55,7 @@ jobs:
           cf target -o "${{ env.PAAS_ORGANISATION }}" -s "${{ env.PAAS_SPACE }}"
           cf push "${{ env.APP_NAME }}"-"${{ env.ENV_STUB }}" \
             --manifest ./config/manifests/review-app-manifest.yml \
-            --var DOCKER_IMAGE_ID="${{ steps.docker_build_push.outputs.digest }}" \
+            --var DOCKER_IMAGE_ID="${{ steps.docker_build.outputs.docker_image_id }}" \
             --var SECRET_KEY_BASE="${{ secrets.RAILS_SECRET_KEY_BASE_DEV }}" \
             --var GOVUK_NOTIFY_API_KEY="${{ secrets.GOVUK_NOTIFY_API_KEY_DEV }}" \
             --var TRA_OIDC_DOMAIN="${{ secrets.TRA_OIDC_DOMAIN_DEV }}" \
@@ -114,7 +103,7 @@ jobs:
             --command "cd /app && /usr/local/bundle/bin/bundle exec rails runner 'ImportGiasSchoolsJob.perform_later'" \
             --process worker \
             --name schedule_school_import
-            
+
           cf run-task "${{ env.APP_NAME }}"-"${{ env.ENV_STUB }}" \
             --command "cd /app && /usr/local/bundle/bin/bundle exec rails runner 'ApplicationSynchronizationJob.perform_later'" \
             --process worker \

--- a/.github/workflows/deploy_to_sandbox.yml
+++ b/.github/workflows/deploy_to_sandbox.yml
@@ -15,9 +15,6 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
       - name: Install CloudFoundry CLI
         shell: bash
         run: |
@@ -26,23 +23,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install cf7-cli
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
+      - name: Build and push Docker image
+        id: docker_build
+        uses: ./.github/actions/build-and-push-docker-image
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_DEV_PASSWORD }}
-
-      - name: Build and push docker image
-        uses: docker/build-push-action@v3
-        id: docker_build_push
-        with:
-          context: .
-          build-args: |
-            BUILDKIT_INLINE_CACHE=1
-            GIT_COMMIT_SHA=${{ github.sha }}
-          push: true
-          tags: dfedigital/early-careers-framework-staging:npq-registration-sandbox
-          provenance: false
+          dockerhub-username: ${{ secrets.DOCKER_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKER_DEV_PASSWORD }}
+          tag: npq-registration-sandbox
+          account: dfedigital/early-careers-framework-staging
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy to Gov.uk PaaS
         id: deploy-to-paas
@@ -63,7 +52,7 @@ jobs:
           cf target -o "${{ env.PAAS_ORGANISATION }}" -s "${{ env.PAAS_SPACE }}"
           cf push "${{ env.APP_NAME }}"-"${{ env.ENV_STUB }}" \
             --manifest ./config/manifests/"${{ env.ENV_STUB }}"-manifest.yml \
-            --var DOCKER_IMAGE_ID="${{ steps.docker_build_push.outputs.digest }}" \
+            --var DOCKER_IMAGE_ID="${{ steps.docker_build.outputs.docker_image_id }}" \
             --var SECRET_KEY_BASE="${{ secrets.RAILS_SECRET_KEY_BASE_SANDBOX }}" \
             --var GOVUK_NOTIFY_API_KEY="${{ secrets.GOVUK_NOTIFY_API_KEY_SANDBOX }}" \
             --var TRA_OIDC_DOMAIN="${{ secrets.TRA_OIDC_DOMAIN_DEV }}" \


### PR DESCRIPTION
### Context

We'll soon be moving the NPQ app from GOV.UK PaaS to Azure and to stay in line with how other projects/teams are deploying, we'll be switching from Dockerhub to GitHub's container registry. This helps simplify deployment by reducing the number of credentials required.

### Changes proposed in this pull request

- Create an action that pushes to DockerHub
- Push images to GitHub container registry too
- Call docker push action from deployment workflows
