### PR TITLE
Synchronize users in separate job

### DIFF
--- a/app/controllers/omniauth_controller.rb
+++ b/app/controllers/omniauth_controller.rb
@@ -16,7 +16,7 @@ class OmniauthController < Devise::OmniauthCallbacksController
     # @user.save checks that any changes made to an existing record have been persisted to that persisted record
     if @user.persisted? && @user.save
       session["user_id"] = @user.id
-      Ecf::EcfUserUpdater.new(user: @user).call if @user.ecf_id.present?
+      EcfUserUpdaterJob.perform_later(user: @user)
 
       sign_in_and_redirect @user
     else

--- a/app/jobs/ecf_user_updater_job.rb
+++ b/app/jobs/ecf_user_updater_job.rb
@@ -1,0 +1,8 @@
+class EcfUserUpdaterJob < ApplicationJob
+  # Set as low priority so that these jobs don't block other time sensitive issue
+  queue_as :low_priority
+
+  def perform(user:)
+    Ecf::EcfUserUpdater.new(user:).call if user.ecf_id.present?
+  end
+end


### PR DESCRIPTION
As we are not validating emails in the NPQ (we rely on GAI), we are allowing to have 2 users with the same emails. This causes problems with ECF synchronization. This is an intermediate fix, as we need to solve the actual issue.