### PR TITLE
Add UI for ECF migration

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 terraform 1.5.4
 ruby 3.1.2
-nodejs 16.20.1
+nodejs 16.20.2
 yarn 1.22.18
 kubectl 1.29.0

--- a/app/controllers/npq_separation/migration/migrations_controller.rb
+++ b/app/controllers/npq_separation/migration/migrations_controller.rb
@@ -1,3 +1,25 @@
 class NpqSeparation::Migration::MigrationsController < ApplicationController
-  def index = head(:method_not_allowed)
+  before_action :require_super_admin
+
+  def index
+    @data_migrations = Migration::DataMigration.all
+    @in_progress_migration = @data_migrations.present? && !@data_migrations.all?(&:complete?)
+    @completed_migration = @data_migrations.present? && @data_migrations.all?(&:complete?)
+  end
+
+  def create
+    Migration::Migrator.prepare_for_migration
+    MigrationJob.perform_later
+
+    redirect_to npq_separation_migration_migrations_path
+  end
+
+private
+
+  def require_super_admin
+    unless current_admin&.super_admin?
+      flash[:negative] = { title: "Unauthorized", text: "Sign in with your admininstrator account" }
+      redirect_to sign_in_path
+    end
+  end
 end

--- a/app/helpers/migration_helper.rb
+++ b/app/helpers/migration_helper.rb
@@ -1,0 +1,50 @@
+module MigrationHelper
+  def migration_started_at(data_migrations)
+    # When a migration is first kicked off all data_migration records are briefly
+    # pending (with a `started_at` of `nil`) until a worker picks up the job.
+    # We use the current time as the start time in this case.
+    data_migrations.map(&:started_at).compact.min || Time.zone.now
+  end
+
+  def migration_completed_at(data_migrations)
+    data_migrations.map(&:completed_at).compact.max
+  end
+
+  def migration_duration_in_words(data_migrations)
+    duration_in_seconds = (migration_completed_at(data_migrations) - migration_started_at(data_migrations)).to_i
+    ActiveSupport::Duration.build(duration_in_seconds).inspect
+  end
+
+  def data_migration_status_tag(data_migration)
+    return govuk_tag(text: "Pending", colour: "grey") if data_migration.pending?
+    return govuk_tag(text: "In progress - #{data_migration.percentage_migrated}%", colour: "blue") if data_migration.in_progress?
+
+    govuk_tag(text: "Completed", colour: "green")
+  end
+
+  def data_migration_failure_count_tag(data_migration)
+    return if data_migration.failure_count.zero?
+
+    govuk_tag(text: number_with_delimiter(data_migration.failure_count), colour: "red")
+  end
+
+  def data_migration_total_count_tag(data_migration)
+    return unless data_migration.total_count&.positive?
+
+    govuk_tag(text: number_with_delimiter(data_migration.total_count), colour: "blue")
+  end
+
+  def data_migration_percentage_migrated_successfully_tag(data_migration)
+    percentage = data_migration.percentage_migrated_successfully
+
+    colour = if percentage < 80
+               "red"
+             elsif percentage < 100
+               "yellow"
+             else
+               "green"
+             end
+
+    govuk_tag(text: "#{percentage}%", colour:)
+  end
+end

--- a/app/jobs/migration_job.rb
+++ b/app/jobs/migration_job.rb
@@ -1,0 +1,6 @@
+class MigrationJob < ApplicationJob
+  def perform
+    migrator = Migration::Migrator.new
+    migrator.migrate!
+  end
+end

--- a/app/models/migration/data_migration.rb
+++ b/app/models/migration/data_migration.rb
@@ -6,5 +6,37 @@ module Migration
     validates :total_count, presence: true, if: ->(m) { m.started_at.present? }
     validates :total_count, numericality: { greater_than: 0 }, allow_nil: true
     validates :completed_at, comparison: { greater_than: :started_at }, if: ->(m) { m.started_at.present? }, allow_nil: true
+
+    default_scope { order(created_at: :asc) }
+
+    def percentage_migrated_successfully
+      return unless processed_count&.positive?
+
+      ((processed_count - failure_count) / processed_count.to_f * 100).round
+    end
+
+    def percentage_migrated
+      return unless total_count
+
+      (processed_count / total_count.to_f * 100).round
+    end
+
+    def duration_in_seconds
+      return unless started_at? && completed_at?
+
+      (completed_at - started_at).to_i
+    end
+
+    def pending?
+      !started_at?
+    end
+
+    def in_progress?
+      !pending? && !complete?
+    end
+
+    def complete?
+      completed_at.present?
+    end
   end
 end

--- a/app/services/migration/migrator.rb
+++ b/app/services/migration/migrator.rb
@@ -1,18 +1,38 @@
 module Migration
   class Migrator
     class UnsupportedEnvironmentError < RuntimeError; end
+    class MigrationAlreadyRanError < RuntimeError; end
+    class MigrationNotPreparedError < RuntimeError; end
 
     MODELS_TO_MIGRATE = %i[lead_provider cohort statement].freeze
 
+    class << self
+      def prepare_for_migration
+        Migration::DataMigration.create!(MODELS_TO_MIGRATE.map { |model| { model: } })
+      end
+    end
+
     def migrate!
       check_environment!
-      initialize_dummy_migration
+      check_migration_prepared!
+      prevent_multiple_migrations!
+
       run_dummy_migration
     end
 
   private
 
-    attr_accessor :data_migrations
+    def data_migrations
+      @data_migrations ||= Migration::DataMigration.all
+    end
+
+    def prevent_multiple_migrations!
+      raise MigrationAlreadyRanError, "The migration has already been run" unless data_migrations.all?(&:pending?)
+    end
+
+    def check_migration_prepared!
+      raise MigrationNotPreparedError, "The migration has not been prepared" if data_migrations.blank?
+    end
 
     def check_environment!
       migration_enabled = Rails.application.config.npq_separation[:migration_enabled]
@@ -20,28 +40,24 @@ module Migration
       raise UnsupportedEnvironmentError, "The migration functionality is disabled for this environment" unless migration_enabled
     end
 
-    def initialize_dummy_migration
-      self.data_migrations = MODELS_TO_MIGRATE.index_with { |model| Migration::DataMigration.create!(model:) }
-    end
-
     def run_dummy_migration
-      MODELS_TO_MIGRATE.each { |model| simulate_model_migration(model) }
+      data_migrations.each { |data_migration| simulate_model_migration(data_migration) }
     end
 
-    def simulate_model_migration(model)
-      data_migrations[model].update!(started_at: Time.zone.now, total_count: rand(1...1000))
+    def simulate_model_migration(data_migration)
+      data_migration.update!(started_at: Time.zone.now, total_count: rand(1...1000))
 
-      data_migrations[model].total_count.times do |processed_count|
+      data_migration.total_count.times do |processed_count|
         # Up to 1 minute of processing time/model
         sleep(rand(0.001...0.06))
 
-        data_migrations[model].update!(processed_count:)
+        data_migration.update!(processed_count:)
 
-        record_failure = rand(1...50) == 50
-        data_migrations[model].update!(failure_count: data_migrations[model].failure_count + 1) if record_failure
+        record_failure = rand(1...25) == 1
+        data_migration.update!(failure_count: data_migration.failure_count + 1) if record_failure
       end
 
-      data_migrations[model].update!(completed_at: Time.zone.now)
+      data_migration.update!(completed_at: Time.zone.now)
     end
   end
 end

--- a/app/views/npq_separation/migration/migrations/_completed_migration.html.erb
+++ b/app/views/npq_separation/migration/migrations/_completed_migration.html.erb
@@ -1,0 +1,29 @@
+
+<h2 class="govuk-heading-l">Completed migration</h2>
+
+<p class="govuk-body">
+  The latest migration was completed <%= tag.strong(time_ago_in_words(migration_completed_at(@data_migrations))) %> ago.<br>
+  The migration took <%= tag.strong(migration_duration_in_words(@data_migrations)) %> to complete.
+</p>
+
+<%= govuk_table do |table|
+  table.with_head do |head|
+    head.with_row do |row|
+      row.with_cell(text: "Model")
+      row.with_cell(text: "Number of records")
+      row.with_cell(text: "Number of failures")
+      row.with_cell(text: "Success rate")
+    end 
+  end 
+  
+  table.with_body do |body|
+    @data_migrations.each do |data_migration|
+      body.with_row do |row|
+        row.with_cell(text: data_migration.model.humanize)
+        row.with_cell(text: data_migration_total_count_tag(data_migration))
+        row.with_cell(text: data_migration_failure_count_tag(data_migration))
+        row.with_cell(text: data_migration_percentage_migrated_successfully_tag(data_migration))
+      end
+    end
+  end
+end %>

--- a/app/views/npq_separation/migration/migrations/_in_progress_migration.html.erb
+++ b/app/views/npq_separation/migration/migrations/_in_progress_migration.html.erb
@@ -1,0 +1,22 @@
+<div class="govuk-notification-banner" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+  <div class="govuk-notification-banner__header">
+    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+      Important
+    </h2>
+  </div>
+  <div class="govuk-notification-banner__content">
+    <h3 class="govuk-notification-banner__heading">
+      A migration is currently in-progress
+    </h3>
+    <p class="govuk-body">It was started <%= tag.strong(time_ago_in_words(migration_started_at(@data_migrations))) %></T=> ago.</p>
+    
+    <%= 
+      govuk_task_list do |task_list|
+        @data_migrations.each do |data_migration|
+          task_list.with_item(title: data_migration.model.humanize, status: data_migration_status_tag(data_migration))
+        end
+      end 
+    %>
+  </div>
+</div>
+

--- a/app/views/npq_separation/migration/migrations/index.html.erb
+++ b/app/views/npq_separation/migration/migrations/index.html.erb
@@ -1,0 +1,15 @@
+<% content_for :title, "Migrations" %>
+
+<% if @starting_migration || @in_progress_migration %>
+  <%= render(partial: "in_progress_migration") %>
+<% end %>
+
+<h1 class="govuk-heading-xl">Migrations</h1>
+
+<p class="govuk-body">You can run the NPQ migration from ECF using this migration tool.</p>
+
+<%= button_to "Run migration", { action: :create }, class: "govuk-button govuk-button--warning", disabled: @data_migrations.present? %>
+
+<% if @completed_migration %>
+  <%= render(partial: "completed_migration") %>
+<% end %>

--- a/app/views/session_wizard/sign_in.html.erb
+++ b/app/views/session_wizard/sign_in.html.erb
@@ -11,7 +11,7 @@
 
 <% if flash[:negative].present? %>
   <%= govuk_notification_banner(title_text: "Unauthorized") do |banner| %>
-    <% banner.with_heading(text: "Sign in with you administrator account") %>
+    <% banner.with_heading(text: "Sign in with your administrator account") %>
   <% end %>
 <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -167,7 +167,7 @@ Rails.application.routes.draw do
     end
 
     namespace :migration, constraints: ->(_request) { Rails.application.config.npq_separation[:migration_enabled] } do
-      resources :migrations, only: %i[index]
+      resources :migrations, only: %i[index create]
     end
   end
 

--- a/spec/controllers/npq_separation/migration/migrations_controller_spec.rb
+++ b/spec/controllers/npq_separation/migration/migrations_controller_spec.rb
@@ -1,9 +1,58 @@
 require "rails_helper"
 
 RSpec.describe NpqSeparation::Migration::MigrationsController, type: :request do
-  describe("index") do
-    before { get(npq_separation_admin_admins_path) }
+  include Helpers::NPQSeparationAdminLogin
 
-    specify { expect(response).to(be_method_not_allowed) }
+  before do
+    allow(Migration::Migrator).to receive(:prepare_for_migration)
+    allow(MigrationJob).to receive(:perform_later)
+    sign_in_as_admin(super_admin:)
+    make_request
+  end
+
+  describe("index") do
+    let(:make_request) { get(npq_separation_migration_migrations_path) }
+
+    context "when not signed in as a super admin" do
+      let(:super_admin) { false }
+
+      it { expect(response).to redirect_to(sign_in_path) }
+
+      it "asks the user to sign in as an admin" do
+        follow_redirect!
+        expect(response.body).to include("Sign in with your administrator account")
+      end
+    end
+
+    context "when signed in as a super admin" do
+      let(:super_admin) { true }
+
+      it { expect(response).to be_successful }
+    end
+  end
+
+  describe("create") do
+    let(:make_request) { post(npq_separation_migration_migrations_path) }
+
+    context "when not signed in as a super admin" do
+      let(:super_admin) { false }
+
+      it { expect(response).to redirect_to(sign_in_path) }
+
+      it "asks the user to sign in as an admin" do
+        follow_redirect!
+        expect(response.body).to include("Sign in with your administrator account")
+      end
+    end
+
+    context "when signed in as a super admin" do
+      let(:super_admin) { true }
+
+      it "triggers a migration" do
+        expect(response).to redirect_to(npq_separation_migration_migrations_path)
+        expect(Migration::Migrator).to have_received(:prepare_for_migration)
+        expect(MigrationJob).to have_received(:perform_later)
+      end
+    end
   end
 end

--- a/spec/factories/migration/data_migrations.rb
+++ b/spec/factories/migration/data_migrations.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :data_migration, class: "Migration::DataMigration" do
+    model { "model" }
+
+    trait :in_progress do
+      started_at { 30.seconds.ago }
+      total_count { 100 }
+    end
+
+    trait :with_failures do
+      failure_count { 27 }
+    end
+
+    trait :completed do
+      completed_at { Time.zone.now }
+    end
+  end
+end

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "admin", type: :feature do
+RSpec.feature "admin", type: :feature, rack_test_driver: true do
   include Helpers::AdminLogin
   include_context "Stub Get An Identity Omniauth Responses"
 
@@ -8,12 +8,10 @@ RSpec.feature "admin", type: :feature do
   let(:admin) { create(:admin) }
 
   around do |example|
-    Capybara.current_driver = :rack_test
     previous_pagination = Pagy::DEFAULT[:items]
     Pagy::DEFAULT[:items] = 3
     example.run
     Pagy::DEFAULT[:items] = previous_pagination
-    Capybara.current_driver = Capybara.default_driver
   end
 
   scenario "when not logged in, admin interface is inaccessible" do

--- a/spec/features/journeys/happy_paths/able_to_receive_targeted_delivery_funding_spec.rb
+++ b/spec/features/journeys/happy_paths/able_to_receive_targeted_delivery_funding_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Happy journeys", type: :feature do
+RSpec.feature "Happy journeys", type: :feature, rack_test_driver: true do
   include Helpers::JourneyAssertionHelper
   include Helpers::JourneyStepHelper
   include ApplicationHelper
@@ -10,14 +10,6 @@ RSpec.feature "Happy journeys", type: :feature do
     let(:api_call_trn) { user_trn }
   end
   include_context "Stub Get An Identity Omniauth Responses"
-
-  around do |example|
-    Capybara.current_driver = :rack_test
-
-    example.run
-
-    Capybara.current_driver = Capybara.default_driver
-  end
 
   context "when JavaScript is enabled", :js do
     scenario("registration journey that is able to receive targeted delivery funding (with JS)") { run_scenario(js: true) }

--- a/spec/features/journeys/happy_paths/funded_ehco_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/funded_ehco_registration_journey_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Happy journeys", type: :feature do
+RSpec.feature "Happy journeys", type: :feature, rack_test_driver: true do
   include Helpers::JourneyAssertionHelper
   include Helpers::JourneyStepHelper
   include ApplicationHelper
@@ -10,14 +10,6 @@ RSpec.feature "Happy journeys", type: :feature do
     let(:api_call_trn) { user_trn }
   end
   include_context "Stub Get An Identity Omniauth Responses"
-
-  around do |example|
-    Capybara.current_driver = :rack_test
-
-    example.run
-
-    Capybara.current_driver = Capybara.default_driver
-  end
 
   context "when JavaScript is enabled", :js do
     scenario("funded EHCO registration journey (with JS)") { run_scenario(js: true) }

--- a/spec/features/journeys/happy_paths/international_teacher_npqh_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/international_teacher_npqh_journey_spec.rb
@@ -1,19 +1,12 @@
 require "rails_helper"
 
-RSpec.feature "Happy journeys", type: :feature do
+RSpec.feature "Happy journeys", type: :feature, rack_test_driver: true do
   include Helpers::JourneyAssertionHelper
   include Helpers::JourneyStepHelper
   include ApplicationHelper
 
   include_context "retrieve latest application data"
   include_context "Stub Get An Identity Omniauth Responses"
-  around do |example|
-    Capybara.current_driver = :rack_test
-
-    example.run
-
-    Capybara.current_driver = Capybara.default_driver
-  end
 
   context "when JavaScript is enabled or disabled" do
     scenario("international teacher NPQH journey", :js, :no_js) { run_scenario(js: false) }

--- a/spec/features/journeys/happy_paths/other_funded_ehco_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/other_funded_ehco_registration_journey_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Happy journeys", type: :feature do
+RSpec.feature "Happy journeys", type: :feature, rack_test_driver: true do
   include Helpers::JourneyAssertionHelper
   include Helpers::JourneyStepHelper
   include ApplicationHelper
@@ -9,14 +9,6 @@ RSpec.feature "Happy journeys", type: :feature do
     let(:api_call_trn) { user_trn }
   end
   include_context "Stub Get An Identity Omniauth Responses"
-
-  around do |example|
-    Capybara.current_driver = :rack_test
-
-    example.run
-
-    Capybara.current_driver = Capybara.default_driver
-  end
 
   context "when JavaScript is enabled", :js do
     scenario("other funded EHCO registration journey (with JS)") { run_scenario(js: true) }

--- a/spec/features/journeys/happy_paths/previously_received_targeted_delivery_funding_spec.rb
+++ b/spec/features/journeys/happy_paths/previously_received_targeted_delivery_funding_spec.rb
@@ -1,20 +1,12 @@
 require "rails_helper"
 
-RSpec.feature "Happy journeys", type: :feature do
+RSpec.feature "Happy journeys", type: :feature, rack_test_driver: true do
   include Helpers::JourneyAssertionHelper
   include Helpers::JourneyStepHelper
   include ApplicationHelper
 
   include_context "retrieve latest application data"
   include_context "Stub Get An Identity Omniauth Responses"
-
-  around do |example|
-    Capybara.current_driver = :rack_test
-
-    example.run
-
-    Capybara.current_driver = Capybara.default_driver
-  end
 
   context "when JavaScript is enabled", :js do
     scenario("registration journey that is blocked from targeted delivery funding because they were previously funded (with JS)") { run_scenario(js: true) }

--- a/spec/features/journeys/happy_paths/via_using_same_name_spec.rb
+++ b/spec/features/journeys/happy_paths/via_using_same_name_spec.rb
@@ -1,19 +1,11 @@
 require "rails_helper"
 
-RSpec.feature "Happy journeys", type: :feature do
+RSpec.feature "Happy journeys", type: :feature, rack_test_driver: true do
   include Helpers::JourneyAssertionHelper
   include Helpers::JourneyStepHelper
   include ApplicationHelper
 
   include_context "Stub Get An Identity Omniauth Responses"
-
-  around do |example|
-    Capybara.current_driver = :rack_test
-
-    example.run
-
-    Capybara.current_driver = Capybara.default_driver
-  end
 
   context "when JavaScript is enabled", :js do
     scenario("registration journey via using same name (with JS)") { run_scenario(js: true) }

--- a/spec/features/migration_spec.rb
+++ b/spec/features/migration_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.feature "Migration", type: :feature, in_memory_rails_cache: true, rack_test_driver: true do
+  include Helpers::AdminLogin
+
+  before { allow_any_instance_of(Migration::Migrator).to receive(:sleep) }
+
+  context "when not authenticated" do
+    scenario "viewing the migrations page" do
+      visit npq_separation_migration_migrations_path
+
+      expect(page).to have_current_path(sign_in_path)
+    end
+  end
+
+  context "when authenticated" do
+    before { sign_in_as(create(:super_admin)) }
+
+    scenario "viewing the migrations prior to running one" do
+      visit npq_separation_migration_migrations_path
+
+      expect(page).to have_button("Run migration")
+
+      expect(page).not_to have_content("A migration is currently in-progress")
+      expect(page).not_to have_content("Completed migration")
+    end
+
+    scenario "running the first migration" do
+      visit npq_separation_migration_migrations_path
+
+      click_button "Run migration"
+
+      expect(page).to have_button("Run migration", disabled: true)
+
+      expect(page).to have_content("A migration is currently in-progress")
+      expect(page).to have_content("It was started less than a minute ago.")
+
+      expect(page).not_to have_content("Completed migration")
+    end
+
+    scenario "viewing the migration after running one" do
+      visit npq_separation_migration_migrations_path
+
+      perform_enqueued_jobs do
+        click_button "Run migration"
+      end
+
+      expect(page).not_to have_content("A migration is currently in-progress")
+      expect(page).not_to have_content("It was started less than a minute ago.")
+
+      expect(page).to have_content("Completed migration")
+
+      expect(page).to have_content("The latest migration was completed less than a minute ago.")
+      expect(page).to have_text(/The migration took (.*) to complete./)
+    end
+  end
+end

--- a/spec/helpers/migration_helper_spec.rb
+++ b/spec/helpers/migration_helper_spec.rb
@@ -1,0 +1,130 @@
+require "rails_helper"
+
+RSpec.describe MigrationHelper, type: :helper do
+  around do |example|
+    freeze_time { example.run }
+  end
+
+  describe ".migration_started_at" do
+    subject { helper.migration_started_at(data_migrations) }
+
+    let(:data_migrations) { [] }
+
+    it { is_expected.to eq(Time.zone.now) }
+
+    context "when there are data migrations with started_at dates" do
+      let(:data_migrations) do
+        [
+          Migration::DataMigration.new(model: "model1", started_at: 2.days.ago),
+          Migration::DataMigration.new(model: "model2", started_at: 3.days.ago),
+          Migration::DataMigration.new(model: "model3", started_at: 1.day.ago),
+        ]
+      end
+
+      it { is_expected.to eq(3.days.ago) }
+    end
+  end
+
+  describe ".migration_completed_at" do
+    subject { helper.migration_completed_at(data_migrations) }
+
+    let(:data_migrations) do
+      [
+        Migration::DataMigration.new(model: "model1", completed_at: 2.days.ago),
+        Migration::DataMigration.new(model: "model2", completed_at: 1.day.ago),
+        Migration::DataMigration.new(model: "model3", completed_at: 3.days.ago),
+      ]
+    end
+
+    it { is_expected.to eq(1.day.ago) }
+  end
+
+  describe ".migration_duration_in_words" do
+    subject { helper.migration_duration_in_words(data_migrations) }
+
+    let(:data_migrations) do
+      [
+        Migration::DataMigration.new(model: "model1", started_at: 3.days.ago, completed_at: 1.day.ago),
+        Migration::DataMigration.new(model: "model1", started_at: 5.days.ago, completed_at: 2.days.ago),
+      ]
+    end
+
+    it { is_expected.to eq("4 days") }
+  end
+
+  describe ".data_migration_status_tag" do
+    subject { helper.data_migration_status_tag(data_migration) }
+
+    context "when the data migration is pending" do
+      let(:data_migration) { Migration::DataMigration.new(model: "model") }
+
+      it { is_expected.to have_css("strong.govuk-tag.govuk-tag--grey", text: "Pending") }
+    end
+
+    context "when the data migration is in progress" do
+      let(:data_migration) { Migration::DataMigration.new(model: "model", started_at: 10.minutes.ago, total_count: 100, processed_count: 50) }
+
+      it { is_expected.to have_css("strong.govuk-tag.govuk-tag--blue", text: "In progress - 50%") }
+    end
+
+    context "when the data migration is complete" do
+      let(:data_migration) { Migration::DataMigration.new(model: "model", started_at: 5.minutes.ago, completed_at: 1.minute.ago) }
+
+      it { is_expected.to have_css("strong.govuk-tag.govuk-tag--green", text: "Completed") }
+    end
+  end
+
+  describe ".data_migration_failure_count_tag" do
+    subject { helper.data_migration_failure_count_tag(data_migration) }
+
+    context "when the data migration has no failures" do
+      let(:data_migration) { Migration::DataMigration.new(failure_count: 0) }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when the data migration has failures" do
+      let(:data_migration) { Migration::DataMigration.new(failure_count: 1_234) }
+
+      it { is_expected.to have_css("strong.govuk-tag.govuk-tag--red", text: "1,234") }
+    end
+  end
+
+  describe ".data_migration_total_count_tag" do
+    subject { helper.data_migration_total_count_tag(data_migration) }
+
+    context "when the data migration has no total_count" do
+      let(:data_migration) { Migration::DataMigration.new(total_count: nil) }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when the data migration has a total_count" do
+      let(:data_migration) { Migration::DataMigration.new(total_count: 5_000) }
+
+      it { is_expected.to have_css("strong.govuk-tag.govuk-tag--blue", text: "5,000") }
+    end
+  end
+
+  describe ".data_migration_percentage_migrated_successfully_tag" do
+    subject(:tag) { Nokogiri.parse(helper.data_migration_percentage_migrated_successfully_tag(data_migration)) }
+
+    context "when the percentage is 100" do
+      let(:data_migration) { Migration::DataMigration.new(processed_count: 100, failure_count: 0) }
+
+      it { is_expected.to have_css("strong.govuk-tag.govuk-tag--green", text: "100%") }
+    end
+
+    context "when the percentage is between 80 and 100" do
+      let(:data_migration) { Migration::DataMigration.new(processed_count: 100, failure_count: 15) }
+
+      it { is_expected.to have_css("strong.govuk-tag.govuk-tag--yellow", text: "85%") }
+    end
+
+    context "when the percentage is less than 80" do
+      let(:data_migration) { Migration::DataMigration.new(processed_count: 100, failure_count: 25) }
+
+      it { is_expected.to have_css("strong.govuk-tag.govuk-tag--red", text: "75%") }
+    end
+  end
+end

--- a/spec/jobs/migration_job_spec.rb
+++ b/spec/jobs/migration_job_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe MigrationJob do
+  let(:instance) { described_class.new }
+
+  describe "#perform" do
+    subject(:perform_migration) { instance.perform }
+
+    let(:migrator_double) { instance_double("Migration::Migrator", migrate!: nil) }
+
+    before { allow(Migration::Migrator).to receive(:new).and_return(migrator_double) }
+
+    it "triggers a migration" do
+      perform_migration
+      expect(migrator_double).to have_received(:migrate!).once
+    end
+  end
+end

--- a/spec/lib/services/migration/migrator_spec.rb
+++ b/spec/lib/services/migration/migrator_spec.rb
@@ -6,14 +6,37 @@ RSpec.describe Migration::Migrator do
 
   before { allow(Rails.application.config).to receive(:npq_separation) { { migration_enabled: } } }
 
+  describe ".prepare_for_migration" do
+    subject(:prepare) { described_class.prepare_for_migration }
+
+    it { expect { prepare }.to change(Migration::DataMigration, :count).by(3) }
+  end
+
   describe "#migrate!" do
     subject(:migrate) { instance.migrate! }
 
     before { allow_any_instance_of(described_class).to receive(:sleep) }
 
-    it { expect { migrate }.not_to raise_error }
+    context "when the migration has been prepared" do
+      before { described_class.prepare_for_migration }
 
-    it { expect { migrate }.to change(Migration::DataMigration, :count).by(3) }
+      it { expect { migrate }.not_to raise_error }
+
+      it "completes the migration" do
+        migrate
+        expect(Migration::DataMigration.all.map(&:completed_at)).to be_present
+      end
+
+      context "when attempting to migrate multiple times" do
+        before { instance.migrate! }
+
+        it { expect { migrate }.to raise_error(Migration::Migrator::MigrationAlreadyRanError, "The migration has already been run") }
+      end
+    end
+
+    context "when the migration has not been prepared" do
+      it { expect { migrate }.to raise_error(Migration::Migrator::MigrationNotPreparedError, "The migration has not been prepared") }
+    end
 
     context "when migration is disabled" do
       let(:migration_enabled) { false }

--- a/spec/models/migration/ecf/base_record_spec.rb
+++ b/spec/models/migration/ecf/base_record_spec.rb
@@ -7,19 +7,17 @@ end
 RSpec.describe Migration::Ecf::BaseRecord, type: :model do
   subject(:instance) { TestEcfModel.new }
 
-  before do
-    allow(Rails).to receive(:env).and_return ActiveSupport::EnvironmentInquirer.new(environment.to_s)
-  end
+  before { allow(Rails).to receive(:env) { environment.inquiry } }
 
   describe "#readonly?" do
     context "when in test environment" do
-      let(:environment) { :test }
+      let(:environment) { "test" }
 
       it { is_expected.not_to be_readonly }
     end
 
     context "when in non-test environment" do
-      let(:environment) { :production }
+      let(:environment) { "production" }
 
       it { is_expected.to be_readonly }
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -73,6 +73,7 @@ end
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   config.include ActiveSupport::Testing::TimeHelpers
+  config.include ActiveJob::TestHelper, type: :feature
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = [
@@ -107,6 +108,18 @@ RSpec.configure do |config|
   config.include Helpers::JourneyHelper, type: :feature
   config.before(:each, type: :feature) do
     stub_env_variables_for_gai
+  end
+
+  config.around(:each, in_memory_rails_cache: true) do |example|
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    example.run
+    Rails.cache.clear
+  end
+
+  config.around(:each, rack_test_driver: true) do |example|
+    Capybara.current_driver = :rack_test
+    example.run
+    Capybara.current_driver = Capybara.default_driver
   end
 end
 

--- a/spec/support/helpers/npq_separation_admin_login.rb
+++ b/spec/support/helpers/npq_separation_admin_login.rb
@@ -1,7 +1,7 @@
 module Helpers
   module NPQSeparationAdminLogin
-    def sign_in_as_admin(email: "test-admin@example.com")
-      FactoryBot.create(:admin, email:).then do |u|
+    def sign_in_as_admin(email: "test-admin@example.com", super_admin: false)
+      FactoryBot.create(:admin, email:, super_admin:).then do |u|
         patch(session_wizard_update_path(step: "sign-in"), params: { session_wizard: { email: } })
         patch(session_wizard_update_path(step: "sign-in-code"), params: { session_wizard: { code: u.reload.otp_hash } })
       end


### PR DESCRIPTION
[Jira-2854](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2854)

### Context

We want to a simple user interface available to super administrators where we can kick off a new migration, keep track of the progress and view the outcome.

### Changes proposed in this pull request

- Add convenience methods to DataMigration

In order to render the state more easily in the UI we want to add some convenience methods to the `DataMigration` model for determining the state of the migration and the outcome.

- Add MigrationJob

Add job for kicking off a migration. Split out the preparation logic on the `Migrator` service so that we can create the `DataMigration` instances in-band and therefore render the state more easily in the UI (if we did this in the job itself it may not happen before the page reloads after starting a migration).

- Add MigrationHelper for rendering migration state in a view

We will want to render the migration state in a view for when a migration is in-progress and completed; this adds the relevant view helper methods.

- Add controller and views for migration

Add the controller actions and views necessary for a user to be able to kick off, view the progress and outcome of a migration. Only super admins will be able to run migrations.

Fixes a typo in the `sign_in.html.erb` error message.

Adds a config option for `rspec` to easily run tests against an in-memory cache and `rack_test` Capybara driver.

- DRY up feature specs using rack_test

- Update nodejs in tool-versions

### Guidance to review

Best reviewed by-commit.

| Start a migration              | Migration in progress | Migration complete |
| ---------------- | ------ | ---- |
|  <img width="1420" alt="Screenshot 2024-03-05 at 09 26 16" src="https://github.com/DFE-Digital/npq-registration/assets/29867726/4bf54ed7-c68e-4769-9002-d78a2652dcbf">      |   <img width="1420" alt="Screenshot 2024-03-05 at 09 26 28" src="https://github.com/DFE-Digital/npq-registration/assets/29867726/5ac4d05d-6106-4764-8487-aadc6a82dd15">   | <img width="1420" alt="Screenshot 2024-03-05 at 09 26 41" src="https://github.com/DFE-Digital/npq-registration/assets/29867726/686ce6aa-d457-4529-8dab-11e49ebb0d3c"> |