### PR TITLE
Update Sandbox ECF Base URL to new azure URL

### DIFF
--- a/config/manifests/sandbox-manifest.yml
+++ b/config/manifests/sandbox-manifest.yml
@@ -27,7 +27,7 @@ applications:
     GOVUK_NOTIFY_API_KEY: ((GOVUK_NOTIFY_API_KEY))
     GOOGLE_TAG_MANAGER_ID: "GTM-N58Z5PG"
     GOOGLE_ANALYTICS_ID: "G-G3823VRN6N"
-    ECF_APP_BASE_URL: "https://ecf-sandbox.london.cloudapps.digital"
+    ECF_APP_BASE_URL: "https://cpd-ecf-sandbox-web.teacherservices.cloud"
     ECF_APP_BEARER_TOKEN: ((ECF_APP_BEARER_TOKEN))
     SENTRY_DSN: ((SENTRY_DSN))
     TRA_OIDC_DOMAIN: ((TRA_OIDC_DOMAIN))


### PR DESCRIPTION
### Context

Ticket: n/a

We're turning off PaaS sandbox ECF instance, and migrating over to Azure which requires a different URL

### Changes proposed in this pull request

Point ECF base URL for Sandbox to new Azure URL for sandbox

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
