### PR TITLE
Add `migration` environment to Rails

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -16,6 +16,9 @@ review:
 staging:
   <<: *default
 
+migration:
+  <<: *default
+
 sandbox:
   <<: *default
 

--- a/config/environments/migration.rb
+++ b/config/environments/migration.rb
@@ -1,0 +1,6 @@
+require Rails.root.join("config/environments/production")
+
+Rails.application.configure do
+  config.log_level = :debug
+  config.ssl_options = { redirect: { exclude: ->(request) { request.path.include?("/healthcheck") } } }
+end

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -100,6 +100,32 @@ staging:
     watch_options:
       ignored: '**/node_modules/**'
 
+migration:
+  <<: *default
+  compile: true
+
+  # Verifies that versions and hashed value of the package contents in the project's package.json
+  check_yarn_integrity: true
+
+  # Reference: https://webpack.js.org/configuration/dev-server/
+  dev_server:
+    https: false
+    host: localhost
+    port: 3035
+    public: localhost:3035
+    hmr: false
+    # Inline should be set to true if using HMR
+    inline: true
+    overlay: true
+    compress: true
+    disable_host_check: true
+    use_local_ip: false
+    quiet: false
+    headers:
+      "Access-Control-Allow-Origin": "*"
+    watch_options:
+      ignored: '**/node_modules/**'
+
 sandbox:
   <<: *default
   compile: true


### PR DESCRIPTION
This environment will sit alongside production and sandbox and will be used to test the import process for ECF data.
