### PR TITLE
CPDNPQ-1678 Retain TSF Info on Registration Details for Past Registrations

### DIFF
--- a/app/helpers/funding_helper.rb
+++ b/app/helpers/funding_helper.rb
@@ -14,9 +14,8 @@ module FundingHelper
       application.teacher_catchment == "england" && application.course.identifier != "npq-early-headship-coaching-offer"
   end
 
-  def targeted_support_funding(application)
-    funding_amount = application.targeted_delivery_funding_eligibility && application.tsf_primary_plus_eligibility ? 800 : 200
-    I18n.t("funding_details.targeted_funding_eligibility", funding_amount:)
+  def targeted_support_funding
+    I18n.t("funding_details.targeted_funding_eligibility").html_safe
   end
 
 private

--- a/app/views/accounts/_funding_details.html.erb
+++ b/app/views/accounts/_funding_details.html.erb
@@ -28,14 +28,14 @@
 
         <% scholarship_funding_row(application) %>
 
-        <% if Flipper.enabled?(:targeted_support_funding) %>
+        <% if Flipper.enabled?(:targeted_support_funding) || application.created_at < APRIL_2024_CUTOFF_DATE %>
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
               Targeted support funding
             </dt>
             <dd class="govuk-summary-list__value">
               <strong class="govuk-tag govuk-tag--green">ELIGIBLE</strong>
-              <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= targeted_support_funding(application) %></p>
+              <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= targeted_support_funding %></p>
             </dd>
           </div>
         <% end %>

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -1,0 +1,1 @@
+APRIL_2024_CUTOFF_DATE = Time.zone.local(2024, 4, 2)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -272,7 +272,7 @@ en:
     no_Ofsted: "You’re not eligible for schools funding because you or your employer is not registered on the Ofsted Early Years Register or with a registered Childminder Agency."
     previously_funded: "You have already been allocated scholarship funding for %{course_name}."
     scholarship_eligibility: "This means that you will not have to pay for the course fees."
-    targeted_funding_eligibility: "Your workplace will receive £%{funding_amount} to support you to do this NPQ."
+    targeted_funding_eligibility: "Your workplace will receive a <a href=\"https://www.gov.uk/government/publications/targeted-support-funding-for-national-professional-qualifications\" class=\"govuk-link\">targeted support funding</a> payment to support you to do this NPQ."
     ineligible_message: "This means that you would need to pay for the course another way."
     not_eligible_ehco: "You’re not eligible for scholarship funding for %{course_name}."
 


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-1678

- Use the existing TSF feature flag 

- On the registration details pages, if the person is marked as eligible for TSF a row should display under the Scholarship funding row. 

- When TSF is shown, an ‘eligible’ green tag should display and below the tag the content: 
 
- Your workplace will receive a targeted support funding payment to support you to do this NPQ.

- If they are not eligible for TSF or the registration is submitted post-April 2024 no info about TSF should display.