### PR TITLE
Add lead provider admin path

### DIFF
--- a/app/components/npq_separation/navigation_structures/admin_navigation_structure.rb
+++ b/app/components/npq_separation/navigation_structures/admin_navigation_structure.rb
@@ -53,7 +53,7 @@ module NpqSeparation
           ) => [],
           Node.new(
             name: "Lead providers",
-            href: "#",
+            href: npq_separation_admin_lead_providers_path,
             prefix: "/npq-separation/admin/lead_providers",
           ) => [],
           Node.new(

--- a/spec/components/npq_separation/navigation_structures/admin_navigation_structure_spec.rb
+++ b/spec/components/npq_separation/navigation_structures/admin_navigation_structure_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe NpqSeparation::NavigationStructures::AdminNavigationStructure, ty
       "Applications" => "/npq-separation/admin/applications",
       "Finance" => "/npq-separation/admin/finance/statements",
       "Schools" => "#",
-      "Lead providers" => "#",
+      "Lead providers" => "/npq-separation/admin/lead-providers",
       "Settings" => "#",
     }.each_with_index do |(name, href), i|
       it "#{name} with href #{href} is at position #{i + 1}" do


### PR DESCRIPTION
### Context

Ticket: n/a
[Why are we making this change?]

### Changes proposed in this pull request

We have a build interface for the lead provider npq separation admin. Add link back to structure

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
