### PR TITLE
Add a devise secret key for the test env

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -5,6 +5,10 @@ require "omniauth/strategies/tra_openid_connect"
 Devise.setup do |config|
   require "devise/orm/active_record"
 
+  if Rails.env.test?
+    config.secret_key = "devisebequiet1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
+  end
+
   # ==> OmniAuth
   tra_oidc_secret  = ENV.fetch("TRA_OIDC_CLIENT_SECRET", nil)
   tra_oidc_id      = ENV.fetch("TRA_OIDC_CLIENT_ID", nil)


### PR DESCRIPTION
Tests keep failing because there's no secret key. This doesn't happen anywhere else, so add a dummy one that's present for the test env.
