### PR TITLE
CPDNPQ-1579 Show Expired Info on Registrations in Account

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -17,6 +17,8 @@ class Application < ApplicationRecord
   has_many :ecf_sync_request_logs, as: :syncable, dependent: :destroy
 
   scope :unsynced, -> { where(ecf_id: nil) }
+  scope :expired_applications, -> { where(lead_provider_approval_status: "rejected").where("created_at < ?", cut_off_date_for_expired_applications) }
+  scope :active_applications, -> { where.not(id: expired_applications) }
 
   enum kind_of_nursery: {
     local_authority_maintained_nursery: "local_authority_maintained_nursery",
@@ -77,5 +79,9 @@ class Application < ApplicationRecord
     when "passed" then "failed"
     else "passed"
     end
+  end
+
+  def self.cut_off_date_for_expired_applications
+    Time.zone.local(2024, 6, 30)
   end
 end

--- a/app/views/accounts/_active_application_table.html.erb
+++ b/app/views/accounts/_active_application_table.html.erb
@@ -26,14 +26,14 @@
           Provider application
         </dt>
         <dd class="govuk-summary-list__value">
-            <% if application.lead_provider_approval_status.blank? || pending?(application) %>
-              <strong class="govuk-tag govuk-tag--yellow">APPLY WITH PROVIDER</strong>
-              <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= I18n.t("provider_details.pending_status")  %></p>
-            <% elsif accepted?(application) %>
-              <strong class="govuk-tag govuk-tag--green">SUCCESSFUL</strong>
-            <% elsif rejected?(application) %>
-              <strong class="govuk-tag govuk-tag--red">UNSUCCESSFUL</strong>
-            <% end %>
+          <% if application.lead_provider_approval_status.blank? || pending?(application) %>
+            <strong class="govuk-tag govuk-tag--yellow">APPLY WITH PROVIDER</strong>
+            <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= I18n.t("provider_details.pending_status")  %></p>
+          <% elsif accepted?(application) %>
+            <strong class="govuk-tag govuk-tag--green">SUCCESSFUL</strong>
+          <% elsif rejected?(application) %>
+            <strong class="govuk-tag govuk-tag--red">UNSUCCESSFUL</strong>
+          <% end %>
         </dd>
       </div>
 

--- a/app/views/accounts/_course_details.html.erb
+++ b/app/views/accounts/_course_details.html.erb
@@ -37,14 +37,14 @@
           Provider application
         </dt>
         <dd class="govuk-summary-list__value">
-            <% if application.lead_provider_approval_status.blank? || pending?(application) %>
-              <strong class="govuk-tag govuk-tag--yellow">APPLY WITH PROVIDER</strong>
-              <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= I18n.t("provider_details.pending_status")  %></p>
-            <% elsif accepted?(application) %>
-              <strong class="govuk-tag govuk-tag--green">SUCCESSFUL</strong>
-            <% elsif rejected?(application) %>
-              <strong class="govuk-tag govuk-tag--red">UNSUCCESSFUL</strong>
-            <% end %>
+          <% if application.lead_provider_approval_status.blank? || pending?(application) %>
+            <strong class="govuk-tag govuk-tag--yellow">APPLY WITH PROVIDER</strong>
+            <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= I18n.t("provider_details.pending_status")  %></p>
+          <% elsif accepted?(application) %>
+            <strong class="govuk-tag govuk-tag--green">SUCCESSFUL</strong>
+          <% elsif rejected?(application) %>
+            <strong class="govuk-tag govuk-tag--red">UNSUCCESSFUL</strong>
+          <% end %>
         </dd>
         <!-- This code is only written for review apps in order to update the external statuses -->
         <% if Rails.env.review? %>

--- a/app/views/accounts/_expired_application_table.html.erb
+++ b/app/views/accounts/_expired_application_table.html.erb
@@ -1,0 +1,38 @@
+<div class="govuk-summary-card">
+  <div class="govuk-summary-card__title-wrapper">
+    <div>
+      <h2 class="govuk-summary-card__title"><%= title_embedded_course_name(application.course) %></h2>
+      <p class="govuk-body">
+        <%= application.lead_provider.name %>
+      </p>
+    </div>
+  </div>
+  <div class="govuk-summary-card__content">
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Registration submitted
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= application.created_at.to_date.to_fs(:govuk_short) %>
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Provider application
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <strong class="govuk-tag govuk-tag--grey">EXPIRED</strong>
+          <% if Feature.registration_closed? %>
+            <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= I18n.t("provider_details.expired_status_when_service_is_closed")  %></p>
+          <% elsif Feature.trn_required? && current_user.trn.blank? %>
+            <p> <%= link_to "Submit a new registration", registration_wizard_show_path(:teacher_reference_number) %> if you still want to take this course. </p>
+          <% else %>
+            <p> <%= link_to "Submit a new registration", registration_wizard_show_path(:provider_check) %> if you still want to take this course. </p>
+          <% end %>
+        </dd>
+      </div>
+    </dl>
+  </div>
+</div>

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -11,10 +11,28 @@
     <%= link_to_identity_account(request.original_url, text: "Visit your DfE Identity account") %> to check or change your personal details.
   </div>
 <% end %>
-<% applications = current_user.applications.order(created_at: :desc) %>
 
-<% applications.each do |application| %>
-  <%= render "application_table", application: application %>
+<% if Time.zone.now > Time.zone.local(2024, 4, 2) %>
+  <% active_applications = current_user.applications.active_applications.order(created_at: :desc) %>
+  <% expired_applications = current_user.applications.expired_applications.order(created_at: :desc) %>
+
+  <% active_applications.each do |application| %>
+    <%= render "active_application_table", application: application %>
+  <% end %>
+
+  <% if expired_applications.count > 0 %>
+    <h3 class="govuk-heading-l">Expired registrations</h3>
+
+    <% expired_applications.each do |application| %>
+      <%= render "expired_application_table", application: application %>
+    <% end %>
+  <% end %>
+<% else %>
+  <% active_applications = current_user.applications.order(created_at: :desc) %>
+
+  <% active_applications.each do |application| %>
+    <%= render "active_application_table", application: application %>
+  <% end %>
 <% end %>
 
 <%= render partial: 'registration_wizard/shared/register_for_an_npq' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -278,6 +278,7 @@ en:
 
   provider_details:
     pending_status: "You need to apply separately with your training provider, if you have not done so already."
+    expired_status_when_service_is_closed: "Your registration has expired but you can register again later for courses starting in October 2024. You'll receive an email when registrations open. This is usually around June."
   course_start_details:
     eligible_for_funding: "If your provider doesn't confirm you've started the course before %{date}, your registration will expire. You can register again later, but your funding may change."
     not_eligible_for_funding: "If your provider doesn't confirm you've started the course before %{date}, your registration will expire. You can register again later."


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-1579

When a registration status is changed to ‘Expired’ the tag next to ‘provider application’ displays as ‘Expired’. And has a grey background.

If the service is closed, this text displays below the tag:

Your registration has expired but you can register again for future courses when registrations open.

If the service is open, this text displays below the tag: 

Submit a new registration if you still want to take this course. 

‘Submit a new registration’ text links to the registration flow (the same as the ‘Register for another NPQ’ button at the bottom of the account page). 

All the expired registrations are grouped together on the account page. 

Above the expired registrations is a h3, large size heading ‘Expired registrations’

Expired registrations have no ‘View details’ link