### PR TITLE
Disable rspec profiling by default

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,1 @@
 --require spec_helper
---profile


### PR DESCRIPTION
### Context

Turn off rspec profiling by default, it adds too much noise.
