### PR TITLE
[CPDLP-2855] Add logic to migrate cohorts and statements

### DIFF
--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -3,7 +3,7 @@ class Statement < ApplicationRecord
   belongs_to :lead_provider
   has_many :statement_items
 
-  validates :output_fee, presence: true
+  validates :output_fee, inclusion: [true, false]
   validates :month, numericality: { in: 1..12, only_integer: true }
   validates :year, numericality: { in: 2020..2050, only_integer: true }
 

--- a/app/services/migration/migrator.rb
+++ b/app/services/migration/migrator.rb
@@ -6,12 +6,12 @@ module Migration
     class MigrationAlreadyPreparedError < RuntimeError; end
 
     class << self
+      MODELS_TO_BE_MIGRATED = %i[lead_provider cohort statement].freeze
+
       def prepare_for_migration
         raise MigrationAlreadyPreparedError, "The migration has already been prepared" if DataMigration.exists?
 
-        DataMigration.create!(model: :lead_provider)
-        DataMigration.create!(model: :cohort)
-        DataMigration.create!(model: :statement)
+        MODELS_TO_BE_MIGRATED.each { |model| DataMigration.create!(model:) }
       end
     end
 
@@ -45,19 +45,23 @@ module Migration
       migrate_statements
     end
 
-    def migrate_lead_providers
-      data_migration = DataMigration.find_by(model: :lead_provider)
+    def migrate(items, model)
+      data_migration = DataMigration.find_by(model:)
+      data_migration.update!(started_at: Time.zone.now, total_count: items.count)
 
-      data_migration.update!(started_at: Time.zone.now, total_count: ecf_npq_lead_providers.count)
-
-      ecf_npq_lead_providers.find_each do |ecf_npq_lead_provider|
+      items.each do |item|
         data_migration.increment!(:processed_count)
-        npq_lead_provider = LeadProvider.find_by(ecf_id: ecf_npq_lead_provider.id)
-
-        data_migration.increment!(:failure_count) unless npq_lead_provider
+        result = yield(item)
+        data_migration.increment!(:failure_count) unless result
       end
 
       data_migration.update!(completed_at: Time.zone.now)
+    end
+
+    def migrate_lead_providers
+      migrate(ecf_npq_lead_providers, :lead_provider) do |ecf_npq_lead_provider|
+        LeadProvider.find_by(ecf_id: ecf_npq_lead_provider.id)
+      end
     end
 
     def ecf_npq_lead_providers
@@ -65,24 +69,15 @@ module Migration
     end
 
     def ecf_cohorts
-      @ecf_cohorts ||= Ecf::Cohort.all
+      @ecf_cohorts ||= Ecf::Cohort.where(start_year: 2021..)
     end
 
     def migrate_cohorts
-      data_migration = DataMigration.find_by(model: :cohort)
-
-      data_migration.update!(started_at: Time.zone.now, total_count: ecf_cohorts.count)
-
-      ecf_cohorts.find_each do |ecf_cohort|
-        data_migration.increment!(:processed_count)
-
+      migrate(ecf_cohorts, :cohort) do |ecf_cohort|
         cohort = Cohort.find_or_initialize_by(start_year: ecf_cohort.start_year)
-        result = cohort.update(registration_start_date: ecf_cohort.registration_start_date)
-
-        data_migration.increment!(:failure_count) unless result
+        result = cohort.update(registration_start_date: ecf_cohort.npq_registration_start_date.presence || ecf_cohort.registration_start_date)
+        result
       end
-
-      data_migration.update!(completed_at: Time.zone.now)
     end
 
     def ecf_statements
@@ -90,13 +85,7 @@ module Migration
     end
 
     def migrate_statements
-      data_migration = DataMigration.find_by(model: :statement)
-
-      data_migration.update!(started_at: Time.zone.now, total_count: ecf_statements.count)
-
-      ecf_statements.find_each do |ecf_statement|
-        data_migration.increment!(:processed_count)
-
+      migrate(ecf_statements, :statement) do |ecf_statement|
         statement = Statement.find_or_initialize_by(month: Date::MONTHNAMES.find_index(ecf_statement.name.split[0]), year: ecf_statement.name.split[1])
 
         result = statement.update(
@@ -104,7 +93,7 @@ module Migration
           payment_date: ecf_statement.payment_date,
           output_fee: ecf_statement.output_fee,
           cohort: Cohort.find_by(start_year: ecf_cohorts.find_by(id: ecf_statement.cohort_id).start_year),
-          lead_provider: LeadProvider.find_by(ecf_id: ecf_npq_lead_providers.find_by(cpd_lead_provider_id: ecf_statement.cpd_lead_provider_id).id),
+          lead_provider: LeadProvider.find_by(ecf_id: ecf_statement.cpd_lead_provider.npq_lead_provider.id),
           marked_as_paid_at: ecf_statement.marked_as_paid_at,
           reconcile_amount: ecf_statement.reconcile_amount,
           state: if ecf_statement.type == "Finance::Statement::NPQ::Payable"
@@ -113,11 +102,8 @@ module Migration
                    ecf_statement.type == "Finance::Statement::NPQ::Paid" ? :paid : :open
                  end,
         )
-
-        data_migration.increment!(:failure_count) unless result
+        result
       end
-
-      data_migration.update!(completed_at: Time.zone.now)
     end
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,6 +38,7 @@ Rails.application.configure do
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.delivery_method = :test
 
   config.action_mailer.perform_caching = false
 

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe Statement, type: :model do
   describe "validations" do
     it { is_expected.to validate_numericality_of(:month).is_in(1..12).only_integer }
     it { is_expected.to validate_numericality_of(:year).only_integer.is_in(2020..2050) }
+    it { is_expected.to allow_value(%w[true false]).for(:output_fee) }
+    it { is_expected.not_to allow_value(nil).for(:output_fee) }
 
     describe "Validation for statement items count" do
       let(:statement) { create(:statement) }


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-2855

We want to migrate cohorts and statements from ECF into NPQ reg. These models are grouped together as they don’t currently exist in NPQ reg (so its all new data coming across/nothing to clash into).

### Changes proposed in this pull request

Add logic to migrate cohorts and statements.

### **Note: Cohort 2020 not migrated due new validation in place (start_year >= 2021)**

![image](https://github.com/DFE-Digital/npq-registration/assets/3020581/a0ec55c6-8024-4511-8df2-9c6b12cf0bf6)

