### PR TITLE
Migrate lead providers from ECF to NPQ registration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ define KONDUIT_CONNECT
 		(tail -f -n0 "$$tmp_file" & ) | grep -q "postgres://"; \
 		postgres_url=$$(grep -o 'postgres://[^ ]*' "$$tmp_file"); \
 		echo "$$postgres_url"; \
-		sed -i '' -e "s|npq_registration_development|&\\n  url: \"$$postgres_url\"|g" config/database.yml; \
+		sed -i '' -e "s|npq_registration_development|&\\n    url: \"$$postgres_url\"|g" config/database.yml; \
 	} & \
 	bin/konduit.sh -d
 endef

--- a/app/models/migration/data_migration.rb
+++ b/app/models/migration/data_migration.rb
@@ -4,19 +4,21 @@ module Migration
     validates :processed_count, presence: true
     validates :failure_count, presence: true
     validates :total_count, presence: true, if: ->(m) { m.started_at.present? }
-    validates :total_count, numericality: { greater_than: 0 }, allow_nil: true
     validates :completed_at, comparison: { greater_than: :started_at }, if: ->(m) { m.started_at.present? }, allow_nil: true
 
     default_scope { order(created_at: :asc) }
 
+    scope :pending, -> { where(started_at: nil) }
+    scope :not_pending, -> { where.not(started_at: nil) }
+
     def percentage_migrated_successfully
-      return unless processed_count&.positive?
+      return 0 unless processed_count&.positive?
 
       ((processed_count - failure_count) / processed_count.to_f * 100).round
     end
 
     def percentage_migrated
-      return unless total_count
+      return 0 unless total_count&.positive?
 
       (processed_count / total_count.to_f * 100).round
     end

--- a/app/views/npq_separation/migration/migrations/_completed_migration.html.erb
+++ b/app/views/npq_separation/migration/migrations/_completed_migration.html.erb
@@ -18,11 +18,11 @@
   
   table.with_body do |body|
     @data_migrations.each do |data_migration|
-      body.with_row do |row|
+      body.with_row(html_attributes: { class: "data-migration-#{data_migration.model.parameterize}" }) do |row|
         row.with_cell(text: data_migration.model.humanize)
-        row.with_cell(text: data_migration_total_count_tag(data_migration))
-        row.with_cell(text: data_migration_failure_count_tag(data_migration))
-        row.with_cell(text: data_migration_percentage_migrated_successfully_tag(data_migration))
+        row.with_cell(html_attributes: { class: "total-count" }, text: data_migration_total_count_tag(data_migration))
+        row.with_cell(html_attributes: { class: "failure-count" }, text: data_migration_failure_count_tag(data_migration))
+        row.with_cell(html_attributes: { class: "percentage-successfully-migrated" }, text: data_migration_percentage_migrated_successfully_tag(data_migration))
       end
     end
   end

--- a/app/views/npq_separation/migration/migrations/_in_progress_migration.html.erb
+++ b/app/views/npq_separation/migration/migrations/_in_progress_migration.html.erb
@@ -13,7 +13,7 @@
     <%= 
       govuk_task_list do |task_list|
         @data_migrations.each do |data_migration|
-          task_list.with_item(title: data_migration.model.humanize, status: data_migration_status_tag(data_migration))
+          task_list.with_item(html_attributes: { class: "data-migration-#{data_migration.model.parameterize}" }, title: data_migration.model.humanize, status: data_migration_status_tag(data_migration))
         end
       end 
     %>


### PR DESCRIPTION
[Jira-2856](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2856)

### Context

As part of the NPQ separation work we want to migrate all `NPQLeadProvider` records from ECF into NPQ reg. In an ideal world the records should already exist in NPQ reg, so this will consist of making integrity checks and recording a failure if a lead provider exists in ECF but not in NPQ reg.

### Changes proposed in this pull request

- Migrate lead providers from ECF to NPQ reg
- Fix adding konduit URL to database config

When we moved to multiple databases (to connect to ECF) we should have updated the indentation on this make command.

### Guidance to review

| Migration running    | Migration complete 
| -------- | ------- |
| <img width="1372" alt="Screenshot 2024-03-06 at 11 08 26" src="https://github.com/DFE-Digital/npq-registration/assets/29867726/60f0b592-cb12-41db-a528-a8b6e155ef3a">  | <img width="1372" alt="Screenshot 2024-03-06 at 11 07 55" src="https://github.com/DFE-Digital/npq-registration/assets/29867726/b06b115c-1108-4e62-aecc-dda6c31c05e5">   |