### PR TITLE
Events

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -16,6 +16,7 @@ class Application < ApplicationRecord
   belongs_to :schedule, optional: true
 
   has_many :declarations
+  has_many :events
   has_many :ecf_sync_request_logs, as: :syncable, dependent: :destroy
 
   scope :unsynced, -> { where(ecf_id: nil) }

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,5 +1,6 @@
 class Course < ApplicationRecord
   belongs_to :course_group, optional: true
+  has_many :events
 
   class << self
     def npqeyl

--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -19,6 +19,7 @@ class Declaration < ApplicationRecord
   belongs_to :application
   has_many :outcomes
   has_many :statement_items
+  has_many :events
 
   # validates :declaration_date - this depends on the schedule
   # theoretically the supplier can make multiple declarations at once, that *is* valid

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,10 @@
+class Event < ApplicationRecord
+  belongs_to :user, optional: true
+  belongs_to :application, optional: true
+  belongs_to :course, optional: true
+  belongs_to :lead_provider, optional: true
+  belongs_to :school, optional: true
+  belongs_to :statement, optional: true
+  belongs_to :statement_item, optional: true
+  belongs_to :declaration, optional: true
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -7,4 +7,15 @@ class Event < ApplicationRecord
   belongs_to :statement, optional: true
   belongs_to :statement_item, optional: true
   belongs_to :declaration, optional: true
+
+  validates :importance,
+            presence: true,
+            numericality: {
+              only_integer: true,
+              in: 1..10,
+            }
+
+  validates :subject,
+            presence: true,
+            length: { maximum: 128 }
 end

--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -76,6 +76,8 @@ class LeadProvider < ApplicationRecord
     "npq-leading-primary-mathematics" => LPM_PROVIDERS,
   }.freeze
 
+  has_many :applications
+
   scope :alphabetical, -> { order(name: :asc) }
 
   def self.for(course:)

--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -77,6 +77,7 @@ class LeadProvider < ApplicationRecord
   }.freeze
 
   has_many :applications
+  has_many :events
 
   scope :alphabetical, -> { order(name: :asc) }
 

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -3,6 +3,8 @@ class School < ApplicationRecord
   PRIMARY_PHASE = "Primary".freeze
   MIDDLE_DEEMED_PRIMARY_PHASE = "Middle deemed primary".freeze
 
+  has_many :events
+
   pg_search_scope :search_by_name,
                   against: [:name],
                   using: {

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -15,6 +15,7 @@
 class Statement < ApplicationRecord
   belongs_to :cohort
   belongs_to :lead_provider
+  has_many :events
   has_many :statement_items
   has_many :contracts
 

--- a/app/models/statement_item.rb
+++ b/app/models/statement_item.rb
@@ -10,6 +10,7 @@ class StatementItem < ApplicationRecord
   belongs_to :statement
   belongs_to :declaration
   belongs_to :clawed_back_by, class_name: "StatementItem", optional: true
+  has_many :events
 
   validates :state, inclusion: { in: STATES }
   validates :clawed_back_by, presence: true, if: -> { state == "clawed_back" }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   has_many :applications, dependent: :destroy
   has_many :ecf_sync_request_logs, as: :syncable, dependent: :destroy
   has_many :participant_id_changes
+  has_many :events
 
   scope :admins, -> { where(admin: true) }
   scope :unsynced, -> { where(ecf_id: nil) }

--- a/db/migrate/20240125095919_create_events.rb
+++ b/db/migrate/20240125095919_create_events.rb
@@ -1,0 +1,26 @@
+class CreateEvents < ActiveRecord::Migration[7.1]
+  def change
+    create_table :events do |t|
+      t.references :user, null: true, foreign_key: true
+      t.references :application, null: true, foreign_key: true
+      t.references :course, null: true, foreign_key: true
+      t.references :lead_provider, null: true, foreign_key: true
+      t.references :school, null: true, foreign_key: true
+      t.references :statement, null: true, foreign_key: true
+      t.references :statement_item, null: true, foreign_key: true
+      t.references :declaration, null: true, foreign_key: true
+
+      # the 'kind' of event, eg. 'declaration made' or 'application submitted'
+      t.string :category, null: false
+
+      # short and long description of what's happened, description optional
+      t.string :subject, limit: 128, null: false
+      t.text :description
+
+      # 1 = debug, 10 = major event?
+      t.integer :importance, default: 4, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_19_150601) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_25_095919) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -163,6 +163,31 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_19_150601) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["syncable_id", "syncable_type"], name: "index_ecf_sync_request_logs_on_syncable_id_and_syncable_type"
+  end
+
+  create_table "events", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "application_id"
+    t.bigint "course_id"
+    t.bigint "lead_provider_id"
+    t.bigint "school_id"
+    t.bigint "statement_id"
+    t.bigint "statement_item_id"
+    t.bigint "declaration_id"
+    t.string "category", null: false
+    t.string "subject", limit: 128, null: false
+    t.text "description"
+    t.integer "importance", default: 4, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["application_id"], name: "index_events_on_application_id"
+    t.index ["course_id"], name: "index_events_on_course_id"
+    t.index ["declaration_id"], name: "index_events_on_declaration_id"
+    t.index ["lead_provider_id"], name: "index_events_on_lead_provider_id"
+    t.index ["school_id"], name: "index_events_on_school_id"
+    t.index ["statement_id"], name: "index_events_on_statement_id"
+    t.index ["statement_item_id"], name: "index_events_on_statement_item_id"
+    t.index ["user_id"], name: "index_events_on_user_id"
   end
 
   create_table "flipper_features", force: :cascade do |t|
@@ -444,6 +469,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_19_150601) do
   add_foreign_key "contracts", "statements"
   add_foreign_key "courses", "course_groups"
   add_foreign_key "declarations", "applications"
+  add_foreign_key "events", "applications"
+  add_foreign_key "events", "courses"
+  add_foreign_key "events", "declarations"
+  add_foreign_key "events", "lead_providers"
+  add_foreign_key "events", "schools"
+  add_foreign_key "events", "statement_items"
+  add_foreign_key "events", "statements"
+  add_foreign_key "events", "users"
   add_foreign_key "outcomes", "declarations"
   add_foreign_key "participant_id_changes", "users"
   add_foreign_key "schedules", "cohorts"

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Application do
     it { is_expected.to belong_to(:itt_provider).optional }
     it { is_expected.to belong_to(:schedule).optional }
 
+    it { is_expected.to have_many(:events) }
     it { is_expected.to have_many(:declarations) }
     it { is_expected.to have_many(:ecf_sync_request_logs).dependent(:destroy) }
   end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -3,6 +3,19 @@ require "rails_helper"
 RSpec.describe Application do
   it { is_expected.to belong_to(:schedule).optional }
 
+  describe "relationships" do
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:course) }
+    it { is_expected.to belong_to(:lead_provider) }
+    it { is_expected.to belong_to(:school).optional }
+    it { is_expected.to belong_to(:private_childcare_provider).optional }
+    it { is_expected.to belong_to(:itt_provider).optional }
+    it { is_expected.to belong_to(:schedule).optional }
+
+    it { is_expected.to have_many(:declarations) }
+    it { is_expected.to have_many(:ecf_sync_request_logs).dependent(:destroy) }
+  end
+
   describe "scopes" do
     describe ".unsynced" do
       it "returns records where ecf_id is null" do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe Course do
   describe "relationships" do
+    it { is_expected.to have_many(:events) }
     it { is_expected.to belong_to(:course_group).optional }
   end
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1,7 +1,9 @@
 require "rails_helper"
 
 RSpec.describe Course do
-  it { is_expected.to belong_to(:course_group).optional }
+  describe "relationships" do
+    it { is_expected.to belong_to(:course_group).optional }
+  end
 
   describe "#eyl?" do
     context "when the course identifier is npq-early-years-leadership" do

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -1,8 +1,13 @@
 require "rails_helper"
 
 RSpec.describe Declaration, type: :model do
-  describe "validations" do
+  describe "relationships" do
     it { is_expected.to belong_to(:application).required }
+    it { is_expected.to have_many(:outcomes) }
+    it { is_expected.to have_many(:statement_items) }
+  end
+
+  describe "validations" do
 
     describe "state validations" do
       let(:valid_states) { %w[submitted eligible ineligible payable voided paid awaiting_clawback clawed_back] }

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -3,12 +3,12 @@ require "rails_helper"
 RSpec.describe Declaration, type: :model do
   describe "relationships" do
     it { is_expected.to belong_to(:application).required }
+    it { is_expected.to have_many(:events) }
     it { is_expected.to have_many(:outcomes) }
     it { is_expected.to have_many(:statement_items) }
   end
 
   describe "validations" do
-
     describe "state validations" do
       let(:valid_states) { %w[submitted eligible ineligible payable voided paid awaiting_clawback clawed_back] }
 

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -11,4 +11,16 @@ RSpec.describe Event, type: :model do
     it { is_expected.to belong_to(:statement_item).required(false) }
     it { is_expected.to belong_to(:declaration).required(false) }
   end
+
+  describe "validation" do
+    describe "importance" do
+      it { is_expected.to validate_presence_of(:importance) }
+      it { is_expected.to validate_numericality_of(:importance).is_in(1..10).only_integer }
+    end
+
+    describe "subject" do
+      it { is_expected.to validate_presence_of(:subject) }
+      it { is_expected.to validate_length_of(:subject).is_at_most(128) }
+    end
+  end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe Event, type: :model do
+  describe "relationships" do
+    it { is_expected.to belong_to(:user).required(false) }
+    it { is_expected.to belong_to(:application).required(false) }
+    it { is_expected.to belong_to(:course).required(false) }
+    it { is_expected.to belong_to(:lead_provider).required(false) }
+    it { is_expected.to belong_to(:school).required(false) }
+    it { is_expected.to belong_to(:statement).required(false) }
+    it { is_expected.to belong_to(:statement_item).required(false) }
+    it { is_expected.to belong_to(:declaration).required(false) }
+  end
+end

--- a/spec/models/lead_provider_spec.rb
+++ b/spec/models/lead_provider_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.describe LeadProvider do
+  describe "relationships" do
+    it { is_expected.to have_many(:applications) }
+  end
+
   describe "#for" do
     subject { described_class.for(course:).map(&:name) }
 

--- a/spec/models/lead_provider_spec.rb
+++ b/spec/models/lead_provider_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe LeadProvider do
   describe "relationships" do
     it { is_expected.to have_many(:applications) }
+    it { is_expected.to have_many(:events) }
   end
 
   describe "#for" do

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.describe School do
+  describe "relationships" do
+    it { is_expected.to have_many(:events) }
+  end
+
   describe ".primary_education_phase?" do
     let(:school) do
       build(:school,

--- a/spec/models/statement_item_spec.rb
+++ b/spec/models/statement_item_spec.rb
@@ -1,9 +1,12 @@
 require "rails_helper"
 
 RSpec.describe StatementItem, type: :model do
-  describe "validations" do
+  describe "relationships" do
     it { is_expected.to belong_to(:statement).required }
     it { is_expected.to belong_to(:declaration).required }
+  end
+
+  describe "validations" do
     it { is_expected.to validate_inclusion_of(:state).in_array(StatementItem::STATES) }
 
     describe "clawed_back_by validation" do

--- a/spec/models/statement_item_spec.rb
+++ b/spec/models/statement_item_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe StatementItem, type: :model do
   describe "relationships" do
     it { is_expected.to belong_to(:statement).required }
     it { is_expected.to belong_to(:declaration).required }
+
+    it { is_expected.to have_many(:events) }
   end
 
   describe "validations" do

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -1,10 +1,14 @@
 require "rails_helper"
 
 RSpec.describe Statement, type: :model do
-  describe "validations" do
+  describe "relationships" do
     it { is_expected.to belong_to(:cohort).required }
     it { is_expected.to belong_to(:lead_provider).required }
+    it { is_expected.to have_many(:statement_items) }
+    it { is_expected.to have_many(:contracts) }
+  end
 
+  describe "validations" do
     it { is_expected.to validate_numericality_of(:month).is_in(1..12).only_integer }
     it { is_expected.to validate_numericality_of(:year).only_integer.is_in(2020..2050) }
 

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Statement, type: :model do
   describe "relationships" do
     it { is_expected.to belong_to(:cohort).required }
     it { is_expected.to belong_to(:lead_provider).required }
+    it { is_expected.to have_many(:events) }
     it { is_expected.to have_many(:statement_items) }
     it { is_expected.to have_many(:contracts) }
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,1 +1,7 @@
 require "rails_helper"
+
+RSpec.describe(User, type: :model) do
+  describe "relationships" do
+    it { is_expected.to have_many(:events) }
+  end
+end


### PR DESCRIPTION
This is an experiment to see how we might sensibly log 'events' that happen within NPQ. It's not intended to be final, but a starting point for a conversation on how we save and present this data, which is **really valuable to the support teams when diagnosing problems**. Being able to show a concise timeline of what happened is necessary.

An event is something of note that happens within the app.

Currently in ECF we struggle with this and to show the 'change log' in the admin console we need to [carefully piece together what happened](https://github.com/DFE-Digital/early-careers-framework/blob/main/app/services/participants/history_builder.rb) in order to build a timeline. This relies on PaperTrail's versions table which is built for record-level auditing purposes not to capture events which affect multiple related entities.

It could be presented using a timeline similar to [MoJ's Timeline component](https://design-patterns.service.justice.gov.uk/components/timeline/).

## How it works

There is an Event model and `events` table. The `events` table has multiple foreign key relationships, because **events don't happen in isolation**. Each one is optional (but it might make sense to have some validation rule requiring at least one is present). Having multiple related records instead of one (like PaperTrail's `object`) means we can look at a single event from multiple points of view.

For example, in the admin console when looking at a _person_ (teacher, applicant, whatever we end up calling them) we might see that they made 2 applications. When looking at the _school_ page in the admin console, using the exact same event data, we can see 3 applications were made by people at their school.

## Finding the events for a thing

```ruby
User.find(123).events                                            # all the events for user 123
Event.where(person: Person.find(123), school: School.find(456))  # events for user 123 at school 456
```

## Metadata

In addition to the foreign keys and Rails' default timestamps there are some fields we can use to add more information about what happened.

* `category` - the kind of thing that happened, 'Application made', 'Statement voided', etc.
* `subject` - a single line of text with an overview of what happened
* `description` - optional, more space to add details of the event
* `importance` - a number (for now) ranging between 1 (not very important) to 10 (critical) - perhaps useful for filtering or not overloading users with boring background stuff

### Examples

### Application creation

This application was created by a teacher at a school:

```mermaid
graph TD
  Event --> Person
  Event --> School
  Event --> Course
```

While this one was created by someone at a private childcare provider:

```mermaid
graph TD
  Event --> Person
  Event --> PCP[Private Childcare Provider]
  Event --> Course
```

### Declaration voided

When a declaration is voided we could show the voiding event in the timelines of the related objects, like:

```mermaid
graph TD
  Event --> Declaration
  Event --> Application
  Event --> SLI[Statement Line Item]
  Event --> Statement
  Event --> LP[Lead Provider]
```

## Changes so far

- Add some missing relationships specs
- Add events table
- Add event model and relationship specs
- Add event relationships and corresponding specs
- Add event validation
