### PR TITLE
Update TRN Guidance in start page

### DIFF
--- a/app/views/registration_wizard/start.html.erb
+++ b/app/views/registration_wizard/start.html.erb
@@ -24,7 +24,7 @@
 
     <p class="govuk-body">If you work in early years or childcare, <%= govuk_link_to("check if your workplace is registered with Ofsted", "https://reports.ofsted.gov.uk/childcare") %> and get their Ofsted unique reference number (URN) if they have one.</p>
 
-    <p class="govuk-body"><%= govuk_link_to("Check if you have a teacher reference number (TRN)", "https://find-a-lost-trn.education.gov.uk/start") %>. If you're not a teacher you can still register, but you'll need to request a TRN. Email <%= govuk_link_to('qts.enquiries@education.gov.uk', 'mailto:qts.enquiries@education.gov.uk') %> to request a TRN.
+    <p class="govuk-body"><%= govuk_link_to("Check if you have a teacher reference number (TRN)", "https://find-a-lost-trn.education.gov.uk/start") %>. If you’re not a teacher you can still register, but you’ll need to request a TRN. Email <%= govuk_link_to('qts.enquiries@education.gov.uk', 'mailto:qts.enquiries@education.gov.uk') %> to request a TRN.
     </p>
 
     <%=


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-1331

### Changes

Update the TRN content in the NPQ start page to the following:

”[Check if you have a teacher reference number (TRN)](https://find-a-lost-trn.education.gov.uk/start). If you’re not a qualified teacher you can still register, but you’ll need to request a TRN. You can do this by contacting [qts.enquiries@education.gov](mailto:qts.enquiries@education.gov)”

<img width="381" alt="image" src="https://github.com/DFE-Digital/npq-registration/assets/227328/375dbdaf-416b-46c4-b93c-5eae7f087040">
