### PR TITLE
Point NPQ reg app to ECF AKS instead of PaaS

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -2,7 +2,7 @@ RAISE_ON_MISSING_TRANSLATIONS=false
 
 GOVUK_NOTIFY_API_KEY=
 
-ECF_APP_BASE_URL="https://ecf-dev.london.cloudapps.digital"
+ECF_APP_BASE_URL="https://cpd-ecf-staging-web.test.teacherservices.cloud"
 ECF_APP_BASE_URL="http://localhost:3001"
 ECF_APP_BEARER_TOKEN=
 

--- a/config/manifests/dev-manifest.yml
+++ b/config/manifests/dev-manifest.yml
@@ -27,7 +27,7 @@ applications:
     GOVUK_NOTIFY_API_KEY: ((GOVUK_NOTIFY_API_KEY))
     GOOGLE_TAG_MANAGER_ID: "GTM-N58Z5PG"
     GOOGLE_ANALYTICS_ID: "G-4QYNT5ZME8"
-    ECF_APP_BASE_URL: "https://ecf-dev.london.cloudapps.digital"
+    ECF_APP_BASE_URL: "https://cpd-ecf-staging-web.test.teacherservices.cloud"
     ECF_APP_BEARER_TOKEN: ((ECF_APP_BEARER_TOKEN))
     SENTRY_DSN: ((SENTRY_DSN))
     TRA_OIDC_DOMAIN: ((TRA_OIDC_DOMAIN))

--- a/config/manifests/review-app-manifest.yml
+++ b/config/manifests/review-app-manifest.yml
@@ -27,7 +27,7 @@ applications:
     GOVUK_NOTIFY_API_KEY: ((GOVUK_NOTIFY_API_KEY))
     GOOGLE_TAG_MANAGER_ID: "GTM-N58Z5PG"
     GOOGLE_ANALYTICS_ID: "G-4QYNT5ZME8"
-    ECF_APP_BASE_URL: "https://ecf-dev.london.cloudapps.digital"
+    ECF_APP_BASE_URL: "https://cpd-ecf-staging-web.test.teacherservices.cloud"
     ECF_APP_BEARER_TOKEN: ((ECF_APP_BEARER_TOKEN))
     SENTRY_DSN: ((SENTRY_DSN))
     TRA_OIDC_DOMAIN: ((TRA_OIDC_DOMAIN))

--- a/config/manifests/staging-manifest.yml
+++ b/config/manifests/staging-manifest.yml
@@ -27,6 +27,6 @@ applications:
     GOVUK_NOTIFY_API_KEY: ((GOVUK_NOTIFY_API_KEY))
     GOOGLE_TAG_MANAGER_ID: "GTM-N58Z5PG"
     GOOGLE_ANALYTICS_ID: "G-G3823VRN6N"
-    ECF_APP_BASE_URL: "https://ecf-staging.london.cloudapps.digital"
+    ECF_APP_BASE_URL: "https://cpd-ecf-staging-web.test.teacherservices.cloud"
     ECF_APP_BEARER_TOKEN: ((ECF_APP_BEARER_TOKEN))
     SENTRY_DSN: ((SENTRY_DSN))


### PR DESCRIPTION

### Context

We are moving off PaaS, point dev NPQ to staging ECF (the new dev)

### Changes proposed in this pull request

Change all references of ecf-dev to new staging AKS environment

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
