### PR TITLE
Log users with duplicated Get-an-identity-id

### DIFF
--- a/lib/tasks/one_off/populate_get_identity.rake
+++ b/lib/tasks/one_off/populate_get_identity.rake
@@ -38,10 +38,10 @@ namespace :get_identity_id do
 
         get_identity_id = attrs.fetch(:user_id)
         if user && user.uid.present? && user.uid != get_identity_id
-          Rails.logger.error("User #{user.id} #{user.email} with existing GIA? different -> (#{user.uid != get_identity_id})")
+          Rails.logger.error("[UID mismatch] User #{user.id} with existing GIA? different -> (#{user.uid != get_identity_id})")
         end
         if user && user.uid.blank? && User.find_by(uid: get_identity_id).present?
-          Rails.logger.error("User UID #{get_identity_id} linked to a different user")
+          Rails.logger.error("[Duplicated] User UID #{get_identity_id} linked to a different user")
         end
       end
     end


### PR DESCRIPTION
Related to: #869 and #862 

https://dfedigital.atlassian.net/browse/CPDNPQ-1269

### Context

Some users have two accounts created in NPQ, one of them has an UID 
assigned and the other account it doesn't.

This PR, logs them by checking if the user if there is an existing user with 
the same UID that we are about to assign.

These cases must be checked individually and an action should be taken.


