### PR TITLE
Cleanup parallel test setup

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -39,11 +39,11 @@ review:
 test:
   primary:
     <<: *default_primary
-    database: npq_registration_test<%= ENV['TEST_ENV_NUMBER'] %>
+    database: npq_registration_test
   ecf:
     <<: *default_ecf
     <<: *default_primary # We share the database in the test environment
-    database: early_careers_framework_test<%= ENV['TEST_ENV_NUMBER'] %>
+    database: early_careers_framework_test
 
 staging:
   primary:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,8 @@
 require "webdrivers"
 Webdrivers.install_dir = [Webdrivers.install_dir, ENV["TEST_ENV_NUMBER"]].compact.join(File::SEPARATOR)
 
-if ENV["TEST_ENV_NUMBER"].nil?
-  require "simplecov"
-  SimpleCov.start "rails"
-end
+require "simplecov"
+SimpleCov.start "rails"
 
 require "webmock/rspec"
 require "with_model"
@@ -93,7 +91,7 @@ RSpec.configure do |config|
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an
   # individual spec file.
-  if config.files_to_run.one? && ENV["TEST_ENV_NUMBER"].nil?
+  if config.files_to_run.one?
     # Use the documentation formatter for detailed output,
     # unless a formatter has already been configured
     # (e.g. via a command-line flag).


### PR DESCRIPTION

### Context

Remove `TEST_ENV_NUMBER` from database setup as parallel gem was removed in the following pr https://github.com/DFE-Digital/npq-registration/pull/1216


### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
