### PR TITLE
CPDNPQ-1343 mimic external Inputs & improve testing in review apps

### DIFF
--- a/app/controllers/admin/applications_controller.rb
+++ b/app/controllers/admin/applications_controller.rb
@@ -1,6 +1,6 @@
 class Admin::ApplicationsController < AdminController
   include Pagy::Backend
-  before_action :find_application, only: %i[update_approval_status update_participant_outcome]
+  before_action :check_review_env, :find_application, only: %i[update_approval_status update_participant_outcome]
 
   def index
     @pagy, @applications = pagy(scope)
@@ -11,7 +11,6 @@ class Admin::ApplicationsController < AdminController
   end
 
   # This method is only written for review apps in order to update the external statuses
-  # It will only be accessible if ALLOW_STATUS_UPDATE feature flag would be enabled
   def update_approval_status
     @application.update!(lead_provider_approval_status: @application.get_approval_status)
 
@@ -19,7 +18,6 @@ class Admin::ApplicationsController < AdminController
   end
 
   # This method is only written for review apps in order to update the external statuses
-  # It will only be accessible if ALLOW_STATUS_UPDATE feature flag would be enabled
   def update_participant_outcome
     @application.update!(participant_outcome_state: @application.get_participant_outcome_state)
 
@@ -34,5 +32,9 @@ private
 
   def find_application
     @application = Application.find(params[:id])
+  end
+
+  def check_review_env
+    redirect_to accounts_user_registration_path(@application), notice: "Access denied. This action is only allowed in review apps." unless Rails.env.review? # rubocop:disable Rails/UnknownEnv
   end
 end

--- a/app/controllers/admin/applications_controller.rb
+++ b/app/controllers/admin/applications_controller.rb
@@ -9,6 +9,33 @@ class Admin::ApplicationsController < AdminController
     @application = Application.includes(:user).find(params[:id])
   end
 
+  def update_approval_status
+    @application = Application.find(params[:id])
+
+    new_status = case @application.lead_provider_approval_status
+                 when "accepted" then "rejected"
+                 when "rejected" then "pending"
+                 else "accepted"
+                 end
+
+    @application.update!(lead_provider_approval_status: new_status)
+
+    redirect_to accounts_user_registration_path(@application), notice: "Status updated successfully."
+  end
+
+  def update_participant_outcome
+    @application = Application.find(params[:id])
+
+    new_outcome = case @application.participant_outcome_state
+                  when "passed" then "failed"
+                  else "passed"
+                  end
+
+    @application.update!(participant_outcome_state: new_outcome)
+
+    redirect_to accounts_user_registration_path(@application), notice: "Outcome updated successfully."
+  end
+
 private
 
   def scope

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -48,4 +48,19 @@ class Application < ApplicationRecord
   def school_urn
     school&.urn
   end
+
+  def get_approval_status
+    case lead_provider_approval_status
+    when "accepted" then "rejected"
+    when "rejected" then "pending"
+    else "accepted"
+    end
+  end
+
+  def get_participant_outcome_state
+    case participant_outcome_state
+    when "passed" then "failed"
+    else "passed"
+    end
+  end
 end

--- a/app/services/feature.rb
+++ b/app/services/feature.rb
@@ -3,9 +3,11 @@ class Feature
 
   REGISTRATION_CLOSED_KEY = "Registration closed".freeze
   REGISTRATION_DISABLED = "Registration disabled".freeze
+  ALLOW_STATUS_UPDATE = "Update allowed".freeze
 
   FEATURE_FLAG_KEYS = [
     REGISTRATION_CLOSED_KEY,
+    ALLOW_STATUS_UPDATE,
   ].freeze
 
   class << self
@@ -45,6 +47,10 @@ class Feature
 
     def enable_registration!
       Flipper.disable(REGISTRATION_DISABLED)
+    end
+
+    def status_update_allowed?
+      Flipper.enabled?(ALLOW_STATUS_UPDATE)
     end
   end
 end

--- a/app/services/feature.rb
+++ b/app/services/feature.rb
@@ -3,11 +3,9 @@ class Feature
 
   REGISTRATION_CLOSED_KEY = "Registration closed".freeze
   REGISTRATION_DISABLED = "Registration disabled".freeze
-  ALLOW_STATUS_UPDATE = "Update allowed".freeze
 
   FEATURE_FLAG_KEYS = [
     REGISTRATION_CLOSED_KEY,
-    ALLOW_STATUS_UPDATE,
   ].freeze
 
   class << self
@@ -47,10 +45,6 @@ class Feature
 
     def enable_registration!
       Flipper.disable(REGISTRATION_DISABLED)
-    end
-
-    def status_update_allowed?
-      Flipper.enabled?(ALLOW_STATUS_UPDATE)
     end
   end
 end

--- a/app/views/accounts/_course_details.html.erb
+++ b/app/views/accounts/_course_details.html.erb
@@ -46,6 +46,11 @@
               <strong class="govuk-tag govuk-tag--red">UNSUCCESSFUL</strong>
             <% end %>
         </dd>
+        <%= form_with(model: application, url: update_approval_status_admin_application_path(application), method: :patch, local: true) do |form| %>
+          <%= form.button type: 'submit', class: 'govuk-button', name: 'status', value: 'update' do %>
+            Update Status
+          <% end %>
+        <% end %>
       </div>
 
       <% if application.participant_outcome_state.present? && accepted?(application) %>
@@ -62,6 +67,11 @@
                 <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= t("course.outcome.failed")  %></p>
               <% end %>
           </dd>
+          <%= form_with(model: application, url: update_participant_outcome_admin_application_path(application), method: :patch, local: true) do |form| %>
+            <%= form.button type: 'submit', class: 'govuk-button', name: 'status', value: 'update' do %>
+              Update Outcome
+            <% end %>
+          <% end %>
         </div>
       <% end %>
     </dl>

--- a/app/views/accounts/_course_details.html.erb
+++ b/app/views/accounts/_course_details.html.erb
@@ -46,9 +46,13 @@
               <strong class="govuk-tag govuk-tag--red">UNSUCCESSFUL</strong>
             <% end %>
         </dd>
-        <%= form_with(model: application, url: update_approval_status_admin_application_path(application), method: :patch, local: true) do |form| %>
-          <%= form.button type: 'submit', class: 'govuk-button', name: 'status', value: 'update' do %>
-            Update Status
+        <!-- This code is only written for review apps in order to update the external statuses -->
+        <!-- It will only be accessible if ALLOW_STATUS_UPDATE feature flag would be enabled -->
+        <% if Feature.status_update_allowed? %>
+          <%= form_with(model: application, url: update_approval_status_admin_application_path(application), method: :patch, local: true) do |form| %>
+            <%= form.button type: 'submit', class: 'govuk-button', name: 'status', value: 'update' do %>
+              Update Status
+            <% end %>
           <% end %>
         <% end %>
       </div>
@@ -67,9 +71,13 @@
                 <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= t("course.outcome.failed")  %></p>
               <% end %>
           </dd>
-          <%= form_with(model: application, url: update_participant_outcome_admin_application_path(application), method: :patch, local: true) do |form| %>
-            <%= form.button type: 'submit', class: 'govuk-button', name: 'status', value: 'update' do %>
-              Update Outcome
+          <!-- This code is only written for review apps in order to update the external statuses -->
+          <!-- It will only be accessible if ALLOW_STATUS_UPDATE feature flag would be enabled -->
+          <% if Feature.status_update_allowed? %>
+            <%= form_with(model: application, url: update_participant_outcome_admin_application_path(application), method: :patch, local: true) do |form| %>
+              <%= form.button type: 'submit', class: 'govuk-button', name: 'status', value: 'update' do %>
+                Update Outcome
+              <% end %>
             <% end %>
           <% end %>
         </div>

--- a/app/views/accounts/_course_details.html.erb
+++ b/app/views/accounts/_course_details.html.erb
@@ -47,8 +47,7 @@
             <% end %>
         </dd>
         <!-- This code is only written for review apps in order to update the external statuses -->
-        <!-- It will only be accessible if ALLOW_STATUS_UPDATE feature flag would be enabled -->
-        <% if Feature.status_update_allowed? %>
+        <% if Rails.env.review? %>
           <dd class="govuk-summary-list__actions">
             <%= link_to 'Update Status', update_approval_status_admin_application_path(application), method: :patch %>
           </dd>
@@ -70,14 +69,13 @@
               <% end %>
           </dd>
           <!-- This code is only written for review apps in order to update the external statuses -->
-          <!-- It will only be accessible if ALLOW_STATUS_UPDATE feature flag would be enabled -->
-          <% if Feature.status_update_allowed? %>
+          <% if Rails.env.review? %>
             <dd class="govuk-summary-list__actions">
               <%= link_to 'Update Outcome', update_participant_outcome_admin_application_path(application), method: :patch %>
             </dd>
           <% end %>
         </div>
-      <% elsif Feature.status_update_allowed? %>
+      <% elsif Rails.env.review? %>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
             Course outcome

--- a/app/views/accounts/_course_details.html.erb
+++ b/app/views/accounts/_course_details.html.erb
@@ -49,11 +49,9 @@
         <!-- This code is only written for review apps in order to update the external statuses -->
         <!-- It will only be accessible if ALLOW_STATUS_UPDATE feature flag would be enabled -->
         <% if Feature.status_update_allowed? %>
-          <%= form_with(model: application, url: update_approval_status_admin_application_path(application), method: :patch, local: true) do |form| %>
-            <%= form.button type: 'submit', class: 'govuk-button', name: 'status', value: 'update' do %>
-              Update Status
-            <% end %>
-          <% end %>
+          <dd class="govuk-summary-list__actions">
+            <%= link_to 'Update Status', update_approval_status_admin_application_path(application), method: :patch %>
+          </dd>
         <% end %>
       </div>
 
@@ -74,11 +72,23 @@
           <!-- This code is only written for review apps in order to update the external statuses -->
           <!-- It will only be accessible if ALLOW_STATUS_UPDATE feature flag would be enabled -->
           <% if Feature.status_update_allowed? %>
-            <%= form_with(model: application, url: update_participant_outcome_admin_application_path(application), method: :patch, local: true) do |form| %>
-              <%= form.button type: 'submit', class: 'govuk-button', name: 'status', value: 'update' do %>
-                Update Outcome
-              <% end %>
-            <% end %>
+            <dd class="govuk-summary-list__actions">
+              <%= link_to 'Update Outcome', update_participant_outcome_admin_application_path(application), method: :patch %>
+            </dd>
+          <% end %>
+        </div>
+      <% elsif Feature.status_update_allowed? %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Course outcome
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <strong class="govuk-tag govuk-tag--red">N/A</strong>
+          </dd>
+          <% if accepted?(application)%>
+            <dd class="govuk-summary-list__actions">
+              <%= link_to 'Update Outcome', update_participant_outcome_admin_application_path(application), method: :patch %>
+            </dd>
           <% end %>
         </div>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,8 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :applications, only: %i[index show]
+    # This routes are only written for review apps in order to update the external statuses
+    # It will only be accessible if ALLOW_STATUS_UPDATE feature flag would be enabled
     resources :applications do
       patch "update_approval_status", on: :member
       patch "update_participant_outcome", on: :member

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,10 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :applications, only: %i[index show]
+    resources :applications do
+      patch "update_approval_status", on: :member
+      patch "update_participant_outcome", on: :member
+    end
     resources :unsynced_applications, only: %i[index], path: "unsynced-applications"
 
     resources :users, only: %i[index show] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,7 +45,6 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :applications, only: %i[index show] do
       # This routes are only written for review apps in order to update the external statuses
-      # It will only be accessible if ALLOW_STATUS_UPDATE feature flag would be enabled
       member do
         patch "update_approval_status"
         patch "update_participant_outcome"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,12 +43,13 @@ Rails.application.routes.draw do
   end
 
   namespace :admin do
-    resources :applications, only: %i[index show]
-    # This routes are only written for review apps in order to update the external statuses
-    # It will only be accessible if ALLOW_STATUS_UPDATE feature flag would be enabled
-    resources :applications do
-      patch "update_approval_status", on: :member
-      patch "update_participant_outcome", on: :member
+    resources :applications, only: %i[index show] do
+      # This routes are only written for review apps in order to update the external statuses
+      # It will only be accessible if ALLOW_STATUS_UPDATE feature flag would be enabled
+      member do
+        patch "update_approval_status"
+        patch "update_participant_outcome"
+      end
     end
     resources :unsynced_applications, only: %i[index], path: "unsynced-applications"
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -125,15 +125,22 @@ if Rails.env.development?
     lead_provider: LeadProvider.last,
     course: Course.all.sample,
     work_setting: school_settings.sample,
+    lead_provider_approval_status: "accepted",
+    participant_outcome_state: "passed",
   )
 
-  5.times do
+  outcome_states = %w[passed failed]
+  approval_statuses = %w[accepted rejected]
+
+  15.times do
     Application.create!(
       user: multiple_app_user,
       ecf_id: SecureRandom.uuid,
       lead_provider: LeadProvider.all.sample,
       course: Course.all.sample,
       work_setting: school_settings.sample,
+      lead_provider_approval_status: approval_statuses.sample,
+      participant_outcome_state: outcome_states.sample,
     )
   end
 end

--- a/spec/controllers/admin/applications_controller_spec.rb
+++ b/spec/controllers/admin/applications_controller_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe Admin::ApplicationsController, type: :controller do
+  describe "PATCH #update_approval_status" do
+    it "updates the approval status and redirects" do
+      application = FactoryBot.create(:application)
+      patch :update_approval_status, params: { id: application.id }
+      expect(application.reload.lead_provider_approval_status).not_to eq(application.get_approval_status)
+    end
+  end
+
+  describe "PATCH #update_participant_outcome" do
+    it "updates the participant outcome and redirects" do
+      application = FactoryBot.create(:application)
+      patch :update_participant_outcome, params: { id: application.id }
+      expect(application.reload.participant_outcome_state).not_to eq(application.get_participant_outcome_state)
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-1343

In user accounts screen we can only ever see the “Apply with provider” status due to having no LP to accept the registrations.

This pr helps add a button that mimics the behaviour according to lead provider output. 

Note: This feature is only available for the review apps and is hidden behind a feature flag. In order to avail this functionality, a user needs to be a super admin and enable the feature flag first and then create an application and on the accounts screen where the application is displayed, the statuses and the course outcomes can be changed i.e (accept/reject a registration & passed/failed)