### PR TITLE
Configure AKS plans and memory

### DIFF
--- a/terraform/application/application.tf
+++ b/terraform/application/application.tf
@@ -43,6 +43,9 @@ module "web_application" {
 
   docker_image = var.docker_image
   command = var.command
+
+  replicas   = var.webapp_replicas
+  max_memory = var.webapp_memory_max
 }
 
 module "worker_application" {
@@ -63,4 +66,7 @@ module "worker_application" {
 
   command       = ["bundle", "exec", "rake", "jobs:work"]
   probe_command = ["pgrep", "-f", "rake"]
+
+  replicas   = var.worker_replicas
+  max_memory = var.worker_memory_max
 }

--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -1,4 +1,6 @@
 {
+  "postgres_flexible_server_sku": "GP_Standard_D2ds_v5",
+  "postgres_enable_high_availability": true,
   "cluster": "production",
   "namespace": "cpd-production",
   "environment": "production",

--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -1,6 +1,6 @@
 {
-    "cluster": "production",
-    "namespace": "cpd-production",
-    "environment": "production",
-    "enable_postgres_backup_storage" : true
+  "cluster": "production",
+  "namespace": "cpd-production",
+  "environment": "production",
+  "enable_postgres_backup_storage" : true,
 }

--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -3,4 +3,8 @@
   "namespace": "cpd-production",
   "environment": "production",
   "enable_postgres_backup_storage" : true,
+  "webapp_replicas": 2,
+  "worker_replicas": 2,
+  "webapp_memory_max": "2Gi",
+  "worker_memory_max": "1Gi"
 }

--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -6,7 +6,7 @@
   "environment": "production",
   "enable_postgres_backup_storage" : true,
   "webapp_replicas": 2,
-  "worker_replicas": 2,
+  "worker_replicas": 0,
   "webapp_memory_max": "2Gi",
   "worker_memory_max": "1Gi"
 }

--- a/terraform/application/database.tf
+++ b/terraform/application/database.tf
@@ -1,16 +1,18 @@
 module "postgres" {
   source = "./vendor/modules/aks//aks/postgres"
 
-  namespace                   = var.namespace
-  environment                 = local.environment
-  azure_resource_prefix       = var.azure_resource_prefix
-  service_name                = var.service_name
-  service_short               = var.service_short
-  config_short                = var.config_short
-  cluster_configuration_map   = module.cluster_data.configuration_map
-  use_azure                   = var.deploy_azure_backing_services
-  azure_enable_monitoring     = var.enable_monitoring
-  azure_enable_backup_storage = var.enable_postgres_backup_storage
-  server_version              = "14"
-  azure_extensions            = ["btree_gin", "citext", "plpgsql"]
+  namespace                      = var.namespace
+  environment                    = local.environment
+  azure_resource_prefix          = var.azure_resource_prefix
+  service_name                   = var.service_name
+  service_short                  = var.service_short
+  config_short                   = var.config_short
+  cluster_configuration_map      = module.cluster_data.configuration_map
+  use_azure                      = var.deploy_azure_backing_services
+  azure_enable_monitoring        = var.enable_monitoring
+  azure_enable_backup_storage    = var.enable_postgres_backup_storage
+  server_version                 = "14"
+  azure_extensions               = ["btree_gin", "citext", "plpgsql"]
+  azure_enable_high_availability = var.postgres_enable_high_availability
+  azure_sku_name                 = var.postgres_flexible_server_sku
 }

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -59,6 +59,36 @@ variable "enable_monitoring" {
   description = "Enable monitoring and alerting"
 }
 
+variable "webapp_memory_max" {
+  type    = string
+  default = "1Gi"
+}
+
+variable "webapp_replicas" {
+  type = number
+  default = 1
+}
+
+variable "worker_memory_max" {
+  type    = string
+  default = "1Gi"
+}
+
+variable "worker_replicas" {
+  type = number
+  default = 1
+}
+
+variable "postgres_flexible_server_sku" {
+  type = string
+  default = "B_Standard_B1ms"
+}
+
+variable "postgres_enable_high_availability" {
+  type = bool
+  default = false
+}
+
 locals {
   azure_credentials = try(jsondecode(var.azure_credentials_json), null)
 


### PR DESCRIPTION
### Context

Set up the number of nodes for the web and worker apps and set the PostgreSQL database size and high availability to true.

- Fix indentation
- Set the webapp and worker replicas
- Set postgres server sku and high availability
