### PR TITLE
Splitting up users

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,6 +59,9 @@ RSpec/FilePath:
 RSpec/AnyInstance:
   Enabled: false
 
+RSpec/DescribedClass:
+  Enabled: false
+
 Rails/UnknownEnv:
   Environments:
     - development

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -7,7 +7,7 @@ class Application < ApplicationRecord
 
   has_paper_trail only: %i[lead_provider_approval_status participant_outcome_state]
 
-  belongs_to :user
+  belongs_to :participant
   belongs_to :course
   belongs_to :lead_provider
   belongs_to :school, optional: true

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -1,0 +1,2 @@
+class Participant < ApplicationRecord
+end

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -1,2 +1,4 @@
 class Participant < ApplicationRecord
+  scope :unsynced, -> { where(ecf_id: nil) }
+  scope :synced, -> { where.not(ecf_id: nil) }
 end

--- a/app/services/participants/sync/sync_all_users.rb
+++ b/app/services/participants/sync/sync_all_users.rb
@@ -1,0 +1,9 @@
+module Participants
+  module Sync
+    class SyncAllUsers
+      def sync_all_users!
+        User.find_each { |user| SyncFromUser.new(user).sync! }
+      end
+    end
+  end
+end

--- a/app/services/participants/sync/sync_from_user.rb
+++ b/app/services/participants/sync/sync_from_user.rb
@@ -1,0 +1,31 @@
+module Participants
+  module Sync
+    class SyncFromUser
+      attr_reader :user, :participant
+
+      def initialize(user)
+        @user = user
+        @participant = Participant.find_or_initialize_by(id: user.id)
+      end
+
+      def sync!
+        participant.tap do |p|
+          p.created_at = user.created_at
+          p.date_of_birth = user.date_of_birth
+          p.email = user.email
+          p.full_name = user.full_name
+          p.get_an_identity_id_synced_to_ecf = user.get_an_identity_id_synced_to_ecf
+          p.provider = user.provider
+          p.raw_tra_provider_data = user.raw_tra_provider_data
+          p.trn = user.trn
+          p.trn_lookup_state = user.trn_lookup_status
+          p.trn_verified = user.trn_verified
+          p.updated_at = user.updated_at
+
+          Rails.logger.debug("Syncing participant #{user.id}")
+          p.save!
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20240206111408_create_participants.rb
+++ b/db/migrate/20240206111408_create_participants.rb
@@ -1,0 +1,27 @@
+class CreateParticipants < ActiveRecord::Migration[7.1]
+  def change
+    create_enum :trn_lookup_states, %w[found failed]
+
+    create_table :participants do |t|
+      # personal stuff
+      t.string "email", null: false
+      t.text "full_name"
+      t.date "date_of_birth"
+
+      # ecf sync stuff
+      t.text "ecf_id"
+      t.boolean "get_an_identity_id_synced_to_ecf", default: false
+
+      # trn stuff
+      t.text "trn"
+      t.boolean "trn_verified", default: false, null: false
+      t.enum "trn_lookup_state", enum_type: :trn_lookup_states # renamed from trn_lookup_status
+
+      # other
+      t.string "provider"
+      t.jsonb "raw_tra_provider_data" # ideally let's not store this raw in the database...
+      t.boolean "notify_user_for_future_reg", default: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240206132508_switch_application_relationship_from_users_to_participants.rb
+++ b/db/migrate/20240206132508_switch_application_relationship_from_users_to_participants.rb
@@ -1,0 +1,9 @@
+class SwitchApplicationRelationshipFromUsersToParticipants < ActiveRecord::Migration[7.1]
+  def change
+    remove_foreign_key :applications, :users
+
+    rename_column :applications, :user_id, :participant_id
+
+    add_foreign_key :applications, :participants
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_10_193259) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_06_111408) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
+
+  # Custom types defined in this database.
+  # Note that some types may not work with other database engines. Be careful if changing database.
+  create_enum "trn_lookup_states", ["found", "failed"]
 
   create_table "applications", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -164,6 +168,22 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_10_193259) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["ukprn"], name: "index_local_authorities_on_ukprn"
+  end
+
+  create_table "participants", force: :cascade do |t|
+    t.string "email", null: false
+    t.text "full_name"
+    t.date "date_of_birth"
+    t.text "ecf_id"
+    t.boolean "get_an_identity_id_synced_to_ecf", default: false
+    t.text "trn"
+    t.boolean "trn_verified", default: false, null: false
+    t.enum "trn_lookup_state", enum_type: "trn_lookup_states"
+    t.string "provider"
+    t.jsonb "raw_tra_provider_data"
+    t.boolean "notify_user_for_future_reg", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "private_childcare_providers", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_06_111408) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_06_132508) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -22,7 +22,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_06_111408) do
   create_enum "trn_lookup_states", ["found", "failed"]
 
   create_table "applications", force: :cascade do |t|
-    t.bigint "user_id", null: false
+    t.bigint "participant_id", null: false
     t.bigint "course_id", null: false
     t.bigint "lead_provider_id", null: false
     t.text "DEPRECATED_school_urn"
@@ -63,9 +63,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_06_111408) do
     t.index ["course_id"], name: "index_applications_on_course_id"
     t.index ["itt_provider_id"], name: "index_applications_on_itt_provider_id"
     t.index ["lead_provider_id"], name: "index_applications_on_lead_provider_id"
+    t.index ["participant_id"], name: "index_applications_on_participant_id"
     t.index ["private_childcare_provider_id"], name: "index_applications_on_private_childcare_provider_id"
     t.index ["school_id"], name: "index_applications_on_school_id"
-    t.index ["user_id"], name: "index_applications_on_user_id"
   end
 
   create_table "courses", force: :cascade do |t|
@@ -313,7 +313,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_06_111408) do
   add_foreign_key "applications", "courses"
   add_foreign_key "applications", "itt_providers"
   add_foreign_key "applications", "lead_providers"
+  add_foreign_key "applications", "participants"
   add_foreign_key "applications", "private_childcare_providers"
   add_foreign_key "applications", "schools"
-  add_foreign_key "applications", "users"
 end

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Participant, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -1,5 +1,25 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Participant, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "scopes" do
+    describe ".unsynced" do
+      expected = %("participants"."ecf_id" IS NULL)
+
+      let(:expected) { expected }
+
+      it "contains #{expected}" do
+        expect(Participant.unsynced.to_sql).to match(Regexp.new(expected))
+      end
+    end
+
+    describe ".synced" do
+      expected = %("participants"."ecf_id" IS NOT NULL)
+
+      let(:expected) { expected }
+
+      it "contains #{expected}" do
+        expect(Participant.synced.to_sql).to match(Regexp.new(expected))
+      end
+    end
+  end
 end


### PR DESCRIPTION
Refs #1130

## Changes so far

- Add participants model with required fields only
- Add a couple of example scopes and specs
- Add some very basic user to participant sync tasks
- Link applications to participants instead of users
