### PR TITLE
Add actions for copying data from PaaS to Azure

### DIFF
--- a/.github/actions/backup-paas-database/action.yml
+++ b/.github/actions/backup-paas-database/action.yml
@@ -1,0 +1,46 @@
+name: Backup DB
+description: Backup GOV.UK PaaS DB upload GitHub artefact
+
+inputs:
+  environment:
+    description: The name of the environment
+    required: true
+  staging-username:
+    description: PAAS staging username
+    required: false
+    default: ""
+  staging-password:
+    description: PAAS staging password
+    required: false
+    default: ""
+
+runs:
+  using: composite
+
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Setup cf cli (staging)
+      if: inputs.environment == 'staging'
+      uses: DFE-Digital/github-actions/setup-cf-cli@master
+      with:
+        CF_USERNAME: ${{ inputs.staging-username }}
+        CF_PASSWORD: ${{ inputs.staging-password }}
+        CF_SPACE_NAME: early-careers-framework-staging
+        INSTALL_CONDUIT: true
+
+    - name: Setup postgres client
+      uses: DFE-Digital/github-actions/install-postgres-client@master
+
+    - name: Backup database
+      shell: bash
+      run: |
+        cf conduit ecf-postgres-${{ inputs.environment }} -- pg_dump -E utf8 --clean --compress=1 --if-exists --no-owner --no-privileges --verbose -f backup-${{ inputs.environment }}.sql.gz
+
+    - name: Upload backup
+      uses: actions/upload-artifact@v3
+      with:
+        name: backup-${{ inputs.environment }}
+        path: backup-${{ inputs.environment }}.sql.gz
+        retention-days: 1

--- a/.github/actions/backup-paas-database/action.yml
+++ b/.github/actions/backup-paas-database/action.yml
@@ -36,7 +36,7 @@ runs:
     - name: Backup database
       shell: bash
       run: |
-        cf conduit ecf-postgres-${{ inputs.environment }} -- pg_dump -E utf8 --clean --compress=1 --if-exists --no-owner --no-privileges --verbose -f backup-${{ inputs.environment }}.sql.gz
+        cf conduit npq-registration-${{ inputs.environment }}-db -- pg_dump -E utf8 --clean --compress=1 --if-exists --no-owner --no-privileges --verbose -f backup-${{ inputs.environment }}.sql.gz
 
     - name: Upload backup
       uses: actions/upload-artifact@v3

--- a/.github/actions/restore-paas-database/action.yml
+++ b/.github/actions/restore-paas-database/action.yml
@@ -40,12 +40,12 @@ runs:
 
     - name: Restore database
       shell: bash
-      run: bin/konduit.sh -i backup-${{ inputs.environment }}.sql.gz -c cpd-ecf-${{ inputs.environment }}-web -- psql
+      run: bin/konduit.sh -i backup-${{ inputs.environment }}.sql.gz -c npq-registration-${{ inputs.environment }}-web -- psql
 
     - name: Remove PaaS event triggers
       shell: bash
       run: |
-        bin/konduit.sh cpd-ecf-${{ inputs.environment }}-web -- psql -c 'drop event trigger forbid_ddl_reader; drop event trigger make_readable; drop event trigger reassign_owned;'
+        bin/konduit.sh npq-registration-${{ inputs.environment }}-web -- psql -c 'drop event trigger forbid_ddl_reader; drop event trigger make_readable; drop event trigger reassign_owned;'
 
     - uses: geekyeggo/delete-artifact@v2
       with:

--- a/.github/actions/restore-paas-database/action.yml
+++ b/.github/actions/restore-paas-database/action.yml
@@ -1,0 +1,52 @@
+name: Restore DB
+description: Restore database backup from GitHub artefact to Azure
+
+inputs:
+  environment:
+    description: The name of the environment
+    required: true
+  azure-credentials:
+    description: Azure credentials
+    required: true
+
+runs:
+  using: composite
+
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Download backup
+      uses: actions/download-artifact@v3
+      with:
+        name: backup-${{ inputs.environment }}
+
+    - name: Login
+      uses: azure/login@v1
+      with:
+        creds: ${{ inputs.azure-credentials }}
+
+    - name: Set AKS credentials (staging)
+      shell: bash
+      if: inputs.environment == 'staging'
+      run: az aks get-credentials -g s189t01-tsc-ts-rg -n s189t01-tsc-test-aks
+
+    - name: Install kubectl
+      uses: azure/setup-kubectl@v3
+
+    - name: Install konduit
+      shell: bash
+      run: make install-konduit
+
+    - name: Restore database
+      shell: bash
+      run: bin/konduit.sh -i backup-${{ inputs.environment }}.sql.gz -c cpd-ecf-${{ inputs.environment }}-web -- psql
+
+    - name: Remove PaaS event triggers
+      shell: bash
+      run: |
+        bin/konduit.sh cpd-ecf-${{ inputs.environment }}-web -- psql -c 'drop event trigger forbid_ddl_reader; drop event trigger make_readable; drop event trigger reassign_owned;'
+
+    - uses: geekyeggo/delete-artifact@v2
+      with:
+        name: backup-${{ inputs.environment }}

--- a/.github/workflows/copy-paas-database-to-azure.yml
+++ b/.github/workflows/copy-paas-database-to-azure.yml
@@ -1,0 +1,26 @@
+name: Copy PaaS database to Azure
+on:
+  schedule:
+    - cron: "30 4 * * *"
+  workflow_dispatch:
+
+jobs:
+  backup-and-restore-staging:
+    runs-on: ubuntu-20.04
+    environment: staging
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Backup
+        uses: ./.github/actions/backup-paas-database
+        with:
+          environment: staging
+          staging-username: ${{ secrets.GOVPAAS_STAG_USERNAME }}
+          staging-password: ${{ secrets.GOVPAAS_STAG_PASSWORD }}
+
+      - name: Restore
+        uses: ./.github/actions/restore-paas-database
+        with:
+          environment: staging
+          azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}


### PR DESCRIPTION
### Context

Prior to the move from GOV.UK PaaS to Azure we need to ensure our environments work properly with 'real' data. This PR introduces actions that copy it, environment by environment.

These actions will be reusable across environments, starting with staging. It uses the same process we used in ECF.
