### PR TITLE
Modifications regarding course provider on the account screen 

### DIFF
--- a/app/forms/questionnaires/base.rb
+++ b/app/forms/questionnaires/base.rb
@@ -84,7 +84,14 @@ module Questionnaires
       wizard.store.slice(*self.class.permitted_params.map(&:to_s)) == attributes.stringify_keys
     end
 
+    def return_to_new_registration_flow?
+      wizard.current_user.present? && wizard.current_step == :change_your_course_or_provider
+    end
+
     def requirements_met?
+      # Redirect to new registration flow if a user wants to change the course or provider details
+      return true if return_to_new_registration_flow?
+
       # Ensures the user is:
       # a) logged in
       # b) has answered at least one question

--- a/app/forms/questionnaires/change_your_course_or_provider.rb
+++ b/app/forms/questionnaires/change_your_course_or_provider.rb
@@ -1,5 +1,7 @@
 module Questionnaires
   class ChangeYourCourseOrProvider < Base
+    def previous_step; end
+
+    def next_step; end
   end
 end
-  

--- a/app/forms/questionnaires/change_your_course_or_provider.rb
+++ b/app/forms/questionnaires/change_your_course_or_provider.rb
@@ -1,0 +1,5 @@
+module Questionnaires
+  class ChangeYourCourseOrProvider < Base
+  end
+end
+  

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -13,6 +13,7 @@ class RegistrationWizard
     teacher_catchment
     work_setting
     provider_check
+    change_your_course_or_provider
     choose_an_npq_and_provider
     get_an_identity_callback
     teacher_reference_number

--- a/app/views/accounts/_course_details.html.erb
+++ b/app/views/accounts/_course_details.html.erb
@@ -12,7 +12,7 @@
           <%= title_embedded_course_name(application.course) %>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <a class="govuk-link" href="/registration/change_your_course_or_provider">
+          <a class="govuk-link" href="<%= registration_wizard_show_url('change_your_course_or_provider'.dasherize) %>">
             Change<span class="govuk-visually-hidden"> Course</span>
           </a>
         </dd>
@@ -26,7 +26,7 @@
           <%= application.lead_provider.name %>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <a class="govuk-link" href="/registration/change_your_course_or_provider">
+          <a class="govuk-link" href="<%= registration_wizard_show_url('change_your_course_or_provider'.dasherize) %>">
             Change<span class="govuk-visually-hidden"> Provider</span>
           </a>
         </dd>

--- a/app/views/accounts/_course_details.html.erb
+++ b/app/views/accounts/_course_details.html.erb
@@ -11,6 +11,11 @@
         <dd class="govuk-summary-list__value">
           <%= title_embedded_course_name(application.course) %>
         </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="/registration/change_your_course_or_provider">
+            Change<span class="govuk-visually-hidden"> Course</span>
+          </a>
+        </dd>
       </div>
 
       <div class="govuk-summary-list__row">
@@ -19,6 +24,11 @@
         </dt>
         <dd class="govuk-summary-list__value">
           <%= application.lead_provider.name %>
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="/registration/change_your_course_or_provider">
+            Change<span class="govuk-visually-hidden"> Provider</span>
+          </a>
         </dd>
       </div>
 

--- a/app/views/accounts/user_registrations/show.html.erb
+++ b/app/views/accounts/user_registrations/show.html.erb
@@ -25,11 +25,6 @@
 <% else %>
   <h1 class="govuk-heading-xl"><%= I18n.t("accounts.show.title") %></h1>
 <% end %>
-<% if @application.participant_outcome_state.blank?%>
-  <div class="govuk-inset-text">
-    If you need to change something about your NPQ, email <a class="govuk-link" href="mailto:continuing-professional-development@digital.education.gov.uk">continuing-professional-development@digital.education.gov.uk</a>.
-  </div>
-<% end %>
 <%= render "accounts/course_details", application: @application %>
 <%= render "accounts/funding_details", application: @application %>
 <%= render "accounts/personal_details", application: @application %>

--- a/app/views/registration_wizard/change_your_course_or_provider.html.erb
+++ b/app/views/registration_wizard/change_your_course_or_provider.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-  <%= t("helpers.title.registration_wizard.#{@wizard.current_step}") %>
+  <%= t("helpers.title.registration_wizard.change_your_course_or_provider") %>
 <% end %>
 
 <% content_for :before_content do %>
@@ -18,9 +18,9 @@
     <p class="govuk-body">If you have already started your course, contact your provider to make any changes.</p>
 
     <% if Feature.trn_required? && current_user.trn.blank? %>
-        <%= govuk_start_button(text: "Register for another NPQ", href: registration_wizard_show_path(:teacher_reference_number)) %>
+      <%= govuk_start_button(text: "Register for another NPQ", href: registration_wizard_show_path(:teacher_reference_number)) %>
     <% else %>
-        <%= govuk_start_button(text: "Register for another NPQ", href: registration_wizard_show_path(:provider_check)) %>
+      <%= govuk_start_button(text: "Register for another NPQ", href: registration_wizard_show_path(:provider_check)) %>
     <% end %>
   </div>
 </div>

--- a/app/views/registration_wizard/change_your_course_or_provider.html.erb
+++ b/app/views/registration_wizard/change_your_course_or_provider.html.erb
@@ -1,0 +1,27 @@
+<% content_for :title do %>
+  <%= t("helpers.title.registration_wizard.#{@wizard.current_step}") %>
+<% end %>
+
+<% content_for :before_content do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: "Back",
+    href: account_path
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Change your course or provider</h1>
+
+    <p class="govuk-body">If you have not started your course, you can change your course or provider by submitting a new registration.</p>
+
+    <p class="govuk-body">If you have already started your course, contact your provider to make any changes.</p>
+
+    <% if Feature.trn_required? && current_user.trn.blank? %>
+        <%= govuk_start_button(text: "Register for another NPQ", href: registration_wizard_show_path(:teacher_reference_number)) %>
+    <% else %>
+        <%= govuk_start_button(text: "Register for another NPQ", href: registration_wizard_show_path(:provider_check)) %>
+    <% end %>
+  </div>
+</div>
+  

--- a/app/views/registration_wizard/change_your_course_or_provider.html.erb
+++ b/app/views/registration_wizard/change_your_course_or_provider.html.erb
@@ -18,9 +18,9 @@
     <p class="govuk-body">If you have already started your course, contact your provider to make any changes.</p>
 
     <% if Feature.trn_required? && current_user.trn.blank? %>
-      <%= govuk_start_button(text: "Register for another NPQ", href: registration_wizard_show_path(:teacher_reference_number)) %>
+      <%= govuk_start_button(text: "Submit a new registration", href: registration_wizard_show_path(:teacher_reference_number)) %>
     <% else %>
-      <%= govuk_start_button(text: "Register for another NPQ", href: registration_wizard_show_path(:provider_check)) %>
+      <%= govuk_start_button(text: "Submit a new registration", href: registration_wizard_show_path(:provider_check)) %>
     <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -302,6 +302,7 @@ en:
         trn: "Teacher reference number (TRN)"
         full_name: "Full name"
         national_insurance_number: "National Insurance number (optional)"
+        Change_your_course_or_provider: "Change your course or provider"
 
     legend:
       registration_wizard:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -302,7 +302,7 @@ en:
         trn: "Teacher reference number (TRN)"
         full_name: "Full name"
         national_insurance_number: "National Insurance number (optional)"
-        Change_your_course_or_provider: "Change your course or provider"
+        change_your_course_or_provider: "Change your course or provider"
 
     legend:
       registration_wizard:


### PR DESCRIPTION
### Context
content changes to account screen so users can change course or provider
### Ticket
https://dfedigital.atlassian.net/browse/CPDNPQ-1473


### Changes proposed in this pull request
Enable users to change their course or provider via the account screen by telling them that they need to submit a new registration.
Clicking the link to change course or provider should take you to a new interstitial page.

