### PR TITLE
Replace map with find_each for reporting

### DIFF
--- a/app/lib/services/report.rb
+++ b/app/lib/services/report.rb
@@ -5,7 +5,9 @@ module Services
     def call
       CSV.generate do |csv|
         csv << headers
-        rows.each { |row| csv << row }
+        applications.find_each do |application|
+          csv << row_for_application(application)
+        end
       end
     end
 
@@ -39,36 +41,36 @@ module Services
       ]
     end
 
-    def rows
-      applications.map do |a|
-        [
-          a.user.id,
-          a.user.ecf_id,
-          a.user.created_at,
-          a.user.trn_verified,
-          a.user.trn_auto_verified,
-          a.id,
-          a.ecf_id,
-          a.created_at,
-          a.headteacher_status,
-          a.eligible_for_funding,
-          a.funding_choice,
-          a.funding_eligiblity_status_code,
-          a.targeted_delivery_funding_eligibility,
-          a.works_in_childcare,
-          a.kind_of_nursery,
-          a.private_childcare_provider_urn,
-          a.school_urn,
-          a.school&.name,
-          a.school&.establishment_type_name,
-          a.school&.high_pupil_premium,
-          a.school&.la_name,
-          a.school&.postcode,
-          a.course.name,
-          a.lead_provider.name,
-          a.employment_type,
-        ]
-      end
+  private
+
+    def row_for_application(a)
+      [
+        a.user.id,
+        a.user.ecf_id,
+        a.user.created_at,
+        a.user.trn_verified,
+        a.user.trn_auto_verified,
+        a.id,
+        a.ecf_id,
+        a.created_at,
+        a.headteacher_status,
+        a.eligible_for_funding,
+        a.funding_choice,
+        a.funding_eligiblity_status_code,
+        a.targeted_delivery_funding_eligibility,
+        a.works_in_childcare,
+        a.kind_of_nursery,
+        a.private_childcare_provider_urn,
+        a.school_urn,
+        a.school&.name,
+        a.school&.establishment_type_name,
+        a.school&.high_pupil_premium,
+        a.school&.la_name,
+        a.school&.postcode,
+        a.course.name,
+        a.lead_provider.name,
+        a.employment_type,
+      ]
     end
 
     def applications

--- a/spec/lib/services/report_spec.rb
+++ b/spec/lib/services/report_spec.rb
@@ -47,11 +47,11 @@ RSpec.describe Services::Report do
     end
 
     it "has the same number of headers and columns" do
-      expect(subject.headers.size).to eql(subject.rows.first.size)
+      expect(subject.headers.size).to eql(subject.call.lines.first.split(",").size)
     end
 
     it "creates the right number of rows" do
-      expect(subject.rows.count).to eql(number_of_rows)
+      expect(subject.call.lines.count).to be(4)
     end
   end
 end


### PR DESCRIPTION
### Context

We are debugging issues with Delayed::Job after the migration from PAAS to Azure. It seems that the jobs related to this report are not finishing in `delayed_jobs`. We are exploring if this could be related to a memory issue as we are loading all Application (with some includes) via Active Record.

This PR uses `find_each` which is a lighter approach.


