### PR TITLE
Capture Sentry errors in ActiveJob

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,2 +1,7 @@
 class ApplicationJob < ActiveJob::Base
+  rescue_from(StandardError) do |exception|
+    Sentry.capture_exception(exception)
+
+    raise exception
+  end
 end

--- a/app/jobs/crons/sentry_checker_job.rb
+++ b/app/jobs/crons/sentry_checker_job.rb
@@ -1,0 +1,11 @@
+# Background job responsible for checking Sentry configuration
+# for our Jobs.
+#
+# Will be safely deleted once its purpose is completed.
+class Crons::SentryCheckerJob < CronJob
+  self.cron_expression = "0 */1 * * *"
+
+  def perform
+    Raven.capture_message("Sentry checker job is running")
+  end
+end


### PR DESCRIPTION
### Context

I can't see any error collected in Sentry for our Jobs, so I am assuming that
this is because we are not rescuing and sending explicitly.

### Note

It also includes a Temporary Job to track the correct execution in all environments.