### PR TITLE
Remove `parallel_tests` gem and all config

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -68,7 +68,7 @@ jobs:
         run: mkdir -p tmp/capybara
 
       - name: Set up test database
-        run: bin/rails parallel:setup
+        run: bin/rails db:setup
 
       - name: Run tests
-        run: bundle exec rake parallel:spec
+        run: bundle exec rspec

--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -1,3 +1,0 @@
---require spec_helper
---format progress
---format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec.log

--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,6 @@ group :development, :test do
   gem "capybara"
   gem "capybara-screenshot"
   gem "dotenv-rails"
-  gem "parallel_tests"
   gem "pry-byebug"
   gem "pry-rails"
   gem "rspec-rails", "~> 6.1.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -376,8 +376,6 @@ GEM
       activerecord (>= 6.1)
       request_store (~> 1.4)
     parallel (1.24.0)
-    parallel_tests (4.5.2)
-      parallel
     parser (3.3.0.5)
       ast (~> 2.4.1)
       racc
@@ -684,7 +682,6 @@ DEPENDENCIES
   omniauth-rails_csrf_protection
   pagy
   paper_trail (~> 15.1)
-  parallel_tests
   pg (>= 0.18, < 2.0)
   pg_search
   pry-byebug


### PR DESCRIPTION
The test suite is now fast enough (since #707, #1115) to run sequentially. This simplifies our setup, makes the test output clearer and removes a dependency.

The entire run is 1 minute slower, from 6 mins to 7 mins.

We could make the whole thing *a lot faster* by testing the JavaScript pages on their own rather than as part of the end-to-end runs.