### PR TITLE
Fix seeding bug where we check multiple envs

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -52,7 +52,7 @@ seed_courses!
 seed_lead_providers!
 seed_itt_providers!
 
-if Rails.env.in?(%i[development review])
+if Rails.env.in?(%w[development review])
   otp_testing_code = "00000"
 
   # Create admin user


### PR DESCRIPTION
I introduced this yesterday under the assumption envs were a list of labels rather than strings 🙈
