### PR TITLE
Serialize legal name for itt providers

### DIFF
--- a/app/services/ecf/npq_profile_creator.rb
+++ b/app/services/ecf/npq_profile_creator.rb
@@ -29,7 +29,7 @@ module Ecf
         funding_eligiblity_status_code: application.funding_eligiblity_status_code,
         teacher_catchment: application.teacher_catchment,
         teacher_catchment_country: application.teacher_catchment_country,
-        itt_provider: application.itt_provider,
+        itt_provider: application.itt_provider&.legal_name,
         lead_mentor: application.lead_mentor,
         relationships: {
           user: ecf_user,

--- a/spec/lib/services/ecf/npq_profile_creator_spec.rb
+++ b/spec/lib/services/ecf/npq_profile_creator_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Ecf::NpqProfileCreator do
   end
   let(:course) { Course.create!(name: "Some course", ecf_id: "234") }
   let(:lead_provider) { LeadProvider.create!(name: "Some lead provider", ecf_id: "345") }
+  let(:itt_provider) { create :itt_provider }
   let(:school) { create(:school) }
   let(:teacher_catchment_country) { AutocompleteCountries.names.sample }
 
@@ -33,7 +34,7 @@ RSpec.describe Ecf::NpqProfileCreator do
       targeted_delivery_funding_eligibility: true,
       works_in_childcare: false,
       kind_of_nursery: nil,
-      itt_provider: nil,
+      itt_provider:,
       lead_mentor: false,
       DEPRECATED_private_childcare_provider_urn: nil,
       private_childcare_provider_id: nil,
@@ -93,7 +94,7 @@ RSpec.describe Ecf::NpqProfileCreator do
             funding_eligiblity_status_code: "funded",
             teacher_catchment: "other",
             teacher_catchment_country:,
-            itt_provider: nil,
+            itt_provider: itt_provider.legal_name,
             lead_mentor: false,
           },
         },


### PR DESCRIPTION
### Context

[Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-000](https://dfedigital.atlassian.net/browse/CPDLP-2777)

### Changes proposed in this pull request

Use the legal name for the ITT provider because so far, we were sending a 
memory reference to the ITT provider.

This is the information stored in ECF:

```
NPQApplication.find("fe36230a-b554-49b8-a576-36eb9ae9562c").itt_provider
 => "#<IttProvider:0x00007f9e910b1c88>" 
```