### PR TITLE
Add namespace to konduit commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,10 +206,10 @@ endef
 
 # Creates a konduit to the DB and points development to it. The konduit URL is removed when the konduit is closed.
 konduit: get-cluster-credentials
-	$(KONDUIT_CONNECT) ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-pg -k ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-app-kv cpd-ecf-${CONFIG_LONG}-web -- psql > "$$tmp_file"
+	$(KONDUIT_CONNECT) ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-pg -n ${NAMESPACE} -k ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-app-kv cpd-ecf-${CONFIG_LONG}-web -- psql > "$$tmp_file"
 	exit 0
 
 # Creates a konduit to the snapshot DB and points development to it. The konduit URL is removed when the konduit is closed.
 konduit-snapshot: get-cluster-credentials
-	$(KONDUIT_CONNECT) ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-pg-snapshot -k ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-app-kv cpd-ecf-${CONFIG_LONG}-web -- psql > "$$tmp_file"
+	$(KONDUIT_CONNECT) ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-pg-snapshot -n ${NAMESPACE} -k ${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-app-kv cpd-ecf-${CONFIG_LONG}-web -- psql > "$$tmp_file"
 	exit 0


### PR DESCRIPTION

### Context

Ticket: n/a

A change to how we authenticate with AKS has been implemented, and konduit script has now been updated.
Since we have make commands that use this script, we have to now pass in a namespace option to konduit

### Changes proposed in this pull request

Pass in namespace option to both konduit commands to connect to dbs

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
