### PR TITLE
Prepare the project for GitHub work queues

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
   docker:
     name: Build and push Docker image
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]'
+    if: github.actor != 'dependabot[bot]' && github.event_name != 'merge_group'
     outputs:
       docker-image: ${{ steps.build-docker-image.outputs.image }}
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
 name: "Deploy"
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 on:


### PR DESCRIPTION
Queues make dealing with a large number of PRs easier. It's most apparent on the first of the month when Dependabot opens lots of small version bumps.

In order to enable them we need to:

* [x] fix the concurrency setting so things later in the queue don't cancel things at the front. (Done 45f0be6f115)
* [x] not run the docker build/deployment parts of the flow for workflow items (Done 6fe73387a2b0)
