### PR TITLE
Set lead provider factory to use faker

### DIFF
--- a/spec/factories/lead_providers.rb
+++ b/spec/factories/lead_providers.rb
@@ -1,11 +1,7 @@
 FactoryBot.define do
   factory :lead_provider do
-    name { LeadProvider::ALL_PROVIDERS.keys.sample }
-    ecf_id { LeadProvider::ALL_PROVIDERS.values.sample }
+    name { Faker::Company.unique.name }
+    ecf_id { Faker::Alphanumeric.alphanumeric(number: 10) }
     hint { Faker::Lorem.sentence }
-
-    initialize_with do
-      LeadProvider.find_by(name:) || new(**attributes)
-    end
   end
 end


### PR DESCRIPTION
### Context

We've had some flakey tests example https://github.com/DFE-Digital/npq-registration/actions/runs/8255008175/job/22581317202 due to the provider factory finding existing providers or creating them which might set lead providers in specs to the same one causing failures

### Changes proposed in this pull request

Revert factory to use faker again

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
