### PR TITLE
Disable email uniquenes checks for Users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,8 +4,6 @@ class User < ApplicationRecord
   has_many :applications, dependent: :destroy
   has_many :ecf_sync_request_logs, as: :syncable, dependent: :destroy
 
-  validates :email, uniqueness: true
-
   scope :admins, -> { where(admin: true) }
   scope :unsynced, -> { where(ecf_id: nil) }
   scope :synced_to_ecf, -> { where.not(ecf_id: nil) }
@@ -28,7 +26,7 @@ class User < ApplicationRecord
   end
 
   def self.find_or_create_from_tra_data_on_uid(provider_data, feature_flag_id:)
-    user_from_provider_data = find_or_initialize_by(email: provider_data.info.email)
+    user_from_provider_data = find_or_initialize_by(provider: provider_data.provider, uid: provider_data.uid)
 
     user_from_provider_data.feature_flag_id = feature_flag_id
 
@@ -43,8 +41,6 @@ class User < ApplicationRecord
       full_name: provider_data.info.preferred_name || provider_data.info.name,
       raw_tra_provider_data: provider_data,
       updated_from_tra_at: Time.zone.now,
-      uid: provider_data.uid,
-      provider: provider_data.provider,
     )
 
     user_from_provider_data.tap(&:save)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,7 +28,7 @@ class User < ApplicationRecord
   end
 
   def self.find_or_create_from_tra_data_on_uid(provider_data, feature_flag_id:)
-    user_from_provider_data = find_or_initialize_by(provider: provider_data.provider, uid: provider_data.uid)
+    user_from_provider_data = find_or_initialize_by(email: provider_data.info.email)
 
     user_from_provider_data.feature_flag_id = feature_flag_id
 
@@ -43,6 +43,8 @@ class User < ApplicationRecord
       full_name: provider_data.info.preferred_name || provider_data.info.name,
       raw_tra_provider_data: provider_data,
       updated_from_tra_at: Time.zone.now,
+      uid: provider_data.uid,
+      provider: provider_data.provider,
     )
 
     user_from_provider_data.tap(&:save)

--- a/db/migrate/20231109124740_remove_uniquenes_from_users_email.rb
+++ b/db/migrate/20231109124740_remove_uniquenes_from_users_email.rb
@@ -1,0 +1,6 @@
+class RemoveUniquenesFromUsersEmail < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :users, :email
+    add_index :users, :email
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_23_083939) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_09_124740) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -268,7 +268,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_23_083939) do
     t.datetime "updated_from_tra_at", precision: nil
     t.string "trn_lookup_status"
     t.index ["ecf_id"], name: "index_users_on_ecf_id"
-    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["email"], name: "index_users_on_email"
     t.index ["provider"], name: "index_users_on_provider"
     t.index ["uid"], name: "index_users_on_uid", unique: true
   end

--- a/spec/features/happy_journeys/non_js/able_to_receive_targeted_delivery_funding_spec.rb
+++ b/spec/features/happy_journeys/non_js/able_to_receive_targeted_delivery_funding_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Happy journeys", type: :feature do
   end
 
   scenario "registration journey that is able to receive targeted delivery funding" do
-    stub_participant_validation_request(trn: "12345", response: { trn: "12345" })
+    stub_participant_validation_request(trn: "1234567", response: { trn: "1234567" })
 
     navigate_to_page(path: "/", submit_form: false, axe_check: false) do
       expect(page).to have_text("Before you start")
@@ -70,7 +70,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
     mock_previous_funding_api_request(
       course_identifier: "npq-senior-leadership",
-      trn: "RP12%2F345",
+      trn: "1234567",
       response: ecf_funding_lookup_response(previously_funded: false),
     )
 

--- a/spec/lib/services/get_an_identity_service/webhooks/user_updated_processor_spec.rb
+++ b/spec/lib/services/get_an_identity_service/webhooks/user_updated_processor_spec.rb
@@ -60,26 +60,6 @@ RSpec.describe GetAnIdentityService::Webhooks::UserUpdatedProcessor do
       })
     end
 
-    context "when the new email is already in use" do
-      before do
-        create(:user, email: new_email)
-      end
-
-      it "marks the webhook_message as failed" do
-        expect {
-          described_class.call(webhook_message:)
-        }.to change {
-          webhook_message.reload.slice(:status, :status_comment)
-        }.from(
-          "status" => "pending",
-          "status_comment" => nil,
-        ).to({
-          "status" => "failed",
-          "status_comment" => "Email has already been taken",
-        })
-      end
-    end
-
     context "when the trn is not present" do
       let(:new_trn) { nil }
       let(:new_trn_status) { "not_found" }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,7 +1,4 @@
 require "rails_helper"
 
 RSpec.describe User, type: :model do
-  describe "validations" do
-    it { is_expected.to validate_uniqueness_of(:email).case_insensitive }
-  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,4 +1,1 @@
 require "rails_helper"
-
-RSpec.describe User, type: :model do
-end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-1470

### Changes proposed in this pull request

There are several instances where users can not log in because email validation failed. As now we are relaying on GAI for authentication, we decided to use only GAI `uid` as unique identifier for user.