### PR TITLE
Add skeleton Migrator service with dummy migration run

### DIFF
--- a/app/models/migration/data_migration.rb
+++ b/app/models/migration/data_migration.rb
@@ -3,6 +3,8 @@ module Migration
     validates :model, presence: true
     validates :processed_count, presence: true
     validates :failure_count, presence: true
+    validates :total_count, presence: true, if: ->(m) { m.started_at.present? }
+    validates :total_count, numericality: { greater_than: 0 }, allow_nil: true
     validates :completed_at, comparison: { greater_than: :started_at }, if: ->(m) { m.started_at.present? }, allow_nil: true
   end
 end

--- a/app/models/migration/data_migration.rb
+++ b/app/models/migration/data_migration.rb
@@ -1,0 +1,8 @@
+module Migration
+  class DataMigration < ApplicationRecord
+    validates :model, presence: true
+    validates :processed_count, presence: true
+    validates :failure_count, presence: true
+    validates :completed_at, comparison: { greater_than: :started_at }, if: ->(m) { m.started_at.present? }, allow_nil: true
+  end
+end

--- a/app/services/migration/migrator.rb
+++ b/app/services/migration/migrator.rb
@@ -1,0 +1,47 @@
+module Migration
+  class Migrator
+    class UnsupportedEnvironmentError < RuntimeError; end
+
+    MODELS_TO_MIGRATE = %i[lead_provider cohort statement].freeze
+
+    def migrate!
+      check_environment!
+      initialize_dummy_migration
+      run_dummy_migration
+    end
+
+  private
+
+    attr_accessor :data_migrations
+
+    def check_environment!
+      migration_enabled = Rails.application.config.npq_separation[:migration_enabled]
+
+      raise UnsupportedEnvironmentError, "The migration functionality is disabled for this environment" unless migration_enabled
+    end
+
+    def initialize_dummy_migration
+      self.data_migrations = MODELS_TO_MIGRATE.index_with { |model| Migration::DataMigration.create!(model:) }
+    end
+
+    def run_dummy_migration
+      MODELS_TO_MIGRATE.each { |model| simulate_model_migration(model) }
+    end
+
+    def simulate_model_migration(model)
+      data_migrations[model].update!(started_at: Time.zone.now)
+
+      rand(1...1000).times do |processed_count|
+        # Up to 1 minute of processing time/model
+        sleep(rand(0.001...0.06))
+
+        data_migrations[model].update!(processed_count:)
+
+        record_failure = rand(1...50) == 50
+        data_migrations[model].update!(failure_count: data_migrations[model].failure_count + 1) if record_failure
+      end
+
+      data_migrations[model].update!(completed_at: Time.zone.now)
+    end
+  end
+end

--- a/app/services/migration/migrator.rb
+++ b/app/services/migration/migrator.rb
@@ -29,9 +29,9 @@ module Migration
     end
 
     def simulate_model_migration(model)
-      data_migrations[model].update!(started_at: Time.zone.now)
+      data_migrations[model].update!(started_at: Time.zone.now, total_count: rand(1...1000))
 
-      rand(1...1000).times do |processed_count|
+      data_migrations[model].total_count.times do |processed_count|
         # Up to 1 minute of processing time/model
         sleep(rand(0.001...0.06))
 

--- a/db/migrate/20240228140211_create_data_migration.rb
+++ b/db/migrate/20240228140211_create_data_migration.rb
@@ -1,0 +1,13 @@
+class CreateDataMigration < ActiveRecord::Migration[7.1]
+  def change
+    create_table :data_migrations do |t|
+      t.string :model, null: false
+      t.integer :processed_count, null: false, default: 0
+      t.integer :failure_count, null: false, default: 0
+      t.datetime :started_at
+      t.datetime :completed_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240301152723_add_total_count_to_data_migrations.rb
+++ b/db/migrate/20240301152723_add_total_count_to_data_migrations.rb
@@ -1,0 +1,7 @@
+class AddTotalCountToDataMigrations < ActiveRecord::Migration[7.1]
+  def change
+    change_table :data_migrations do |t|
+      t.integer :total_count, null: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_28_140211) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_01_152723) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -106,6 +106,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_28_140211) do
     t.datetime "completed_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "total_count"
   end
 
   create_table "delayed_jobs", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_21_114716) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_28_140211) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -96,6 +96,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_21_114716) do
     t.integer "position", default: 0
     t.boolean "display", default: true
     t.string "identifier"
+  end
+
+  create_table "data_migrations", force: :cascade do |t|
+    t.string "model", null: false
+    t.integer "processed_count", default: 0, null: false
+    t.integer "failure_count", default: 0, null: false
+    t.datetime "started_at"
+    t.datetime "completed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "delayed_jobs", force: :cascade do |t|

--- a/spec/lib/services/migration/migrator_spec.rb
+++ b/spec/lib/services/migration/migrator_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe Migration::Migrator do
+  let(:migration_enabled) { true }
+  let(:instance) { described_class.new }
+
+  before { allow(Rails.application.config).to receive(:npq_separation) { { migration_enabled: } } }
+
+  describe "#migrate!" do
+    subject(:migrate) { instance.migrate! }
+
+    before { allow_any_instance_of(described_class).to receive(:sleep) }
+
+    it { expect { migrate }.not_to raise_error }
+
+    it { expect { migrate }.to change(Migration::DataMigration, :count).by(3) }
+
+    context "when migration is disabled" do
+      let(:migration_enabled) { false }
+
+      it { expect { migrate }.to raise_error(Migration::Migrator::UnsupportedEnvironmentError, "The migration functionality is disabled for this environment") }
+    end
+  end
+end

--- a/spec/models/migration/data_migration_spec.rb
+++ b/spec/models/migration/data_migration_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe Migration::DataMigration, type: :model do
+  subject(:instance) { described_class.new }
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:model) }
+    it { is_expected.to validate_presence_of(:processed_count) }
+    it { is_expected.to validate_presence_of(:failure_count) }
+    it { is_expected.not_to validate_presence_of(:completed_at) }
+
+    context "when started_at is present" do
+      before { instance.started_at = 1.day.ago }
+
+      it { is_expected.to validate_comparison_of(:completed_at).is_greater_than(instance.started_at).allow_nil }
+    end
+  end
+
+  describe "defaults" do
+    it { expect(instance.processed_count).to eq(0) }
+    it { expect(instance.failure_count).to eq(0) }
+  end
+end

--- a/spec/models/migration/data_migration_spec.rb
+++ b/spec/models/migration/data_migration_spec.rb
@@ -7,12 +7,15 @@ RSpec.describe Migration::DataMigration, type: :model do
     it { is_expected.to validate_presence_of(:model) }
     it { is_expected.to validate_presence_of(:processed_count) }
     it { is_expected.to validate_presence_of(:failure_count) }
+    it { is_expected.to validate_numericality_of(:total_count).is_greater_than(0).allow_nil }
     it { is_expected.not_to validate_presence_of(:completed_at) }
+    it { is_expected.not_to validate_presence_of(:total_count) }
 
     context "when started_at is present" do
       before { instance.started_at = 1.day.ago }
 
       it { is_expected.to validate_comparison_of(:completed_at).is_greater_than(instance.started_at).allow_nil }
+      it { is_expected.to validate_presence_of(:total_count) }
     end
   end
 


### PR DESCRIPTION
[Jira-2853](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2853)

### Context

We want to introduce the skeleton migration service that we can build on going forward. Initially, we want to simulate a migration so that we can more easily create a UI off the resulting `DataMigration` models.

### Changes proposed in this pull request

- Add skeleton Migrator service with dummy migration run

Add the skeleton `Migrator` service, ensuring it can only run on environments where the data migration feature is enabled.

Run a dummy migration for `LeadProvider`, `Cohort` and `Statement`. The dummy migration will simulate processing up to 1,000 records per model and each will take less than a minute to complete. Failures are added at random (with a 1 in 50 change of occurring).

- Add DataMigration model

We will use this model to keep track of how a migration is progressing and the outcome/failure counts.

- Add total_count to DataMigration model

We want to have a clear indication of how many entities we need to migrate.