### PR TITLE
Add users section to NPQ separation admin area

### DIFF
--- a/app/components/npq_separation/navigation_structures/admin_navigation_structure.rb
+++ b/app/components/npq_separation/navigation_structures/admin_navigation_structure.rb
@@ -30,6 +30,11 @@ module NpqSeparation
             prefix: "/npq-separation/admin/applications",
           ) => [],
           Node.new(
+            name: "Participants",
+            href: npq_separation_admin_users_path,
+            prefix: "/npq-separation/admin/users",
+          ) => [],
+          Node.new(
             name: "Finance",
             href: npq_separation_admin_finance_statements_path,
             prefix: "/npq-separation/admin/finance",

--- a/app/controllers/npq_separation/admin/users_controller.rb
+++ b/app/controllers/npq_separation/admin/users_controller.rb
@@ -1,0 +1,15 @@
+class NpqSeparation::Admin::UsersController < NpqSeparation::AdminController
+  def index
+    @pagy, @users = pagy(find_user.all)
+  end
+
+  def show
+    @user = find_user.by_id(params[:id])
+  end
+
+private
+
+  def find_user
+    @find_user ||= Users::Find.new
+  end
+end

--- a/app/services/users/find.rb
+++ b/app/services/users/find.rb
@@ -1,0 +1,11 @@
+module Users
+  class Find
+    def all
+      User.all
+    end
+
+    def by_id(id)
+      User.find(id)
+    end
+  end
+end

--- a/app/views/npq_separation/admin/users/index.html.erb
+++ b/app/views/npq_separation/admin/users/index.html.erb
@@ -1,0 +1,24 @@
+<h1 class="govuk-heading-l">All participants</h1>
+<%=
+  govuk_table do |table|
+    table.with_head do |header|
+      header.with_row do |row|
+        row.with_cell(text: "Name")
+        row.with_cell(text: "TRN")
+        row.with_cell(text: "Date added")
+      end
+    end
+
+    table.with_body do |body|
+      @users.each do |user|
+        body.with_row do |row|
+          row.with_cell(text: govuk_link_to(user.full_name, npq_separation_admin_user_path(user)))
+          row.with_cell(text: user.trn)
+          row.with_cell(text: user.created_at.to_date.to_formatted_s(:govuk))
+        end
+      end
+    end
+  end
+%>
+
+<%= govuk_pagination(pagy: @pagy) %>

--- a/app/views/npq_separation/admin/users/show.html.erb
+++ b/app/views/npq_separation/admin/users/show.html.erb
@@ -1,0 +1,42 @@
+<%= govuk_back_link(href: url_for(:back)) %>
+
+<h1 class="govuk-heading-l"><%= @user.full_name %></h1>
+
+<%=
+  govuk_summary_list do |sl|
+    sl.with_row do |row|
+      row.with_key(text: "ID")
+      row.with_value(text: @user.id)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "ECF ID")
+      row.with_value(text: @user.ecf_id)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Email")
+      row.with_value(text: @user.email)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Name")
+      row.with_value(text: @user.full_name)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "TRN")
+      row.with_value(text: @user.trn)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "TRN validated")
+      row.with_value(text: boolean_red_green_tag(@user.trn_verified) + (" (automatically)" if @user.trn_auto_verified))
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Get an Identity ID")
+      row.with_value(text: @user.uid)
+    end
+  end
+%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -173,6 +173,7 @@ Rails.application.routes.draw do
         end
 
         resources :applications, only: %i[index]
+        resources :users, only: %i[index show]
 
         namespace :finance do
           resources :statements, only: %i[index show] do

--- a/spec/components/npq_separation/navigation_structures/admin_navigation_structure_spec.rb
+++ b/spec/components/npq_separation/navigation_structures/admin_navigation_structure_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe NpqSeparation::NavigationStructures::AdminNavigationStructure, ty
     {
       "Dashboard" => "/npq-separation/admin",
       "Applications" => "/npq-separation/admin/applications",
+      "Participants" => "/npq-separation/admin/users",
       "Finance" => "/npq-separation/admin/finance/statements",
       "Schools" => "#",
       "Lead providers" => "#",

--- a/spec/features/npq_separation/admin/users_spec.rb
+++ b/spec/features/npq_separation/admin/users_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.feature "Listing and viewing users", type: :feature do
+  include Helpers::AdminLogin
+
+  let(:users_per_page) { Pagy::DEFAULT[:items] }
+
+  before do
+    create_list(:user, users_per_page + 1, :with_ecf_id, :with_get_an_identity_id)
+    sign_in_as(create(:admin))
+  end
+
+  scenario "viewing the list of users" do
+    visit(npq_separation_admin_users_path)
+
+    expect(page).to have_css("h1", text: "All participants")
+
+    User.limit(users_per_page).each do |user|
+      expect(page).to have_css("td a", text: user.full_name)
+      expect(page).to have_css("td", text: user.trn)
+      expect(page).to have_css("td", text: user.created_at.to_date.to_formatted_s(:govuk))
+    end
+
+    expect(page).to have_css(".govuk-pagination__item--current", text: 1)
+  end
+
+  scenario "navigating to the second page of users" do
+    visit(npq_separation_admin_users_path)
+
+    click_on("Next")
+
+    expect(page).to have_css("table.govuk-table tbody tr", count: 1)
+    expect(page).to have_css(".govuk-pagination__item--current", text: "2")
+  end
+
+  scenario "viewing user details" do
+    visit(npq_separation_admin_users_path)
+
+    user = User.first
+
+    first("td").click_link(user.full_name)
+
+    expect(page).to have_css("h1", text: user.full_name)
+
+    within(".govuk-summary-list") do |summary_list|
+      expect(summary_list).to have_text(user.id)
+      expect(summary_list).to have_text(user.ecf_id)
+      expect(summary_list).to have_text(user.email)
+      expect(summary_list).to have_text(user.full_name)
+      expect(summary_list).to have_text(user.trn)
+      expect(summary_list).to have_text(user.get_an_identity_id)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -117,7 +117,7 @@ RSpec.configure do |config|
     # Make the app behave how it does in non dev/test environments and use the
     # ErrorsController via config.exceptions_app = routes in config/application.rb
     method = Rails.application.method(:env_config)
-    expect(Rails.application).to receive(:env_config).with(no_args) do
+    allow(Rails.application).to receive(:env_config).with(no_args) do
       method.call.merge(
         "action_dispatch.show_exceptions" => :all,
         "action_dispatch.show_detailed_exceptions" => false,

--- a/spec/requests/npq_separation/admin/users_controller_spec.rb
+++ b/spec/requests/npq_separation/admin/users_controller_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe NpqSeparation::Admin::UsersController, type: :request do
+  include Helpers::NPQSeparationAdminLogin
+
+  before { sign_in_as_admin }
+
+  describe "/npq_separation/admin/users" do
+    subject do
+      get npq_separation_admin_users_path
+      response
+    end
+
+    it { is_expected.to have_http_status(:ok) }
+  end
+
+  describe "/npq_separation/admin/users/{id}" do
+    let(:user_id) { create(:user).id }
+
+    subject do
+      get npq_separation_admin_user_path(user_id)
+      response
+    end
+
+    it { is_expected.to have_http_status(:ok) }
+
+    context "when the user cannot be found", exceptions_app: true do
+      let(:user_id) { -1 }
+
+      it { is_expected.to have_http_status(:not_found) }
+    end
+  end
+end

--- a/spec/services/users/find_spec.rb
+++ b/spec/services/users/find_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe Users::Find do
+  before { create(:user) }
+
+  describe "#all" do
+    subject { Users::Find.new.all }
+
+    it { is_expected.to contain_exactly(*User.all) }
+  end
+
+  describe "#by_id" do
+    let(:user) { create(:user) }
+
+    subject { Users::Find.new.by_id(user.id) }
+
+    it { is_expected.to eq(user) }
+  end
+end


### PR DESCRIPTION
### Context

We want to be able to view the basic user information in the NPQ separation admin area.

### Changes proposed in this pull request

- Add users section to NPQ separation admin area

Add index/show actions for users. List all users with pagination and display details when clicking through.

### Guidance to review

[Link to users in admin dashboard](https://npq-registration-review-1240-web.test.teacherservices.cloud/npq-separation/admin/users)

| All Participants    | Participant |
| -------- | ------- |
| <img width="1388" alt="Screenshot 2024-03-21 at 08 07 05" src="https://github.com/DFE-Digital/npq-registration/assets/29867726/b48f2c0d-7107-4cfa-94fe-5af1697befb0">  | <img width="1432" alt="Screenshot 2024-03-21 at 08 07 12" src="https://github.com/DFE-Digital/npq-registration/assets/29867726/f6079999-dfdb-4749-a630-f96039ed1d2f">   |




