### PR TITLE
Set the default `statuscake_contact_groups` to CPD

### DIFF
--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -55,7 +55,7 @@ variable "external_url" {
   description = "Healthcheck URL for StatusCake monitoring"
 }
 variable "statuscake_contact_groups" {
-  default     = []
+  default     = [291418]
   description = "ID of the contact group in statuscake web UI"
 }
 variable "enable_monitoring" {


### PR DESCRIPTION
This should make any alerts that fire go to all the people assigned to the CPD group (`291418`) on StatusCake
