### PR TITLE
Add RSpec workflow to new deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,3 +22,7 @@ jobs:
   lint:
     name: Lint
     uses: ./.github/workflows/lint.yml
+
+  rspec:
+    name: RSpec
+    uses: ./.github/workflows/rspec.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,3 +26,10 @@ jobs:
   rspec:
     name: RSpec
     uses: ./.github/workflows/rspec.yml
+
+  permit-merge:
+    name: Permit merge
+    needs: [lint, rspec]
+    runs-on: ubuntu-latest
+    steps:
+      - run: "echo 'Linting and tests passed, this branch is ready to be merged'"

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,0 +1,65 @@
+name: "RSpec"
+
+on:
+  workflow_call:
+    inputs:
+      ruby-version:
+        description: Ruby version
+        type: string
+        required: false
+        default: "3.1.2"
+      node-version:
+        description: Node version
+        type: string
+        required: false
+        default: "16.20.1"
+
+jobs:
+  rspec:
+    name: Run Rspec
+
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:11.6-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: ''
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ inputs.ruby-version }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: Install gems
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+
+      - name: Install yarn
+        run: npm install yarn -g
+
+      - name: Install node.js dependencies
+        run: yarn install
+
+      - name: Create screenshots directory
+        run: mkdir -p tmp/capybara
+
+      - name: Set up test database
+        run: bin/rails parallel:setup
+
+      - name: Run tests
+        run: bundle exec rake parallel:spec

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -20,6 +20,13 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    env:
+      RAILS_ENV: test
+      DB_USERNAME: postgres
+      DB_PASSWORD: ""
+      DB_HOSTNAME: 127.0.0.1
+      DB_PORT: 5432
+
     services:
       postgres:
         image: postgres:11.6-alpine

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -26,6 +26,7 @@ jobs:
       DB_PASSWORD: ""
       DB_HOSTNAME: 127.0.0.1
       DB_PORT: 5432
+      DATABASE_URL: postgres://postgres:@localhost:5432
 
     services:
       postgres:


### PR DESCRIPTION
### Context

This follows on from #925 and should be ignored until that's merged 😄

It adds a workflow that _just_ runs RSpec that we can call from the main Deploy flow.
