### PR TITLE
Change fd origin for aks migration

### DIFF
--- a/terraform/domains/environment_domains/config/production.tfvars.json
+++ b/terraform/domains/environment_domains/config/production.tfvars.json
@@ -10,8 +10,7 @@
         "/packs/*"
       ],
       "environment_short": "pd",
-      "origin_hostname": "npq-registration-prod.london.cloudapps.digital",
-      "null_host_header": true,
+      "origin_hostname": "npq-registration-production-web.teacherservices.cloud",
       "cnames": {
         "_14c49b3a20d4ad049e0708795e1f8ca4": {
           "target": "_9156bba248c12a46b784f7312750bd29.gwpjclltnz.acm-validations.aws.",


### PR DESCRIPTION
### Context

Change Azure front door origin for migration from PaaS to AKS

### Changes proposed in this pull request

Update production env domain configuration file, and point to AKS 
(this has already been manually applied to production during the migration)
