### PR TITLE
CPDNPQ-1697 Add form-level validation for trns to only be numerical

### DIFF
--- a/app/forms/questionnaires/qualified_teacher_check.rb
+++ b/app/forms/questionnaires/qualified_teacher_check.rb
@@ -77,7 +77,7 @@ module Questionnaires
     end
 
     def processed_trn
-      @processed_trn ||= (trn || "").gsub("RP", "").gsub("/", "")
+      @processed_trn ||= (trn || "")
     end
 
     def next_step

--- a/app/forms/questionnaires/qualified_teacher_check.rb
+++ b/app/forms/questionnaires/qualified_teacher_check.rb
@@ -77,7 +77,7 @@ module Questionnaires
     end
 
     def processed_trn
-      @processed_trn ||= (trn || "")
+      @processed_trn ||= trn || ""
     end
 
     def next_step

--- a/app/forms/questionnaires/qualified_teacher_check.rb
+++ b/app/forms/questionnaires/qualified_teacher_check.rb
@@ -69,8 +69,8 @@ module Questionnaires
     def validate_processed_trn
       if processed_trn !~ /\A\d+\z/
         errors.add(:trn, :invalid)
-      elsif processed_trn.length < 5
-        errors.add(:trn, :too_short, count: 5)
+      elsif processed_trn.length < 7
+        errors.add(:trn, :too_short, count: 7)
       elsif processed_trn.length > 7
         errors.add(:trn, :too_long, count: 7)
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -376,7 +376,7 @@ en:
         course_start_date_hint: "You can also select this option if you have already started"
         maths_understanding_of_approach_hint: "For example, a reference from a professional who has supported your mastery professional development."
         lead_provider_id: These are the training providers who provide <b>%{course_name}</b>. Providers may have different entry requirements.
-        trn: Your TRN is between 6 and 7 characters long. It may begin with 'RP'
+        trn: Your TRN is between 6 and 7 characters long.
         full_name: Your full name exactly as it appears on the Teaching Regulation Agency records
         date_of_birth: For example, 31 3 1980
         national_insurance_number: This will help us match your details. It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -376,7 +376,7 @@ en:
         course_start_date_hint: "You can also select this option if you have already started"
         maths_understanding_of_approach_hint: "For example, a reference from a professional who has supported your mastery professional development."
         lead_provider_id: These are the training providers who provide <b>%{course_name}</b>. Providers may have different entry requirements.
-        trn: Your TRN is between 6 and 7 characters long.
+        trn: TRNs should be 7 digits.
         full_name: Your full name exactly as it appears on the Teaching Regulation Agency records
         date_of_birth: For example, 31 3 1980
         national_insurance_number: This will help us match your details. It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.

--- a/spec/lib/questionnaires/qualified_teacher_check_spec.rb
+++ b/spec/lib/questionnaires/qualified_teacher_check_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Questionnaires::QualifiedTeacherCheck, type: :model do
     end
 
     describe "#processed_trn" do
-      it "Not permits legacy style trns" do
+      it "doesn't permit legacy style TRNs" do
         subject.trn = "RP99/12345"
         subject.valid?
         expect(subject.errors[:trn]).to be_present
@@ -132,7 +132,7 @@ RSpec.describe Questionnaires::QualifiedTeacherCheck, type: :model do
         expect(subject.errors[:trn]).to be_present
       end
 
-      it "denies trns under 5 characters" do
+      it "denies trns under 7 characters" do
         subject.trn = "1234"
         subject.valid?
         expect(subject.errors[:trn]).to be_present

--- a/spec/lib/questionnaires/qualified_teacher_check_spec.rb
+++ b/spec/lib/questionnaires/qualified_teacher_check_spec.rb
@@ -119,21 +119,21 @@ RSpec.describe Questionnaires::QualifiedTeacherCheck, type: :model do
     end
 
     describe "#processed_trn" do
-      it "permits legacy style trns" do
+      it "Not permits legacy style trns" do
         subject.trn = "RP99/12345"
         subject.valid?
-        expect(subject.errors[:trn]).to be_blank
-        expect(subject.processed_trn).to eql("9912345")
+        expect(subject.errors[:trn]).to be_present
+        expect(subject.processed_trn).not_to eql("9912345")
       end
 
       it "denies trns over 7 characters" do
-        subject.trn = "RP99/123456"
+        subject.trn = "99123456"
         subject.valid?
         expect(subject.errors[:trn]).to be_present
       end
 
       it "denies trns under 5 characters" do
-        subject.trn = "RP/1234"
+        subject.trn = "1234"
         subject.valid?
         expect(subject.errors[:trn]).to be_present
       end


### PR DESCRIPTION
### Context
Unvalidate trn user should not be bypass
### Ticket
https://dfedigital.atlassian.net.mcas.ms/browse/CPDNPQ-1697

### Changes proposed in this pull request
This PR includes essential updates to the `qualification_teacher_check` questionnaire, specifically focusing on the `processed_trn` validations. The modifications encompass both the questionnaire itself and the associated spec file to ensure accurate and reliable validation processes.

**Note**
It's important to note that, due to certain constraints, we are refraining from updating model-level validations in this iteration. The reason behind this decision is that implementing model-level validations at this stage could lead to failures in cases where user information is being updated for individuals with unverified TRNs, such as "/", are present in the previously stored data within the database.

As a strategic measure, the current update enforces the acceptance criteria that users cannot submit with an unverified TRN specifically on the page "/registration/qualified-teacher-check." Once all unverified TRNs have been successfully updated, we can proceed to incorporate model-level validations seamlessly into the system.

This approach ensures a smoother transition and mitigates potential issues arising from the current state of user data, providing a robust foundation for future updates and improvements.

