### PR TITLE
Add StatusCake config for SSL expiry date

### DIFF
--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -10,5 +10,7 @@
   "webapp_memory_max": "2Gi",
   "worker_memory_max": "1Gi",
   "enable_monitoring": true,
-  "deploy_snapshot_database": true
+  "deploy_snapshot_database": true,
+  "statuscake_ssl_contact_group": 249142,
+  "statuscake_domain": "register-national-professional-qualifications.education.gov.uk"
 }

--- a/terraform/application/modules/statuscake/main.tf
+++ b/terraform/application/modules/statuscake/main.tf
@@ -1,0 +1,40 @@
+resource "statuscake_uptime_check" "alert" {
+  for_each       = var.statuscake_alerts
+  name           = each.value.website_name
+  contact_groups = each.value.contact_group
+  confirmation   = 1
+  trigger_rate   = 0
+  check_interval = 30
+  regions        = ["london", "dublin"]
+  http_check {
+    follow_redirects = true
+    timeout          = 40
+    request_method   = "HTTP"
+    status_codes     = ["204", "205", "206", "303", "400", "401", "403", "404", "405", "406", "408", "410", "413", "444", "429", "494", "495", "496", "499", "500", "501", "502", "503", "504", "505", "506", "507", "508", "509", "510", "511", "521", "522", "523", "524", "520", "598", "599"]
+    validate_ssl     = false
+  }
+  monitored_resource {
+    address = each.value.website_url
+  }
+}
+
+resource "statuscake_ssl_check" "domain-alert" {
+  count = var.statuscake_ssl_contact_group != null ? 1 : 0
+
+  check_interval   = 3600 # Check once per hour
+  contact_groups   = [var.statuscake_ssl_contact_group]
+  follow_redirects = true
+
+  alert_config {
+    alert_at = [3, 7, 30] # Alert 1 month, 1 week then 3 days before expiration
+
+    on_reminder = true
+    on_expiry   = true
+    on_broken   = true
+    on_mixed    = true
+  }
+
+  monitored_resource {
+    address = "https://${var.statuscake_domain}"
+  }
+}

--- a/terraform/application/modules/statuscake/variables.tf
+++ b/terraform/application/modules/statuscake/variables.tf
@@ -1,0 +1,19 @@
+variable "environment" {
+}
+
+variable "service_name" {
+}
+
+variable "statuscake_alerts" {
+  description = "Define Statuscake alerts with the attributes below"
+}
+
+variable "statuscake_domain" {
+  type        = string
+  description = "Domain for SSL check"
+}
+
+variable "statuscake_ssl_contact_group" {
+  type        = string
+  description = "ID of the StatusCake contact group. If empty, SSL check is not enabled"
+}

--- a/terraform/application/terraform.tf
+++ b/terraform/application/terraform.tf
@@ -48,3 +48,13 @@ provider "kubernetes" {
 provider "statuscake" {
   api_token = module.infrastructure_secrets.map.STATUSCAKE-API-TOKEN
 }
+
+module "statuscake" {
+  source = "./modules/statuscake"
+
+  environment                  = var.environment
+  service_name                 = local.service_name
+  statuscake_alerts            = var.statuscake_alerts
+  statuscake_ssl_contact_group = var.statuscake_ssl_contact_group
+  statuscake_domain            = var.statuscake_domain
+}

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -102,3 +102,15 @@ locals {
 
   postgres_ssl_mode = var.enable_postgres_ssl ? "require" : "disable"
 }
+
+variable statuscake_domain {
+  type        = string
+  default     = null
+  description = "Domain for SSL check"
+}
+
+variable "statuscake_ssl_contact_group" {
+  type        = string
+  default     = null
+  description = "ID of the StatusCake contact group. If empty, SSL check is not enabled"
+}


### PR DESCRIPTION
We aren't able to automatically renew the TLS/SSL certs in Azure
FrontDoor for NPQ reg so we need to be alerted when they're about to
expire.

To renew them use the instructions provided in the runbook:

https://dfedigital.atlassian.net/wiki/spaces/CPD/pages/4051664899/Renew+Domain+SSL+Certificate

