### PR TITLE
Removed 'labeled' trigger from PR deploy run

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,11 +12,6 @@ on:
   pull_request:
     branches:
       - main
-    types:
-      - labeled
-      - synchronize
-      - reopened
-      - opened
 
 jobs:
   lint:


### PR DESCRIPTION
This isn't needed as we always build review apps now instead of just building them when the `review-app` label is present. The defaults are synchronize, reopened, opened so we don't need to specify anything here.
