### PR TITLE
Fixed registration_wizard:visualise[png] rake task

### DIFF
--- a/app/forms/questionnaires/base.rb
+++ b/app/forms/questionnaires/base.rb
@@ -2,7 +2,7 @@ module Questionnaires
   class Base
     include ActiveModel::Model
     include ActiveModel::Validations::Callbacks
-    include Forms::FlowHelper
+    include Questionnaires::FlowHelper
 
     attr_accessor :wizard
 

--- a/app/forms/questionnaires/flow_helper.rb
+++ b/app/forms/questionnaires/flow_helper.rb
@@ -1,4 +1,4 @@
-module Forms::FlowHelper
+module Questionnaires::FlowHelper
   def first_questionnaire_step
     if Feature.trn_required? && query_store.current_user.trn.blank?
       :teacher_reference_number

--- a/app/services/registration_wizard_visualiser.rb
+++ b/app/services/registration_wizard_visualiser.rb
@@ -203,7 +203,7 @@ private
     flow_helper_method_node_structs.map do |node|
       build_node_string(
         name: node.name,
-        settings: node_settings(node.name, HELPER_COLOR, description: "Forms::FlowHelper"),
+        settings: node_settings(node.name, HELPER_COLOR, description: "Questionnaires::FlowHelper"),
       )
     end
   end
@@ -260,18 +260,18 @@ private
   ## Source helpers
 
   def step_options
-    Forms.constants
+    Questionnaires.constants
          .sort
          .map { |f| "Questionnaires::#{f}".constantize }
          .select { |f| f < Questionnaires::Base }
   end
 
   def flow_helper_methods
-    Forms::FlowHelper.instance_methods
+    Questionnaires::FlowHelper.instance_methods
   end
 
   def flow_helper_method_source(method_name)
-    Forms::FlowHelper.instance_method(method_name).source
+    Questionnaires::FlowHelper.instance_method(method_name).source
   end
 
   def extract_steps_from_source(method_source)


### PR DESCRIPTION
### Context
Fixed registration_wizard:visualise[png] rake task and moved FlowHelper to refactored forms folder.
Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-1338

### Changes proposed in this pull request

Fixed registration_wizard:visualise[png] rake task