### PR TITLE
Rename Raven to Sentry

### DIFF
--- a/app/jobs/crons/sentry_checker_job.rb
+++ b/app/jobs/crons/sentry_checker_job.rb
@@ -6,6 +6,6 @@ class Crons::SentryCheckerJob < CronJob
   self.cron_expression = "0 */1 * * *"
 
   def perform
-    Raven.capture_message("Sentry checker job is running")
+    Sentry.capture_message("Sentry checker job is running")
   end
 end


### PR DESCRIPTION
We are not using Raven by Sentry, hence we need to rename it.

