### PR TITLE
CPDNPQ-1344 Improve signposting for users to create another registration

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,22 @@
 module ApplicationHelper
   include Pagy::Frontend
 
+  def application_count_based_account_url
+    current_user.applications.size == 1 ? accounts_user_registration_path(current_user.applications.first) : account_path
+  end
+
+  def npq_registration_link
+    if signed_in?
+      if Services::Feature.trn_required? && current_user.trn.blank?
+        registration_wizard_show_path(:teacher_reference_number)
+      else
+        registration_wizard_show_path(:provider_check)
+      end
+    else
+      "/"
+    end
+  end
+
   def boolean_red_green_tag(bool, text = nil)
     text ||= bool ? "YES" : "NO"
     colour = bool ? "green" : "red"

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -1,5 +1,6 @@
 <% application_count = current_user.applications.count %>
 
+<% content_for :title, "Your NPQ registrations" %>
 <% if application_count > 0%>
   <% if application_count == 1 %>
     <h2 class="govuk-heading-xl"><%= title ||= t(".title") %></h2>

--- a/app/views/accounts/user_registrations/show.html.erb
+++ b/app/views/accounts/user_registrations/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :title, "Your registration details" %>
 <% if params[:success] == "true" %>
   <%= render GovukComponent::NotificationBannerComponent.new(
     success: true,

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -15,15 +15,19 @@
     </div>
 
     <div class="govuk-header__content">
-      <%= link_to "Register for a national professional qualification", "/", class: "govuk-header__link govuk-header__link--service-name" %>
-
+      <%= link_to "Register for a national professional qualification", npq_registration_link, class: "govuk-header__link govuk-header__link--service-name" %>
+      
       <% unless current_user.null_user? %>
         <nav aria-label="Menu" class="govuk-header__navigation ">
           <ul id="navigation" class="govuk-header__navigation-list">
             <li class="govuk-header__navigation-item ">
               <%= link_to_identity_account(request.original_url, classes: 'govuk-header__link') %>
             </li>
-
+            <% unless current_user.applications.empty? %>
+              <li class="govuk-header__navigation-item ">
+                <%= link_to "NPQ account", application_count_based_account_url, class: 'govuk-header__link' %>
+              </li>
+            <% end %>
             <li class="govuk-header__navigation-item">
               <%= link_to "Sign out", sign_out_user_path, class: 'govuk-header__link' %>
             </li>

--- a/app/views/registration_wizard/shared/_register_for_an_npq.html.erb
+++ b/app/views/registration_wizard/shared/_register_for_an_npq.html.erb
@@ -1,10 +1,11 @@
+<hr class="govuk-!-margin-top-8"/>
 <div class="govuk-!-padding-top-5">
-  <h1 class="govuk-heading-l">Register for an NPQ</h1>
+  <h1 class="govuk-heading-l">Register for another NPQ</h1>
 
   <p class="govuk-body">Use this service to submit a new registration.</p>
   <% if Services::Feature.trn_required? && current_user.trn.blank? %>
-    <%= govuk_start_button(text: "Register for an NPQ", href: registration_wizard_show_path(:teacher_reference_number)) %>
+    <%= govuk_start_button(text: "Register for another NPQ", href: registration_wizard_show_path(:teacher_reference_number)) %>
   <% else %>
-    <%= govuk_start_button(text: "Register for an NPQ", href: registration_wizard_show_path(:provider_check)) %>
+    <%= govuk_start_button(text: "Register for another NPQ", href: registration_wizard_show_path(:provider_check)) %>
   <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -323,7 +323,7 @@ en:
         npqh_status: "What stage are you at with the Headship NPQ?"
         trn_knowledge: "Do you have a TRN?"
         lead_provider_id: "Select your provider"
-        chosen_provider: "Have you already chosen an NPQ and provider?"
+        chosen_provider: "Have you chosen an NPQ and provider?"
         has_ofsted_urn: "Do you or your employer have an Ofsted unique reference number (URN)?"
         qualified_teacher_check: "Check your details"
         date_of_birth: "Date of birth"

--- a/spec/features/happy_journeys/js/when_working_at_an_eligible_primary_school_spec.rb
+++ b/spec/features/happy_journeys/js/when_working_at_an_eligible_primary_school_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
-      expect(page).to have_text("Have you already chosen an NPQ and provider?")
+      expect(page).to have_text("Have you chosen an NPQ and provider?")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/happy_journeys/js/while_not_currently_working_at_school_spec.rb
+++ b/spec/features/happy_journeys/js/while_not_currently_working_at_school_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Happy journeys",
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
-      expect(page).to have_text("Have you already chosen an NPQ and provider?")
+      expect(page).to have_text("Have you chosen an NPQ and provider?")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/happy_journeys/js/while_working_at_private_childcare_provider_but_not_a_nursery_spec.rb
+++ b/spec/features/happy_journeys/js/while_working_at_private_childcare_provider_but_not_a_nursery_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
-      expect(page).to have_text("Have you already chosen an NPQ and provider?")
+      expect(page).to have_text("Have you chosen an NPQ and provider?")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/happy_journeys/js/while_working_at_private_nursery_spec.rb
+++ b/spec/features/happy_journeys/js/while_working_at_private_nursery_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
-      expect(page).to have_text("Have you already chosen an NPQ and provider?")
+      expect(page).to have_text("Have you chosen an NPQ and provider?")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/happy_journeys/js/while_working_at_public_nursery_spec.rb
+++ b/spec/features/happy_journeys/js/while_working_at_public_nursery_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
-      expect(page).to have_text("Have you already chosen an NPQ and provider?")
+      expect(page).to have_text("Have you chosen an NPQ and provider?")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/happy_journeys/js/while_working_in_neither_a_school_nor_childcare_spec.rb
+++ b/spec/features/happy_journeys/js/while_working_in_neither_a_school_nor_childcare_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
-      expect(page).to have_text("Have you already chosen an NPQ and provider?")
+      expect(page).to have_text("Have you chosen an NPQ and provider?")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/happy_journeys/non_js/able_to_receive_targeted_delivery_funding_spec.rb
+++ b/spec/features/happy_journeys/non_js/able_to_receive_targeted_delivery_funding_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
-      expect(page).to have_text("Have you already chosen an NPQ and provider?")
+      expect(page).to have_text("Have you chosen an NPQ and provider?")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/happy_journeys/non_js/funded_ehco_registration_journey_spec.rb
+++ b/spec/features/happy_journeys/non_js/funded_ehco_registration_journey_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
-      expect(page).to have_text("Have you already chosen an NPQ and provider?")
+      expect(page).to have_text("Have you chosen an NPQ and provider?")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/happy_journeys/non_js/international_teacher_npqh_journey_spec.rb
+++ b/spec/features/happy_journeys/non_js/international_teacher_npqh_journey_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
-      expect(page).to have_text("Have you already chosen an NPQ and provider?")
+      expect(page).to have_text("Have you chosen an NPQ and provider?")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/happy_journeys/non_js/other_funded_ehco_registration_journey_spec.rb
+++ b/spec/features/happy_journeys/non_js/other_funded_ehco_registration_journey_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
-      expect(page).to have_text("Have you already chosen an NPQ and provider?")
+      expect(page).to have_text("Have you chosen an NPQ and provider?")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/happy_journeys/non_js/previously_received_targeted_delivery_funding_spec.rb
+++ b/spec/features/happy_journeys/non_js/previously_received_targeted_delivery_funding_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
-      expect(page).to have_text("Have you already chosen an NPQ and provider?")
+      expect(page).to have_text("Have you chosen an NPQ and provider?")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/happy_journeys/non_js/via_using_old_name_and_not_headship_spec.rb
+++ b/spec/features/happy_journeys/non_js/via_using_old_name_and_not_headship_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
-      expect(page).to have_text("Have you already chosen an NPQ and provider?")
+      expect(page).to have_text("Have you chosen an NPQ and provider?")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/happy_journeys/non_js/via_using_same_name_spec.rb
+++ b/spec/features/happy_journeys/non_js/via_using_same_name_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
-      expect(page).to have_text("Have you already chosen an NPQ and provider?")
+      expect(page).to have_text("Have you chosen an NPQ and provider?")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
-      expect(page).to have_text("Have you already chosen an NPQ and provider?")
+      expect(page).to have_text("Have you chosen an NPQ and provider?")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
-      expect(page).to have_text("Have you already chosen an NPQ and provider?")
+      expect(page).to have_text("Have you chosen an NPQ and provider?")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
-      expect(page).to have_text("Have you already chosen an NPQ and provider?")
+      expect(page).to have_text("Have you chosen an NPQ and provider?")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/changing_from_outside_of_catchment_area_to_inside_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_from_outside_of_catchment_area_to_inside_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
-      expect(page).to have_text("Have you already chosen an NPQ and provider?")
+      expect(page).to have_text("Have you chosen an NPQ and provider?")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/changing_npq_to_one_leadprovider_no_longer_supports_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_npq_to_one_leadprovider_no_longer_supports_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
-      expect(page).to have_text("Have you already chosen an NPQ and provider?")
+      expect(page).to have_text("Have you chosen an NPQ and provider?")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/via_using_old_name_and_not_headship_spec.rb
+++ b/spec/features/journeys/happy_paths/via_using_old_name_and_not_headship_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
-      expect(page).to have_text("Have you already chosen an NPQ and provider?")
+      expect(page).to have_text("Have you chosen an NPQ and provider?")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/when_choose_lead_mentor_course_spec.rb
+++ b/spec/features/journeys/happy_paths/when_choose_lead_mentor_course_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
-      expect(page).to have_text("Have you already chosen an NPQ and provider?")
+      expect(page).to have_text("Have you chosen an NPQ and provider?")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/when_choose_maths_course_spec.rb
+++ b/spec/features/journeys/happy_paths/when_choose_maths_course_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature "Happy journeys", type: :feature do
       expect(page).not_to have_content("Before you start")
 
       expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
-        expect(page).to have_text("Have you already chosen an NPQ and provider?")
+        expect(page).to have_text("Have you chosen an NPQ and provider?")
         page.choose("Yes", visible: :all)
       end
 

--- a/spec/features/journeys/happy_paths/when_get_an_identity_returns_no_trn_spec.rb
+++ b/spec/features/journeys/happy_paths/when_get_an_identity_returns_no_trn_spec.rb
@@ -59,7 +59,7 @@ RSpec.feature "Happy journeys", type: :feature do
     end
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
-      expect(page).to have_text("Have you already chosen an NPQ and provider?")
+      expect(page).to have_text("Have you chosen an NPQ and provider?")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/when_outside_of_catchment_area_crown_dependencies_spec.rb
+++ b/spec/features/journeys/happy_paths/when_outside_of_catchment_area_crown_dependencies_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
-      expect(page).to have_text("Have you already chosen an NPQ and provider?")
+      expect(page).to have_text("Have you chosen an NPQ and provider?")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/when_outside_of_catchment_area_spec.rb
+++ b/spec/features/journeys/happy_paths/when_outside_of_catchment_area_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
-      expect(page).to have_text("Have you already chosen an NPQ and provider?")
+      expect(page).to have_text("Have you chosen an NPQ and provider?")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/when_previously_funded_spec.rb
+++ b/spec/features/journeys/happy_paths/when_previously_funded_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
-      expect(page).to have_text("Have you already chosen an NPQ and provider?")
+      expect(page).to have_text("Have you chosen an NPQ and provider?")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/sad_journeys/applying_for_ehco_but_not_new_headteacher_spec.rb
+++ b/spec/features/sad_journeys/applying_for_ehco_but_not_new_headteacher_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
-      expect(page).to have_text("Have you already chosen an NPQ and provider?")
+      expect(page).to have_text("Have you chosen an NPQ and provider?")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/sad_journeys/lead_mentor_journey_with_incorrect_course_spec.rb
+++ b/spec/features/sad_journeys/lead_mentor_journey_with_incorrect_course_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Sad journeys", type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
-      expect(page).to have_text("Have you already chosen an NPQ and provider?")
+      expect(page).to have_text("Have you chosen an NPQ and provider?")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/sad_journeys/not_chosen_dqt_or_provider_spec.rb
+++ b/spec/features/sad_journeys/not_chosen_dqt_or_provider_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
-      expect(page).to have_text("Have you already chosen an NPQ and provider?")
+      expect(page).to have_text("Have you chosen an NPQ and provider?")
       page.choose("No", visible: :all)
     end
 

--- a/spec/features/sad_journeys/school_not_in_england_spec.rb
+++ b/spec/features/sad_journeys/school_not_in_england_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
-      expect(page).to have_text("Have you already chosen an NPQ and provider?")
+      expect(page).to have_text("Have you chosen an NPQ and provider?")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/sad_journeys/works_in_childcare_but_not_in_england_spec.rb
+++ b/spec/features/sad_journeys/works_in_childcare_but_not_in_england_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
-      expect(page).to have_text("Have you already chosen an NPQ and provider?")
+      expect(page).to have_text("Have you chosen an NPQ and provider?")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/service_closed_spec.rb
+++ b/spec/features/service_closed_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "Service is hard closed", type: :feature do
     expect(page).to have_text("Before you start")
     page.click_button("Start now")
 
-    expect(page).to have_text("Have you already chosen an NPQ and provider?")
+    expect(page).to have_text("Have you chosen an NPQ and provider?")
     page.choose("Yes", visible: :all)
 
     # Registration is now closed

--- a/spec/features/sessions_spec.rb
+++ b/spec/features/sessions_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature "Sessions", type: :feature do
     page.click_button "Sign in"
 
     expect(page).to be_axe_clean
-    expect(page).to have_content("Register for an NPQ")
+    expect(page).to have_content("Register for a national professional qualification")
     expect(page).not_to have_content("Admin")
 
     visit "/admin"

--- a/spec/support/helpers/journey_assertion_helper.rb
+++ b/spec/support/helpers/journey_assertion_helper.rb
@@ -34,7 +34,7 @@ module Helpers
     def expect_applicant_reached_end_of_journey
       expect_page_to_have(path: "/accounts/user_registrations/#{Application.last.id}?success=true", submit_form: false) do
         expect(page).to have_text("Registration successfully submitted")
-        expect(page).to have_link("Register for an NPQ", href: /\/registration\/provider_check/)
+        expect(page).to have_link("Register for another NPQ", href: /\/registration\/provider_check/)
       end
 
       expect(User.count).to be(1)


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-1344

### Changes proposed in this pull request

Some UI changes mentioned in the ticket.
'Register for a national professional qualification' button in header now imitates the 'Register for another NPQ' button. 
Spec fixes

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
