### PR TITLE
Remove sandbox/staging data copy from PaaS to Azure

### DIFF
--- a/.github/workflows/copy-paas-database-to-azure.yml
+++ b/.github/workflows/copy-paas-database-to-azure.yml
@@ -5,48 +5,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  backup-and-restore-staging:
-    runs-on: ubuntu-20.04
-    environment: staging
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      # copying from dev to staging
-      - name: Backup
-        uses: ./.github/actions/backup-paas-database
-        with:
-          environment: staging
-          staging-username: ${{ secrets.GOVPAAS_DEV_USERNAME }}
-          staging-password: ${{ secrets.GOVPAAS_DEV_PASSWORD }}
-
-      - name: Restore
-        uses: ./.github/actions/restore-paas-database
-        with:
-          environment: staging
-          azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
-
-  backup-and-restore-sandbox:
-    runs-on: ubuntu-20.04
-    environment: sandbox
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Backup
-        uses: ./.github/actions/backup-paas-database
-        with:
-          environment: sandbox
-          # sandbox appears to use the same credentials as staging
-          sandbox-username: ${{ secrets.GOVPAAS_STAG_USERNAME }}
-          sandbox-password: ${{ secrets.GOVPAAS_STAG_PASSWORD }}
-
-      - name: Restore
-        uses: ./.github/actions/restore-paas-database
-        with:
-          environment: sandbox
-          azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
-
   backup-and-restore-production:
     runs-on: ubuntu-20.04
     environment: production


### PR DESCRIPTION
These environments have been migrated to Azure, we no longer need them in PaaS and they will soon be deleted.
