### PR TITLE
Add statuscake checks for external_url

### DIFF
--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -10,5 +10,6 @@
   "webapp_memory_max": "2Gi",
   "worker_memory_max": "1Gi",
   "enable_monitoring": true,
-  "deploy_snapshot_database": true
+  "deploy_snapshot_database": true,
+  "external_url": "https://register-national-professional-qualifications.education.gov.uk/healthcheck"
 }


### PR DESCRIPTION
### Context

Ticket: https://trello.com/c/9WQqXVn8/1647-review-all-ssl-monitors

Add missing statuscake monitoring to terraform
(then remove manually added ones)

### Changes proposed in this pull request

Add external_url for prod, so we get uptime and ssl checks for the education.gov.uk domain

### How to review

make production terraform-plan CONFIRM_PRODUCTION=yes


