### PR TITLE
Disable NPQ separation functionality by environment

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,0 +1,4 @@
+module Api
+  class BaseController < ApplicationController
+  end
+end

--- a/app/controllers/api/v1/applications_controller.rb
+++ b/app/controllers/api/v1/applications_controller.rb
@@ -1,0 +1,10 @@
+module Api
+  module V1
+    class ApplicationsController < BaseController
+      def index = head(:method_not_allowed)
+      def show = head(:method_not_allowed)
+      def accept = head(:method_not_allowed)
+      def reject = head(:method_not_allowed)
+    end
+  end
+end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,6 +1,0 @@
-module Api
-  module V1
-    class BaseController < ApplicationController
-    end
-  end
-end

--- a/app/controllers/api/v1/declarations_controller.rb
+++ b/app/controllers/api/v1/declarations_controller.rb
@@ -1,0 +1,10 @@
+module Api
+  module V1
+    class DeclarationsController < BaseController
+      def create = head(:method_not_allowed)
+      def show = head(:method_not_allowed)
+      def index = head(:method_not_allowed)
+      def void = head(:method_not_allowed)
+    end
+  end
+end

--- a/app/controllers/api/v1/get_an_identity/webhook_messages_controller.rb
+++ b/app/controllers/api/v1/get_an_identity/webhook_messages_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     module GetAnIdentity
-      class WebhookMessagesController < V1::BaseController
+      class WebhookMessagesController < BaseController
         skip_before_action :verify_authenticity_token
 
         before_action :log_incoming_message

--- a/app/controllers/api/v1/outcomes_controller.rb
+++ b/app/controllers/api/v1/outcomes_controller.rb
@@ -1,0 +1,7 @@
+module Api
+  module V1
+    class OutcomesController < BaseController
+      def index = head(:method_not_allowed)
+    end
+  end
+end

--- a/app/controllers/api/v1/participants_controller.rb
+++ b/app/controllers/api/v1/participants_controller.rb
@@ -1,0 +1,13 @@
+module Api
+  module V1
+    class ParticipantsController < BaseController
+      def index = head(:method_not_allowed)
+      def show = head(:method_not_allowed)
+      def change_schedule = head(:method_not_allowed)
+      def defer = head(:method_not_allowed)
+      def withdraw = head(:method_not_allowed)
+      def resume = head(:method_not_allowed)
+      def outcomes = head(:method_not_allowed)
+    end
+  end
+end

--- a/app/controllers/api/v2/applications_controller.rb
+++ b/app/controllers/api/v2/applications_controller.rb
@@ -1,0 +1,10 @@
+module Api
+  module V2
+    class ApplicationsController < BaseController
+      def index = head(:method_not_allowed)
+      def show = head(:method_not_allowed)
+      def accept = head(:method_not_allowed)
+      def reject = head(:method_not_allowed)
+    end
+  end
+end

--- a/app/controllers/api/v2/declarations_controller.rb
+++ b/app/controllers/api/v2/declarations_controller.rb
@@ -1,0 +1,10 @@
+module Api
+  module V2
+    class DeclarationsController < BaseController
+      def create = head(:method_not_allowed)
+      def show = head(:method_not_allowed)
+      def index = head(:method_not_allowed)
+      def void = head(:method_not_allowed)
+    end
+  end
+end

--- a/app/controllers/api/v2/enrolments_controller.rb
+++ b/app/controllers/api/v2/enrolments_controller.rb
@@ -1,0 +1,7 @@
+module Api
+  module V2
+    class EnrolmentsController < BaseController
+      def index = head(:method_not_allowed)
+    end
+  end
+end

--- a/app/controllers/api/v2/outcomes_controller.rb
+++ b/app/controllers/api/v2/outcomes_controller.rb
@@ -1,0 +1,7 @@
+module Api
+  module V2
+    class OutcomesController < BaseController
+      def index = head(:method_not_allowed)
+    end
+  end
+end

--- a/app/controllers/api/v2/participants/outcomes_controller.rb
+++ b/app/controllers/api/v2/participants/outcomes_controller.rb
@@ -1,0 +1,10 @@
+module Api
+  module V2
+    module Participants
+      class OutcomesController < BaseController
+        def index = head(:method_not_allowed)
+        def create = head(:method_not_allowed)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/participants_controller.rb
+++ b/app/controllers/api/v2/participants_controller.rb
@@ -1,0 +1,13 @@
+module Api
+  module V2
+    class ParticipantsController < BaseController
+      def index = head(:method_not_allowed)
+      def show = head(:method_not_allowed)
+      def change_schedule = head(:method_not_allowed)
+      def defer = head(:method_not_allowed)
+      def withdraw = head(:method_not_allowed)
+      def resume = head(:method_not_allowed)
+      def outcomes = head(:method_not_allowed)
+    end
+  end
+end

--- a/app/controllers/api/v3/applications_controller.rb
+++ b/app/controllers/api/v3/applications_controller.rb
@@ -1,0 +1,10 @@
+module Api
+  module V3
+    class ApplicationsController < BaseController
+      def index = head(:method_not_allowed)
+      def show = head(:method_not_allowed)
+      def accept = head(:method_not_allowed)
+      def reject = head(:method_not_allowed)
+    end
+  end
+end

--- a/app/controllers/api/v3/declarations_controller.rb
+++ b/app/controllers/api/v3/declarations_controller.rb
@@ -1,0 +1,10 @@
+module Api
+  module V3
+    class DeclarationsController < BaseController
+      def create = head(:method_not_allowed)
+      def show = head(:method_not_allowed)
+      def index = head(:method_not_allowed)
+      def void = head(:method_not_allowed)
+    end
+  end
+end

--- a/app/controllers/api/v3/outcomes_controller.rb
+++ b/app/controllers/api/v3/outcomes_controller.rb
@@ -1,0 +1,7 @@
+module Api
+  module V3
+    class OutcomesController < BaseController
+      def index = head(:method_not_allowed)
+    end
+  end
+end

--- a/app/controllers/api/v3/participants/outcomes_controller.rb
+++ b/app/controllers/api/v3/participants/outcomes_controller.rb
@@ -1,0 +1,10 @@
+module Api
+  module V3
+    module Participants
+      class OutcomesController < BaseController
+        def index = head(:method_not_allowed)
+        def create = head(:method_not_allowed)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v3/participants_controller.rb
+++ b/app/controllers/api/v3/participants_controller.rb
@@ -1,0 +1,13 @@
+module Api
+  module V3
+    class ParticipantsController < BaseController
+      def index = head(:method_not_allowed)
+      def show = head(:method_not_allowed)
+      def change_schedule = head(:method_not_allowed)
+      def defer = head(:method_not_allowed)
+      def withdraw = head(:method_not_allowed)
+      def resume = head(:method_not_allowed)
+      def outcomes = head(:method_not_allowed)
+    end
+  end
+end

--- a/app/controllers/api/v3/statements_controller.rb
+++ b/app/controllers/api/v3/statements_controller.rb
@@ -1,0 +1,8 @@
+module Api
+  module V3
+    class StatementsController < BaseController
+      def show = head(:method_not_allowed)
+      def index = head(:method_not_allowed)
+    end
+  end
+end

--- a/app/controllers/npq_separation/admin/admins_controller.rb
+++ b/app/controllers/npq_separation/admin/admins_controller.rb
@@ -1,0 +1,3 @@
+class NpqSeparation::Admin::AdminsController < ApplicationController
+  def index = head(:method_not_allowed)
+end

--- a/app/controllers/npq_separation/migration/migrations_controller.rb
+++ b/app/controllers/npq_separation/migration/migrations_controller.rb
@@ -1,0 +1,3 @@
+class NpqSeparation::Migration::MigrationsController < ApplicationController
+  def index = head(:method_not_allowed)
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -70,4 +70,11 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  # Enable/disable aspects of the NPQ separation
+  config.npq_separation = {
+    admin_portal_enabled: true,
+    api_enabled: true,
+    migration_enabled: true,
+  }
 end

--- a/config/environments/migration.rb
+++ b/config/environments/migration.rb
@@ -3,4 +3,11 @@ require Rails.root.join("config/environments/production")
 Rails.application.configure do
   config.log_level = :debug
   config.ssl_options = { redirect: { exclude: ->(request) { request.path.include?("/healthcheck") } } }
+
+  # Enable/disable aspects of the NPQ separation
+  config.npq_separation = {
+    admin_portal_enabled: true,
+    api_enabled: true,
+    migration_enabled: true,
+  }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -123,4 +123,11 @@ Rails.application.configure do
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 
   config.session_store :active_record_store, key: "_npq_registration_session", secure: true, expire_after: 2.weeks
+
+  # Enable/disable aspects of the NPQ separation
+  config.npq_separation = {
+    admin_portal_enabled: false,
+    api_enabled: false,
+    migration_enabled: false,
+  }
 end

--- a/config/environments/review.rb
+++ b/config/environments/review.rb
@@ -3,4 +3,11 @@ require Rails.root.join("config/environments/production")
 Rails.application.configure do
   config.log_level = :debug
   config.ssl_options = { redirect: { exclude: ->(request) { request.path.include?("/healthcheck") } } }
+
+  # Enable/disable aspects of the NPQ separation
+  config.npq_separation = {
+    admin_portal_enabled: true,
+    api_enabled: true,
+    migration_enabled: true,
+  }
 end

--- a/config/environments/sandbox.rb
+++ b/config/environments/sandbox.rb
@@ -3,4 +3,11 @@ require Rails.root.join("config/environments/production")
 Rails.application.configure do
   config.log_level = :info
   config.ssl_options = { redirect: { exclude: ->(request) { request.path.include?("/healthcheck") } } }
+
+  # Enable/disable aspects of the NPQ separation
+  config.npq_separation = {
+    admin_portal_enabled: false,
+    api_enabled: false,
+    migration_enabled: false,
+  }
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -3,4 +3,11 @@ require Rails.root.join("config/environments/production")
 Rails.application.configure do
   config.log_level = :debug
   config.ssl_options = { redirect: { exclude: ->(request) { request.path.include?("/healthcheck") } } }
+
+  # Enable/disable aspects of the NPQ separation
+  config.npq_separation = {
+    admin_portal_enabled: true,
+    api_enabled: true,
+    migration_enabled: true,
+  }
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -57,4 +57,11 @@ Rails.application.configure do
   config.active_job.queue_adapter = :test
 
   config.session_store :active_record_store, key: "_npq_registration_session", secure: false, expire_after: 2.weeks
+
+  # Enable/disable aspects of the NPQ separation
+  config.npq_separation = {
+    admin_portal_enabled: true,
+    api_enabled: true,
+    migration_enabled: true,
+  }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -153,6 +153,16 @@ Rails.application.routes.draw do
     end
   end
 
+  namespace :npq_separation do
+    namespace :admin do
+      resources :admins, only: %i[index]
+    end
+
+    namespace :migration do
+      resources :migrations, only: %i[index]
+    end
+  end
+
   resource :csp_reports, only: %i[create]
 
   get "/404", to: "errors#not_found", via: :all

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,18 +85,15 @@ Rails.application.routes.draw do
         post :accept, path: "accept"
       end
 
-      namespace :participants do
-        resources :npq, only: %i[index show] do
-          put :change_schedule, path: "change-schedule"
-          put :defer, path: "defer"
-          put :resume, path: "resume"
-          put :withdraw, path: "withdraw"
-
-          get :outcomes, path: "outcomes"
-        end
-
-        resources :outcomes, only: %i[index]
+      resources :participants, only: %i[index show], path: "participants/npq" do
+        put :change_schedule, path: "change-schedule"
+        put :defer
+        put :resume
+        put :withdraw
+        get :outcomes
       end
+
+      resources :outcomes, only: %i[index]
 
       resources :declarations, only: %i[create show index] do
         put :void, path: "void"
@@ -111,18 +108,18 @@ Rails.application.routes.draw do
 
       resources :enrolments, path: "npq-enrolments", only: %i[index]
 
-      namespace :participants do
-        resources :npq, only: %i[index show] do
-          put :change_schedule, path: "change-schedule"
-          put :defer, path: "defer"
-          put :resume, path: "resume"
-          put :withdraw, path: "withdraw"
+      resources :participants, only: %i[index show], path: "participants/npq" do
+        put :change_schedule, path: "change-schedule"
+        put :defer
+        put :resume
+        put :withdraw
 
-          get :outcomes, path: "outcomes"
+        scope module: :participants do
+          resources :outcomes, only: %i[create index]
         end
-
-        resources :outcomes, only: %i[index]
       end
+
+      resources :outcomes, only: %i[index]
 
       resources :declarations, only: %i[create show index] do
         put :void, path: "void"
@@ -135,18 +132,18 @@ Rails.application.routes.draw do
         post :accept, path: "accept"
       end
 
-      namespace :participants do
-        resources :npq, only: %i[index show] do
-          put :change_schedule, path: "change-schedule"
-          put :defer, path: "defer"
-          put :resume, path: "resume"
-          put :withdraw, path: "withdraw"
+      resources :participants, only: %i[index show], path: "participants/npq" do
+        put :change_schedule, path: "change-schedule"
+        put :defer
+        put :resume
+        put :withdraw
 
-          resources :outcomes, path: "outcomes", only: %i[index create]
+        scope module: :participants do
+          resources :outcomes, only: %i[create index]
         end
-
-        resources :outcomes, only: %i[index]
       end
+
+      resources :outcomes, only: %i[index]
 
       resources :declarations, only: %i[create show index] do
         put :void, path: "void"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,80 @@ Rails.application.routes.draw do
       namespace :get_an_identity do
         resource :webhook_messages, only: %i[create]
       end
+
+      resources :applications, path: "npq-applications", only: %i[index show] do
+        post :reject, path: "reject"
+        post :accept, path: "accept"
+      end
+
+      namespace :participants do
+        resources :npq, only: %i[index show] do
+          put :change_schedule, path: "change-schedule"
+          put :defer, path: "defer"
+          put :resume, path: "resume"
+          put :withdraw, path: "withdraw"
+
+          get :outcomes, path: "outcomes"
+        end
+
+        resources :outcomes, only: %i[index]
+      end
+
+      resources :declarations, only: %i[create show index] do
+        put :void, path: "void"
+      end
+    end
+
+    namespace :v2 do
+      resources :applications, path: "npq-applications", only: %i[index show] do
+        post :reject, path: "reject"
+        post :accept, path: "accept"
+      end
+
+      resources :enrolments, path: "npq-enrolments", only: %i[index]
+
+      namespace :participants do
+        resources :npq, only: %i[index show] do
+          put :change_schedule, path: "change-schedule"
+          put :defer, path: "defer"
+          put :resume, path: "resume"
+          put :withdraw, path: "withdraw"
+
+          get :outcomes, path: "outcomes"
+        end
+
+        resources :outcomes, only: %i[index]
+      end
+
+      resources :declarations, only: %i[create show index] do
+        put :void, path: "void"
+      end
+    end
+
+    namespace :v3 do
+      resources :applications, path: "npq-applications", only: %i[index show] do
+        post :reject, path: "reject"
+        post :accept, path: "accept"
+      end
+
+      namespace :participants do
+        resources :npq, only: %i[index show] do
+          put :change_schedule, path: "change-schedule"
+          put :defer, path: "defer"
+          put :resume, path: "resume"
+          put :withdraw, path: "withdraw"
+
+          resources :outcomes, path: "outcomes", only: %i[index create]
+        end
+
+        resources :outcomes, only: %i[index]
+      end
+
+      resources :declarations, only: %i[create show index] do
+        put :void, path: "void"
+      end
+
+      resources :statements, only: %i[index show]
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,27 +80,29 @@ Rails.application.routes.draw do
         resource :webhook_messages, only: %i[create]
       end
 
-      resources :applications, path: "npq-applications", only: %i[index show] do
-        post :reject, path: "reject"
-        post :accept, path: "accept"
-      end
+      constraints -> { Rails.application.config.npq_separation[:api_enabled] } do
+        resources :applications, path: "npq-applications", only: %i[index show] do
+          post :reject, path: "reject"
+          post :accept, path: "accept"
+        end
 
-      resources :participants, only: %i[index show], path: "participants/npq" do
-        put :change_schedule, path: "change-schedule"
-        put :defer
-        put :resume
-        put :withdraw
-        get :outcomes
-      end
+        resources :participants, only: %i[index show], path: "participants/npq" do
+          put :change_schedule, path: "change-schedule"
+          put :defer
+          put :resume
+          put :withdraw
+          get :outcomes
+        end
 
-      resources :outcomes, only: %i[index]
+        resources :outcomes, only: %i[index]
 
-      resources :declarations, only: %i[create show index] do
-        put :void, path: "void"
+        resources :declarations, only: %i[create show index] do
+          put :void, path: "void"
+        end
       end
     end
 
-    namespace :v2 do
+    namespace :v2, constraints: ->(_request) { Rails.application.config.npq_separation[:api_enabled] } do
       resources :applications, path: "npq-applications", only: %i[index show] do
         post :reject, path: "reject"
         post :accept, path: "accept"
@@ -126,7 +128,7 @@ Rails.application.routes.draw do
       end
     end
 
-    namespace :v3 do
+    namespace :v3, constraints: ->(_request) { Rails.application.config.npq_separation[:api_enabled] } do
       resources :applications, path: "npq-applications", only: %i[index show] do
         post :reject, path: "reject"
         post :accept, path: "accept"
@@ -154,11 +156,11 @@ Rails.application.routes.draw do
   end
 
   namespace :npq_separation do
-    namespace :admin do
+    namespace :admin, constraints: ->(_request) { Rails.application.config.npq_separation[:admin_portal_enabled] } do
       resources :admins, only: %i[index]
     end
 
-    namespace :migration do
+    namespace :migration, constraints: ->(_request) { Rails.application.config.npq_separation[:migration_enabled] } do
       resources :migrations, only: %i[index]
     end
   end

--- a/spec/controllers/api/v1/applications_controller_spec.rb
+++ b/spec/controllers/api/v1/applications_controller_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe Api::V1::ApplicationsController, type: "request" do
+  describe("index") do
+    before { get(api_v1_applications_path) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("show") do
+    before { get(api_v1_application_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("accept") do
+    before { post(api_v1_application_accept_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("reject") do
+    before { post(api_v1_application_reject_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+end

--- a/spec/controllers/api/v1/declarations_controller_spec.rb
+++ b/spec/controllers/api/v1/declarations_controller_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe Api::V1::DeclarationsController, type: "request" do
+  describe("index") do
+    before { get(api_v1_applications_path) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("show") do
+    before { get(api_v1_application_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("accept") do
+    before { post(api_v1_application_accept_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("reject") do
+    before { post(api_v1_application_reject_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+end

--- a/spec/controllers/api/v1/outcomes_controller_spec.rb
+++ b/spec/controllers/api/v1/outcomes_controller_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe Api::V1::OutcomesController, type: "request" do
+  describe("index") do
+    before { get(api_v1_outcomes_path) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+end

--- a/spec/controllers/api/v1/participants_controller_spec.rb
+++ b/spec/controllers/api/v1/participants_controller_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe Api::V1::ParticipantsController, type: "request" do
+  describe("index") do
+    before { get(api_v1_participants_path) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("show") do
+    before { get(api_v1_participant_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("change_schedule") do
+    before { put(api_v1_participant_change_schedule_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("defer") do
+    before { put(api_v1_participant_defer_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("withdraw") do
+    before { put(api_v1_participant_withdraw_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("resume") do
+    before { put(api_v1_participant_resume_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("outcomes") do
+    before { get(api_v1_participant_outcomes_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+end

--- a/spec/controllers/api/v2/applications_controller_spec.rb
+++ b/spec/controllers/api/v2/applications_controller_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe Api::V2::ApplicationsController, type: "request" do
+  describe("index") do
+    before { get(api_v2_applications_path) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("show") do
+    before { get(api_v2_application_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("accept") do
+    before { post(api_v2_application_accept_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("reject") do
+    before { post(api_v2_application_reject_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+end

--- a/spec/controllers/api/v2/declarations_controller_spec.rb
+++ b/spec/controllers/api/v2/declarations_controller_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe Api::V2::DeclarationsController, type: "request" do
+  describe("index") do
+    before { get(api_v2_applications_path) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("show") do
+    before { get(api_v2_application_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("accept") do
+    before { post(api_v2_application_accept_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("reject") do
+    before { post(api_v2_application_reject_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+end

--- a/spec/controllers/api/v2/enrolments_controller_spec.rb
+++ b/spec/controllers/api/v2/enrolments_controller_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe Api::V2::EnrolmentsController, type: "request" do
+  describe("index") do
+    before { get(api_v2_enrolments_path) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+end

--- a/spec/controllers/api/v2/outcomes_controller_spec.rb
+++ b/spec/controllers/api/v2/outcomes_controller_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe Api::V2::OutcomesController, type: "request" do
+  describe("index") do
+    before { get(api_v2_outcomes_path) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+end

--- a/spec/controllers/api/v2/participants/outcomes_controller_spec.rb
+++ b/spec/controllers/api/v2/participants/outcomes_controller_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe Api::V2::Participants::OutcomesController, type: "request" do
+  describe("index") do
+    before { get(api_v2_participant_outcomes_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("create") do
+    before { post(api_v2_participant_outcomes_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+end

--- a/spec/controllers/api/v2/participants_controller_spec.rb
+++ b/spec/controllers/api/v2/participants_controller_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe Api::V2::ParticipantsController, type: "request" do
+  describe("index") do
+    before { get(api_v2_participants_path) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("show") do
+    before { get(api_v2_participant_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("change_schedule") do
+    before { put(api_v2_participant_change_schedule_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("defer") do
+    before { put(api_v2_participant_defer_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("withdraw") do
+    before { put(api_v2_participant_withdraw_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("resume") do
+    before { put(api_v2_participant_resume_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("outcomes") do
+    before { get(api_v2_participant_outcomes_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+end

--- a/spec/controllers/api/v3/applications_controller_spec.rb
+++ b/spec/controllers/api/v3/applications_controller_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe Api::V3::ApplicationsController, type: "request" do
+  describe("index") do
+    before { get(api_v3_applications_path) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("show") do
+    before { get(api_v3_application_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("accept") do
+    before { post(api_v3_application_accept_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("reject") do
+    before { post(api_v3_application_reject_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+end

--- a/spec/controllers/api/v3/declarations_controller_spec.rb
+++ b/spec/controllers/api/v3/declarations_controller_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe Api::V3::DeclarationsController, type: "request" do
+  describe("index") do
+    before { get(api_v3_statements_path) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("show") do
+    before { get(api_v3_statement_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+end

--- a/spec/controllers/api/v3/outcomes_controller_spec.rb
+++ b/spec/controllers/api/v3/outcomes_controller_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe Api::V3::OutcomesController, type: "request" do
+  describe("index") do
+    before { get(api_v3_outcomes_path) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+end

--- a/spec/controllers/api/v3/participants/outcomes_controller_spec.rb
+++ b/spec/controllers/api/v3/participants/outcomes_controller_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe Api::V3::Participants::OutcomesController, type: "request" do
+  describe("index") do
+    before { get(api_v3_participant_outcomes_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("create") do
+    before { post(api_v3_participant_outcomes_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+end

--- a/spec/controllers/api/v3/participants_controller_spec.rb
+++ b/spec/controllers/api/v3/participants_controller_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe Api::V3::ParticipantsController, type: "request" do
+  describe("index") do
+    before { get(api_v3_participants_path) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("show") do
+    before { get(api_v3_participant_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("change_schedule") do
+    before { put(api_v3_participant_change_schedule_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("defer") do
+    before { put(api_v3_participant_defer_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("withdraw") do
+    before { put(api_v3_participant_withdraw_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("resume") do
+    before { put(api_v3_participant_resume_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+
+  describe("outcomes") do
+    before { get(api_v3_participant_outcomes_path(123)) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+end

--- a/spec/controllers/npq_separation/admin/admins_controller_spec.rb
+++ b/spec/controllers/npq_separation/admin/admins_controller_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe NpqSeparation::Admin::AdminsController, type: :request do
+  describe("index") do
+    before { get(npq_separation_admin_admins_path) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+end

--- a/spec/controllers/npq_separation/migration/migrations_controller_spec.rb
+++ b/spec/controllers/npq_separation/migration/migrations_controller_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe NpqSeparation::Migration::MigrationsController, type: :request do
+  describe("index") do
+    before { get(npq_separation_admin_admins_path) }
+
+    specify { expect(response).to(be_method_not_allowed) }
+  end
+end

--- a/spec/routing/npq_separation_routes_spec.rb
+++ b/spec/routing/npq_separation_routes_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe "NPQ separation routes" do
+  let(:api_enabled) { true }
+  let(:admin_portal_enabled) { true }
+  let(:migration_enabled) { true }
+
+  before do
+    allow(Rails.application.config).to receive(:npq_separation) do
+      {
+        api_enabled:,
+        admin_portal_enabled:,
+        migration_enabled:,
+      }
+    end
+  end
+
+  it { expect(get(api_v1_applications_path)).to route_to("api/v1/applications#index") }
+  it { expect(get(api_v2_applications_path)).to route_to("api/v2/applications#index") }
+  it { expect(get(api_v3_applications_path)).to route_to("api/v3/applications#index") }
+  it { expect(get(npq_separation_admin_admins_path)).to route_to("npq_separation/admin/admins#index") }
+  it { expect(get(npq_separation_migration_migrations_path)).to route_to("npq_separation/migration/migrations#index") }
+
+  context "when api_enabled is false" do
+    let(:api_enabled) { false }
+
+    it { expect(get(api_v1_applications_path)).not_to be_routable }
+    it { expect(get(api_v2_applications_path)).not_to be_routable }
+    it { expect(get(api_v3_applications_path)).not_to be_routable }
+
+    it { expect(get(npq_separation_admin_admins_path)).to be_routable }
+    it { expect(get(npq_separation_migration_migrations_path)).to be_routable }
+  end
+
+  context "when admin_portal_enabled is false" do
+    let(:admin_portal_enabled) { false }
+
+    it { expect(get(npq_separation_admin_admins_path)).not_to be_routable }
+
+    it { expect(get(api_v1_applications_path)).to be_routable }
+    it { expect(get(api_v2_applications_path)).to be_routable }
+    it { expect(get(api_v3_applications_path)).to be_routable }
+    it { expect(get(npq_separation_migration_migrations_path)).to be_routable }
+  end
+
+  context "when migration_enabled is false" do
+    let(:migration_enabled) { false }
+
+    it { expect(get(npq_separation_migration_migrations_path)).not_to be_routable }
+
+    it { expect(get(api_v1_applications_path)).to be_routable }
+    it { expect(get(api_v2_applications_path)).to be_routable }
+    it { expect(get(api_v3_applications_path)).to be_routable }
+    it { expect(get(npq_separation_admin_admins_path)).to be_routable }
+  end
+end


### PR DESCRIPTION
[Jira-2829](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2829)

### Context

We want to be able to develop/merge NPQ separation changes into `main` without exposing them on all environments until we're ready. In order to do this we need a mechanism to exclude routes from certain environments (we are favouring this high-level approach instead of peppering feature checks throughout the codebase).

### Changes proposed in this pull request

- Bring in skeleton API endpoints

These were implemented by Pete as part of the NPQ separation spike and provides a nice set of boilerplate controllers/actions we can work from. It also means we can write tests against the routes.

- Add per-env config variables to control NPQ separation access

We only want to allow access to the NPQ separation API endpoints, admin area and migration functionality for non-production environments initially.

Disable access for all environments apart from development, test, review, staging and migration. We may want to allow access in sandbox in once we've briefed providers and then finally production.

- Add stub controllers for NPQ separation admin/migration endpoints

We will be adding routes and controlling access per environment; in order to test we need something to route to.

- Restrict access to NPQ separation routes

While we are migrating across from ECF and developing the functionality in NPQ registration we don't want to allow access to the new routes until we are ready.

Constrain access according to the environment configuration.

### Guidance to review

NPQ separation functionality will initially be enabled everywhere apart from sandbox and production, which are the provider-facing environments.