### PR TITLE
Add sentry monitor for cron Jobs

### DIFF
--- a/app/jobs/crons/generate_dashboard_report_job.rb
+++ b/app/jobs/crons/generate_dashboard_report_job.rb
@@ -1,6 +1,10 @@
 class Crons::GenerateDashboardReportJob < CronJob
+  include Sentry::Cron::MonitorCheckIns
+
   # Run every hour
   self.cron_expression = "0 * * * *"
+
+  sentry_monitor_check_ins slug: "generate-dashboard"
 
   def perform
     DashboardReportJob.perform_later

--- a/app/jobs/crons/generate_dashboard_report_job.rb
+++ b/app/jobs/crons/generate_dashboard_report_job.rb
@@ -1,4 +1,5 @@
 class Crons::GenerateDashboardReportJob < CronJob
+  # Run every hour
   self.cron_expression = "0 * * * *"
 
   def perform

--- a/app/jobs/crons/sweep_stale_sessions_job.rb
+++ b/app/jobs/crons/sweep_stale_sessions_job.rb
@@ -1,6 +1,10 @@
 class Crons::SweepStaleSessionsJob < CronJob
+  include Sentry::Cron::MonitorCheckIns
+
   # run at 3:30 AM every day
   self.cron_expression = "30 3 * * *"
+
+  sentry_monitor_check_ins slug: "sweep-stale-sessions"
 
   def perform
     SweepStaleSessionsJob.perform_later

--- a/app/jobs/crons/sweep_stale_sessions_job.rb
+++ b/app/jobs/crons/sweep_stale_sessions_job.rb
@@ -1,4 +1,5 @@
 class Crons::SweepStaleSessionsJob < CronJob
+  # run at 3:30 AM every day
   self.cron_expression = "30 3 * * *"
 
   def perform

--- a/app/jobs/crons/update_applications_statuses_job.rb
+++ b/app/jobs/crons/update_applications_statuses_job.rb
@@ -1,6 +1,10 @@
 class Crons::UpdateApplicationsStatusesJob < CronJob
+  include Sentry::Cron::MonitorCheckIns
+
   # run every two hours
   self.cron_expression = "0 */2 * * *"
+
+  sentry_monitor_check_ins slug: "update-application-statuses"
 
   def perform
     ApplicationSynchronizationJob.perform_later

--- a/app/jobs/crons/update_applications_statuses_job.rb
+++ b/app/jobs/crons/update_applications_statuses_job.rb
@@ -1,4 +1,5 @@
 class Crons::UpdateApplicationsStatusesJob < CronJob
+  # run every two hours
   self.cron_expression = "0 */2 * * *"
 
   def perform

--- a/app/jobs/crons/update_schools_job.rb
+++ b/app/jobs/crons/update_schools_job.rb
@@ -1,6 +1,10 @@
 class Crons::UpdateSchoolsJob < CronJob
+  include Sentry::Cron::MonitorCheckIns
+
   # run at 4:30 AM every day
   self.cron_expression = "30 4 * * *"
+
+  sentry_monitor_check_ins slug: "update-schools"
 
   def perform
     ImportGiasSchoolsJob.perform_later

--- a/app/jobs/crons/update_schools_job.rb
+++ b/app/jobs/crons/update_schools_job.rb
@@ -1,4 +1,5 @@
 class Crons::UpdateSchoolsJob < CronJob
+  # run at 4:30 AM every day
   self.cron_expression = "30 4 * * *"
 
   def perform


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-1466

### Context

## Description

This pull request introduces four new monitors to make sure that the jobs are executed as intended:

1. `Crons::UpdateApplicationsStatusesJob`: Updates application statuses every two hours.
2. `Crons::UpdateSchoolsJob`: Performs daily updates of school data at 4:30 AM.
3. `Crons::SweepStaleSessionsJob`: Clears stale user sessions daily at 3:30 AM
4. `Crons::GenerateDashboardReportJob`: Generates hourly dashboard reports .

By incorporating Sentry monitoring into these cron jobs, we can proactively identify and address any potential errors or exceptions, ensuring the reliability and stability of these critical tasks.

### Credits

Thanks @slawosz for suggesting it.



