### PR TITLE
Allow to disable registration in Flipper

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -12,7 +12,7 @@ on:
         description: Node version
         type: string
         required: false
-        default: "16.20.1"
+        default: "16.20.2"
 
 jobs:
   rspec:

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v1
         with:
-          node-version: '16.20.1'
+          node-version: '16.20.2'
 
       - name: Set up ruby gem cache
         uses: actions/cache@v3
@@ -126,7 +126,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v1
         with:
-          node-version: '16.20.1'
+          node-version: '16.20.2'
 
       - name: Set up ruby gem cache
         uses: actions/cache@v3
@@ -160,7 +160,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v1
         with:
-          node-version: '16.20.1'
+          node-version: '16.20.2'
 
       - name: Set up ruby gem cache
         uses: actions/cache@v3

--- a/app/lib/services/feature.rb
+++ b/app/lib/services/feature.rb
@@ -2,7 +2,8 @@ module Services
   class Feature
     REGISTRATION_OPEN_DATE = Time.zone.parse("6 June 2022 12:00")
 
-    REGISTRATION_CLOSED_KEY = "Registration closed".freeze
+    REGISTRATION_CLOSED_KEY   = "Registration closed".freeze
+    REGISTRATION_DISABLED = "Registration disabled".freeze
 
     FEATURE_FLAG_KEYS = [
       REGISTRATION_CLOSED_KEY,
@@ -14,7 +15,6 @@ module Services
           Flipper.add(feature_flag_key)
         end
         Flipper.enable(:maths_npq)
-        Flipper.enable(:disable_new_registrations)
       end
 
       # This is always true but is checked so that it is explicit
@@ -30,6 +30,22 @@ module Services
 
       def registration_closed?
         Flipper.enabled?(REGISTRATION_CLOSED_KEY)
+      end
+
+      def registration_disabled?
+        Flipper.enabled?(REGISTRATION_DISABLED)
+      end
+
+      def registration_enabled?
+        !Flipper.enabled?(REGISTRATION_DISABLED)
+      end
+
+      def disable_registration!
+        Flipper.enable(REGISTRATION_DISABLED)
+      end
+
+      def enable_registration!
+        Flipper.disable(REGISTRATION_DISABLED)
       end
     end
   end

--- a/app/lib/services/feature.rb
+++ b/app/lib/services/feature.rb
@@ -2,7 +2,7 @@ module Services
   class Feature
     REGISTRATION_OPEN_DATE = Time.zone.parse("6 June 2022 12:00")
 
-    REGISTRATION_CLOSED_KEY   = "Registration closed".freeze
+    REGISTRATION_CLOSED_KEY = "Registration closed".freeze
     REGISTRATION_DISABLED = "Registration disabled".freeze
 
     FEATURE_FLAG_KEYS = [

--- a/app/lib/services/feature.rb
+++ b/app/lib/services/feature.rb
@@ -14,6 +14,7 @@ module Services
           Flipper.add(feature_flag_key)
         end
         Flipper.enable(:maths_npq)
+        Flipper.enable(:disable_new_registrations)
       end
 
       # This is always true but is checked so that it is explicit

--- a/app/views/accounts/user_registrations/show.html.erb
+++ b/app/views/accounts/user_registrations/show.html.erb
@@ -35,4 +35,7 @@
 <%= render "accounts/personal_details", application: @application %>
 <%= render "accounts/work_details", application: @application %>
 
-<%= render partial: 'registration_wizard/shared/register_for_an_npq' %>
+
+<% if Services::Feature.registration_enabled? %>
+  <%= render partial: 'registration_wizard/shared/register_for_an_npq' %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -68,7 +68,6 @@
         <% end %>
 
         <% if Flipper.enabled?(:disable_new_registrations) %>
-          foo bar
           <%= govuk_notification_banner(title_text: "Maintenance notice") do |banner| %>
             <% banner.with_heading(
               text: "Due to scheduled mainenance taking place soon, the new registrations are currently disabled. If you already started your registration, you can continue.")

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -67,7 +67,7 @@
           <% end %>
         <% end %>
 
-        <% if Flipper.enabled?(:disable_new_registrations) %>
+        <% if Services::Feature.registration_disabled? %>
           <%= govuk_notification_banner(title_text: "Maintenance notice") do |banner| %>
             <% banner.with_heading(
               text: "Due to scheduled mainenance taking place soon, the new registrations are currently disabled. If you already started your registration, you can continue.")

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -67,6 +67,14 @@
           <% end %>
         <% end %>
 
+        <% if Flipper.enabled?(:disable_new_registrations) %>
+          <%= govuk_notification_banner(title_text: "Maintenance notice") do |banner| %>
+            <% banner.with_heading(
+              text: "Due to scheduled mainenance taking place soon, the new registrations are currently disabled. If you already started your registration, you can continue.")
+            %>
+          <% end %>
+        <% end %>
+
         <% if flash[:success] %>
           <%=
             render GovukComponent::NotificationBannerComponent.new(

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -70,7 +70,7 @@
         <% if Services::Feature.registration_disabled? %>
           <%= govuk_notification_banner(title_text: "Maintenance notice") do |banner| %>
             <% banner.with_heading(
-              text: "Due to scheduled mainenance taking place soon, the new registrations are currently disabled. If you already started your registration, you can continue.")
+              text: "Due to scheduled mainenance taking place soon, new registrations are currently disabled. If you already started your registration, you can continue.")
             %>
           <% end %>
         <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -68,6 +68,7 @@
         <% end %>
 
         <% if Flipper.enabled?(:disable_new_registrations) %>
+          foo bar
           <%= govuk_notification_banner(title_text: "Maintenance notice") do |banner| %>
             <% banner.with_heading(
               text: "Due to scheduled mainenance taking place soon, the new registrations are currently disabled. If you already started your registration, you can continue.")

--- a/app/views/registration_wizard/start.html.erb
+++ b/app/views/registration_wizard/start.html.erb
@@ -26,7 +26,7 @@
 
     <p class="govuk-body"><%= govuk_link_to("Check if you have a teacher reference number (TRN)", "https://find-a-lost-trn.education.gov.uk/start") %>. If you’re not a teacher you can still register, but you’ll need to request a TRN. We’ll show you how to do this.</p>
 
-    <% if Flipper.enabled?(:disable_new_registrations) %>
+    <% unless Flipper.enabled?(:disable_new_registrations) %>
       <%=
         render(
           'shared/get_an_identity/redirect_button',

--- a/app/views/registration_wizard/start.html.erb
+++ b/app/views/registration_wizard/start.html.erb
@@ -26,13 +26,14 @@
 
     <p class="govuk-body"><%= govuk_link_to("Check if you have a teacher reference number (TRN)", "https://find-a-lost-trn.education.gov.uk/start") %>. If you’re not a teacher you can still register, but you’ll need to request a TRN. We’ll show you how to do this.</p>
 
-    <%=
-      render(
-        'shared/get_an_identity/redirect_button',
-        button_text: "Start now"
-      )
-    %>
+    <% if Flipper.enabled?(:disable_new_registrations) %>
+      <%=
+        render(
+          'shared/get_an_identity/redirect_button',
+          button_text: "Start now"
+        )
+      %>
+    <% end %>
 
- 
   </div>
 </div>

--- a/app/views/registration_wizard/start.html.erb
+++ b/app/views/registration_wizard/start.html.erb
@@ -26,7 +26,7 @@
 
     <p class="govuk-body"><%= govuk_link_to("Check if you have a teacher reference number (TRN)", "https://find-a-lost-trn.education.gov.uk/start") %>. If you’re not a teacher you can still register, but you’ll need to request a TRN. We’ll show you how to do this.</p>
 
-    <% unless Flipper.enabled?(:disable_new_registrations) %>
+    <% if Services::Feature.registration_enabled? %>
       <%=
         render(
           'shared/get_an_identity/redirect_button',

--- a/global_config/review.sh
+++ b/global_config/review.sh
@@ -5,4 +5,4 @@ AZURE_SUBSCRIPTION=s189-teacher-services-cloud-test
 AZURE_RESOURCE_PREFIX=s189t01
 KV_PURGE_PROTECTION=false
 CONFIG_LONG=review
-NAMESPACE=cpd-review
+NAMESPACE=cpd-development

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "node": "16.20.2"
+    "node": "16.20.1"
   },
   "dependencies": {
     "@babel/preset-react": "^7.22.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "node": "16.20.1"
+    "node": "16.20.2"
   },
   "dependencies": {
     "@babel/preset-react": "^7.22.15",


### PR DESCRIPTION
For the Azure migration, we would like to disable registrations and inform user.

To disable the registration, either switch the flag in console or web admin. To switch flag in console, simply use `Services::Feature.disable_registration!` and to enable it back `Services::Feature.enable_registration!`