### PR TITLE
Add a terraform-unlock step to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,12 @@ terraform-plan: terraform-init
 terraform-apply: terraform-init
 	terraform -chdir=terraform/application apply -var-file "config/${CONFIG}.tfvars.json" ${AUTO_APPROVE}
 
+## DOCKER_IMAGE=fake-image make review terraform-unlock PULL_REQUEST_NUMBER=4169 LOCK_ID=123456
+## DOCKER_IMAGE=fake-image make staging terraform-unlock LOCK_ID=123456
+.PHONY: terraform-unlock
+terraform-unlock: terraform-init
+	terraform -chdir=terraform/application force-unlock ${LOCK_ID}
+
 set-what-if:
 	$(eval WHAT_IF=--what-if)
 


### PR DESCRIPTION
This can be used when the lockfile is left locked by a failed/aborted
deploy or other odd circumstances. It should be used very carefully
anywhere except on review apps

Get the LOCK_ID from the error output:

```
│ Error: Error acquiring the state lock
│
│ Error message: state blob is already locked
│ Lock Info:
│   ID:        60302718-88ca-73d7-7feb-7c7dbe35be11
│   Path:      terraform-state/963.tfstate
│   Operation: OperationTypeApply
│   Who:       runner@fv-az574-93
│   Version:   1.5.4
│   Created:   2023-10-25 06:59:29.495925764 +0000 UTC
│   Info:
```
