### PR TITLE
Disable validation of user email

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -2,3 +2,4 @@ terraform 1.5.4
 ruby 3.1.2
 nodejs 16.20.1
 yarn 1.22.18
+kubectl 1.29.0

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,11 +13,6 @@ class User < ApplicationRecord
          .where(provider: "tra_openid_connect")
   }
 
-  # TODO: for investigation of the GAI error, we currently have very small number of duplicated emails
-  # rubocop:disable Rails/UniqueValidationWithoutIndex
-  validates :email, uniqueness: true
-  # rubocop:enable Rails/UniqueValidationWithoutIndex
-
   def self.find_by_get_an_identity_id(get_an_identity_id)
     with_get_an_identity_id.find_by(uid: get_an_identity_id)
   end


### PR DESCRIPTION
As we moved to GAI, we don't need email validation anymore. With each login, we receive the most recent user email and we update the database accordingly. With validation, we are having a clash when the GAI email is changed and we can not update the GAI user due to having a non-GAI account with the current GAI email. This change will cause duplicated identities on the ECF side, but it does not happen often and we can easily track those.

### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-1570