### PR TITLE
Update state type with PostgreSQL native enum type: Outcomes

### DIFF
--- a/db/migrate/20240115034236_create_enum_for_outcome_state.rb
+++ b/db/migrate/20240115034236_create_enum_for_outcome_state.rb
@@ -1,0 +1,5 @@
+class CreateEnumForOutcomeState < ActiveRecord::Migration[7.1]
+  def change
+    create_enum :outcome_states, %w[passed failed voided]
+  end
+end

--- a/db/migrate/20240115034348_change_outcome_state_column_type.rb
+++ b/db/migrate/20240115034348_change_outcome_state_column_type.rb
@@ -1,0 +1,15 @@
+class ChangeOutcomeStateColumnType < ActiveRecord::Migration[7.1]
+  def up
+    execute <<-SQL
+      ALTER TABLE outcomes
+      ALTER COLUMN state
+      TYPE outcome_states
+      USING state::outcome_states;
+    SQL
+  end
+
+  def down
+    # Reverting this migration may not be straightforward due to enum type changes
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -19,6 +19,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_19_150601) do
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
+  create_enum "outcome_states", ["passed", "failed", "voided"]
   create_enum "schedule_declaration_types", ["started", "retained-1", "retained-2", "retained-3", "retained-4", "completed"]
 
   create_table "api_tokens", force: :cascade do |t|
@@ -245,7 +246,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_19_150601) do
   end
 
   create_table "outcomes", force: :cascade do |t|
-    t.string "state", null: false
+    t.enum "state", null: false, enum_type: "outcome_states"
     t.date "completion_date", null: false
     t.bigint "declaration_id", null: false
     t.datetime "created_at", null: false


### PR DESCRIPTION
### Description

We are decided to use PostgreSQL native enum types to store the different 
types (statuses) of a number of entities within NPQ.

In this PR I am updating Outcomes so it validates at the DB level:

```ruby
STATES = %w[passed failed voided].freeze
validates :state, inclusion: { in: STATES }
```


