### PR TITLE
Change CODEOWNERS to use CPD NPQ team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Lockyy @leoapost @peteryates @javier-npq @slawosz @pmanrubia
+* @DFE-Digital/npq-cpd


### PR DESCRIPTION
This will make managing who gets notifications easier in the long term as it can be done via GitHub's interface rather than via commits.
