### PR TITLE
Enabled maths_npq feature flag for all environments

### DIFF
--- a/app/lib/services/feature.rb
+++ b/app/lib/services/feature.rb
@@ -13,7 +13,7 @@ module Services
         FEATURE_FLAG_KEYS.each do |feature_flag_key|
           Flipper.add(feature_flag_key)
         end
-        ENV["SERVICE_ENV"] == "sandbox" ? Flipper.enable(:maths_npq) : Flipper.disable(:maths_npq)
+        Flipper.enable(:maths_npq)
       end
 
       # This is always true but is checked so that it is explicit


### PR DESCRIPTION
### Context
Enabled maths_npq feature flag for all environments
### Ticket
https://dfedigital.atlassian.net/browse/CPDNPQ-1257

### Changes proposed in this pull request
In feature.rb file removes sandbox condition for maths_npq flag. Now maths_npq needs to be live. So, enabled maths_npq feature_flag for all environments.