### PR TITLE
[CPDLP-2879] Add missing `ecf_id` to statements

### DIFF
--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -6,6 +6,7 @@ class Statement < ApplicationRecord
   validates :output_fee, inclusion: [true, false]
   validates :month, numericality: { in: 1..12, only_integer: true }
   validates :year, numericality: { in: 2020..2050, only_integer: true }
+  validates :ecf_id, presence: true, uniqueness: { case_sensitive: false }
 
   validate :validate_max_statement_items_count
 

--- a/app/serializers/api/v3/statement_serializer.rb
+++ b/app/serializers/api/v3/statement_serializer.rb
@@ -17,6 +17,7 @@ module API
         field :deadline_date, name: :cut_off_date, datetime_format: "%Y-%m-%d"
         field :payment_date, datetime_format: "%Y-%m-%d"
         field(:paid) { |s, _| s.payment_date.present? }
+        field :ecf_id
         field :created_at
         field :updated_at
       end

--- a/app/serializers/api/v3/statement_serializer.rb
+++ b/app/serializers/api/v3/statement_serializer.rb
@@ -1,7 +1,7 @@
 module API
   module V3
     class StatementSerializer < Blueprinter::Base
-      identifier :id
+      identifier :ecf_id, name: :id
       field(:type) { "statement" }
 
       field :attributes do |statement, _options|
@@ -17,7 +17,6 @@ module API
         field :deadline_date, name: :cut_off_date, datetime_format: "%Y-%m-%d"
         field :payment_date, datetime_format: "%Y-%m-%d"
         field(:paid) { |s, _| s.payment_date.present? }
-        field :ecf_id
         field :created_at
         field :updated_at
       end

--- a/app/services/migration/migrator.rb
+++ b/app/services/migration/migrator.rb
@@ -101,6 +101,7 @@ module Migration
                  else
                    ecf_statement.type == "Finance::Statement::NPQ::Paid" ? :paid : :open
                  end,
+          ecf_id: ecf_statement.id,
         )
         result
       end

--- a/db/ecf_schema.rb
+++ b/db/ecf_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_06_170145) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_26_135601) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "fuzzystrmatch"
@@ -207,6 +207,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_06_170145) do
     t.datetime "updated_at", null: false
     t.integer "disable_from_year"
     t.boolean "listed", default: false, null: false
+    t.integer "listed_for_school_type_codes", default: [], array: true
     t.index ["body_type", "name"], name: "index_appropriate_bodies_on_body_type_and_name", unique: true
   end
 

--- a/db/migrate/20240312212008_add_ecf_id_to_statements.rb
+++ b/db/migrate/20240312212008_add_ecf_id_to_statements.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddEcfIdToStatements < ActiveRecord::Migration[7.1]
+  def change
+    add_column :statements, :ecf_id, :text, null: true
+    add_index :statements, :ecf_id, unique: true
+  end
+end

--- a/db/migrate/20240312212008_add_ecf_id_to_statements.rb
+++ b/db/migrate/20240312212008_add_ecf_id_to_statements.rb
@@ -2,7 +2,7 @@
 
 class AddEcfIdToStatements < ActiveRecord::Migration[7.1]
   def change
-    add_column :statements, :ecf_id, :text, null: true
+    add_column :statements, :ecf_id, :uuid, default: "gen_random_uuid()", null: false
     add_index :statements, :ecf_id, unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_01_152723) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_12_212008) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -321,7 +321,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_01_152723) do
     t.enum "state", default: "open", null: false, enum_type: "statement_states"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "ecf_id"
     t.index ["cohort_id"], name: "index_statements_on_cohort_id"
+    t.index ["ecf_id"], name: "index_statements_on_ecf_id", unique: true
     t.index ["lead_provider_id"], name: "index_statements_on_lead_provider_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -321,7 +321,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_12_212008) do
     t.enum "state", default: "open", null: false, enum_type: "statement_states"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "ecf_id"
+    t.uuid "ecf_id", default: -> { "gen_random_uuid()" }, null: false
     t.index ["cohort_id"], name: "index_statements_on_cohort_id"
     t.index ["ecf_id"], name: "index_statements_on_ecf_id", unique: true
     t.index ["lead_provider_id"], name: "index_statements_on_lead_provider_id"

--- a/spec/factories/statements.rb
+++ b/spec/factories/statements.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     lead_provider { association :lead_provider }
     reconcile_amount { Faker::Number.decimal(l_digits: 3, r_digits: 2) }
     state { "open" }
+    ecf_id { SecureRandom.uuid }
 
     trait(:paid) do
       state { "paid" }

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Statement, type: :model do
+  subject(:statement) { build(:statement) }
+
   describe "relationships" do
     it { is_expected.to belong_to(:cohort).required }
     it { is_expected.to belong_to(:lead_provider).required }
@@ -12,10 +14,10 @@ RSpec.describe Statement, type: :model do
     it { is_expected.to validate_numericality_of(:year).only_integer.is_in(2020..2050) }
     it { is_expected.to allow_value(%w[true false]).for(:output_fee) }
     it { is_expected.not_to allow_value(nil).for(:output_fee) }
+    it { is_expected.to validate_presence_of(:ecf_id) }
+    it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive }
 
     describe "Validation for statement items count" do
-      let(:statement) { create(:statement) }
-
       context "when the statement has two or fewer statement items" do
         it "is valid" do
           create_list(:statement_item, 2, statement:)

--- a/spec/requests/api/v3/statements_spec.rb
+++ b/spec/requests/api/v3/statements_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe "Statements endpoint", type: "request" do
           expect(response.status).to eq 200
           expect(response.content_type).to eql("application/json")
           expect(parsed_response["data"].size).to eq(2)
-          expect(parsed_response["data"][0]["id"]).to eq(statement1.id)
-          expect(parsed_response["data"][1]["id"]).to eq(statement2.id)
+          expect(parsed_response["data"][0]["id"]).to eq(statement1.ecf_id)
+          expect(parsed_response["data"][1]["id"]).to eq(statement2.ecf_id)
         end
       end
 
@@ -55,7 +55,7 @@ RSpec.describe "Statements endpoint", type: "request" do
 
           expect(response.status).to eq 200
           expect(response.content_type).to eql("application/json")
-          expect(parsed_response["data"]["id"]).to eq(statement.id)
+          expect(parsed_response["data"]["id"]).to eq(statement.ecf_id)
         end
       end
 

--- a/spec/serializers/api/v3/statement_serializer_spec.rb
+++ b/spec/serializers/api/v3/statement_serializer_spec.rb
@@ -70,6 +70,12 @@ RSpec.describe API::V3::StatementSerializer, type: :serializer do
       end
     end
 
+    it "serializes the `ecf_id`" do
+      statement.ecf_id = "123456"
+
+      expect(attributes["ecf_id"]).to eq("123456")
+    end
+
     describe "timestamp serialization" do
       it "serializes the `created_at`" do
         statement.created_at = Time.utc(2023, 7, 1, 12, 0, 0)

--- a/spec/serializers/api/v3/statement_serializer_spec.rb
+++ b/spec/serializers/api/v3/statement_serializer_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe API::V3::StatementSerializer, type: :serializer do
     subject(:response) { JSON.parse(described_class.render(statement)) }
 
     it "serializes the `id`" do
-      cohort.save!
+      statement.ecf_id = "fe1a5280-1b13-4b09-b9c7-e2b01d37e851"
 
-      expect(response["id"]).to eq(statement.id)
+      expect(response["id"]).to eq("fe1a5280-1b13-4b09-b9c7-e2b01d37e851")
     end
 
     it "serializes the `type`" do
@@ -68,12 +68,6 @@ RSpec.describe API::V3::StatementSerializer, type: :serializer do
 
         expect(attributes["paid"]).to eq(false)
       end
-    end
-
-    it "serializes the `ecf_id`" do
-      statement.ecf_id = "123456"
-
-      expect(attributes["ecf_id"]).to eq("123456")
     end
 
     describe "timestamp serialization" do


### PR DESCRIPTION
### Context

Ticket: [CPDLP-2879](https://dfedigital.atlassian.net/browse/CPDLP-2879)

We need to maintain all existing ecf ids in the API. This also applies to statements.

### Changes proposed in this pull request

- Add `ecf_id` to the statements table
- Migrate the `ecf_id` when copying over statement data
- Surface `ecf_id` and the id of the statement in the API
- Add to seeds as well as a generated UUID

[CPDLP-2879]: https://dfedigital.atlassian.net/browse/CPDLP-2879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ