### PR TITLE
CPDNPQ-1703 Update Cookies Banner to GDS Font

### DIFF
--- a/app/views/shared/cookies/_accepted.html.erb
+++ b/app/views/shared/cookies/_accepted.html.erb
@@ -4,7 +4,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
 
-        <div class="govuk-cookie-banner__content">
+        <div class="govuk-cookie-banner__content govuk-body">
           <p>You’ve accepted additional cookies. You can <%= govuk_link_to "change your cookie settings", cookies_path %> at any time.</p>
         </div>
       </div>

--- a/app/views/shared/cookies/_accepted.html.erb
+++ b/app/views/shared/cookies/_accepted.html.erb
@@ -4,8 +4,8 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
 
-        <div class="govuk-cookie-banner__content govuk-body">
-          <p>You’ve accepted additional cookies. You can <%= govuk_link_to "change your cookie settings", cookies_path %> at any time.</p>
+        <div class="govuk-cookie-banner__content">
+          <p class="govuk-body">You’ve accepted additional cookies. You can <%= govuk_link_to "change your cookie settings", cookies_path %> at any time.</p>
         </div>
       </div>
     </div>

--- a/app/views/shared/cookies/_not_set.html.erb
+++ b/app/views/shared/cookies/_not_set.html.erb
@@ -5,9 +5,9 @@
       <div class="govuk-grid-column-two-thirds">
         <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on Register for a national professional qualification</h2>
 
-        <div class="govuk-cookie-banner__content govuk-body">
-          <p>We use some essential cookies to make this service work.</p>
-          <p>We’d like to set additional cookies so we can remember your settings, understand how people use the service and make improvements.</p>
+        <div class="govuk-cookie-banner__content">
+          <p class="govuk-body">We use some essential cookies to make this service work.</p>
+          <p class="govuk-body">We’d like to set additional cookies so we can remember your settings, understand how people use the service and make improvements.</p>
         </div>
       </div>
     </div>

--- a/app/views/shared/cookies/_not_set.html.erb
+++ b/app/views/shared/cookies/_not_set.html.erb
@@ -5,7 +5,7 @@
       <div class="govuk-grid-column-two-thirds">
         <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on Register for a national professional qualification</h2>
 
-        <div class="govuk-cookie-banner__content">
+        <div class="govuk-cookie-banner__content govuk-body">
           <p>We use some essential cookies to make this service work.</p>
           <p>We’d like to set additional cookies so we can remember your settings, understand how people use the service and make improvements.</p>
         </div>

--- a/app/views/shared/cookies/_rejected.html.erb
+++ b/app/views/shared/cookies/_rejected.html.erb
@@ -4,7 +4,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
 
-        <div class="govuk-cookie-banner__content">
+        <div class="govuk-cookie-banner__content govuk-body">
           <p>You’ve rejected additional cookies. You can <%= govuk_link_to "change your cookie settings", cookies_path %> at any time.</p>
         </div>
       </div>

--- a/app/views/shared/cookies/_rejected.html.erb
+++ b/app/views/shared/cookies/_rejected.html.erb
@@ -4,8 +4,8 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
 
-        <div class="govuk-cookie-banner__content govuk-body">
-          <p>You’ve rejected additional cookies. You can <%= govuk_link_to "change your cookie settings", cookies_path %> at any time.</p>
+        <div class="govuk-cookie-banner__content">
+          <p class="govuk-body">You’ve rejected additional cookies. You can <%= govuk_link_to "change your cookie settings", cookies_path %> at any time.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-1703
Font in the description text of the cookies banner is not displaying in the GDS style font.

Post fix:
<img width="1093" alt="Screenshot 2024-03-01 at 11 55 21 AM" src="https://github.com/DFE-Digital/npq-registration/assets/132997928/64d11dd6-a7d3-417f-bf41-e90ff031f60f">
