### PR TITLE
Update ECF details on user login

### DIFF
--- a/app/controllers/omniauth_controller.rb
+++ b/app/controllers/omniauth_controller.rb
@@ -16,6 +16,7 @@ class OmniauthController < Devise::OmniauthCallbacksController
     # @user.save checks that any changes made to an existing record have been persisted to that persisted record
     if @user.persisted? && @user.save
       session["user_id"] = @user.id
+      Ecf::EcfUserUpdater.new(user: @user).call if @user.ecf_id.present?
 
       sign_in_and_redirect @user
     else


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-1442

### Context

If the user decides to change the personal details in GAI (via the account page), then we update those details on NPQ the next time the user logs in, but we are not updating these details in ECF.

In this PR, we update the user details in ECF each time a user logs in, which will guarantee that the information is synchronised in both systems.
