### PR TITLE
CPDNPQ-1580 Add Course Start Row to Registration Details

### DIFF
--- a/app/views/accounts/_course_details.html.erb
+++ b/app/views/accounts/_course_details.html.erb
@@ -54,14 +54,14 @@
         <% end %>
       </div>
 
-      <% if pending?(application) %>
+      <% if application.lead_provider_approval_status.blank? || pending?(application) %>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
             Course start
           </dt>
           <dd class="govuk-summary-list__value">
             February 2024
-            <% if application.targeted_delivery_funding_eligibility %>  
+            <% if application.eligible_for_funding %>  
               <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= I18n.t("course_start_details.eligible_for_funding")  %></p>
             <% else %>
               <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= I18n.t("course_start_details.not_eligible_for_funding")  %></p>

--- a/app/views/accounts/_course_details.html.erb
+++ b/app/views/accounts/_course_details.html.erb
@@ -54,6 +54,22 @@
         <% end %>
       </div>
 
+      <% if pending?(application) %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Course start
+          </dt>
+          <dd class="govuk-summary-list__value">
+            February 2024
+            <% if application.targeted_delivery_funding_eligibility %>  
+              <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= I18n.t("course_start_details.eligible_for_funding")  %></p>
+            <% else %>
+              <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= I18n.t("course_start_details.not_eligible_for_funding")  %></p>
+            <% end %>
+          </dd>
+        </div>
+      <% end %>
+
       <% if application.participant_outcome_state.present? && accepted?(application) %>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -275,8 +275,8 @@ en:
   provider_details:
     pending_status: "You need to apply separately with your training provider, if you have not done so already."
   course_start_details:
-    eligible_for_funding: "If you do not to join the February course, your registration will expire. You can register again later, but your funding may change."
-    not_eligible_for_funding: "If you do not to join the February course, your registration will expire. You can register again later."
+    eligible_for_funding: "If you do not apply to join the February course, your registration will expire. You can register again later, but your funding may change."
+    not_eligible_for_funding: "If you do not apply to join the February course, your registration will expire. You can register again later."
 
   helpers:
     title:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -274,6 +274,9 @@ en:
 
   provider_details:
     pending_status: "You need to apply separately with your training provider, if you have not done so already."
+  course_start_details:
+    eligible_for_funding: "If you do not to join the February course, your registration will expire. You can register again later, but your funding may change."
+    not_eligible_for_funding: "If you do not to join the February course, your registration will expire. You can register again later."
 
   helpers:
     title:


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-1580

We want to make users aware that registrations will expire if not used in the next course start, in Feb. We are sending emails to tell them about expiring, which could then nudge them to sign in to their NPQ account, so we want their account to have a consistent message. 

For all registrations with the ‘provider application’ status of ‘pending' (which displays as ‘apply with provider’)
On the registration details page there is a new ‘Course start’ row. 
If the user is eligible for scholarship funding, the text for this row is:

February 2024
If you do not to join the February course, your registration will expire. You can register again later, but your funding may change.

If the user is not eligible (or it is in review) for scholarship funding, the text for this row is:

February 2024
If you do not to join the February course, your registration will expire. You can register again later.