### PR TITLE
Add snapshot database backup/restore actions

### DIFF
--- a/.github/actions/backup-and-restore-snapshot-database/action.yml
+++ b/.github/actions/backup-and-restore-snapshot-database/action.yml
@@ -1,0 +1,42 @@
+name: Backup DB
+description: Backup production DB and restore to snapshot DB
+
+inputs:
+  environment:
+    description: The name of the environment
+    required: true
+  azure-credentials:
+    description: Azure credentials
+    required: true
+
+runs:
+  using: composite
+
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Login
+      uses: azure/login@v1
+      with:
+        creds: ${{ inputs.azure-credentials }}
+
+    - name: Set AKS credentials
+      shell: bash
+      run: az aks get-credentials -g s189p01-tsc-pd-rg -n s189p01-tsc-production-aks
+
+    - name: Install kubectl
+      uses: azure/setup-kubectl@v3
+
+    - name: Install konduit
+      shell: bash
+      run: make install-konduit
+
+    - name: Backup database
+      shell: bash
+      run: |
+        bin/konduit.sh npq-registration-${{ inputs.environment }}-web -- pg_dump -E utf8 --compress=1 --clean --if-exists --no-privileges --no-owner --verbose -f backup-${{ inputs.environment }}.sql.gz
+
+    - name: Restore snapshot database
+      shell: bash
+      run: bin/konduit.sh -d s189p01-cpdnpq-pd-pg-snapshot -k s189p01-cpdnpq-pd-app-kv -i backup-${{ inputs.environment }}.sql.gz -c -t 7200 npq-registration-${{ inputs.environment }}-web -- psql

--- a/.github/workflows/restore_snapshot_database.yml
+++ b/.github/workflows/restore_snapshot_database.yml
@@ -1,0 +1,25 @@
+name: Restore Snapshot DB from production DB
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: GitHub environment to backup and restore
+        type: choice
+        default: production
+        options:
+          - production
+        required: true
+
+jobs:
+  backup-and-restore-production:
+    runs-on: ubuntu-20.04
+    environment: production
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Backup and restore snapshot
+        uses: ./.github/actions/backup-and-restore-snapshot-database
+        with:
+          environment: production
+          azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,5 @@ terraform/domains/infrastructure/vendor
 terraform/domains/environment_domains/vendor
 terraform.tfstate*
 bin/terrafile
+bin/konduit.sh
 *.hcl

--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -9,5 +9,6 @@
   "worker_replicas": 2,
   "webapp_memory_max": "2Gi",
   "worker_memory_max": "1Gi",
-  "enable_monitoring": true
+  "enable_monitoring": true,
+  "deploy_snapshot_database": true
 }

--- a/terraform/application/database.tf
+++ b/terraform/application/database.tf
@@ -16,3 +16,25 @@ module "postgres" {
   azure_enable_high_availability = var.postgres_enable_high_availability
   azure_sku_name                 = var.postgres_flexible_server_sku
 }
+
+module "postgres-snapshot" {
+  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/postgres?ref=testing"
+
+  count                 = var.deploy_snapshot_database ? 1 : 0
+  name                  = "snapshot"
+  namespace             = var.namespace
+  environment           = local.environment
+  azure_resource_prefix = var.azure_resource_prefix
+  service_name          = local.service_name
+  service_short         = var.service_short
+  config_short          = var.config_short
+
+  cluster_configuration_map = module.cluster_data.configuration_map
+
+  azure_sku_name                 = var.postgres_snapshot_flexible_server_sku
+  use_azure                      = var.deploy_azure_backing_services
+  azure_enable_high_availability = false
+  azure_enable_backup_storage    = false
+  azure_enable_monitoring        = false
+  azure_extensions               = ["btree_gin", "citext", "plpgsql", "pg_trgm"]
+}

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -35,6 +35,10 @@ variable "deploy_azure_backing_services" {
   default     = true
   description = "Deploy real Azure backing services like databases, as opposed to containers inside of AKS"
 }
+variable "deploy_snapshot_database" {
+  type    = string
+  default = false
+}
 variable "enable_postgres_ssl" {
   default     = true
   description = "Enforce SSL connection from the client side"
@@ -82,6 +86,10 @@ variable "worker_replicas" {
 variable "postgres_flexible_server_sku" {
   type = string
   default = "B_Standard_B1ms"
+}
+
+variable "postgres_snapshot_flexible_server_sku" {
+  default = "B_Standard_B2ms"
 }
 
 variable "postgres_enable_high_availability" {


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-000

As part of the work to pull NPQ out of the ECF application we want to perform a number of data integrity checks. In order to do this we ideally need safe access to production data.

### Changes proposed in this pull request

- Add snapshot database backup/restore actions

Add a GitHub action and associated workflow to generate a snapshot of the production database, that we can then use `konduit` to access.

Add a make command to create the `konduit` and update the development database config with the resulting connection string.

### Guidance to review

Successful snapshot creation is [here](https://github.com/DFE-Digital/npq-registration/actions/runs/7048219760/job/19183879927)

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
