### PR TITLE
Update state type with PostgreSQL native enum type

### DIFF
--- a/db/migrate/20240115032403_create_declaration_status_enum.rb
+++ b/db/migrate/20240115032403_create_declaration_status_enum.rb
@@ -1,13 +1,9 @@
 class CreateDeclarationStatusEnum < ActiveRecord::Migration[7.1]
   def up
-    execute <<-SQL
-      CREATE TYPE declaration_status_enum AS ENUM ('eligible', 'payable', 'paid', 'voided', 'ineligible', 'awaiting_clawback', 'clawed_back');
-    SQL
+    create_enum :declaration_status_enum, ['eligible', 'payable', 'paid', 'voided', 'ineligible', 'awaiting_clawback', 'clawed_back']
   end
 
   def down
-    execute <<-SQL
-      DROP TYPE IF EXISTS declaration_status_enum;
-    SQL
+    drop_enum :declaration_status_enum
   end
 end

--- a/db/migrate/20240115032403_create_declaration_status_enum.rb
+++ b/db/migrate/20240115032403_create_declaration_status_enum.rb
@@ -1,6 +1,6 @@
 class CreateDeclarationStatusEnum < ActiveRecord::Migration[7.1]
   def up
-    create_enum :declaration_status_enum, ['eligible', 'payable', 'paid', 'voided', 'ineligible', 'awaiting_clawback', 'clawed_back']
+    create_enum :declaration_status_enum, %w[eligible payable paid voided ineligible awaiting_clawback clawed_back]
   end
 
   def down

--- a/db/migrate/20240115032403_create_declaration_status_enum.rb
+++ b/db/migrate/20240115032403_create_declaration_status_enum.rb
@@ -1,0 +1,13 @@
+class CreateDeclarationStatusEnum < ActiveRecord::Migration[7.1]
+  def up
+    execute <<-SQL
+      CREATE TYPE declaration_status_enum AS ENUM ('eligible', 'payable', 'paid', 'voided', 'ineligible', 'awaiting_clawback', 'clawed_back');
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      DROP TYPE IF EXISTS declaration_status_enum;
+    SQL
+  end
+end

--- a/db/migrate/20240115032446_change_declaration_and_statement_item_columns.rb
+++ b/db/migrate/20240115032446_change_declaration_and_statement_item_columns.rb
@@ -1,0 +1,21 @@
+class ChangeDeclarationAndStatementItemColumns < ActiveRecord::Migration[7.1]
+  def up
+    # Use the USING clause to specify the conversion
+    execute <<-SQL
+      ALTER TABLE declarations
+      ALTER COLUMN state
+      TYPE declaration_status_enum
+      USING state::declaration_status_enum;
+
+      ALTER TABLE statement_items
+      ALTER COLUMN state
+      TYPE declaration_status_enum
+      USING state::declaration_status_enum;
+    SQL
+  end
+
+  def down
+    # Reverting this migration may not be straightforward due to enum type changes
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20240123085818_rename_declaration_status_enum.rb
+++ b/db/migrate/20240123085818_rename_declaration_status_enum.rb
@@ -1,0 +1,13 @@
+class RenameDeclarationStatusEnum < ActiveRecord::Migration[7.1]
+  def up
+    execute <<-SQL
+      ALTER TYPE declaration_status_enum RENAME TO declaration_states;
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      ALTER TYPE declaration_states RENAME TO declaration_status_enum;
+    SQL
+    end
+end

--- a/db/migrate/20240123085818_rename_declaration_status_enum.rb
+++ b/db/migrate/20240123085818_rename_declaration_status_enum.rb
@@ -9,5 +9,5 @@ class RenameDeclarationStatusEnum < ActiveRecord::Migration[7.1]
     execute <<-SQL
       ALTER TYPE declaration_states RENAME TO declaration_status_enum;
     SQL
-    end
+  end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -19,8 +19,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_25_095919) do
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
-  create_enum "declaration_status_enum", ["eligible", "payable", "paid", "voided", "ineligible", "awaiting_clawback", "clawed_back"]
   create_enum "outcome_states", ["passed", "failed", "voided"]
+  create_enum "declaration_states", ["eligible", "payable", "paid", "voided", "ineligible", "awaiting_clawback", "clawed_back"]
   create_enum "schedule_declaration_types", ["started", "retained-1", "retained-2", "retained-3", "retained-4", "completed"]
 
   create_table "api_tokens", force: :cascade do |t|
@@ -131,7 +131,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_25_095919) do
 
   create_table "declarations", force: :cascade do |t|
     t.bigint "application_id", null: false
-    t.enum "state", enum_type: "declaration_status_enum"
+    t.enum "state", enum_type: "declaration_states"
     t.string "declaration_type"
     t.date "declaration_date"
     t.datetime "created_at", null: false
@@ -392,7 +392,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_25_095919) do
   create_table "statement_items", force: :cascade do |t|
     t.bigint "statement_id", null: false
     t.bigint "declaration_id", null: false
-    t.enum "state", null: false, enum_type: "declaration_status_enum"
+    t.enum "state", null: false, enum_type: "declaration_states"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "clawed_back_by_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -19,6 +19,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_25_095919) do
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
+  create_enum "declaration_status_enum", ["eligible", "payable", "paid", "voided", "ineligible", "awaiting_clawback", "clawed_back"]
   create_enum "outcome_states", ["passed", "failed", "voided"]
   create_enum "schedule_declaration_types", ["started", "retained-1", "retained-2", "retained-3", "retained-4", "completed"]
 
@@ -130,7 +131,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_25_095919) do
 
   create_table "declarations", force: :cascade do |t|
     t.bigint "application_id", null: false
-    t.string "state"
+    t.enum "state", enum_type: "declaration_status_enum"
     t.string "declaration_type"
     t.date "declaration_date"
     t.datetime "created_at", null: false
@@ -391,7 +392,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_25_095919) do
   create_table "statement_items", force: :cascade do |t|
     t.bigint "statement_id", null: false
     t.bigint "declaration_id", null: false
-    t.string "state", null: false
+    t.enum "state", null: false, enum_type: "declaration_status_enum"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "clawed_back_by_id"

--- a/spec/factories/declarations.rb
+++ b/spec/factories/declarations.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :declaration do
     application { association(:application) }
-    state { "submitted" }
+    state { "eligible" }
     declaration_type { "some_type" }
     declaration_date { Time.zone.today }
   end


### PR DESCRIPTION
### Description

We are decided to use PostgreSQL native enum types to store the different types (statuses) of a number of entities within NPQ.

In this PR I am updating Outcomes so it validates at the DB level:

```ruby
STATES = %w[submitted eligible ineligible payable voided paid awaiting_clawback clawed_back].freeze
validates :state, inclusion: { in: STATES }
```