### PR TITLE
Make sandbox and prod use staging's docker image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,7 +105,7 @@ jobs:
     environment:
       name: sandbox
     outputs:
-      docker-image: ${{ needs.docker.outputs.docker-image }}
+      docker-image: ${{ needs.deploy_staging.outputs.docker-image }}
     steps:
       - uses: actions/checkout@v3
 
@@ -126,7 +126,7 @@ jobs:
     environment:
       name: production
     outputs:
-      docker-image: ${{ needs.docker.outputs.docker-image }}
+      docker-image: ${{ needs.deploy_staging.outputs.docker-image }}
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
The 'needs' directive can only access the things directly needed by the current step, so must refer to deploy_staging instead of docker.
