### PR TITLE
Setup migration environment in Azure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,6 +116,25 @@ jobs:
           current-commit-sha: ${{ github.sha }}
           statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
 
+  deploy-migration:
+    name: Deploy migration
+    needs: [deploy-staging]
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    environment:
+      name: migration
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/deploy-environment-to-aks
+        id: deploy
+        with:
+          environment: migration
+          docker-image: ${{ needs.deploy-staging.outputs.docker-image }}
+          azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
+          current-commit-sha: ${{ github.sha }}
+          statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
+
   deploy-production:
     name: Deploy production
     needs: [deploy-staging]

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ staging: test-cluster
 sandbox: production-cluster
 	$(eval include global_config/sandbox.sh)
 
+migration: production-cluster
+	$(eval include global_config/migration.sh)
+
 production: production-cluster
 	$(if $(or ${SKIP_CONFIRM}, ${CONFIRM_PRODUCTION}), , $(error Missing CONFIRM_PRODUCTION=yes))
 	$(eval include global_config/production.sh)

--- a/global_config/migration.sh
+++ b/global_config/migration.sh
@@ -1,0 +1,7 @@
+CONFIG=migration
+ENVIRONMENT=migration
+CONFIG_SHORT=mg
+AZURE_SUBSCRIPTION=s189-teacher-services-cloud-production
+AZURE_RESOURCE_PREFIX=s189p01
+CONFIG_LONG=migration
+NAMESPACE=cpd-production

--- a/terraform/application/config/migration.tfvars.json
+++ b/terraform/application/config/migration.tfvars.json
@@ -1,0 +1,5 @@
+{
+    "cluster": "production",
+    "namespace": "cpd-production",
+    "environment": "migration"
+}

--- a/terraform/application/config/migration_Terrafile
+++ b/terraform/application/config/migration_Terrafile
@@ -1,0 +1,3 @@
+aks:
+    source:  "https://github.com/DFE-Digital/terraform-modules"
+    version: "testing"


### PR DESCRIPTION
**This follows on from #1046**

### Context

This PR adds a new migration environment in Azure that sits alongside the sandbox. It's intended to be used to test the data migration of NPQ data from ECF to NPQ and will work alongside the corresponding environment there, see DFE-Digital/early-careers-framework/pull/4376.

The NPQ environment will connect to the ECF database and pull data directly.

### Final steps

* [ ] needs to be run manually first time so we can seed the database
    we can do this by adding this `command` attribute to the tfvars:
    ```json
    "command": ["RAILS_ENV=migration", "bundle", "exec", "rails", "db:schema:load", "&&", "RAILS_ENV=migration", "bundle", "exec", "db:seed", "&&", "RAILS_ENV=migration", "bundle", "exec", "rails", "server"]
    ````
* [ ] double check that WebPacker's working properly, its flaky at the best of times