### PR TITLE
Mapping provider with math npq course

### DIFF
--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -45,6 +45,15 @@ class LeadProvider < ApplicationRecord
     "UCL Institute of Education",
   ].freeze
 
+  LPM_PROVIDERS = [
+    "Ambition Institute",
+    "Church of England",
+    "Education Development Trust",
+    "LLSE",
+    "Teach First",
+    "UCL Institute of Education",
+  ].freeze
+
   # TODO: Move all of this mapping into the database
   #       Hardcoding this has been done for expediency but
   #       longterm having this handled in the DB so none of
@@ -62,6 +71,8 @@ class LeadProvider < ApplicationRecord
     "npq-leading-literacy" => EYL_LL_PROVIDERS,
 
     "npq-executive-leadership" => EL_PROVIDERS,
+
+    "npq-leading-primary-mathematics" => LPM_PROVIDERS,
   }.freeze
 
   scope :alphabetical, -> { order(name: :asc) }

--- a/config/initializers/courses.rb
+++ b/config/initializers/courses.rb
@@ -46,7 +46,7 @@ module Courses
     {
       position: 5,
       name: "Leading primary mathematics (NPQLPM)",
-      ecf_id: nil,
+      ecf_id: "604c0c72-0e4b-42e7-ba5a-4aac7cafe1c5",
       identifier: "npq-leading-primary-mathematics",
       display: true,
     },

--- a/spec/lib/forms/choose_your_provider_spec.rb
+++ b/spec/lib/forms/choose_your_provider_spec.rb
@@ -56,7 +56,10 @@ RSpec.describe Forms::ChooseYourProvider, type: :model do
       npq-early-headship-coaching-offer
       npq-additional-support-offer
     ].freeze
-    other_npq_codes = Course.pluck(:identifier) - npqeyl_and_npqll_codes - npqel_code - npqh_sl_lt_ltd_lbc_ehco_codes
+    npqlpm_codes = %w[
+      npq-leading-primary-mathematics
+    ]
+    other_npq_codes = Course.pluck(:identifier) - npqeyl_and_npqll_codes - npqel_code - npqh_sl_lt_ltd_lbc_ehco_codes - npqlpm_codes
 
     other_npq_codes.each do |course_code|
       context "when applying for #{course_code}" do
@@ -296,7 +299,10 @@ RSpec.describe Forms::ChooseYourProvider, type: :model do
       npq-early-headship-coaching-offer
       npq-additional-support-offer
     ].freeze
-    other_npq_codes = Course.pluck(:identifier) - npqeyl_and_npqll_codes - npqel_code - npqh_sl_lt_ltd_lbc_ehco_codes
+    npqlpm_codes = %w[
+      npq-leading-primary-mathematics
+    ]
+    other_npq_codes = Course.pluck(:identifier) - npqeyl_and_npqll_codes - npqel_code - npqh_sl_lt_ltd_lbc_ehco_codes - npqlpm_codes
 
     other_npq_codes.each do |course_code|
       context "when applying for #{course_code}" do


### PR DESCRIPTION
### Context

Mapping provider with math npq course

### Ticket

 https://dfedigital.atlassian.net/browse/CPDNPQ-1257

### Changes proposed in this pull request

Created a mapping for successful lead_providers that we can show for our maths npq course.

List of lead providers to show:

- Ambition Institute
-  Church of England
- Education Development Trust
- LLSE
- Teach First
- UCL Institute of Education
