### PR TITLE
Update GAI link to match Get an Identity service standards

### DIFF
--- a/app/helpers/identity_account_helper.rb
+++ b/app/helpers/identity_account_helper.rb
@@ -8,6 +8,6 @@ module IdentityAccountHelper
   end
 
   def link_to_identity_account(redirect_uri)
-    "#{tra_oidc_domain}account?client_id=#{tra_oidc_client_id}&redirect_uri=#{redirect_uri}&sign_out_uri=#{redirect_uri}"
+    "#{tra_oidc_domain}/account?client_id=#{tra_oidc_client_id}&redirect_uri=#{redirect_uri}&sign_out_uri=#{redirect_uri}"
   end
 end

--- a/app/helpers/identity_account_helper.rb
+++ b/app/helpers/identity_account_helper.rb
@@ -8,6 +8,7 @@ module IdentityAccountHelper
   end
 
   def link_to_identity_account(redirect_uri)
-    "#{tra_oidc_domain}/account?client_id=#{tra_oidc_client_id}&redirect_uri=#{redirect_uri}&sign_out_uri=#{redirect_uri}"
+    encoded_redirect_uri = CGI::escape(redirect_uri)
+    "#{tra_oidc_domain}/account?client_id=#{tra_oidc_client_id}&redirect_uri=#{encoded_redirect_uri}&sign_out_uri=#{redirect_uri}"
   end
 end

--- a/app/helpers/identity_account_helper.rb
+++ b/app/helpers/identity_account_helper.rb
@@ -8,7 +8,7 @@ module IdentityAccountHelper
   end
 
   def link_to_identity_account(redirect_uri)
-    encoded_redirect_uri = CGI::escape(redirect_uri)
+    encoded_redirect_uri = CGI.escape(redirect_uri)
     "#{tra_oidc_domain}/account?client_id=#{tra_oidc_client_id}&redirect_uri=#{encoded_redirect_uri}&sign_out_uri=#{redirect_uri}"
   end
 end

--- a/spec/helpers/identity_account_helper_spec.rb
+++ b/spec/helpers/identity_account_helper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe IdentityAccountHelper, type: :helper do
   before { stub_env_variables_for_gai }
 
   describe "#link_to_identity_account" do
-    let(:redirect_uri) { "https://redirect.uri" }
+    let(:redirect_uri) { "https://redirect.uri?param=value" }
 
     subject(:link) { link_to_identity_account(redirect_uri) }
 
@@ -16,6 +16,13 @@ RSpec.describe IdentityAccountHelper, type: :helper do
 
     it "includes the client_id query parameter" do
       expect(link).to match("client_id=#{ENV["TRA_OIDC_CLIENT_ID"]}")
+    end
+
+    it "includes the URL encoded redirect_id query parameter" do
+      # CGI::escape('https://redirect.uri?param=value')
+      url_encoded = "https%3A%2F%2Fredirect.uri%3Fparam%3Dvalue"
+
+      expect(link).to match("redirect_uri=#{url_encoded}")
     end
   end
 end

--- a/spec/helpers/identity_account_helper_spec.rb
+++ b/spec/helpers/identity_account_helper_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe IdentityAccountHelper, type: :helper do
+  include Helpers::JourneyHelper
+
+  before { stub_env_variables_for_gai }
+
+  describe "#link_to_identity_account" do
+    let(:redirect_uri) { "https://redirect.uri" }
+
+    subject(:link) { link_to_identity_account(redirect_uri) }
+
+    it "is built with the TRA domain" do
+      expect(link).to match(ENV["TRA_OIDC_DOMAIN"])
+    end
+  end
+end

--- a/spec/helpers/identity_account_helper_spec.rb
+++ b/spec/helpers/identity_account_helper_spec.rb
@@ -13,5 +13,9 @@ RSpec.describe IdentityAccountHelper, type: :helper do
     it "is built with the TRA domain" do
       expect(link).to match(ENV["TRA_OIDC_DOMAIN"])
     end
+
+    it "includes the client_id query parameter" do
+      expect(link).to match("client_id=#{ENV["TRA_OIDC_CLIENT_ID"]}")
+    end
   end
 end

--- a/spec/helpers/identity_account_helper_spec.rb
+++ b/spec/helpers/identity_account_helper_spec.rb
@@ -6,16 +6,16 @@ RSpec.describe IdentityAccountHelper, type: :helper do
   before { stub_env_variables_for_gai }
 
   describe "#link_to_identity_account" do
-    let(:redirect_uri) { "https://redirect.uri?param=value" }
-
     subject(:link) { link_to_identity_account(redirect_uri) }
 
+    let(:redirect_uri) { "https://redirect.uri?param=value" }
+
     it "is built with the TRA domain" do
-      expect(link).to match(ENV["TRA_OIDC_DOMAIN"])
+      expect(link).to match("https://tra-domain.com")
     end
 
     it "includes the client_id query parameter" do
-      expect(link).to match("client_id=#{ENV["TRA_OIDC_CLIENT_ID"]}")
+      expect(link).to match("client_id=register-for-npq")
     end
 
     it "includes the URL encoded redirect_id query parameter" do

--- a/spec/helpers/identity_account_helper_spec.rb
+++ b/spec/helpers/identity_account_helper_spec.rb
@@ -24,5 +24,7 @@ RSpec.describe IdentityAccountHelper, type: :helper do
 
       expect(link).to match("redirect_uri=#{url_encoded}")
     end
+
+    xit "includes the URL encoded for the sign_out parameter"
   end
 end

--- a/spec/support/helpers/journey_helper.rb
+++ b/spec/support/helpers/journey_helper.rb
@@ -35,7 +35,7 @@ module Helpers
         .to_return(status: 200, body: participant_validator_response(**response), headers: {})
     end
 
-    def stub_env_variables_for_gai(stubbed_url: "https://example.com", stubbed_client_id: "register-for-npq")
+    def stub_env_variables_for_gai(stubbed_url: "https://tra-domain.com", stubbed_client_id: "register-for-npq")
       stub_const("ENV", ENV.to_hash.merge("TRA_OIDC_DOMAIN" => stubbed_url))
       stub_const("ENV", ENV.to_hash.merge("TRA_OIDC_CLIENT_ID" => stubbed_client_id))
     end


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CPDNPQ-1305

### Context

Following on the work for #867 I am updating the GAI link (Identity service) 
by url encoding the `redirect_uri` according to [the specs](https://github.com/DFE-Digital/get-an-identity/blob/main/docs/account-page.md#example-url) from the Get-an-identity
service team.

<img width="731" alt="image" src="https://github.com/DFE-Digital/npq-registration/assets/227328/3df65bed-56d2-40e3-82f3-fa54b7703327">
