### PR TITLE
Spike swagger documentation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -58,3 +58,11 @@ RSpec/FilePath:
 
 RSpec/AnyInstance:
   Enabled: false
+
+RSpec/EmptyExampleGroup:
+  Exclude:
+    - "spec/requests/api/*"
+
+RSpec/VariableName:
+  Exclude:
+    - "spec/requests/api/*"

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,8 @@ gem "sentry-ruby"
 gem "stimulus-rails"
 gem "webpacker"
 gem "whenever"
+gem "rswag-api"
+gem "rswag-ui"
 
 gem "net-imap", "~> 0.4.9", require: false
 gem "net-pop", require: false
@@ -60,6 +62,7 @@ group :development, :test do
   gem "rspec-rails", "~> 6.1.0"
   gem "rubocop-govuk"
   gem "scss_lint-govuk"
+  gem "rswag-specs"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -280,6 +280,8 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.7.1)
+    json-schema (4.1.1)
+      addressable (>= 2.8)
     json_api_client (1.22.0)
       activemodel (>= 3.2.0)
       activesupport (>= 3.2.0)
@@ -476,6 +478,17 @@ GEM
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
     rspec-support (3.12.1)
+    rswag-api (2.13.0)
+      activesupport (>= 3.1, < 7.2)
+      railties (>= 3.1, < 7.2)
+    rswag-specs (2.13.0)
+      activesupport (>= 3.1, < 7.2)
+      json-schema (>= 2.2, < 5.0)
+      railties (>= 3.1, < 7.2)
+      rspec-core (>= 2.14)
+    rswag-ui (2.13.0)
+      actionpack (>= 3.1, < 7.2)
+      railties (>= 3.1, < 7.2)
     rubocop (1.59.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -676,6 +689,9 @@ DEPENDENCIES
   rack-attack
   rails (~> 7)
   rspec-rails (~> 6.1.0)
+  rswag-api
+  rswag-specs
+  rswag-ui
   rubocop-govuk
   rubyzip
   scss_lint-govuk

--- a/app/views/rswag/ui/home/index.html.erb
+++ b/app/views/rswag/ui/home/index.html.erb
@@ -1,0 +1,139 @@
+﻿<!-- HTML for static distribution bundle build -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Swagger UI</title>
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700" rel="stylesheet">
+    <link rel="stylesheet" type="text/css" href="./swagger-ui.css" >
+    <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16" />
+    <style>
+      html
+      {
+        box-sizing: border-box;
+        overflow: -moz-scrollbars-vertical;
+        overflow-y: scroll;
+      }
+      *,
+      *:before,
+      *:after
+      {
+        box-sizing: inherit;
+      }
+
+      body {
+        margin:0;
+        background: #fafafa;
+      }
+
+      .topbar,
+      .info .main a {
+        display: none;
+      }
+    </style>
+    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/babel-standalone@6/babel.js"></script>
+  </head>
+  <body>
+    <div id="swagger-ui"></div>
+
+    <!-- Workaround for https://github.com/swagger-api/swagger-editor/issues/1371 -->
+    <script>
+      if (window.navigator.userAgent.indexOf("Edge") > -1) {
+        console.log("Removing native Edge fetch in favor of swagger-ui's polyfill")
+        window.fetch = undefined;
+      }
+    </script>
+
+    <script src="./swagger-ui-bundle.js"> </script>
+    <script src="./swagger-ui-standalone-preset.js"> </script>
+    <script type="text/babel">
+      window.onload = function () {
+        var configObject = JSON.parse('<%= config_object.to_json %>');
+        var oauthConfigObject = JSON.parse('<%= oauth_config_object.to_json %>');
+
+        // Apply mandatory parameters
+        configObject.dom_id = "#swagger-ui";
+        configObject.presets = [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset];
+
+        class LayoutWrapper extends React.Component {
+          render() {
+            const { getComponent } = this.props
+
+            const StandaloneLayout = getComponent("StandaloneLayout", true)
+
+            return (
+              <StandaloneLayout />
+            )
+          }
+        }
+
+        class CustomContact extends React.Component {
+          render() {
+            const { data, getComponent, selectedServer, url: specUrl } = this.props
+            const name = data.get("name")
+            const url = data.get("url")
+
+            const Link = getComponent("Link")
+
+            return (
+              <div className="info__contact">
+                {url && (
+                  <div>
+                    <Link href={url} target="_blank">
+                      {name}
+                    </Link>
+                  </div>
+                )}
+              </div>
+            )
+          }
+        }
+
+        const CustomComponentsPlugin = () => {
+          return {
+            components: {
+              LayoutWrapper: LayoutWrapper,
+              Contact: CustomContact,
+              Logo: () => null,
+              onlineValidatorBadge: () => null,
+            }
+          }
+        }
+
+        // Example of overriding React state (though most of it comes
+        // from the swagger.yaml so best to change there if possible).
+        //
+        // const CustomInfoPlugin = function(system) {
+        //   return {
+        //     statePlugins: {
+        //       spec: {
+        //         wrapSelectors: {
+        //           info: (oriSelector, system) => (state, ...args) => {
+        //             const result = oriSelector(state, ...args);
+        //             return result.set("title", "Swagger: NPQs data management API for lead providers")
+        //           }
+        //         }
+        //       }
+        //     }
+        //   }
+        // }
+
+        configObject.plugins = [CustomComponentsPlugin];
+        configObject.layout = "LayoutWrapper";
+
+        // If oauth2RedirectUrl isn't specified, use the built-in default
+        if (!configObject.hasOwnProperty("oauth2RedirectUrl"))
+          configObject.oauth2RedirectUrl = window.location.href.replace("index.html", "oauth2-redirect.html");
+
+        // Build a system
+        const ui = SwaggerUIBundle(configObject);
+
+        // Apply OAuth config
+        ui.initOAuth(oauthConfigObject);
+      }
+    </script>
+  </body>
+</html>

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,0 +1,13 @@
+Rswag::Api.configure do |c|
+  # Specify a root folder where Swagger JSON files are located
+  # This is used by the Swagger middleware to serve requests for API descriptions
+  # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
+  # that it's configured to generate files in the same folder
+  c.openapi_root = Rails.root.to_s + '/swagger'
+
+  # Inject a lambda function to alter the returned Swagger prior to serialization
+  # The function will have access to the rack env for the current request
+  # For example, you could leverage this to dynamically assign the "host" property
+  #
+  #c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -1,0 +1,15 @@
+Rswag::Ui.configure do |c|
+  # List the Swagger endpoints that you want to be documented through the
+  # swagger-ui. The first parameter is the path (absolute or relative to the UI
+  # host) to the corresponding endpoint and the second is a title that will be
+  # displayed in the document selector.
+  # NOTE: If you're using rspec-api to expose Swagger files
+  # (under openapi_root) as JSON or YAML endpoints, then the list below should
+  # correspond to the relative paths for those endpoints.
+
+  c.swagger_endpoint '/api-docs/v1/swagger.yaml', 'API V1 Docs'
+
+  # Add Basic Auth in case your API is private
+  # c.basic_auth_enabled = true
+  # c.basic_auth_credentials 'username', 'password'
+end

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -12,7 +12,11 @@ SecureHeaders::Configuration.default do |config|
   google_analytics = %w[www.google-analytics.com ssl.google-analytics.com *.googletagmanager.com tagmanager.google.com *.googleusercontent.com *.gstatic.com]
   tracking_pixels = %w[www.facebook.com px.ads.linkedin.com]
 
-  config.csp = SecureHeaders::OPT_OUT
+  config.csp = {
+    default_src: SecureHeaders::OPT_OUT,
+    img_src: %w['self' data: validator.swagger.io],
+    script_src: %w['self' 'unsafe-inline' 'unsafe-eval' unpkg.com],
+  }
 
   config.csp_report_only = {
     default_src: %w['none'],
@@ -24,10 +28,10 @@ SecureHeaders::Configuration.default do |config|
     form_action: %w['self'],
     frame_ancestors: %w['self'],
     frame_src: %w['self'] + google_analytics,
-    img_src: %W['self' data: *.gov.uk] + google_analytics + tracking_pixels,
+    img_src: %W['self' data: *.gov.uk validator.swagger.io] + google_analytics + tracking_pixels,
     manifest_src: %w['self'],
     media_src: %w['self'],
-    script_src: %W['self' 'unsafe-inline' 'unsafe-eval' *.gov.uk] + google_analytics,
+    script_src: %W['self' 'unsafe-inline' 'unsafe-eval' *.gov.uk unpkg.com] + google_analytics,
     style_src: %w['self' 'unsafe-inline' *.gov.uk fonts.googleapis.com] + google_analytics,
     worker_src: %w['self'],
     # upgrade_insecure_requests: !Rails.env.development?, # see https://www.w3.org/TR/upgrade-insecure-requests/

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  mount Rswag::Ui::Engine => '/api-docs'
+  mount Rswag::Api::Engine => '/api-docs'
   devise_for :users,
              controllers: { omniauth_callbacks: "omniauth" }
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_10_193259) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_15_204129) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
+
+  # Custom types defined in this database.
+  # Note that some types may not work with other database engines. Be careful if changing database.
+  create_enum "schedule_declaration_types", ["started", "retained-1", "retained-2", "retained-3", "retained-4", "completed"]
 
   create_table "applications", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -56,12 +60,47 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_10_193259) do
     t.bigint "private_childcare_provider_id"
     t.bigint "itt_provider_id"
     t.bigint "school_id"
+    t.bigint "schedule_id"
     t.index ["course_id"], name: "index_applications_on_course_id"
     t.index ["itt_provider_id"], name: "index_applications_on_itt_provider_id"
     t.index ["lead_provider_id"], name: "index_applications_on_lead_provider_id"
     t.index ["private_childcare_provider_id"], name: "index_applications_on_private_childcare_provider_id"
+    t.index ["schedule_id"], name: "index_applications_on_schedule_id"
     t.index ["school_id"], name: "index_applications_on_school_id"
     t.index ["user_id"], name: "index_applications_on_user_id"
+  end
+
+  create_table "cohorts", force: :cascade do |t|
+    t.integer "start_year", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["start_year"], name: "index_cohorts_on_start_year", unique: true
+  end
+
+  create_table "contracts", force: :cascade do |t|
+    t.boolean "special_course", default: false, null: false
+    t.bigint "statement_id", null: false
+    t.bigint "course_id", null: false
+    t.integer "recruitment_target", null: false
+    t.decimal "per_participant", null: false
+    t.integer "output_payment_percentage", default: 60, null: false
+    t.integer "number_of_payment_periods", null: false
+    t.integer "service_fee_percentage", default: 40, null: false
+    t.integer "service_fee_installments", null: false
+    t.bigint "cohort_id", null: false
+    t.bigint "lead_provider_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["cohort_id"], name: "index_contracts_on_cohort_id"
+    t.index ["course_id"], name: "index_contracts_on_course_id"
+    t.index ["lead_provider_id"], name: "index_contracts_on_lead_provider_id"
+    t.index ["statement_id"], name: "index_contracts_on_statement_id"
+  end
+
+  create_table "course_groups", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "courses", force: :cascade do |t|
@@ -73,6 +112,19 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_10_193259) do
     t.integer "position", default: 0
     t.boolean "display", default: true
     t.string "identifier"
+    t.bigint "course_group_id"
+    t.index ["course_group_id"], name: "index_courses_on_course_group_id"
+    t.index ["identifier"], name: "index_courses_on_identifier", unique: true
+  end
+
+  create_table "declarations", force: :cascade do |t|
+    t.bigint "application_id", null: false
+    t.string "state"
+    t.string "declaration_type"
+    t.date "declaration_date"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["application_id"], name: "index_declarations_on_application_id"
   end
 
   create_table "delayed_jobs", force: :cascade do |t|
@@ -166,6 +218,42 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_10_193259) do
     t.index ["ukprn"], name: "index_local_authorities_on_ukprn"
   end
 
+  create_table "migration_results", force: :cascade do |t|
+    t.datetime "completed_at"
+    t.integer "users_count"
+    t.integer "orphaned_ecf_users_count"
+    t.integer "orphaned_npq_users_count"
+    t.integer "duplicate_users_count"
+    t.integer "matched_users_count"
+    t.integer "applications_count"
+    t.integer "orphaned_ecf_applications_count"
+    t.integer "orphaned_npq_applications_count"
+    t.integer "duplicate_applications_count"
+    t.integer "matched_applications_count"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "outcomes", force: :cascade do |t|
+    t.string "state", null: false
+    t.date "completion_date", null: false
+    t.bigint "declaration_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["declaration_id"], name: "index_outcomes_on_declaration_id"
+  end
+
+  create_table "participant_id_changes", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.uuid "from_participant_id", null: false
+    t.uuid "to_participant_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["from_participant_id"], name: "index_participant_id_changes_on_from_participant_id"
+    t.index ["to_participant_id"], name: "index_participant_id_changes_on_to_participant_id"
+    t.index ["user_id"], name: "index_participant_id_changes_on_user_id"
+  end
+
   create_table "private_childcare_providers", force: :cascade do |t|
     t.text "provider_urn", null: false
     t.text "provider_name"
@@ -204,6 +292,20 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_10_193259) do
     t.text "data"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "schedules", force: :cascade do |t|
+    t.string "name", null: false
+    t.date "declaration_starts_on", null: false
+    t.date "schedule_applies_from", null: false
+    t.date "schedule_applies_to", null: false
+    t.bigint "course_group_id", null: false
+    t.bigint "cohort_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.enum "declaration_types", default: ["started", "retained-1", "retained-2", "completed"], null: false, array: true, enum_type: "schedule_declaration_types"
+    t.index ["cohort_id"], name: "index_schedules_on_cohort_id"
+    t.index ["course_group_id"], name: "index_schedules_on_course_group_id"
   end
 
   create_table "schools", force: :cascade do |t|
@@ -250,6 +352,35 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_10_193259) do
     t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
 
+  create_table "statement_items", force: :cascade do |t|
+    t.bigint "statement_id", null: false
+    t.bigint "declaration_id", null: false
+    t.string "state", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "clawed_back_by_id"
+    t.index ["clawed_back_by_id"], name: "index_statement_items_on_clawed_back_by_id"
+    t.index ["declaration_id"], name: "index_statement_items_on_declaration_id"
+    t.index ["statement_id"], name: "index_statement_items_on_statement_id"
+  end
+
+  create_table "statements", force: :cascade do |t|
+    t.integer "month", null: false
+    t.integer "year", null: false
+    t.date "deadline_date"
+    t.date "payment_date"
+    t.boolean "output_fee", default: true, null: false
+    t.bigint "cohort_id", null: false
+    t.bigint "lead_provider_id", null: false
+    t.datetime "marked_as_paid_at"
+    t.decimal "reconcile_amount", precision: 8, scale: 2
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "frozen_at"
+    t.index ["cohort_id"], name: "index_statements_on_cohort_id"
+    t.index ["lead_provider_id"], name: "index_statements_on_lead_provider_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.datetime "created_at", null: false
@@ -294,6 +425,22 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_10_193259) do
   add_foreign_key "applications", "itt_providers"
   add_foreign_key "applications", "lead_providers"
   add_foreign_key "applications", "private_childcare_providers"
+  add_foreign_key "applications", "schedules"
   add_foreign_key "applications", "schools"
   add_foreign_key "applications", "users"
+  add_foreign_key "contracts", "cohorts"
+  add_foreign_key "contracts", "courses"
+  add_foreign_key "contracts", "lead_providers"
+  add_foreign_key "contracts", "statements"
+  add_foreign_key "courses", "course_groups"
+  add_foreign_key "declarations", "applications"
+  add_foreign_key "outcomes", "declarations"
+  add_foreign_key "participant_id_changes", "users"
+  add_foreign_key "schedules", "cohorts"
+  add_foreign_key "schedules", "course_groups"
+  add_foreign_key "statement_items", "declarations"
+  add_foreign_key "statement_items", "statement_items", column: "clawed_back_by_id"
+  add_foreign_key "statement_items", "statements"
+  add_foreign_key "statements", "cohorts"
+  add_foreign_key "statements", "lead_providers"
 end

--- a/spec/requests/api/delivery_partners_spec.rb
+++ b/spec/requests/api/delivery_partners_spec.rb
@@ -1,0 +1,36 @@
+require "swagger_helper"
+
+RSpec.describe "api/applications", type: :request do
+  path "/applications/{id}" do
+    get "Retrieves an application" do
+      tags "Applications"
+      produces "application/json", "application/xml"
+      parameter name: :id, in: :path, type: :string
+
+      response "200", "application found" do
+        schema type: :object,
+               properties: {
+                 id: { type: :integer },
+                 lead_provider_id: { type: :integer },
+                 user_id: { type: :integer },
+                 lead_provider_approval_status: { type: :string },
+                 participant_outcome_state: { type: :string },
+               },
+               required: %w[id user_id lead_provider_approval_status]
+
+        let(:id) { create(:application).id }
+        run_test!
+      end
+
+      response "404", "application not found" do
+        let(:id) { "invalid" }
+        run_test!
+      end
+
+      response "406", "unsupported accept header" do
+        let(:Accept) { "application/foo" }
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.configure do |config|
+  # Specify a root folder where Swagger JSON files are generated
+  # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
+  # to ensure that it's configured to serve Swagger from the same folder
+  config.openapi_root = Rails.root.join('swagger').to_s
+
+  # Define one or more Swagger documents and provide global metadata for each one
+  # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
+  # be generated at the provided relative path under openapi_root
+  # By default, the operations defined in spec files are added to the first
+  # document below. You can override this behavior by adding a openapi_spec tag to the
+  # the root example_group in your specs, e.g. describe '...', openapi_spec: 'v2/swagger.json'
+  config.openapi_specs = {
+    "v1/swagger.yaml" => {
+      openapi: "3.0.1",
+      info: {
+        title: "Swagger: NPQs data management API for lead providers",
+        version: "v1",
+        contact: {
+          name: "Contact the developer",
+          url: "http://test.com",
+        },
+        license: {
+          name: "Apache 2.0",
+          url: "https://www.apache.org/licenses/LICENSE-2.0",
+        },
+      },
+      externalDocs: {
+        description: "Find out more about Swagger",
+        url: "https://swagger.io/",
+      },
+      paths: {},
+      servers: [
+        {
+          url: "https://register-national-professional-qualifications.sandbox.education.gov.uk/",
+        },
+      ],
+      components: {
+        securitySchemes: {
+          basic_auth: {
+            type: :http,
+            scheme: :basic,
+          },
+          api_key: {
+            type: :apiKey,
+            name: "api_key",
+            in: :query,
+          }
+        }
+      }
+    }
+  }
+
+  # Specify the format of the output Swagger file when running 'rswag:specs:swaggerize'.
+  # The openapi_specs configuration option has the filename including format in
+  # the key, this may want to be changed to avoid putting yaml in json files.
+  # Defaults to json. Accepts ':json' and ':yaml'.
+  config.openapi_format = :yaml
+end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -1,0 +1,81 @@
+---
+openapi: 3.0.1
+info:
+  title: 'Swagger: NPQs data management API for lead providers'
+  version: v1
+  contact:
+    name: Contact the developer
+    url: http://test.com
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+externalDocs:
+  description: Find out more about Swagger
+  url: https://swagger.io/
+paths:
+  "/applications/{id}":
+    get:
+      summary: Retrieves an application
+      tags:
+      - Applications
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: application found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  lead_provider_id:
+                    type: integer
+                  user_id:
+                    type: integer
+                  lead_provider_approval_status:
+                    type: string
+                  participant_outcome_state:
+                    type: string
+                required:
+                - id
+                - user_id
+                - lead_provider_approval_status
+            application/xml:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  lead_provider_id:
+                    type: integer
+                  user_id:
+                    type: integer
+                  lead_provider_approval_status:
+                    type: string
+                  participant_outcome_state:
+                    type: string
+                required:
+                - id
+                - user_id
+                - lead_provider_approval_status
+        '404':
+          description: application not found
+        '406':
+          description: unsupported accept header
+servers:
+- url: https://register-national-professional-qualifications.sandbox.education.gov.uk/
+components:
+  securitySchemes:
+    basic_auth:
+      type: http
+      scheme: basic
+    api_key:
+      type: apiKey
+      name: api_key
+      in: query


### PR DESCRIPTION
A spike to generate a Swagger yaml spec and documentation UI using the `rswag` gem.

I looked at other gems that can do this, but `rswag` appears to be the defacto-standard and most flexible all-round way of Swaggerizing a Rails application. nd generating a documentation UI.

`rswag` generates a Swagger yaml file from descriptive specs, which is nice as it kills two birds with one stone. It should do everything that we would need and more.

The `rswag-ui` package leverages `swagger-ui` under the hood, which generates a UI that mostly matches Mark's design and has a decent plugin system for customizing the various components. It uses `React` and appears to operate as `Rack` middleware, which is a bit of a pain when it comes to customising the `Components`. The issue is we can't import `React` with `webpacker` as the helpers aren't available in middleware. Instead, I've pulled `React` from a CDN and inlined the plugins to customise the UI. There's probably a better way of doing this.

Between the plugin system and CSS/custom JS we should be able to change any of the design we like, though some changes are easier than others. I wasn't able to hide the `Topbar` component, for example, as it appears to set `Redux` state for other parts of the page, so I had to hide this with CSS. If we want to modify a particular `Component` we have to redefine it and pass it in as a plugin, which is OK for most scenarios but some of the default components are quite complex and redefining them can be verbose.

Most of the `Redux` state is pulled from the `swagger.yaml` generated in Rails, but `swagger-ui` also has a way of overriding selectors and reducers so that we can modify the state if we have to.

Overall I think its a decent solution, as long as we don't go too crazy with the UI it should be fairly painless to implement.

If we do go with `rswag` we should add the `rails rswag` task to CI to ensure the yaml file doesn't get modified manually (which is what has happened on ECF!).

On looking at what other Ruby projects in DfE use for Swagger, there's not very many but they all appear to use `rswag`:

- https://github.com/DFE-Digital/curriculum-materials
- https://github.com/DFE-Digital/publish-teacher-training
- https://github.com/DFE-Digital/early-careers-framework

I also checked the `alphagov` repositories and couldn't find any Ruby projects using swagger.

There is also a [DfE fork of rswag](https://github.com/DFE-Digital/open-api-rswag) that adds support for v3 of the openapi spec, but as of v2.3.0 the core `rswag` gem supports v3 so we shouldn't need to use this. That being said, if we put work into making `swagger-ui` look different from the default and more geared towards a GOV.UK audience it may be worth having our own fork that we can share.

|  Design |  Implementation |
|---|---|
| <img width="780" alt="Screenshot 2024-01-24 at 13 59 23" src="https://github.com/DFE-Digital/npq-registration/assets/29867726/382bfccf-3039-49f8-8178-56ca58c0ac07"> |  <img width="780" alt="Screenshot 2024-01-24 at 13 56 55" src="https://github.com/DFE-Digital/npq-registration/assets/29867726/ef5c78ca-fb84-4298-bd2b-a5a6b9f31f4a"> |