### PR TITLE
Update LeadProvider model for parity with ECF

### DIFF
--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -76,6 +76,8 @@ class LeadProvider < ApplicationRecord
     "npq-leading-primary-mathematics" => LPM_PROVIDERS,
   }.freeze
 
+  has_many :applications
+
   scope :alphabetical, -> { order(name: :asc) }
 
   def self.for(course:)

--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -78,6 +78,8 @@ class LeadProvider < ApplicationRecord
 
   has_many :applications
 
+  validates :name, presence: true
+
   scope :alphabetical, -> { order(name: :asc) }
 
   def self.for(course:)

--- a/db/migrate/20240219160343_add_vat_chargeable_to_lead_providers.rb
+++ b/db/migrate/20240219160343_add_vat_chargeable_to_lead_providers.rb
@@ -1,0 +1,5 @@
+class AddVatChargeableToLeadProviders < ActiveRecord::Migration[7.1]
+  def change
+    add_column :lead_providers, :vat_chargeable, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_13_164111) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_19_160343) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -158,6 +158,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_13_164111) do
     t.datetime "updated_at", null: false
     t.text "ecf_id"
     t.string "hint"
+    t.boolean "vat_chargeable", default: true
   end
 
   create_table "local_authorities", force: :cascade do |t|

--- a/spec/factories/lead_providers.rb
+++ b/spec/factories/lead_providers.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :lead_provider do
+    sequence(:name) { |i| "Lead Provider #{i}" }
+  end
+end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -1,6 +1,17 @@
 require "rails_helper"
 
 RSpec.describe Application do
+  describe "relationships" do
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:course) }
+    it { is_expected.to belong_to(:lead_provider) }
+    it { is_expected.to belong_to(:school).optional }
+    it { is_expected.to belong_to(:private_childcare_provider).optional }
+    it { is_expected.to belong_to(:itt_provider).optional }
+
+    it { is_expected.to have_many(:ecf_sync_request_logs).dependent(:destroy) }
+  end
+
   describe "scopes" do
     describe ".unsynced" do
       it "returns records where ecf_id is null" do

--- a/spec/models/ecf_sync_request_log_spec.rb
+++ b/spec/models/ecf_sync_request_log_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.describe EcfSyncRequestLog, type: :model do
+  describe "relationships" do
+    it { is_expected.to belong_to(:syncable) }
+  end
+
   describe "validations" do
     it { is_expected.to validate_presence_of(:syncable) }
     it { is_expected.to validate_presence_of(:status) }

--- a/spec/models/lead_provider_spec.rb
+++ b/spec/models/lead_provider_spec.rb
@@ -5,6 +5,19 @@ RSpec.describe LeadProvider do
     it { is_expected.to have_many(:applications) }
   end
 
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:name) }
+  end
+
+  describe "scopes" do
+    describe "#alphabetical" do
+      it "orders by name ascending" do
+        expect(described_class.count).to be > 1
+        expect(described_class.alphabetical.map(&:name)).to eq(described_class.pluck(:name).sort)
+      end
+    end
+  end
+
   describe "#for" do
     subject { described_class.for(course:).map(&:name) }
 

--- a/spec/models/lead_provider_spec.rb
+++ b/spec/models/lead_provider_spec.rb
@@ -1,14 +1,16 @@
 require "rails_helper"
 
 RSpec.describe LeadProvider do
+  describe "relationships" do
+    it { is_expected.to have_many(:applications) }
+  end
+
   describe "#for" do
     subject { described_class.for(course:).map(&:name) }
 
     let(:course) { Course.find_by!(identifier: course_identifier) }
 
-    before do
-      LeadProviders::Updater.call
-    end
+    before { LeadProviders::Updater.call }
 
     context "with course npq-headship" do
       let(:course_identifier) { "npq-headship" }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,1 +1,8 @@
 require "rails_helper"
+
+RSpec.describe User do
+  describe "relationships" do
+    it { is_expected.to belong_to(:applications) }
+    it { is_expected.to have_many(:ecf_sync_request_logs).dependent(:destroy) }
+  end
+end


### PR DESCRIPTION
[Jira-2828](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2828)

### Context

As part of the NPQ separation work we want to update the existing `LeadProvider` model to make it consistent with ECF in terms of relationships and validation.

### Changes proposed in this pull request

- Add missing applications relationship to LeadProvider

Add a missing relationship between `LeadProvider` and `Application`.

Add test coverage for relationships in general.

- Add missing validation to LeadProvider model

Add missing `name` validation to `LeadProvider` model, as per ECF.

Add missing test coverage for `alphabetical` scope.
