### PR TITLE
Added NIoT to Math_npq course provider list

### DIFF
--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -52,6 +52,7 @@ class LeadProvider < ApplicationRecord
     "LLSE",
     "Teach First",
     "UCL Institute of Education",
+    "National Institute of Teaching",
   ].freeze
 
   # TODO: Move all of this mapping into the database


### PR DESCRIPTION
### Context
National Institute of Teaching (NIoT) also won the bid to supply Maths NPQ; however, this bid was completed after all the other providers and it looks like NPQ Reg was not notified of NIoT winning the bid. Now added NIoT to Math_npq course provider list.
### Ticket
https://dfedigital.atlassian.net/browse/CPDNPQ-1397

[What has been changed?]

Just mapped NIoT to math_npq lead_provider list.
