### PR TITLE
Add the initial migration mechanism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ define KONDUIT_CONNECT
 		(tail -f -n0 "$$tmp_file" & ) | grep -q "postgres://"; \
 		postgres_url=$$(grep -o 'postgres://[^ ]*' "$$tmp_file"); \
 		echo "$$postgres_url"; \
-		sed -i '' -e "s|npq_registration_development|&\\n  url: \"$$postgres_url\"|g" config/database.yml; \
+		sed -i '' -e "s|npq_registration_development|&\\n    url: \"$$postgres_url\"|g" config/database.yml; \
 	} & \
 	bin/konduit.sh -d
 endef

--- a/app/controllers/migrations_controller.rb
+++ b/app/controllers/migrations_controller.rb
@@ -11,4 +11,11 @@ class MigrationsController < ApplicationController
 
     redirect_to migrations_path
   end
+
+  def download_orphan_report
+    result = Migration::Result.find(params[:id])
+    yaml = result.cached_orphan_report(params[:key])
+
+    render plain: yaml, content_type: "text/yaml"
+  end
 end

--- a/app/controllers/migrations_controller.rb
+++ b/app/controllers/migrations_controller.rb
@@ -1,4 +1,6 @@
 class MigrationsController < ApplicationController
+  before_action :authenticate
+
   def index
     @most_recent_migration = Migration::Result.most_recent_complete
     @in_progress_migration = Migration::Result.in_progress
@@ -17,5 +19,16 @@ class MigrationsController < ApplicationController
     yaml = result.cached_orphan_report(params[:key])
 
     render plain: yaml, content_type: "text/yaml"
+  end
+
+private
+
+  def authenticate
+    authenticate_or_request_with_http_basic do |username, password|
+      credentials_are_set = [ENV["MIGRATION_USERNAME"], ENV["MIGRATION_PASSWORD"]].all?(&:present?)
+      credentials_match = username == ENV["MIGRATION_USERNAME"] && password == ENV["MIGRATION_PASSWORD"]
+
+      credentials_are_set && credentials_match
+    end
   end
 end

--- a/app/controllers/migrations_controller.rb
+++ b/app/controllers/migrations_controller.rb
@@ -1,0 +1,14 @@
+class MigrationsController < ApplicationController
+  def index
+    @most_recent_migration = Migration::Result.most_recent_complete
+    @in_progress_migration = Migration::Result.in_progress
+  end
+
+  def create
+    Migration::Migrator.prepare_for_migration!
+
+    MigrationJob.perform_later
+
+    redirect_to migrations_path
+  end
+end

--- a/app/helpers/migration_helper.rb
+++ b/app/helpers/migration_helper.rb
@@ -1,0 +1,27 @@
+module MigrationHelper
+  def migration_result_attributes(result, key)
+    result.attribute_names.filter { |attribute_name| attribute_name.include?(key) }
+  end
+
+  def migration_result_summary_row(result, key, attribute)
+    value = result.send(attribute)
+    total = result.send("#{key}_count")
+    percentage = number_to_percentage((value.to_f / total) * 100, precision: 0)
+    tag_color = migration_result_percentage_color(key, attribute, value)
+
+    content_tag(:div, class: "govuk-summary-list__row") do
+      content_tag(:dt, attribute.gsub(key.pluralize, "").humanize, class: "govuk-summary-list__key govuk-!-width-one-half") +
+        content_tag(:dd, number_with_delimiter(value), class: "govuk-summary-list__value") +
+        content_tag(:dd, class: "govuk-summary-list__actions") do
+          content_tag(:strong, percentage, class: "govuk-tag govuk-tag--#{tag_color}") if tag_color
+        end
+    end
+  end
+
+  def migration_result_percentage_color(key, attribute, value)
+    return if value.zero?
+    return :green if attribute.include?("matched")
+
+    :red if attribute != "#{key}_count"
+  end
+end

--- a/app/helpers/migration_helper.rb
+++ b/app/helpers/migration_helper.rb
@@ -24,4 +24,9 @@ module MigrationHelper
 
     :red if attribute != "#{key}_count"
   end
+
+  def migration_result_duration_in_words(result)
+    duration_in_seconds = (result.completed_at - result.created_at).to_i
+    ActiveSupport::Duration.build(duration_in_seconds).inspect
+  end
 end

--- a/app/jobs/migration_job.rb
+++ b/app/jobs/migration_job.rb
@@ -1,0 +1,6 @@
+class MigrationJob < ApplicationJob
+  def perform
+    migrator = Migration::Migrator.new
+    migrator.migrate!
+  end
+end

--- a/app/models/migration/ecf/user.rb
+++ b/app/models/migration/ecf/user.rb
@@ -5,6 +5,7 @@ module Migration::Ecf
 
     delegate :trn, to: :teacher_profile, allow_nil: true
     alias_method :ecf_id, :id
+    attr_writer :migration_npq_applications
 
     def participant_identity
       participant_identities.first
@@ -12,9 +13,9 @@ module Migration::Ecf
 
     def migration_npq_applications
       @migration_npq_applications ||= NpqApplication.joins(:participant_identity)
-      .includes(:school)
-      .where(participant_identity: { user_id: id })
-      .to_a
+                                          .includes(:school)
+                                          .where(participant_identity: { user_id: id })
+                                          .to_a
     end
     alias_method :applications, :migration_npq_applications
   end

--- a/app/models/migration/result.rb
+++ b/app/models/migration/result.rb
@@ -1,0 +1,5 @@
+module Migration
+  class Result < ApplicationRecord
+    self.table_name = "migration_results"
+  end
+end

--- a/app/models/migration/result.rb
+++ b/app/models/migration/result.rb
@@ -1,5 +1,19 @@
 module Migration
   class Result < ApplicationRecord
     self.table_name = "migration_results"
+
+    scope :complete, -> { where.not(completed_at: nil) }
+    scope :incomplete, -> { where(completed_at: nil) }
+    scope :ordered_by_most_recent, -> { order(created_at: :desc) }
+
+    class << self
+      def in_progress
+        incomplete.first
+      end
+
+      def most_recent_complete
+        complete.ordered_by_most_recent.first
+      end
+    end
   end
 end

--- a/app/models/migration/result.rb
+++ b/app/models/migration/result.rb
@@ -15,5 +15,13 @@ module Migration
         complete.ordered_by_most_recent.first
       end
     end
+
+    def cache_orphan_report(report, key)
+      Rails.cache.write("orphaned_#{key}_#{id}", report.to_yaml, expires_in: 1.month)
+    end
+
+    def cached_orphan_report(key)
+      Rails.cache.read("orphaned_#{key}_#{id}")
+    end
   end
 end

--- a/app/services/migration/indexer.rb
+++ b/app/services/migration/indexer.rb
@@ -17,50 +17,98 @@ module Migration
     # perform a lookup on any matched objects in order to expand the
     # search as far as possible and infer matches.
     def lookup(obj, looked_up_objects = Set.new)
+      # End condition for recursion; we've already looked up this object.
       return Set[obj] if looked_up_objects.include?(obj)
 
+      # Add the object to the set of looked up objects.
       looked_up_objects.add(obj)
 
+      # For each indexed attribute.
       indexes
+        # Fetch the matching objects from the index.
         .map { |attr| fetch(obj, attr) }
+        # Flatten the array of matching objects to a single array.
         .flatten
+        # Convert to a set (removing duplicates).
         .reduce(Set.new, &:merge)
+        # Recursively lookup each matching object to find further matches.
         .flat_map { |matching_obj| lookup(matching_obj, looked_up_objects) }
+        # Convert to a set (removing duplicates).
         .reduce(Set.new, &:merge)
     end
 
   private
 
+    # Fetches objects from the index for the given attribute.
     def fetch(obj, attr)
+      # Get the keys from the value of the attribute on the object.
       keys = sanitize_keys(obj, attr)
+      # Compact an array of objects from the index for each key.
       keys.map { |k| index.dig(attr, k) }.compact
     end
 
+    # Construct the index by indexing each individual object.
     def index
       @index ||= indexes.index_with { {} }.tap do |index|
         objects.each { |obj| index_object(obj, index) }
       end
     end
 
+    # Add an object to the index. An index might look like:
+    #
+    # {
+    #   index1: {
+    #     key1: Set[object1, object2],
+    #   },
+    #   index2: {
+    #     key1: Set[object1, object3],
+    #   }
+    # }
+    #
+    # This means that object1 and object2 both share the value 'key1'
+    # for the attribute 'index1'. Note that array values are indexed individually,
+    # so if object1 has an array value of '[key1, key2]' for attribute 'index1' the
+    # index will look like this:
+    #
+    # {
+    #   index1: {
+    #     key1: Set[object1],
+    #     key2: Set[object1],
+    #   }
+    # }
+    #
+    # The purpose of this is to ensure we match objects that have a common array
+    # value (for example if indexing users we can then infer user1 matches user2
+    # if both share an application id on an indexed `application_ids` attribute).
     def index_object(obj, index)
+      # Add the object to the index for each indexed attribute.
       results = indexes.map { |attr| index_object_attribute(obj, index, attr) }
 
       raise UnindexableError, "unable to index #{obj}" if results.all?(&:nil?)
     end
 
+    # Add the object to the index for each indexed attribute.
     def index_object_attribute(obj, index, attr)
+      # Get the keys from the value of the attribute on the object.
       keys = sanitize_keys(obj, attr)
       return if keys.blank?
 
+      # Add the object to the index for each key.
       keys.each do |key|
         index[attr][key] ||= Set.new
         index[attr][key].add(obj)
       end
     end
 
+    # Given an object and an attribute, returns a set of indexed keys.
+    # Usually this will be a single key, but if the attribute
+    # has an array value it will be multiple keys.
     def sanitize_keys(obj, attr)
+      # If the object doesn't respond to the attribute, return an empty set.
       return Set.new unless obj.respond_to?(attr)
 
+      # Return a set of keys, downcased and converted to strings for
+      # case-insensitive comparisons.
       keys = Array.wrap(obj.send(attr))
       keys.map { |v| v.to_s.downcase }
     end

--- a/app/services/migration/match.rb
+++ b/app/services/migration/match.rb
@@ -10,6 +10,14 @@ module Migration
       @matches = matches
     end
 
+    def ecf_match
+      matches.find { |m| NamespaceCheck.ecf?(m) }
+    end
+
+    def npq_match
+      matches.find { |m| NamespaceCheck.npq?(m) }
+    end
+
     def orphan
       raise NotOrphanedError unless orphaned?
 

--- a/app/services/migration/migrator.rb
+++ b/app/services/migration/migrator.rb
@@ -7,6 +7,7 @@ module Migration
 
     def migrate!
       retrieve_prepared_result
+      cache_orphan_details
       write_reconciliation_metrics!
       finalise_result!
     end
@@ -25,6 +26,11 @@ module Migration
       @result = Migration::Result.in_progress
 
       raise NoMigrationInProgressError if result.blank?
+    end
+
+    def cache_orphan_details
+      result.cache_orphan_report(Migration::OrphanReport.new(users_reconciler), "users")
+      result.cache_orphan_report(Migration::OrphanReport.new(applications_reconciler), "applications")
     end
 
     def write_reconciliation_metrics!

--- a/app/services/migration/migrator.rb
+++ b/app/services/migration/migrator.rb
@@ -7,6 +7,7 @@ module Migration
 
     def migrate!
       retrieve_prepared_result
+      migrate_applications!
       write_reconciliation_metrics!
       cache_orphan_details
       finalise_result!
@@ -21,6 +22,14 @@ module Migration
     end
 
   private
+
+    def migrate_applications!
+      applications_reconciler.matched.each do |match|
+        # This is just a proof of concept, we'll need to do something more sophisticated
+        # when we actually migrate the data.
+        match.npq_match.update!(lead_provider_approval_status: match.ecf_match.lead_provider_approval_status)
+      end
+    end
 
     def retrieve_prepared_result
       @result = Migration::Result.in_progress

--- a/app/services/migration/migrator.rb
+++ b/app/services/migration/migrator.rb
@@ -1,0 +1,32 @@
+module Migration
+  class Migrator
+    def migrate!
+      write_migration_result!
+    end
+
+  private
+
+    def write_migration_result!
+      Migration::Result.create!(
+        users_count: users_reconciler.matches.size,
+        orphaned_ecf_users_count: users_reconciler.orphaned_ecf.size,
+        orphaned_npq_users_count: users_reconciler.orphaned_npq.size,
+        duplicate_users_count: users_reconciler.duplicated.size,
+        matched_users_count: users_reconciler.matched.size,
+        applications_count: applications_reconciler.matches.size,
+        orphaned_ecf_applications_count: applications_reconciler.orphaned_ecf.size,
+        orphaned_npq_applications_count: applications_reconciler.orphaned_npq.size,
+        duplicate_applications_count: applications_reconciler.duplicated.size,
+        matched_applications_count: applications_reconciler.matched.size,
+      )
+    end
+
+    def applications_reconciler
+      @applications_reconciler ||= ReconcileApplications.new
+    end
+
+    def users_reconciler
+      @users_reconciler ||= Migration::ReconcileUsers.new
+    end
+  end
+end

--- a/app/services/migration/migrator.rb
+++ b/app/services/migration/migrator.rb
@@ -7,8 +7,8 @@ module Migration
 
     def migrate!
       retrieve_prepared_result
-      cache_orphan_details
       write_reconciliation_metrics!
+      cache_orphan_details
       finalise_result!
     end
 

--- a/app/services/migration/namespace_check.rb
+++ b/app/services/migration/namespace_check.rb
@@ -1,0 +1,13 @@
+module Migration
+  class NamespaceCheck
+    class << self
+      def ecf?(obj)
+        obj.class.to_s.include?("Ecf")
+      end
+
+      def npq?(obj)
+        !ecf?(obj)
+      end
+    end
+  end
+end

--- a/app/services/migration/orphan_report.rb
+++ b/app/services/migration/orphan_report.rb
@@ -7,7 +7,9 @@ module Migration
     end
 
     def to_yaml
-      orphaned_matches.map { |orphan_match|
+      orphaned_matches.each_with_index.map { |orphan_match, index|
+        Rails.logger.info("Processing orphan #{index + 1} of #{orphaned_matches.size} for #{reconciler.class}")
+
         {
           orphan: extract_attributes(orphan_match.orphan),
           potential_matches: orphan_match.potential_matches.map(&method(:extract_attributes)),

--- a/app/services/migration/reconcile_applications.rb
+++ b/app/services/migration/reconcile_applications.rb
@@ -13,14 +13,6 @@ module Migration
       ].freeze
     end
 
-    def orphaned_ecf
-      @orphaned_ecf ||= orphaned.select { |m| m.orphan.is_a?(Migration::Ecf::NpqApplication) }
-    end
-
-    def orphaned_npq
-      @orphaned_npq ||= orphaned.select { |m| m.orphan.is_a?(Application) }
-    end
-
   protected
 
     def all_objects

--- a/app/services/migration/reconcile_applications.rb
+++ b/app/services/migration/reconcile_applications.rb
@@ -34,11 +34,19 @@ module Migration
     end
 
     def ecf_applications
-      @ecf_applications ||= Migration::Ecf::NpqApplication.includes(:npq_course, participant_identity: :user).all.to_a
+      @ecf_applications ||= Migration::Ecf::NpqApplication
+        .select(indexes.excluding(:ecf_id) + %i[npq_course_id participant_identity_id lead_provider_approval_status])
+        .includes(:npq_course, participant_identity: :user)
+        .all
+        .to_a
     end
 
     def npq_applications
-      @npq_applications ||= Application.includes(:course, :user).all.to_a
+      @npq_applications ||= Application
+        .select(indexes + %i[course_id user_id lead_provider_approval_status lead_provider_id])
+        .includes(:course, :user, :lead_provider)
+        .all
+        .to_a
     end
   end
 end

--- a/app/services/migration/reconcile_users.rb
+++ b/app/services/migration/reconcile_users.rb
@@ -10,14 +10,6 @@ module Migration
       end
     end
 
-    def orphaned_ecf
-      @orphaned_ecf ||= orphaned.select { |m| m.orphan.is_a?(Migration::Ecf::User) }
-    end
-
-    def orphaned_npq
-      @orphaned_npq ||= orphaned.select { |m| m.orphan.is_a?(User) }
-    end
-
     def indexes
       %i[
         id

--- a/app/services/migration/reconciler.rb
+++ b/app/services/migration/reconciler.rb
@@ -4,6 +4,14 @@ module Migration
       @orphaned ||= matches.select(&:orphaned?)
     end
 
+    def orphaned_ecf
+      @orphaned_ecf ||= orphaned.select { |m| NamespaceCheck.ecf?(m.orphan) }
+    end
+
+    def orphaned_npq
+      @orphaned_npq ||= orphaned.select { |m| NamespaceCheck.npq?(m.orphan) }
+    end
+
     def duplicated
       @duplicated ||= matches.select(&:duplicated?)
     end

--- a/app/views/migrations/_in_progress_migration.html.erb
+++ b/app/views/migrations/_in_progress_migration.html.erb
@@ -1,0 +1,13 @@
+<div class="govuk-notification-banner" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+  <div class="govuk-notification-banner__header">
+    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+      Important
+    </h2>
+  </div>
+  <div class="govuk-notification-banner__content">
+    <h3 class="govuk-notification-banner__heading">
+      A migration is currently in-progress
+    </h3>
+    <p class="govuk-body">It was started <strong><%= time_ago_in_words(@in_progress_migration.created_at) %></strong> ago.</p>
+  </div>
+</div>

--- a/app/views/migrations/_most_recent_migration.html.erb
+++ b/app/views/migrations/_most_recent_migration.html.erb
@@ -2,7 +2,8 @@
 <h2 class="govuk-heading-l">Latest migration</h2>
 
 <p class="govuk-body">
-  The latest migration was completed <strong><%= time_ago_in_words(@most_recent_migration.completed_at) %></strong> ago.
+  The latest migration was completed <strong><%= time_ago_in_words(@most_recent_migration.completed_at) %></strong> ago.<br>
+  The migration took <strong><%= migration_result_duration_in_words(@most_recent_migration) %></strong> to complete.
 </p>
 
 <div class="govuk-grid-row">
@@ -11,6 +12,11 @@
       <%= tag.div(class: "govuk-summary-card #{key}") do %>
         <div class="govuk-summary-card__title-wrapper">
           <h2 class="govuk-summary-card__title"><%= key.pluralize.titleize %> Reconciliation</h2>
+          <ul class="govuk-summary-card__actions">
+            <li class="govuk-summary-card__action">
+              <%= link_to("Orphan report", download_orphan_report_migrations_path(@most_recent_migration.id, key)) %>
+            </li>
+          </ul>
         </div>
         <div class="govuk-summary-card__content">
           <dl class="govuk-summary-list">

--- a/app/views/migrations/_most_recent_migration.html.erb
+++ b/app/views/migrations/_most_recent_migration.html.erb
@@ -1,0 +1,25 @@
+
+<h2 class="govuk-heading-l">Latest migration</h2>
+
+<p class="govuk-body">
+  The latest migration was completed <strong><%= time_ago_in_words(@most_recent_migration.completed_at) %></strong> ago.
+</p>
+
+<div class="govuk-grid-row">
+  <% %w[users applications].each do |key| %>
+    <div class="govuk-grid-column-one-half">
+      <%= tag.div(class: "govuk-summary-card #{key}") do %>
+        <div class="govuk-summary-card__title-wrapper">
+          <h2 class="govuk-summary-card__title"><%= key.pluralize.titleize %> Reconciliation</h2>
+        </div>
+        <div class="govuk-summary-card__content">
+          <dl class="govuk-summary-list">
+            <% migration_result_attributes(@most_recent_migration, key).each do |attribute| %>
+              <%= migration_result_summary_row(@most_recent_migration, key, attribute) %>
+            <% end %>
+          </dl>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/migrations/index.html.erb
+++ b/app/views/migrations/index.html.erb
@@ -1,0 +1,15 @@
+<% content_for :title, "Migrations" %>
+
+<% if @in_progress_migration.present? %>
+  <%= render(partial: "in_progress_migration") %>
+<% end %>
+
+<h1 class="govuk-heading-xl">Migrations</h1>
+
+<p class="govuk-body">You can run the NPQ migration from ECF using this migration tool.</p>
+
+<%= button_to "Run migration", { action: :create }, class: "govuk-button govuk-button--warning", disabled: @in_progress_migration.present? %>
+
+<% if @most_recent_migration.present? %>
+  <%= render(partial: "most_recent_migration") %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@ Rails.application.routes.draw do
   devise_for :users,
              controllers: { omniauth_callbacks: "omniauth" }
 
+  resources :migrations, only: %i[index create]
+
   get "/healthcheck", to: "monitoring#healthcheck", format: :json
 
   resources :schools, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,9 @@ Rails.application.routes.draw do
   devise_for :users,
              controllers: { omniauth_callbacks: "omniauth" }
 
-  resources :migrations, only: %i[index create]
+  resources :migrations, only: %i[index create] do
+    get "download_orphan_report/:id/:key", on: :collection, action: :download_orphan_report, as: :download_orphan_report
+  end
 
   get "/healthcheck", to: "monitoring#healthcheck", format: :json
 

--- a/db/migrate/20240109141144_create_migration_results.rb
+++ b/db/migrate/20240109141144_create_migration_results.rb
@@ -1,0 +1,19 @@
+class CreateMigrationResults < ActiveRecord::Migration[7.0]
+  def change
+    create_table :migration_results do |t|
+      t.integer :users_count
+      t.integer :orphaned_ecf_users_count
+      t.integer :orphaned_npq_users_count
+      t.integer :duplicate_users_count
+      t.integer :matched_users_count
+
+      t.integer :applications_count
+      t.integer :orphaned_ecf_applications_count
+      t.integer :orphaned_npq_applications_count
+      t.integer :duplicate_applications_count
+      t.integer :matched_applications_count
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240109141144_create_migration_results.rb
+++ b/db/migrate/20240109141144_create_migration_results.rb
@@ -1,6 +1,8 @@
 class CreateMigrationResults < ActiveRecord::Migration[7.0]
   def change
     create_table :migration_results do |t|
+      t.datetime :completed_at
+
       t.integer :users_count
       t.integer :orphaned_ecf_users_count
       t.integer :orphaned_npq_users_count

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -218,6 +218,21 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_15_204129) do
     t.index ["ukprn"], name: "index_local_authorities_on_ukprn"
   end
 
+  create_table "migration_results", force: :cascade do |t|
+    t.integer "users_count"
+    t.integer "orphaned_ecf_users_count"
+    t.integer "orphaned_npq_users_count"
+    t.integer "duplicate_users_count"
+    t.integer "matched_users_count"
+    t.integer "applications_count"
+    t.integer "orphaned_ecf_applications_count"
+    t.integer "orphaned_npq_applications_count"
+    t.integer "duplicate_applications_count"
+    t.integer "matched_applications_count"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "outcomes", force: :cascade do |t|
     t.string "state", null: false
     t.date "completion_date", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -219,6 +219,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_15_204129) do
   end
 
   create_table "migration_results", force: :cascade do |t|
+    t.datetime "completed_at"
     t.integer "users_count"
     t.integer "orphaned_ecf_users_count"
     t.integer "orphaned_npq_users_count"

--- a/spec/factories/migration/ecf/users.rb
+++ b/spec/factories/migration/ecf/users.rb
@@ -6,5 +6,12 @@ FactoryBot.define do
     trait :teacher do
       teacher_profile { create(:ecf_teacher_profile) }
     end
+
+    trait :with_application do
+      after(:create) do |user|
+        participant_identity = create(:ecf_participant_identity, user:)
+        create(:ecf_npq_application, participant_identity:)
+      end
+    end
   end
 end

--- a/spec/factories/migration/results.rb
+++ b/spec/factories/migration/results.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :migration_result, class: "Migration::Result" do
+    trait :complete do
+      completed_at { 1.day.ago }
+    end
+
+    trait :incomplete do
+      completed_at { nil }
+    end
+  end
+end

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "admin", type: :feature do
+RSpec.feature "admin", type: :feature, rack_test_driver: true do
   include_context "Stub Get An Identity Omniauth Responses"
 
   let(:admin) { create(:admin, :with_ecf_id) }

--- a/spec/features/happy_journeys/non_js/able_to_receive_targeted_delivery_funding_spec.rb
+++ b/spec/features/happy_journeys/non_js/able_to_receive_targeted_delivery_funding_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Happy journeys", type: :feature do
+RSpec.feature "Happy journeys", type: :feature, rack_test_driver: true do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"

--- a/spec/features/happy_journeys/non_js/funded_ehco_registration_journey_spec.rb
+++ b/spec/features/happy_journeys/non_js/funded_ehco_registration_journey_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Happy journeys", type: :feature do
+RSpec.feature "Happy journeys", type: :feature, rack_test_driver: true do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"

--- a/spec/features/happy_journeys/non_js/international_teacher_npqh_journey_spec.rb
+++ b/spec/features/happy_journeys/non_js/international_teacher_npqh_journey_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Happy journeys", type: :feature do
+RSpec.feature "Happy journeys", type: :feature, rack_test_driver: true do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"

--- a/spec/features/happy_journeys/non_js/other_funded_ehco_registration_journey_spec.rb
+++ b/spec/features/happy_journeys/non_js/other_funded_ehco_registration_journey_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Happy journeys", type: :feature do
+RSpec.feature "Happy journeys", type: :feature, rack_test_driver: true do
   include Helpers::JourneyAssertionHelper
 
   include_context "Stub previously funding check for all courses" do

--- a/spec/features/happy_journeys/non_js/previously_received_targeted_delivery_funding_spec.rb
+++ b/spec/features/happy_journeys/non_js/previously_received_targeted_delivery_funding_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Happy journeys", type: :feature do
+RSpec.feature "Happy journeys", type: :feature, rack_test_driver: true do
   include Helpers::JourneyAssertionHelper
 
   include_context "retrieve latest application data"

--- a/spec/features/happy_journeys/non_js/via_using_old_name_and_not_headship_spec.rb
+++ b/spec/features/happy_journeys/non_js/via_using_old_name_and_not_headship_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Happy journeys", type: :feature do
+RSpec.feature "Happy journeys", type: :feature, rack_test_driver: true do
   include Helpers::JourneyAssertionHelper
 
   include_context "Stub previously funding check for all courses" do

--- a/spec/features/happy_journeys/non_js/via_using_same_name_spec.rb
+++ b/spec/features/happy_journeys/non_js/via_using_same_name_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Happy journeys", type: :feature do
+RSpec.feature "Happy journeys", type: :feature, rack_test_driver: true do
   include Helpers::JourneyAssertionHelper
 
   include_context "Stub Get An Identity Omniauth Responses"

--- a/spec/features/migration_spec.rb
+++ b/spec/features/migration_spec.rb
@@ -1,147 +1,180 @@
 require "rails_helper"
 
-RSpec.feature "Migration", type: :feature, in_memory_rails_cache: true do
-  scenario "viewing the migrations prior to running one" do
-    visit migrations_path
-
-    expect(page).to have_button("Run migration")
-
-    expect(page).not_to have_content("A migration is currently in-progress")
-    expect(page).not_to have_content("Latest migration")
+RSpec.feature "Migration", type: :feature, in_memory_rails_cache: true, rack_test_driver: true do
+  before do
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with("MIGRATION_USERNAME").and_return("username")
+    allow(ENV).to receive(:[]).with("MIGRATION_PASSWORD").and_return("password")
   end
 
-  scenario "running the first migration" do
-    visit migrations_path
-
-    click_button "Run migration"
-
-    expect(page).to have_button("Run migration", disabled: true)
-
-    expect(page).to have_content("A migration is currently in-progress")
-    expect(page).to have_content("It was started less than a minute ago.")
-
-    expect(page).not_to have_content("Latest migration")
-  end
-
-  context "with user data" do
-    let(:users_counts) do
-      {
-        orphaned_ecf_users_count: 1,
-        orphaned_npq_users_count: 4,
-        duplicated_users_count: 3,
-        matched_users_count: 2,
-      }
-    end
-
-    before do
-      users_counts[:orphaned_ecf_users_count].times { create(:ecf_user, :teacher, :with_application) }
-      users_counts[:orphaned_npq_users_count].times { |trn| create(:user, trn:) }
-      users_counts[:duplicated_users_count].times do
-        ecf_user = create(:ecf_user, :teacher, :with_application)
-        create(:user, trn: ecf_user.trn)
-        create(:user, trn: ecf_user.trn)
-      end
-      users_counts[:matched_users_count].times do
-        ecf_user = create(:ecf_user, :teacher, :with_application)
-        create(:user, trn: ecf_user.trn)
-      end
+  context "when not authenticated" do
+    scenario "viewing the migrations page" do
+      page.driver.browser.basic_authorize("wrong", "credentials")
 
       visit migrations_path
 
-      perform_enqueued_jobs do
-        click_button "Run migration"
-      end
-    end
-
-    scenario "viewing the general page state" do
-      expect(page).not_to have_content("A migration is currently in-progress")
-
-      expect(page).to have_button("Run migration")
-
-      expect(page).to have_content("Latest migration")
-      expect(page).to have_text("The latest migration was completed less than a minute ago.")
-      expect(page).to have_text(/The migration took (.*) to complete./)
-    end
-
-    scenario "viewing the user reconcilliation metrics" do
-      within(".govuk-summary-card.users") do
-        expect(find("dt", text: "Count")).to have_sibling("dd", text: users_counts.values.sum)
-        expect(find("dt", text: "Orphaned ecf count")).to have_sibling("dd", text: users_counts[:orphaned_ecf_users_count])
-        expect(find("dt", text: "Orphaned npq count")).to have_sibling("dd", text: users_counts[:orphaned_npq_users_count])
-        expect(find("dt", text: "Duplicate count")).to have_sibling("dd", text: users_counts[:duplicated_users_count])
-        expect(find("dt", text: "Matched count")).to have_sibling("dd", text: users_counts[:matched_users_count])
-      end
-    end
-
-    scenario "downloading the orphaned users report" do
-      within(".govuk-summary-card.users") do
-        click_on "Orphan report"
-      end
-
-      yaml = YAML.load(page.text)
-
-      expect(yaml.map { |h| h.dig(:orphan, :class) }).to include("User", "Migration::Ecf::User")
+      expect(page).to have_http_status(:unauthorized)
     end
   end
 
-  context "with application data" do
-    let(:application_counts) do
-      {
-        orphaned_ecf_applications_count: 4,
-        orphaned_npq_applications_count: 2,
-        duplicated_applications_count: 1,
-        matched_applications_count: 3,
-      }
-    end
+  context "when migration username/password is not set for the environment" do
+    scenario "viewing the migrations page" do
+      allow(ENV).to receive(:[]).with("MIGRATION_USERNAME").and_return("")
+      allow(ENV).to receive(:[]).with("MIGRATION_PASSWORD").and_return("")
 
-    before do
-      application_counts[:orphaned_ecf_applications_count].times { create(:ecf_npq_application) }
-      application_counts[:orphaned_npq_applications_count].times { create(:application) }
-      application_counts[:duplicated_applications_count].times do
-        ecf_application = create(:ecf_npq_application)
-        create(:application, ecf_id: ecf_application.id)
-        create(:application, ecf_id: ecf_application.id)
-      end
-      application_counts[:matched_applications_count].times do
-        ecf_application = create(:ecf_npq_application)
-        create(:application, ecf_id: ecf_application.id)
-      end
+      page.driver.browser.basic_authorize("", "")
 
       visit migrations_path
 
-      perform_enqueued_jobs do
-        click_button "Run migration"
-      end
+      expect(page).to have_http_status(:unauthorized)
     end
+  end
 
-    scenario "viewing the general page state" do
-      expect(page).not_to have_content("A migration is currently in-progress")
+  context "when authenticated" do
+    before { page.driver.browser.basic_authorize("username", "password") }
+
+    scenario "viewing the migrations prior to running one" do
+      visit migrations_path
 
       expect(page).to have_button("Run migration")
 
-      expect(page).to have_content("Latest migration")
-      expect(page).to have_text("The latest migration was completed less than a minute ago.")
-      expect(page).to have_text(/The migration took (.*) to complete./)
+      expect(page).not_to have_content("A migration is currently in-progress")
+      expect(page).not_to have_content("Latest migration")
     end
 
-    scenario "viewing the application reconcilliation metrics" do
-      within(".govuk-summary-card.applications") do
-        expect(find("dt", text: "Count")).to have_sibling("dd", text: application_counts.values.sum)
-        expect(find("dt", text: "Orphaned ecf count")).to have_sibling("dd", text: application_counts[:orphaned_ecf_applications_count])
-        expect(find("dt", text: "Orphaned npq count")).to have_sibling("dd", text: application_counts[:orphaned_npq_applications_count])
-        expect(find("dt", text: "Duplicate count")).to have_sibling("dd", text: application_counts[:duplicated_applications_count])
-        expect(find("dt", text: "Matched count")).to have_sibling("dd", text: application_counts[:matched_applications_count])
+    scenario "running the first migration" do
+      visit migrations_path
+
+      click_button "Run migration"
+
+      expect(page).to have_button("Run migration", disabled: true)
+
+      expect(page).to have_content("A migration is currently in-progress")
+      expect(page).to have_content("It was started less than a minute ago.")
+
+      expect(page).not_to have_content("Latest migration")
+    end
+
+    context "with user data" do
+      let(:users_counts) do
+        {
+          orphaned_ecf_users_count: 1,
+          orphaned_npq_users_count: 4,
+          duplicated_users_count: 3,
+          matched_users_count: 2,
+        }
+      end
+
+      before do
+        users_counts[:orphaned_ecf_users_count].times { create(:ecf_user, :teacher, :with_application) }
+        users_counts[:orphaned_npq_users_count].times { |trn| create(:user, trn:) }
+        users_counts[:duplicated_users_count].times do
+          ecf_user = create(:ecf_user, :teacher, :with_application)
+          create(:user, trn: ecf_user.trn)
+          create(:user, trn: ecf_user.trn)
+        end
+        users_counts[:matched_users_count].times do
+          ecf_user = create(:ecf_user, :teacher, :with_application)
+          create(:user, trn: ecf_user.trn)
+        end
+
+        visit migrations_path
+
+        perform_enqueued_jobs do
+          click_button "Run migration"
+        end
+      end
+
+      scenario "viewing the general page state" do
+        expect(page).not_to have_content("A migration is currently in-progress")
+
+        expect(page).to have_button("Run migration")
+
+        expect(page).to have_content("Latest migration")
+        expect(page).to have_text("The latest migration was completed less than a minute ago.")
+        expect(page).to have_text(/The migration took (.*) to complete./)
+      end
+
+      scenario "viewing the user reconcilliation metrics" do
+        within(".govuk-summary-card.users") do
+          expect(find("dt", text: "Count")).to have_sibling("dd", text: users_counts.values.sum)
+          expect(find("dt", text: "Orphaned ecf count")).to have_sibling("dd", text: users_counts[:orphaned_ecf_users_count])
+          expect(find("dt", text: "Orphaned npq count")).to have_sibling("dd", text: users_counts[:orphaned_npq_users_count])
+          expect(find("dt", text: "Duplicate count")).to have_sibling("dd", text: users_counts[:duplicated_users_count])
+          expect(find("dt", text: "Matched count")).to have_sibling("dd", text: users_counts[:matched_users_count])
+        end
+      end
+
+      scenario "downloading the orphaned users report" do
+        within(".govuk-summary-card.users") do
+          click_on "Orphan report"
+        end
+
+        yaml = YAML.load(page.body)
+
+        expect(yaml.map { |h| h.dig(:orphan, :class) }).to include("User", "Migration::Ecf::User")
       end
     end
 
-    scenario "downloading the orphaned applications report" do
-      within(".govuk-summary-card.applications") do
-        click_on "Orphan report"
+    context "with application data" do
+      let(:application_counts) do
+        {
+          orphaned_ecf_applications_count: 4,
+          orphaned_npq_applications_count: 2,
+          duplicated_applications_count: 1,
+          matched_applications_count: 3,
+        }
       end
 
-      yaml = YAML.load(page.text)
+      before do
+        application_counts[:orphaned_ecf_applications_count].times { create(:ecf_npq_application) }
+        application_counts[:orphaned_npq_applications_count].times { create(:application) }
+        application_counts[:duplicated_applications_count].times do
+          ecf_application = create(:ecf_npq_application)
+          create(:application, ecf_id: ecf_application.id)
+          create(:application, ecf_id: ecf_application.id)
+        end
+        application_counts[:matched_applications_count].times do
+          ecf_application = create(:ecf_npq_application)
+          create(:application, ecf_id: ecf_application.id)
+        end
 
-      expect(yaml.map { |h| h.dig(:orphan, :class) }).to include("Application", "Migration::Ecf::NpqApplication")
+        visit migrations_path
+
+        perform_enqueued_jobs do
+          click_button "Run migration"
+        end
+      end
+
+      scenario "viewing the general page state" do
+        expect(page).not_to have_content("A migration is currently in-progress")
+
+        expect(page).to have_button("Run migration")
+
+        expect(page).to have_content("Latest migration")
+        expect(page).to have_text("The latest migration was completed less than a minute ago.")
+        expect(page).to have_text(/The migration took (.*) to complete./)
+      end
+
+      scenario "viewing the application reconcilliation metrics" do
+        within(".govuk-summary-card.applications") do
+          expect(find("dt", text: "Count")).to have_sibling("dd", text: application_counts.values.sum)
+          expect(find("dt", text: "Orphaned ecf count")).to have_sibling("dd", text: application_counts[:orphaned_ecf_applications_count])
+          expect(find("dt", text: "Orphaned npq count")).to have_sibling("dd", text: application_counts[:orphaned_npq_applications_count])
+          expect(find("dt", text: "Duplicate count")).to have_sibling("dd", text: application_counts[:duplicated_applications_count])
+          expect(find("dt", text: "Matched count")).to have_sibling("dd", text: application_counts[:matched_applications_count])
+        end
+      end
+
+      scenario "downloading the orphaned applications report" do
+        within(".govuk-summary-card.applications") do
+          click_on "Orphan report"
+        end
+
+        yaml = YAML.load(page.body)
+
+        expect(yaml.map { |h| h.dig(:orphan, :class) }).to include("Application", "Migration::Ecf::NpqApplication")
+      end
     end
   end
 end

--- a/spec/features/migration_spec.rb
+++ b/spec/features/migration_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Migration", type: :feature do
+RSpec.feature "Migration", type: :feature, in_memory_rails_cache: true do
   scenario "viewing the migrations prior to running one" do
     visit migrations_path
 
@@ -23,89 +23,125 @@ RSpec.feature "Migration", type: :feature do
     expect(page).not_to have_content("Latest migration")
   end
 
-  scenario "after the migration completes (check user reconciliation metrics)" do
-    users_counts = {
-      orphaned_ecf_users_count: 1,
-      orphaned_npq_users_count: 4,
-      duplicated_users_count: 3,
-      matched_users_count: 2,
-    }
-
-    # Create user data
-    users_counts[:orphaned_ecf_users_count].times { create(:ecf_user, :teacher, :with_application) }
-    users_counts[:orphaned_npq_users_count].times { |trn| create(:user, trn:) }
-    users_counts[:duplicated_users_count].times do
-      ecf_user = create(:ecf_user, :teacher, :with_application)
-      create(:user, trn: ecf_user.trn)
-      create(:user, trn: ecf_user.trn)
-    end
-    users_counts[:matched_users_count].times do
-      ecf_user = create(:ecf_user, :teacher, :with_application)
-      create(:user, trn: ecf_user.trn)
+  context "with user data" do
+    let(:users_counts) do
+      {
+        orphaned_ecf_users_count: 1,
+        orphaned_npq_users_count: 4,
+        duplicated_users_count: 3,
+        matched_users_count: 2,
+      }
     end
 
-    visit migrations_path
+    before do
+      users_counts[:orphaned_ecf_users_count].times { create(:ecf_user, :teacher, :with_application) }
+      users_counts[:orphaned_npq_users_count].times { |trn| create(:user, trn:) }
+      users_counts[:duplicated_users_count].times do
+        ecf_user = create(:ecf_user, :teacher, :with_application)
+        create(:user, trn: ecf_user.trn)
+        create(:user, trn: ecf_user.trn)
+      end
+      users_counts[:matched_users_count].times do
+        ecf_user = create(:ecf_user, :teacher, :with_application)
+        create(:user, trn: ecf_user.trn)
+      end
 
-    perform_enqueued_jobs do
-      click_button "Run migration"
+      visit migrations_path
+
+      perform_enqueued_jobs do
+        click_button "Run migration"
+      end
     end
 
-    expect(page).not_to have_content("A migration is currently in-progress")
+    scenario "viewing the general page state" do
+      expect(page).not_to have_content("A migration is currently in-progress")
 
-    expect(page).to have_button("Run migration")
+      expect(page).to have_button("Run migration")
 
-    expect(page).to have_content("Latest migration")
-    expect(page).to have_text("The latest migration was completed less than a minute ago.")
+      expect(page).to have_content("Latest migration")
+      expect(page).to have_text("The latest migration was completed less than a minute ago.")
+      expect(page).to have_text(/The migration took (.*) to complete./)
+    end
 
-    within(".govuk-summary-card.users") do
-      expect(find("dt", text: "Count")).to have_sibling("dd", text: users_counts.values.sum)
-      expect(find("dt", text: "Orphaned ecf count")).to have_sibling("dd", text: users_counts[:orphaned_ecf_users_count])
-      expect(find("dt", text: "Orphaned npq count")).to have_sibling("dd", text: users_counts[:orphaned_npq_users_count])
-      expect(find("dt", text: "Duplicate count")).to have_sibling("dd", text: users_counts[:duplicated_users_count])
-      expect(find("dt", text: "Matched count")).to have_sibling("dd", text: users_counts[:matched_users_count])
+    scenario "viewing the user reconcilliation metrics" do
+      within(".govuk-summary-card.users") do
+        expect(find("dt", text: "Count")).to have_sibling("dd", text: users_counts.values.sum)
+        expect(find("dt", text: "Orphaned ecf count")).to have_sibling("dd", text: users_counts[:orphaned_ecf_users_count])
+        expect(find("dt", text: "Orphaned npq count")).to have_sibling("dd", text: users_counts[:orphaned_npq_users_count])
+        expect(find("dt", text: "Duplicate count")).to have_sibling("dd", text: users_counts[:duplicated_users_count])
+        expect(find("dt", text: "Matched count")).to have_sibling("dd", text: users_counts[:matched_users_count])
+      end
+    end
+
+    scenario "downloading the orphaned users report" do
+      within(".govuk-summary-card.users") do
+        click_on "Orphan report"
+      end
+
+      yaml = YAML.load(page.text)
+
+      expect(yaml.map { |h| h.dig(:orphan, :class) }).to include("User", "Migration::Ecf::User")
     end
   end
 
-  scenario "after the migration completes (check application reconciliation metrics)" do
-    application_counts = {
-      orphaned_ecf_applications_count: 4,
-      orphaned_npq_applications_count: 2,
-      duplicated_applications_count: 1,
-      matched_applications_count: 3,
-    }
-
-    # Create application data
-    application_counts[:orphaned_ecf_applications_count].times { create(:ecf_npq_application) }
-    application_counts[:orphaned_npq_applications_count].times { create(:application) }
-    application_counts[:duplicated_applications_count].times do
-      ecf_application = create(:ecf_npq_application)
-      create(:application, ecf_id: ecf_application.id)
-      create(:application, ecf_id: ecf_application.id)
-    end
-    application_counts[:matched_applications_count].times do
-      ecf_application = create(:ecf_npq_application)
-      create(:application, ecf_id: ecf_application.id)
+  context "with application data" do
+    let(:application_counts) do
+      {
+        orphaned_ecf_applications_count: 4,
+        orphaned_npq_applications_count: 2,
+        duplicated_applications_count: 1,
+        matched_applications_count: 3,
+      }
     end
 
-    visit migrations_path
+    before do
+      application_counts[:orphaned_ecf_applications_count].times { create(:ecf_npq_application) }
+      application_counts[:orphaned_npq_applications_count].times { create(:application) }
+      application_counts[:duplicated_applications_count].times do
+        ecf_application = create(:ecf_npq_application)
+        create(:application, ecf_id: ecf_application.id)
+        create(:application, ecf_id: ecf_application.id)
+      end
+      application_counts[:matched_applications_count].times do
+        ecf_application = create(:ecf_npq_application)
+        create(:application, ecf_id: ecf_application.id)
+      end
 
-    perform_enqueued_jobs do
-      click_button "Run migration"
+      visit migrations_path
+
+      perform_enqueued_jobs do
+        click_button "Run migration"
+      end
     end
 
-    expect(page).not_to have_content("A migration is currently in-progress")
+    scenario "viewing the general page state" do
+      expect(page).not_to have_content("A migration is currently in-progress")
 
-    expect(page).to have_button("Run migration")
+      expect(page).to have_button("Run migration")
 
-    expect(page).to have_content("Latest migration")
-    expect(page).to have_text("The latest migration was completed less than a minute ago.")
+      expect(page).to have_content("Latest migration")
+      expect(page).to have_text("The latest migration was completed less than a minute ago.")
+      expect(page).to have_text(/The migration took (.*) to complete./)
+    end
 
-    within(".govuk-summary-card.applications") do
-      expect(find("dt", text: "Count")).to have_sibling("dd", text: application_counts.values.sum)
-      expect(find("dt", text: "Orphaned ecf count")).to have_sibling("dd", text: application_counts[:orphaned_ecf_applications_count])
-      expect(find("dt", text: "Orphaned npq count")).to have_sibling("dd", text: application_counts[:orphaned_npq_applications_count])
-      expect(find("dt", text: "Duplicate count")).to have_sibling("dd", text: application_counts[:duplicated_applications_count])
-      expect(find("dt", text: "Matched count")).to have_sibling("dd", text: application_counts[:matched_applications_count])
+    scenario "viewing the application reconcilliation metrics" do
+      within(".govuk-summary-card.applications") do
+        expect(find("dt", text: "Count")).to have_sibling("dd", text: application_counts.values.sum)
+        expect(find("dt", text: "Orphaned ecf count")).to have_sibling("dd", text: application_counts[:orphaned_ecf_applications_count])
+        expect(find("dt", text: "Orphaned npq count")).to have_sibling("dd", text: application_counts[:orphaned_npq_applications_count])
+        expect(find("dt", text: "Duplicate count")).to have_sibling("dd", text: application_counts[:duplicated_applications_count])
+        expect(find("dt", text: "Matched count")).to have_sibling("dd", text: application_counts[:matched_applications_count])
+      end
+    end
+
+    scenario "downloading the orphaned applications report" do
+      within(".govuk-summary-card.applications") do
+        click_on "Orphan report"
+      end
+
+      yaml = YAML.load(page.text)
+
+      expect(yaml.map { |h| h.dig(:orphan, :class) }).to include("Application", "Migration::Ecf::NpqApplication")
     end
   end
 end

--- a/spec/features/migration_spec.rb
+++ b/spec/features/migration_spec.rb
@@ -1,0 +1,111 @@
+require "rails_helper"
+
+RSpec.feature "Migration", type: :feature do
+  scenario "viewing the migrations prior to running one" do
+    visit migrations_path
+
+    expect(page).to have_button("Run migration")
+
+    expect(page).not_to have_content("A migration is currently in-progress")
+    expect(page).not_to have_content("Latest migration")
+  end
+
+  scenario "running the first migration" do
+    visit migrations_path
+
+    click_button "Run migration"
+
+    expect(page).to have_button("Run migration", disabled: true)
+
+    expect(page).to have_content("A migration is currently in-progress")
+    expect(page).to have_content("It was started less than a minute ago.")
+
+    expect(page).not_to have_content("Latest migration")
+  end
+
+  scenario "after the migration completes (check user reconciliation metrics)" do
+    users_counts = {
+      orphaned_ecf_users_count: 1,
+      orphaned_npq_users_count: 4,
+      duplicated_users_count: 3,
+      matched_users_count: 2,
+    }
+
+    # Create user data
+    users_counts[:orphaned_ecf_users_count].times { create(:ecf_user, :teacher, :with_application) }
+    users_counts[:orphaned_npq_users_count].times { |trn| create(:user, trn:) }
+    users_counts[:duplicated_users_count].times do
+      ecf_user = create(:ecf_user, :teacher, :with_application)
+      create(:user, trn: ecf_user.trn)
+      create(:user, trn: ecf_user.trn)
+    end
+    users_counts[:matched_users_count].times do
+      ecf_user = create(:ecf_user, :teacher, :with_application)
+      create(:user, trn: ecf_user.trn)
+    end
+
+    visit migrations_path
+
+    perform_enqueued_jobs do
+      click_button "Run migration"
+    end
+
+    expect(page).not_to have_content("A migration is currently in-progress")
+
+    expect(page).to have_button("Run migration")
+
+    expect(page).to have_content("Latest migration")
+    expect(page).to have_text("The latest migration was completed less than a minute ago.")
+
+    within(".govuk-summary-card.users") do
+      expect(find("dt", text: "Count")).to have_sibling("dd", text: users_counts.values.sum)
+      expect(find("dt", text: "Orphaned ecf count")).to have_sibling("dd", text: users_counts[:orphaned_ecf_users_count])
+      expect(find("dt", text: "Orphaned npq count")).to have_sibling("dd", text: users_counts[:orphaned_npq_users_count])
+      expect(find("dt", text: "Duplicate count")).to have_sibling("dd", text: users_counts[:duplicated_users_count])
+      expect(find("dt", text: "Matched count")).to have_sibling("dd", text: users_counts[:matched_users_count])
+    end
+  end
+
+  scenario "after the migration completes (check application reconciliation metrics)" do
+    application_counts = {
+      orphaned_ecf_applications_count: 4,
+      orphaned_npq_applications_count: 2,
+      duplicated_applications_count: 1,
+      matched_applications_count: 3,
+    }
+
+    # Create application data
+    application_counts[:orphaned_ecf_applications_count].times { create(:ecf_npq_application) }
+    application_counts[:orphaned_npq_applications_count].times { create(:application) }
+    application_counts[:duplicated_applications_count].times do
+      ecf_application = create(:ecf_npq_application)
+      create(:application, ecf_id: ecf_application.id)
+      create(:application, ecf_id: ecf_application.id)
+    end
+    application_counts[:matched_applications_count].times do
+      ecf_application = create(:ecf_npq_application)
+      create(:application, ecf_id: ecf_application.id)
+    end
+
+    visit migrations_path
+
+    perform_enqueued_jobs do
+      click_button "Run migration"
+    end
+
+    expect(page).not_to have_content("A migration is currently in-progress")
+
+    expect(page).to have_button("Run migration")
+
+    expect(page).to have_content("Latest migration")
+    expect(page).to have_text("The latest migration was completed less than a minute ago.")
+
+    within(".govuk-summary-card.applications") do
+      expect(find("dt", text: "Count")).to have_sibling("dd", text: application_counts.values.sum)
+      expect(find("dt", text: "Orphaned ecf count")).to have_sibling("dd", text: application_counts[:orphaned_ecf_applications_count])
+      expect(find("dt", text: "Orphaned npq count")).to have_sibling("dd", text: application_counts[:orphaned_npq_applications_count])
+      expect(find("dt", text: "Duplicate count")).to have_sibling("dd", text: application_counts[:duplicated_applications_count])
+      expect(find("dt", text: "Matched count")).to have_sibling("dd", text: application_counts[:matched_applications_count])
+    end
+  end
+end

--- a/spec/helpers/migration_helper_spec.rb
+++ b/spec/helpers/migration_helper_spec.rb
@@ -1,0 +1,78 @@
+require "rails_helper"
+
+RSpec.describe MigrationHelper, type: :helper do
+  describe "#migration_result_attributes" do
+    let(:result) { create(:migration_result) }
+
+    it "returns the attributes that match the given key" do
+      expect(helper.migration_result_attributes(result, "users")).to match_array(
+        %w[
+          users_count
+          orphaned_ecf_users_count
+          orphaned_npq_users_count
+          duplicate_users_count
+          matched_users_count
+        ],
+      )
+    end
+  end
+
+  describe "#migration_result_summary_row" do
+    subject { helper.migration_result_summary_row(result, "users", "orphaned_ecf_users_count") }
+
+    let(:result) { create(:migration_result, orphaned_ecf_users_count: 8, users_count: 11) }
+
+    it "returns a summary row for the given attribute" do
+      expect(subject).to have_css(".govuk-summary-list__row")
+      expect(subject).to have_css(".govuk-summary-list__key", text: "Orphaned ecf")
+      expect(subject).to have_css(".govuk-summary-list__value", text: result.orphaned_ecf_users_count)
+      expect(subject).to have_css(".govuk-summary-list__actions .govuk-tag--red", text: "73%")
+    end
+  end
+
+  describe "#migration_result_percentage_color" do
+    subject { helper.migration_result_percentage_color("users", attribute, value) }
+
+    context "when the attribute is matched and the value is greater than zero" do
+      let(:value) { 1 }
+      let(:attribute) { "matched_users_count" }
+
+      it { is_expected.to eq(:green) }
+    end
+
+    context "when the attribute is matched and the value is zero" do
+      let(:value) { 0 }
+      let(:attribute) { "matched_users_count" }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when the value is greater than zero and the attribute is not the total count" do
+      let(:value) { 1 }
+      let(:attribute) { "orphaned_ecf_users_count" }
+
+      it { is_expected.to eq(:red) }
+    end
+
+    context "when the value is zero and the attribute is not the total count" do
+      let(:value) { 0 }
+      let(:attribute) { "orphaned_ecf_users_count" }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when the value is greater than zero and the attribute is the total count" do
+      let(:value) { 1 }
+      let(:attribute) { "users_count" }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when the value is zero and the attribute is the total count" do
+      let(:value) { 0 }
+      let(:attribute) { "users_count" }
+
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/spec/helpers/migration_helper_spec.rb
+++ b/spec/helpers/migration_helper_spec.rb
@@ -75,4 +75,14 @@ RSpec.describe MigrationHelper, type: :helper do
       it { is_expected.to be_nil }
     end
   end
+
+  describe "#migration_result_duration_in_words" do
+    subject { helper.migration_result_duration_in_words(result) }
+
+    let(:result) { freeze_time { create(:migration_result, completed_at: (3.hours + 10.minutes + 5.seconds).from_now) } }
+
+    it "returns the duration of the migration" do
+      expect(subject).to eq("3 hours, 10 minutes, and 5 seconds")
+    end
+  end
 end

--- a/spec/jobs/migration_job_spec.rb
+++ b/spec/jobs/migration_job_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe MigrationJob do
+  let(:instance) { described_class.new }
+
+  describe "#perform" do
+    subject(:perform_migration) { instance.perform }
+
+    let(:migrator_double) { instance_double("Migration::Migrator", migrate!: nil) }
+
+    before { allow(Migration::Migrator).to receive(:new).and_return(migrator_double) }
+
+    it "triggers a migration" do
+      perform_migration
+      expect(migrator_double).to have_received(:migrate!).once
+    end
+  end
+end

--- a/spec/lib/services/migration/match_spec.rb
+++ b/spec/lib/services/migration/match_spec.rb
@@ -66,4 +66,34 @@ RSpec.describe Migration::Match do
       it { expect(instance).to be_duplicated }
     end
   end
+
+  describe "namespace matching" do
+    let(:ecf_match) { create(:ecf_user) }
+    let(:npq_match) { create(:user) }
+    let(:matches) { Set[ecf_match, npq_match] }
+
+    describe "ecf_match" do
+      subject { instance.ecf_match }
+
+      it { is_expected.to eq(ecf_match) }
+
+      context "when there is no ecf match" do
+        let(:ecf_match) { nil }
+
+        it { is_expected.to be_nil }
+      end
+    end
+
+    describe "#npq_match" do
+      subject { instance.npq_match }
+
+      it { is_expected.to eq(npq_match) }
+
+      context "when there is no npq match" do
+        let(:npq_match) { nil }
+
+        it { is_expected.to be_nil }
+      end
+    end
+  end
 end

--- a/spec/lib/services/migration/migrator_spec.rb
+++ b/spec/lib/services/migration/migrator_spec.rb
@@ -121,5 +121,12 @@ RSpec.describe Migration::Migrator, in_memory_rails_cache: true do
 
       expect(ids).to contain_exactly(npq_orphan.id.to_s, ecf_orphan.id)
     end
+
+    it "updates the lead provider approval status of the matched applications" do
+      ecf_application = create(:ecf_npq_application, lead_provider_approval_status: "accepted")
+      npq_application = create(:application, ecf_id: ecf_application.id, lead_provider_approval_status: "pending")
+
+      expect { migrate }.to change { npq_application.reload.lead_provider_approval_status }.to(ecf_application.lead_provider_approval_status)
+    end
   end
 end

--- a/spec/lib/services/migration/migrator_spec.rb
+++ b/spec/lib/services/migration/migrator_spec.rb
@@ -3,73 +3,95 @@ require "rails_helper"
 RSpec.describe Migration::Migrator do
   let(:instance) { described_class.new }
 
+  describe ".prepare_for_migration!" do
+    subject(:prepare) { described_class.prepare_for_migration! }
+
+    context "when there is no migration in progress" do
+      it { expect { prepare }.to change(Migration::Result, :count).by(1) }
+    end
+
+    context "when there is a migration in progress" do
+      before { create(:migration_result, :incomplete) }
+
+      it { expect { prepare }.to raise_error(described_class::MigrationInProgressError) }
+    end
+  end
+
   describe "#migrate!" do
     subject(:migrate) { instance.migrate! }
 
-    it { expect { migrate }.to change(Migration::Result, :count).by(1) }
+    before { described_class.prepare_for_migration! }
 
-    context "when creating a migration result" do
-      it "writes a Migration::Result containing details of the users migration" do
-        # Matched (2)
-        ecf_user1 = create(:ecf_user, :teacher, :with_application)
-        create(:user, trn: ecf_user1.trn)
+    context "when the migration has not been prepared" do
+      before { Migration::Result.destroy_all }
 
-        ecf_user2 = create(:ecf_user, :teacher, :with_application)
-        create(:user, trn: ecf_user2.trn)
+      it { expect { migrate }.to raise_error(described_class::NoMigrationInProgressError) }
+    end
 
-        # Orphaned (1 ECF, 2 NPQ)
-        create(:ecf_user, :teacher, :with_application)
-        create(:user, trn: "1213443")
-        create(:user, trn: "3435675")
+    it "sets the completed_at timestamp on the result" do
+      migrate
+      result = Migration::Result.most_recent_complete
+      expect(result.completed_at).to be_present
+    end
 
-        # Duplicated (1)
-        ecf_user_3 = create(:ecf_user, :teacher, :with_application)
-        create(:user, trn: ecf_user_3.trn)
-        create(:user, trn: ecf_user_3.trn)
+    it "writes details of the users reconciliation to the result" do
+      # Matched (2)
+      ecf_user1 = create(:ecf_user, :teacher, :with_application)
+      create(:user, trn: ecf_user1.trn)
 
-        migrate
+      ecf_user2 = create(:ecf_user, :teacher, :with_application)
+      create(:user, trn: ecf_user2.trn)
 
-        migration_result = Migration::Result.last
+      # Orphaned (1 ECF, 2 NPQ)
+      create(:ecf_user, :teacher, :with_application)
+      create(:user, trn: "1213443")
+      create(:user, trn: "3435675")
 
-        expect(migration_result).to have_attributes({
-          users_count: 6,
-          orphaned_ecf_users_count: 1,
-          orphaned_npq_users_count: 2,
-          duplicate_users_count: 1,
-          matched_users_count: 2,
-        })
-      end
+      # Duplicated (1)
+      ecf_user_3 = create(:ecf_user, :teacher, :with_application)
+      create(:user, trn: ecf_user_3.trn)
+      create(:user, trn: ecf_user_3.trn)
 
-      it "writes a Migration::Result containing details of the applications migration" do
-        # Matched (2)
-        ecf_application1 = create(:ecf_npq_application)
-        create(:application, ecf_id: ecf_application1.id)
+      migrate
+      result = Migration::Result.most_recent_complete
 
-        ecf_application2 = create(:ecf_npq_application)
-        create(:application, ecf_id: ecf_application2.id)
+      expect(result).to have_attributes({
+        users_count: 6,
+        orphaned_ecf_users_count: 1,
+        orphaned_npq_users_count: 2,
+        duplicate_users_count: 1,
+        matched_users_count: 2,
+      })
+    end
 
-        # Orphaned (2 ECF, 1 NPQ)
-        create(:ecf_npq_application)
-        create(:ecf_npq_application)
-        create(:application)
+    it "writes details of the applications reconciliation to the result" do
+      # Matched (2)
+      ecf_application1 = create(:ecf_npq_application)
+      create(:application, ecf_id: ecf_application1.id)
 
-        # Duplicated (1)
-        ecf_application3 = create(:ecf_npq_application)
-        create(:application, ecf_id: ecf_application3.id)
-        create(:application, ecf_id: ecf_application3.id)
+      ecf_application2 = create(:ecf_npq_application)
+      create(:application, ecf_id: ecf_application2.id)
 
-        expect { instance.migrate! }.to change(Migration::Result, :count).by(1)
+      # Orphaned (2 ECF, 1 NPQ)
+      create(:ecf_npq_application)
+      create(:ecf_npq_application)
+      create(:application)
 
-        migration_result = Migration::Result.last
+      # Duplicated (1)
+      ecf_application3 = create(:ecf_npq_application)
+      create(:application, ecf_id: ecf_application3.id)
+      create(:application, ecf_id: ecf_application3.id)
 
-        expect(migration_result).to have_attributes({
-          applications_count: 6,
-          orphaned_ecf_applications_count: 2,
-          orphaned_npq_applications_count: 1,
-          duplicate_applications_count: 1,
-          matched_applications_count: 2,
-        })
-      end
+      migrate
+      result = Migration::Result.most_recent_complete
+
+      expect(result).to have_attributes({
+        applications_count: 6,
+        orphaned_ecf_applications_count: 2,
+        orphaned_npq_applications_count: 1,
+        duplicate_applications_count: 1,
+        matched_applications_count: 2,
+      })
     end
   end
 end

--- a/spec/lib/services/migration/migrator_spec.rb
+++ b/spec/lib/services/migration/migrator_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.describe Migration::Migrator do
+  let(:instance) { described_class.new }
+
+  describe "#migrate!" do
+    subject(:migrate) { instance.migrate! }
+
+    it { expect { migrate }.to change(Migration::Result, :count).by(1) }
+
+    context "when creating a migration result" do
+      it "writes a Migration::Result containing details of the users migration" do
+        # Matched (2)
+        ecf_user1 = create(:ecf_user, :teacher, :with_application)
+        create(:user, trn: ecf_user1.trn)
+
+        ecf_user2 = create(:ecf_user, :teacher, :with_application)
+        create(:user, trn: ecf_user2.trn)
+
+        # Orphaned (1 ECF, 2 NPQ)
+        create(:ecf_user, :teacher, :with_application)
+        create(:user, trn: "1213443")
+        create(:user, trn: "3435675")
+
+        # Duplicated (1)
+        ecf_user_3 = create(:ecf_user, :teacher, :with_application)
+        create(:user, trn: ecf_user_3.trn)
+        create(:user, trn: ecf_user_3.trn)
+
+        migrate
+
+        migration_result = Migration::Result.last
+
+        expect(migration_result).to have_attributes({
+          users_count: 6,
+          orphaned_ecf_users_count: 1,
+          orphaned_npq_users_count: 2,
+          duplicate_users_count: 1,
+          matched_users_count: 2,
+        })
+      end
+
+      it "writes a Migration::Result containing details of the applications migration" do
+        # Matched (2)
+        ecf_application1 = create(:ecf_npq_application)
+        create(:application, ecf_id: ecf_application1.id)
+
+        ecf_application2 = create(:ecf_npq_application)
+        create(:application, ecf_id: ecf_application2.id)
+
+        # Orphaned (2 ECF, 1 NPQ)
+        create(:ecf_npq_application)
+        create(:ecf_npq_application)
+        create(:application)
+
+        # Duplicated (1)
+        ecf_application3 = create(:ecf_npq_application)
+        create(:application, ecf_id: ecf_application3.id)
+        create(:application, ecf_id: ecf_application3.id)
+
+        expect { instance.migrate! }.to change(Migration::Result, :count).by(1)
+
+        migration_result = Migration::Result.last
+
+        expect(migration_result).to have_attributes({
+          applications_count: 6,
+          orphaned_ecf_applications_count: 2,
+          orphaned_npq_applications_count: 1,
+          duplicate_applications_count: 1,
+          matched_applications_count: 2,
+        })
+      end
+    end
+  end
+end

--- a/spec/lib/services/migration/namespace_check_spec.rb
+++ b/spec/lib/services/migration/namespace_check_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe Migration::NamespaceCheck do
+  describe "#ecf?" do
+    it "returns true if the object is an ECF object" do
+      expect(described_class.ecf?(Migration::Ecf::NpqApplication.new)).to eq(true)
+    end
+
+    it "returns false if the object is not an ECF object" do
+      expect(described_class.ecf?(Application.new)).to eq(false)
+    end
+  end
+
+  describe "#npq?" do
+    it "returns true if the object is an NPQ object" do
+      expect(described_class.npq?(Application.new)).to eq(true)
+    end
+
+    it "returns false if the object is not an NPQ object" do
+      expect(described_class.npq?(Migration::Ecf::NpqApplication.new)).to eq(false)
+    end
+  end
+end

--- a/spec/lib/services/migration/orphan_report_spec.rb
+++ b/spec/lib/services/migration/orphan_report_spec.rb
@@ -1,12 +1,14 @@
 require "rails_helper"
 
 RSpec.describe Migration::OrphanReport do
+  before { allow(Rails.logger).to receive(:info) }
+
   let(:indexes) { %i[foo bar] }
   let(:reconciler) { instance_double(Migration::Reconciler, indexes:, orphaned_matches:) }
   let(:instance) { described_class.new(reconciler) }
 
   describe "#to_yaml" do
-    subject { instance.to_yaml }
+    subject(:to_yaml) { instance.to_yaml }
 
     context "when there are no orphans" do
       let(:orphaned_matches) { [] }
@@ -47,6 +49,12 @@ RSpec.describe Migration::OrphanReport do
                 :foo: quux
           YAML
         )
+      end
+
+      it "logs the progress" do
+        to_yaml
+        expect(Rails.logger).to have_received(:info).with("Processing orphan 1 of 2 for #{reconciler.class}")
+        expect(Rails.logger).to have_received(:info).with("Processing orphan 2 of 2 for #{reconciler.class}")
       end
     end
   end

--- a/spec/models/migration/result_spec.rb
+++ b/spec/models/migration/result_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe Migration::Result, type: :model do
+  it { expect(described_class.table_name).to eq("migration_results") }
+end

--- a/spec/models/migration/result_spec.rb
+++ b/spec/models/migration/result_spec.rb
@@ -2,4 +2,52 @@ require "rails_helper"
 
 RSpec.describe Migration::Result, type: :model do
   it { expect(described_class.table_name).to eq("migration_results") }
+
+  describe "scopes" do
+    describe "#complete" do
+      it "only returns complete migration results" do
+        complete_result = create(:migration_result, :complete)
+        create(:migration_result, :incomplete)
+        expect(described_class.complete).to contain_exactly(complete_result)
+      end
+    end
+
+    describe "#incomplete" do
+      it "returns the incomplete migration results" do
+        incomplete_result = create(:migration_result, :incomplete)
+        create(:migration_result, :complete)
+        expect(described_class.incomplete).to contain_exactly(incomplete_result)
+      end
+    end
+
+    describe "#ordered_by_most_recent" do
+      it "returns the most recent records first" do
+        middle = travel_to(1.day.ago) { create(:migration_result) }
+        latest = create(:migration_result)
+        oldest = travel_to(3.days.ago) { create(:migration_result) }
+
+        expect(described_class.ordered_by_most_recent).to eq([latest, middle, oldest])
+      end
+    end
+  end
+
+  describe ".most_recent_complete" do
+    it "returns the most recent complete migration result" do
+      travel_to(1.day.ago) { create(:migration_result, :complete) }
+      latest = create(:migration_result, :complete)
+      travel_to(3.days.ago) { create(:migration_result, :complete) }
+
+      expect(described_class.most_recent_complete).to eq(latest)
+    end
+  end
+
+  describe ".in_progress" do
+    it "returns the most recent in progress migration result (although there should only ever be one in-progress)" do
+      create(:migration_result, :complete)
+      in_progress = create(:migration_result, :incomplete)
+      travel_to(3.days.ago) { create(:migration_result, :incomplete) }
+
+      expect(described_class.in_progress).to eq(in_progress)
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -107,6 +107,12 @@ RSpec.configure do |config|
   config.before(:each, type: :feature) do
     stub_env_variables_for_gai
   end
+
+  config.around(:each, in_memory_rails_cache: true) do |example|
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    example.run
+    Rails.cache.clear
+  end
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -73,6 +73,7 @@ end
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   config.include ActiveSupport::Testing::TimeHelpers
+  config.include ActiveJob::TestHelper, type: :feature
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = Rails.root.join("spec/fixtures")

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -113,6 +113,12 @@ RSpec.configure do |config|
     example.run
     Rails.cache.clear
   end
+
+  config.around(:each, rack_test_driver: true) do |example|
+    Capybara.current_driver = :rack_test
+    example.run
+    Capybara.current_driver = Capybara.default_driver
+  end
 end
 
 Shoulda::Matchers.configure do |config|


### PR DESCRIPTION
### Context

We want to automate the ECF -> NPQ migration on a nightly basis within the migration environment and be able to easily see the status/outcome of the migration and iterate/improve on it going forwards.

### Changes proposed in this pull request

- DRY up namespace checking logic

Clean up the logic to check if something belongs to ECF or NPQ by pushing it up into the `Reconciler` and abstracting the check into a `NamespaceCheck` service.

- Add skeleton migration service

Add a skeleton migration service that outputs reconciliation metrics to a new `Migration::Result` model.

This will form the basis of the migration script; the migration results will be exposed in a basic UI so that we can easily see the outcome of the migration.

- Flesh out migration service and add UI

Wraps the migration service in a job so that we can run it async and adds a basic UI to trigger and then display the current state/outcome of the migration.

- Add ability to download orphan reports

When we run the migration we have already queried all the data required to compile an orphan report.

Save the orphan reports in the Rails cache (not ideal, but the esiest way to have this work across multiple web instances) and add an endpoint to retrieve the reports for a given migration.

DRY up mocking the in-memory Rails cache.

- Fix indentation on konduit command

It should be indented twice to align with the correct yaml key.

- Minor performance optimizations

Loading the applications for the users (ECF in particular) takes a _long_ time. We use this when tentatively matching orphans on school. By touching the applications in the memoization it means we'll only do this for every user once, but as there are ~270k users it takes quite a while. If it becomes a problem we can look at further optimisations, such as a custom subquery.

- Example of how NPQ data can be updated during migration

Add a contrived example of how the NPQ data can be updated from its ECF counterpart during the migration process.

### Review guidance

As the orphan reports are stored in the Rails cache if you want them to work in development you'll need to enable caching with `rails dev:cache`.

| Start Migration      | Migration Running |  Migration Complete | 
| ----------- | ----------- | ----------- |
|   <img width="1268" alt="Screenshot 2024-01-11 at 15 38 08" src="https://github.com/DFE-Digital/npq-registration/assets/29867726/a386b7a6-3eb0-40c1-80f2-c67a0c26bdcd">   |   <img width="1268" alt="Screenshot 2024-01-11 at 15 38 24" src="https://github.com/DFE-Digital/npq-registration/assets/29867726/39d9bb48-d828-47c9-b970-97bbc96fa92b">    |    <img width="1268" alt="Screenshot 2024-01-11 at 15 39 10" src="https://github.com/DFE-Digital/npq-registration/assets/29867726/43ba3e31-b1e4-4c25-b184-49a44edf9b25"> |




