### PR TITLE
Fallback to github.sha in Docker push action

### DIFF
--- a/.github/actions/build-and-push-docker-image/action.yml
+++ b/.github/actions/build-and-push-docker-image/action.yml
@@ -54,5 +54,5 @@ runs:
         push: true
         tags: |
           ${{ inputs.account }}:${{ inputs.tag }}
-          ghcr.io/dfe-digital/npq-registration:${{ github.event.pull_request.head.sha }}
+          ghcr.io/dfe-digital/npq-registration:${{ github.event.pull_request.head.sha || github.sha }}
         provenance: false


### PR DESCRIPTION
### Context

When the action is triggered by a non-pull-request event there's no sha at the head of the PR branch. Instead use github.sha which is the SHA that triggered the event.
