### PR TITLE
[CPDLP-2866] TS1 - Statements endpoint - API base and error handling

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,5 +1,25 @@
 module API
-  class BaseController < ApplicationController
+  class BaseController < ActionController::API
     include API::TokenAuthenticatable
+
+    before_action :remove_charset
+    rescue_from ActionController::UnpermittedParameters, with: :unpermitted_parameter_response
+    rescue_from ActionController::BadRequest, with: :bad_request_response
+    rescue_from ArgumentError, with: :bad_request_response
+
+  private
+
+    def remove_charset
+      ActionDispatch::Response.default_charset = nil
+    end
+
+    def unpermitted_parameter_response(exception)
+      render json: { errors: API::Errors::Response.new(error: I18n.t(:unpermitted_parameters), params: exception.params).call }, status: :unprocessable_entity
+    end
+
+    def bad_request_response(exception)
+      Sentry.capture_exception(exception)
+      render json: { errors: API::Errors::Response.new(error: I18n.t(:bad_request), params: exception.message).call }, status: :bad_request
+    end
   end
 end

--- a/app/services/api/errors/response.rb
+++ b/app/services/api/errors/response.rb
@@ -1,0 +1,26 @@
+module API
+  module Errors
+    class Response
+      attr_reader :error, :params
+
+      def initialize(error:, params:)
+        @params = params
+        @error = error
+      end
+
+      def call
+        params.map do |param|
+          {
+            title: error,
+            detail: param,
+          }
+        end
+      rescue StandardError
+        [{
+          title: error,
+          detail: params,
+        }]
+      end
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,8 @@
 en:
   # Errors
+  unpermitted_parameters: "Unpermitted parameters"
   unauthorized: "HTTP Token: Access denied"
+  bad_request: "Bad request"
 
   time:
     formats:

--- a/spec/requests/api/v3/statements_spec.rb
+++ b/spec/requests/api/v3/statements_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Statements endpoint", type: "request" do
         api_get("/api/v3/statements")
 
         expect(response.status).to eq 200
-        expect(response.headers["Content-Type"]).to include("application/json")
+        expect(response.headers["Content-Type"]).to eql("application/json")
       end
     end
 
@@ -17,7 +17,7 @@ RSpec.describe "Statements endpoint", type: "request" do
 
         expect(response.status).to eq 401
         expect(parsed_response["error"]).to eql("HTTP Token: Access denied")
-        expect(response.headers["Content-Type"]).to include("application/json")
+        expect(response.headers["Content-Type"]).to eql("application/json")
       end
     end
   end

--- a/spec/services/api/errors/response_spec.rb
+++ b/spec/services/api/errors/response_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe API::Errors::Response do
+  subject { described_class.new(error:, params:) }
+
+  let(:error) { "StandardError" }
+  let(:params) do
+    [
+      "Error 1",
+      "Error 2",
+    ]
+  end
+
+  describe "#call" do
+    it "returns formatted errors" do
+      result = subject.call
+      expect(result.size).to be(2)
+
+      expect(result[0][:title]).to eql("StandardError")
+      expect(result[0][:detail]).to eql("Error 1")
+
+      expect(result[1][:title]).to eql("StandardError")
+      expect(result[1][:detail]).to eql("Error 2")
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-2866

### Changes proposed in this pull request

* Added error handling for `BaseController`
* Created `API::Errors::Response` service class to render errors as JSON