### PR TITLE
[CPDLP-2898] Add logic to migrate ECF user data into NPQ

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,17 +5,6 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  workflow_dispatch:
-    inputs:
-      environment:
-        description: "Deploy environment"
-        required: true
-        default: migration
-        type: choice
-        options:
-          - migration
-          - separation
-
   push:
     branches:
       - main

--- a/app/models/migration/ecf/finance/schedule.rb
+++ b/app/models/migration/ecf/finance/schedule.rb
@@ -1,0 +1,10 @@
+module Migration::Ecf::Finance
+  class Schedule < Migration::Ecf::BaseRecord
+    self.inheritance_column = nil
+
+    belongs_to :cohort
+    has_many :participant_profiles
+
+    default_scope { where("schedules.type ilike ?", "Finance::Schedule::NPQ%") }
+  end
+end

--- a/app/models/migration/ecf/npq_application.rb
+++ b/app/models/migration/ecf/npq_application.rb
@@ -1,0 +1,10 @@
+module Migration::Ecf
+  class NpqApplication < BaseRecord
+    belongs_to :participant_identity
+    belongs_to :npq_lead_provider
+    belongs_to :npq_course
+    belongs_to :cohort, optional: true
+    has_one :profile, class_name: "ParticipantProfile", foreign_key: :id
+    has_one :user, through: :participant_identity
+  end
+end

--- a/app/models/migration/ecf/npq_course.rb
+++ b/app/models/migration/ecf/npq_course.rb
@@ -1,0 +1,5 @@
+module Migration::Ecf
+  class NpqCourse < BaseRecord
+    has_many :npq_applications
+  end
+end

--- a/app/models/migration/ecf/participant_identity.rb
+++ b/app/models/migration/ecf/participant_identity.rb
@@ -1,0 +1,7 @@
+module Migration::Ecf
+  class ParticipantIdentity < BaseRecord
+    belongs_to :user
+    has_many :participant_profiles
+    has_many :npq_applications
+  end
+end

--- a/app/models/migration/ecf/participant_profile.rb
+++ b/app/models/migration/ecf/participant_profile.rb
@@ -1,0 +1,12 @@
+module Migration::Ecf
+  class ParticipantProfile < BaseRecord
+    self.inheritance_column = nil
+
+    belongs_to :teacher_profile
+    belongs_to :schedule, class_name: "Finance::Schedule"
+    has_one :user, through: :teacher_profile
+    has_one :npq_application, foreign_key: :id
+
+    default_scope { where(type: "ParticipantProfile::NPQ") }
+  end
+end

--- a/app/models/migration/ecf/teacher_profile.rb
+++ b/app/models/migration/ecf/teacher_profile.rb
@@ -1,0 +1,7 @@
+module Migration::Ecf
+  class TeacherProfile < BaseRecord
+    belongs_to :user
+    has_many :npq_profiles, class_name: "ParticipantProfile"
+    has_many :participant_profiles
+  end
+end

--- a/app/models/migration/ecf/user.rb
+++ b/app/models/migration/ecf/user.rb
@@ -1,0 +1,11 @@
+module Migration::Ecf
+  class User < BaseRecord
+    has_many :participant_identities
+    has_one :teacher_profile
+    has_many :npq_profiles, through: :teacher_profile
+
+    def npq_applications
+      Migration::Ecf::NpqApplication.joins(:participant_identity).where(participant_identity: { user_id: id })
+    end
+  end
+end

--- a/app/services/migration/migrator.rb
+++ b/app/services/migration/migrator.rb
@@ -5,13 +5,18 @@ module Migration
     class MigrationNotPreparedError < RuntimeError; end
     class MigrationAlreadyPreparedError < RuntimeError; end
 
-    class << self
-      MODELS_TO_BE_MIGRATED = %i[lead_provider cohort statement].freeze
+    MIGRATORS = [
+      Migration::Migrators::LeadProvider,
+      Migration::Migrators::Cohort,
+      Migration::Migrators::Statement,
+      Migration::Migrators::User,
+    ].freeze
 
+    class << self
       def prepare_for_migration
         raise MigrationAlreadyPreparedError, "The migration has already been prepared" if DataMigration.exists?
 
-        MODELS_TO_BE_MIGRATED.each { |model| DataMigration.create!(model:) }
+        MIGRATORS.each(&:prepare!)
       end
     end
 
@@ -40,75 +45,7 @@ module Migration
     end
 
     def run_migration
-      migrate_lead_providers
-      migrate_cohorts
-      migrate_statements
-    end
-
-    def migrate(items, model)
-      data_migration = DataMigration.find_by(model:)
-      data_migration.update!(started_at: Time.zone.now, total_count: items.count)
-
-      failure_manager = FailureManager.new(data_migration:)
-
-      items.each do |item|
-        data_migration.increment!(:processed_count)
-        begin
-          yield(item)
-        rescue ActiveRecord::ActiveRecordError => e
-          data_migration.increment!(:failure_count)
-          failure_manager.record_failure(item, e.message)
-        end
-      end
-
-      data_migration.update!(completed_at: Time.zone.now)
-    end
-
-    def migrate_lead_providers
-      migrate(ecf_npq_lead_providers, :lead_provider) do |ecf_npq_lead_provider|
-        LeadProvider.find_by!(ecf_id: ecf_npq_lead_provider.id)
-      end
-    end
-
-    def ecf_npq_lead_providers
-      @ecf_npq_lead_providers ||= Ecf::NpqLeadProvider.all
-    end
-
-    def ecf_cohorts
-      @ecf_cohorts ||= Ecf::Cohort.where(start_year: 2021..)
-    end
-
-    def migrate_cohorts
-      migrate(ecf_cohorts, :cohort) do |ecf_cohort|
-        cohort = Cohort.find_or_initialize_by(start_year: ecf_cohort.start_year)
-        cohort.update!(registration_start_date: ecf_cohort.npq_registration_start_date.presence || ecf_cohort.registration_start_date)
-      end
-    end
-
-    def ecf_statements
-      @ecf_statements ||= Ecf::Finance::Statement.all
-    end
-
-    def migrate_statements
-      migrate(ecf_statements, :statement) do |ecf_statement|
-        statement = Statement.find_or_initialize_by(month: Date::MONTHNAMES.find_index(ecf_statement.name.split[0]), year: ecf_statement.name.split[1])
-
-        statement.update!(
-          deadline_date: ecf_statement.deadline_date,
-          payment_date: ecf_statement.payment_date,
-          output_fee: ecf_statement.output_fee,
-          cohort: Cohort.find_by(start_year: ecf_cohorts.find_by(id: ecf_statement.cohort_id).start_year),
-          lead_provider: LeadProvider.find_by(ecf_id: ecf_statement.cpd_lead_provider.npq_lead_provider.id),
-          marked_as_paid_at: ecf_statement.marked_as_paid_at,
-          reconcile_amount: ecf_statement.reconcile_amount,
-          state: if ecf_statement.type == "Finance::Statement::NPQ::Payable"
-                   :payable
-                 else
-                   ecf_statement.type == "Finance::Statement::NPQ::Paid" ? :paid : :open
-                 end,
-          ecf_id: ecf_statement.id,
-        )
-      end
+      MIGRATORS.each(&:call)
     end
   end
 end

--- a/app/services/migration/migrators/base.rb
+++ b/app/services/migration/migrators/base.rb
@@ -1,0 +1,36 @@
+module Migration::Migrators
+  class Base
+    class << self
+      def call(**args)
+        new(**args).call
+      end
+
+      def prepare!
+        model = name.gsub(/^.*::/, "").underscore.to_sym
+
+        Migration::DataMigration.create!(model:)
+      end
+    end
+
+  private
+
+    def migrate(items, model)
+      data_migration = Migration::DataMigration.find_by(model:)
+      data_migration.update!(started_at: Time.zone.now, total_count: items.count)
+
+      failure_manager = Migration::FailureManager.new(data_migration:)
+
+      items.each do |item|
+        data_migration.increment!(:processed_count)
+        begin
+          yield(item)
+        rescue ActiveRecord::ActiveRecordError => e
+          data_migration.increment!(:failure_count)
+          failure_manager.record_failure(item, e.message)
+        end
+      end
+
+      data_migration.update!(completed_at: Time.zone.now)
+    end
+  end
+end

--- a/app/services/migration/migrators/base.rb
+++ b/app/services/migration/migrators/base.rb
@@ -20,7 +20,7 @@ module Migration::Migrators
 
       failure_manager = Migration::FailureManager.new(data_migration:)
 
-      items.each do |item|
+      items.in_batches.each_record do |item|
         data_migration.increment!(:processed_count)
         begin
           yield(item)

--- a/app/services/migration/migrators/cohort.rb
+++ b/app/services/migration/migrators/cohort.rb
@@ -1,0 +1,16 @@
+module Migration::Migrators
+  class Cohort < Base
+    def call
+      migrate(ecf_cohorts, :cohort) do |ecf_cohort|
+        cohort = ::Cohort.find_or_initialize_by(start_year: ecf_cohort.start_year)
+        cohort.update!(registration_start_date: ecf_cohort.npq_registration_start_date.presence || ecf_cohort.registration_start_date)
+      end
+    end
+
+  private
+
+    def ecf_cohorts
+      @ecf_cohorts ||= Migration::Ecf::Cohort.where(start_year: 2021..)
+    end
+  end
+end

--- a/app/services/migration/migrators/lead_provider.rb
+++ b/app/services/migration/migrators/lead_provider.rb
@@ -1,0 +1,15 @@
+module Migration::Migrators
+  class LeadProvider < Base
+    def call
+      migrate(ecf_npq_lead_providers, :lead_provider) do |ecf_npq_lead_provider|
+        ::LeadProvider.find_by!(ecf_id: ecf_npq_lead_provider.id)
+      end
+    end
+
+  private
+
+    def ecf_npq_lead_providers
+      @ecf_npq_lead_providers ||= Migration::Ecf::NpqLeadProvider.all
+    end
+  end
+end

--- a/app/services/migration/migrators/statement.rb
+++ b/app/services/migration/migrators/statement.rb
@@ -1,0 +1,35 @@
+module Migration::Migrators
+  class Statement < Base
+    def call
+      migrate(ecf_statements, :statement) do |ecf_statement|
+        statement = ::Statement.find_or_initialize_by(month: Date::MONTHNAMES.find_index(ecf_statement.name.split[0]), year: ecf_statement.name.split[1])
+
+        statement.update!(
+          deadline_date: ecf_statement.deadline_date,
+          payment_date: ecf_statement.payment_date,
+          output_fee: ecf_statement.output_fee,
+          cohort: ::Cohort.find_by(start_year: ecf_cohorts.find_by(id: ecf_statement.cohort_id).start_year),
+          lead_provider: ::LeadProvider.find_by(ecf_id: ecf_statement.cpd_lead_provider.npq_lead_provider.id),
+          marked_as_paid_at: ecf_statement.marked_as_paid_at,
+          reconcile_amount: ecf_statement.reconcile_amount,
+          state: if ecf_statement.type == "Finance::Statement::NPQ::Payable"
+                   :payable
+                 else
+                   ecf_statement.type == "Finance::Statement::NPQ::Paid" ? :paid : :open
+                 end,
+          ecf_id: ecf_statement.id,
+        )
+      end
+    end
+
+  private
+
+    def ecf_statements
+      @ecf_statements ||= Migration::Ecf::Finance::Statement.all
+    end
+
+    def ecf_cohorts
+      @ecf_cohorts ||= Migration::Ecf::Cohort.where(start_year: 2021..)
+    end
+  end
+end

--- a/app/services/migration/migrators/user.rb
+++ b/app/services/migration/migrators/user.rb
@@ -1,0 +1,34 @@
+module Migration::Migrators
+  class User < Base
+    def call
+      migrate(ecf_users, :user) do |ecf_user|
+        user = ::User.find_or_initialize_by(ecf_id: ecf_user.id)
+
+        user.update!(
+          trn: ecf_user.teacher_profile&.trn ? ecf_user.teacher_profile.trn : ecf_user.npq_applications.map(&:teacher_reference_number).compact.uniq.last,
+          full_name: ecf_user.full_name || user.full_name,
+          email: ecf_user.email || user.email,
+          uid: ecf_user.get_an_identity_id || user.uid,
+        )
+      end
+    end
+
+  private
+
+    def ecf_users
+      @ecf_users ||= begin
+        users_with_npq_profiles = Migration::Ecf::User
+          .joins(teacher_profile: :npq_profiles)
+          .all
+          .where("participant_profiles.id is not NULL")
+
+        users_with_npq_applications = Migration::Ecf::User
+          .joins(participant_identities: :npq_applications)
+          .all
+          .where("npq_applications.id is not NULL")
+
+        (users_with_npq_profiles + users_with_npq_applications).flatten.uniq
+      end
+    end
+  end
+end

--- a/app/services/migration/migrators/user.rb
+++ b/app/services/migration/migrators/user.rb
@@ -4,6 +4,8 @@ module Migration::Migrators
       migrate(ecf_users, :user) do |ecf_user|
         user = ::User.find_or_initialize_by(ecf_id: ecf_user.id)
 
+        validate_multiple_trns!(ecf_user, user)
+
         user.update!(
           trn: ecf_user.teacher_profile&.trn ? ecf_user.teacher_profile.trn : ecf_user.npq_applications.map(&:teacher_reference_number).compact.uniq.last,
           full_name: ecf_user.full_name || user.full_name,
@@ -29,6 +31,13 @@ module Migration::Migrators
 
         Migration::Ecf::User.from("(#{users_with_npq_profiles.to_sql} UNION #{users_with_npq_applications.to_sql}) AS users")
       end
+    end
+
+    def validate_multiple_trns!(ecf_user, user)
+      return unless ecf_user.npq_applications.map(&:teacher_reference_number).compact.uniq.size > 1
+
+      user.errors.add(:base, "There are multiple different TRNs from NPQ applications")
+      raise ActiveRecord::RecordInvalid, user
     end
   end
 end

--- a/app/services/migration/migrators/user.rb
+++ b/app/services/migration/migrators/user.rb
@@ -27,7 +27,7 @@ module Migration::Migrators
           .all
           .where("npq_applications.id is not NULL")
 
-        (users_with_npq_profiles + users_with_npq_applications).flatten.uniq
+        Migration::Ecf::User.from("(#{users_with_npq_profiles.to_sql} UNION #{users_with_npq_applications.to_sql}) AS users")
       end
     end
   end

--- a/spec/factories/migration/ecf/finance/schedules.rb
+++ b/spec/factories/migration/ecf/finance/schedules.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :ecf_migration_schedule, class: "Migration::Ecf::Finance::Schedule" do
+    name { Course.all.sample.name }
+    cohort { create(:ecf_migration_cohort) }
+    sequence(:schedule_identifier) { |n| "schedule-identifier-#{n}" }
+    type { "Finance::Schedule::NPQ" }
+  end
+end

--- a/spec/factories/migration/ecf/npq_applications.rb
+++ b/spec/factories/migration/ecf/npq_applications.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :ecf_migration_npq_application, class: "Migration::Ecf::NpqApplication" do
+    cohort_id { create(:ecf_migration_cohort).id }
+    npq_course_id { create(:ecf_migration_npq_course).id }
+    npq_lead_provider_id { create(:ecf_migration_npq_lead_provider).id }
+    participant_identity_id { create(:ecf_migration_participant_identity, user:).id }
+    works_in_school { true }
+    school_urn { rand(100_000..999_999).to_s }
+    school_ukprn { rand(10_000_000..99_999_999).to_s }
+    date_of_birth { rand(25..50).years.ago + rand(0..365).days }
+    teacher_reference_number { rand(1_000_000..9_999_999).to_s }
+    teacher_reference_number_verified { true }
+    nino { SecureRandom.hex }
+    active_alert { false }
+    eligible_for_funding { false }
+    funding_eligiblity_status_code { :ineligible_establishment_type }
+    targeted_delivery_funding_eligibility { false }
+    teacher_catchment { "england" }
+    teacher_catchment_country { nil }
+    itt_provider { "University of Southampton" }
+    lead_mentor { true }
+
+    trait :accepted do
+      lead_provider_approval_status { "accepted" }
+
+      after(:create) do |npq_application|
+        Migration::Ecf::ParticipantProfile.create!(
+          id: npq_application.id,
+          teacher_profile: npq_application.user.teacher_profile,
+          user: npq_application.user,
+          type: "ParticipantProfile::NPQ",
+          schedule: create(:ecf_migration_schedule, cohort: npq_application.cohort, schedule_identifier: npq_application.npq_course.identifier),
+        )
+      end
+    end
+  end
+end

--- a/spec/factories/migration/ecf/npq_courses.rb
+++ b/spec/factories/migration/ecf/npq_courses.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :ecf_migration_npq_course, class: "Migration::Ecf::NpqCourse" do
+    sequence(:name) { |n| "NPQ Course #{n}" }
+    identifier { Course.all.sample.identifier }
+  end
+end

--- a/spec/factories/migration/ecf/participant_identities.rb
+++ b/spec/factories/migration/ecf/participant_identities.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :ecf_migration_participant_identity, class: "Migration::Ecf::ParticipantIdentity" do
+    user { create(:ecf_migration_user) }
+    email { user.email }
+    external_identifier { user.id }
+    origin { "npq" }
+  end
+end

--- a/spec/factories/migration/ecf/participant_profiles.rb
+++ b/spec/factories/migration/ecf/participant_profiles.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :ecf_migration_npq_participant_profile, class: "Migration::Ecf::ParticipantProfile" do
+    transient do
+      user { create(:ecf_migration_user) }
+      cohort { create(:ecf_migration_cohort) }
+      npq_course { create(:ecf_migration_npq_course) }
+      participant_identity { user.participant_identities.first || create(:ecf_migration_participant_identity, user:) }
+      npq_lead_provider { create(:ecf_migration_npq_lead_provider) }
+      teacher_reference_number { user.teacher_profile&.trn || sprintf("%07i", Random.random_number(9_999_999)) }
+      npq_application { create(:ecf_migration_npq_application, participant_identity:) }
+    end
+
+    type { "ParticipantProfile::NPQ" }
+    schedule { create(:ecf_migration_schedule) }
+    teacher_profile { user.teacher_profile || create(:ecf_migration_teacher_profile, user:) }
+
+    trait :with_accepted_npq_application do
+      npq_application do
+        create(:ecf_migration_npq_application, :accepted, npq_lead_provider:, npq_course:, cohort:, participant_identity:, teacher_reference_number:)
+      end
+    end
+
+    initialize_with do
+      npq_application.profile
+    end
+  end
+end

--- a/spec/factories/migration/ecf/teacher_profiles.rb
+++ b/spec/factories/migration/ecf/teacher_profiles.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :ecf_migration_teacher_profile, class: "Migration::Ecf::TeacherProfile" do
+    user { create(:ecf_migration_user) }
+    trn { sprintf("%07i", Random.random_number(9_999_999)) }
+
+    initialize_with do
+      Migration::Ecf::TeacherProfile.find_by(user:) || new(**attributes)
+    end
+  end
+end

--- a/spec/factories/migration/ecf/users.rb
+++ b/spec/factories/migration/ecf/users.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :ecf_migration_user, class: "Migration::Ecf::User" do
+    email { Faker::Internet.unique.email }
+    sequence(:full_name) { |n| "John Doe #{n}" }
+
+    trait :npq do
+      after(:create) do |user|
+        user.teacher_profile = create(:ecf_migration_teacher_profile, user:, participant_profiles: [create(:ecf_migration_npq_participant_profile, :with_accepted_npq_application, user:)])
+      end
+    end
+
+    trait :with_random_name do
+      full_name { Faker::Name.name }
+    end
+  end
+end

--- a/spec/models/migration/ecf/finance/schedule_spec.rb
+++ b/spec/models/migration/ecf/finance/schedule_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe Migration::Ecf::Finance::Schedule, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:cohort) }
+    it { is_expected.to have_many(:participant_profiles) }
+  end
+
+  describe "scopes" do
+    describe "default_scope" do
+      let!(:ecf_migration_schedule) { create(:ecf_migration_schedule) }
+
+      before { create(:ecf_migration_schedule, type: "Finance::Schedule::ECF") }
+
+      it "returns NPQ schedules only" do
+        expect(described_class.all).to eq([ecf_migration_schedule])
+      end
+    end
+  end
+end

--- a/spec/models/migration/ecf/npq_application_spec.rb
+++ b/spec/models/migration/ecf/npq_application_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe Migration::Ecf::NpqApplication, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:participant_identity) }
+    it { is_expected.to belong_to(:npq_lead_provider) }
+    it { is_expected.to belong_to(:npq_course) }
+    it { is_expected.to belong_to(:cohort).optional }
+    it { is_expected.to have_one(:profile).class_name("ParticipantProfile").with_foreign_key(:id) }
+    it { is_expected.to have_one(:user).through(:participant_identity) }
+  end
+end

--- a/spec/models/migration/ecf/npq_course_spec.rb
+++ b/spec/models/migration/ecf/npq_course_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+RSpec.describe Migration::Ecf::NpqCourse, type: :model do
+  describe "associations" do
+    it { is_expected.to have_many(:npq_applications) }
+  end
+end

--- a/spec/models/migration/ecf/participant_identity_spec.rb
+++ b/spec/models/migration/ecf/participant_identity_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe Migration::Ecf::ParticipantIdentity, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to have_many(:participant_profiles) }
+    it { is_expected.to have_many(:npq_applications) }
+  end
+end

--- a/spec/models/migration/ecf/participant_profile_spec.rb
+++ b/spec/models/migration/ecf/participant_profile_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe Migration::Ecf::ParticipantProfile, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:teacher_profile) }
+    it { is_expected.to belong_to(:schedule).class_name("Finance::Schedule") }
+    it { is_expected.to have_one(:user).through(:teacher_profile) }
+    it { is_expected.to have_one(:npq_application).with_foreign_key(:id) }
+  end
+
+  describe "scopes" do
+    describe "default_scope" do
+      let!(:ecf_migration_user) { create(:ecf_migration_user, :npq) }
+
+      it "returns NPQ profiles only" do
+        expect(described_class.all).to eq([ecf_migration_user.npq_profiles.first])
+      end
+    end
+  end
+end

--- a/spec/models/migration/ecf/teacher_profile_spec.rb
+++ b/spec/models/migration/ecf/teacher_profile_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe Migration::Ecf::TeacherProfile, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to have_many(:npq_profiles).class_name("ParticipantProfile") }
+    it { is_expected.to have_many(:participant_profiles) }
+  end
+end

--- a/spec/models/migration/ecf/user_spec.rb
+++ b/spec/models/migration/ecf/user_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe Migration::Ecf::User, type: :model do
+  describe "associations" do
+    it { is_expected.to have_many(:participant_identities) }
+    it { is_expected.to have_one(:teacher_profile) }
+    it { is_expected.to have_many(:npq_profiles).through(:teacher_profile) }
+  end
+
+  describe "instance methods" do
+    subject(:instance) { create(:ecf_migration_user, :npq) }
+
+    describe "#npq_applications" do
+      let(:ecf_migration_user) { create(:ecf_migration_user, :npq) }
+
+      it "returns the npq applications from user" do
+        expect(instance.npq_applications.size).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/services/migration/migrator_spec.rb
+++ b/spec/services/migration/migrator_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Migration::Migrator do
   describe ".prepare_for_migration" do
     subject(:prepare) { described_class.prepare_for_migration }
 
-    it { expect { prepare }.to change(Migration::DataMigration, :count).by(3) }
+    it { expect { prepare }.to change(Migration::DataMigration, :count).by(4) }
 
     context "when attempting to prepare multiple times" do
       before { described_class.prepare_for_migration }
@@ -26,6 +26,30 @@ RSpec.describe Migration::Migrator do
 
       it { expect { migrate }.not_to raise_error }
 
+      it "calls Migration::Migrators::LeadProvider correctly" do
+        expect(Migration::Migrators::LeadProvider).to receive(:call)
+
+        migrate
+      end
+
+      it "calls Migration::Migrators::Cohort correctly" do
+        expect(Migration::Migrators::Cohort).to receive(:call)
+
+        migrate
+      end
+
+      it "calls Migration::Migrators::Statement correctly" do
+        expect(Migration::Migrators::Statement).to receive(:call)
+
+        migrate
+      end
+
+      it "calls Migration::Migrators::User correctly" do
+        expect(Migration::Migrators::User).to receive(:call)
+
+        migrate
+      end
+
       it "completes the migration" do
         migrate
         expect(Migration::DataMigration.all.map(&:completed_at)).to be_present
@@ -35,110 +59,6 @@ RSpec.describe Migration::Migrator do
         before { instance.migrate! }
 
         it { expect { migrate }.to raise_error(Migration::Migrator::MigrationAlreadyRanError, "The migration has already been run") }
-      end
-
-      context "when migrating lead providers" do
-        before do
-          ecf_npq_lead_provider1 = create(:ecf_migration_npq_lead_provider)
-          ecf_npq_lead_provider2 = create(:ecf_migration_npq_lead_provider)
-
-          create(:lead_provider, ecf_id: ecf_npq_lead_provider1.id)
-          create(:lead_provider, ecf_id: ecf_npq_lead_provider2.id)
-        end
-
-        it "migrates the lead providers" do
-          migrate
-
-          expect(Migration::DataMigration.find_by(model: :lead_provider).processed_count).to eq(2)
-        end
-
-        context "when a lead provider cannot be found" do
-          let!(:ecf_migration_npq_lead_provider) { create(:ecf_migration_npq_lead_provider) }
-
-          it "increments the failure count" do
-            migrate
-
-            expect(Migration::DataMigration.find_by(model: :lead_provider).processed_count).to eq(3)
-            expect(Migration::DataMigration.find_by(model: :lead_provider).failure_count).to eq(1)
-          end
-
-          it "calls FailureManager with correct params" do
-            expect_any_instance_of(Migration::FailureManager).to receive(:record_failure).with(ecf_migration_npq_lead_provider, "Couldn't find LeadProvider with [WHERE \"lead_providers\".\"ecf_id\" = $1]").and_call_original
-
-            migrate
-          end
-        end
-      end
-
-      context "when migrating cohorts" do
-        before do
-          ecf_cohort1 = create(:ecf_migration_cohort, start_year: 2026)
-          ecf_cohort2 = create(:ecf_migration_cohort, start_year: 2029)
-
-          create(:cohort, start_year: ecf_cohort1.start_year)
-          create(:cohort, start_year: ecf_cohort2.start_year)
-        end
-
-        it "migrates the cohorts" do
-          migrate
-
-          expect(Migration::DataMigration.find_by(model: :cohort).processed_count).to eq(2)
-        end
-
-        context "when a cohort is not correctly created" do
-          let!(:ecf_migration_cohort) { create(:ecf_migration_cohort, registration_start_date: nil) }
-
-          it "increments the failure count" do
-            migrate
-
-            expect(Migration::DataMigration.find_by(model: :cohort).processed_count).to eq(3)
-            expect(Migration::DataMigration.find_by(model: :cohort).failure_count).to eq(1)
-          end
-
-          it "calls FailureManager with correct params" do
-            expect_any_instance_of(Migration::FailureManager).to receive(:record_failure).with(ecf_migration_cohort, "Validation failed: Registration start date can't be blank").and_call_original
-
-            migrate
-          end
-        end
-      end
-
-      context "when migrating statements" do
-        before do
-          ecf_statement1 = create(:ecf_migration_statement, name: "July 2026")
-          ecf_statement2 = create(:ecf_migration_statement, name: "January 2030")
-
-          lead_provider1 = create(:lead_provider, ecf_id: ecf_statement1.npq_lead_provider.id)
-          lead_provider2 = create(:lead_provider, ecf_id: ecf_statement2.npq_lead_provider.id)
-
-          create(:statement, month: 7, year: 2026, lead_provider: lead_provider1)
-          create(:statement, month: 1, year: 2030, lead_provider: lead_provider2)
-        end
-
-        it "migrates the statements" do
-          migrate
-
-          expect(Migration::DataMigration.find_by(model: :statement).processed_count).to eq(2)
-        end
-
-        context "when a statement is not correctly created" do
-          let!(:ecf_migration_statement) { create(:ecf_migration_statement, output_fee: nil) }
-
-          before { create(:lead_provider, ecf_id: ecf_migration_statement.npq_lead_provider.id) }
-
-          it "increments the failure count" do
-            migrate
-
-            expect(Migration::DataMigration.find_by(model: :statement).processed_count).to eq(3)
-            expect(Migration::DataMigration.find_by(model: :statement).failure_count).to eq(1)
-          end
-
-          it "calls FailureManager with correct params" do
-            expect_any_instance_of(Migration::FailureManager).to receive(:record_failure).with(ecf_migration_statement, "Validation failed: Output fee is not included in the list").and_call_original
-
-            migrate
-          end
-        end
       end
     end
 

--- a/spec/services/migration/migrators/cohort_spec.rb
+++ b/spec/services/migration/migrators/cohort_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe Migration::Migrators::Cohort do
+  let(:instance) { described_class.new }
+
+  subject { instance.call }
+
+  describe "#call" do
+    before do
+      ecf_cohort1 = create(:ecf_migration_cohort, start_year: 2026)
+      ecf_cohort2 = create(:ecf_migration_cohort, start_year: 2029)
+
+      create(:cohort, start_year: ecf_cohort1.start_year)
+      create(:cohort, start_year: ecf_cohort2.start_year)
+
+      create(:data_migration, model: :cohort)
+    end
+
+    it "migrates the cohorts" do
+      subject
+
+      expect(Migration::DataMigration.find_by(model: :cohort).processed_count).to eq(2)
+    end
+
+    context "when a cohort is not correctly created" do
+      let!(:ecf_migration_cohort) { create(:ecf_migration_cohort, registration_start_date: nil) }
+
+      it "increments the failure count" do
+        subject
+
+        expect(Migration::DataMigration.find_by(model: :cohort).processed_count).to eq(3)
+        expect(Migration::DataMigration.find_by(model: :cohort).failure_count).to eq(1)
+      end
+
+      it "calls FailureManager with correct params" do
+        expect_any_instance_of(Migration::FailureManager).to receive(:record_failure).with(ecf_migration_cohort, "Validation failed: Registration start date can't be blank").and_call_original
+
+        subject
+      end
+    end
+  end
+end

--- a/spec/services/migration/migrators/lead_provider_spec.rb
+++ b/spec/services/migration/migrators/lead_provider_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe Migration::Migrators::LeadProvider do
+  let(:instance) { described_class.new }
+
+  subject { instance.call }
+
+  describe "#call" do
+    before do
+      ecf_npq_lead_provider1 = create(:ecf_migration_npq_lead_provider)
+      ecf_npq_lead_provider2 = create(:ecf_migration_npq_lead_provider)
+
+      create(:lead_provider, ecf_id: ecf_npq_lead_provider1.id)
+      create(:lead_provider, ecf_id: ecf_npq_lead_provider2.id)
+
+      create(:data_migration, model: :lead_provider)
+    end
+
+    it "migrates the lead providers" do
+      subject
+
+      expect(Migration::DataMigration.find_by(model: :lead_provider).processed_count).to eq(2)
+    end
+
+    context "when a lead provider cannot be found" do
+      let!(:ecf_migration_npq_lead_provider) { create(:ecf_migration_npq_lead_provider) }
+
+      it "increments the failure count" do
+        subject
+
+        expect(Migration::DataMigration.find_by(model: :lead_provider).processed_count).to eq(3)
+        expect(Migration::DataMigration.find_by(model: :lead_provider).failure_count).to eq(1)
+      end
+
+      it "calls FailureManager with correct params" do
+        expect_any_instance_of(Migration::FailureManager).to receive(:record_failure).with(ecf_migration_npq_lead_provider, "Couldn't find LeadProvider with [WHERE \"lead_providers\".\"ecf_id\" = $1]").and_call_original
+
+        subject
+      end
+    end
+  end
+end

--- a/spec/services/migration/migrators/statement_spec.rb
+++ b/spec/services/migration/migrators/statement_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe Migration::Migrators::Statement do
+  let(:instance) { described_class.new }
+
+  subject { instance.call }
+
+  describe "#call" do
+    before do
+      ecf_statement1 = create(:ecf_migration_statement, name: "July 2026")
+      ecf_statement2 = create(:ecf_migration_statement, name: "January 2030")
+
+      lead_provider1 = create(:lead_provider, ecf_id: ecf_statement1.npq_lead_provider.id)
+      lead_provider2 = create(:lead_provider, ecf_id: ecf_statement2.npq_lead_provider.id)
+
+      cohort1 = create(:cohort, start_year: ecf_statement1.cohort.start_year)
+      cohort2 = create(:cohort, start_year: ecf_statement2.cohort.start_year)
+
+      create(:statement, month: 7, year: 2026, lead_provider: lead_provider1, cohort: cohort1)
+      create(:statement, month: 1, year: 2030, lead_provider: lead_provider2, cohort: cohort2)
+
+      create(:data_migration, model: :statement)
+    end
+
+    it "migrates the statements" do
+      subject
+
+      expect(Migration::DataMigration.find_by(model: :statement).processed_count).to eq(2)
+    end
+
+    context "when a statement is not correctly created" do
+      let!(:ecf_migration_statement) { create(:ecf_migration_statement, output_fee: nil) }
+
+      before { create(:lead_provider, ecf_id: ecf_migration_statement.npq_lead_provider.id) }
+
+      it "increments the failure count" do
+        subject
+
+        expect(Migration::DataMigration.find_by(model: :statement).processed_count).to eq(3)
+        expect(Migration::DataMigration.find_by(model: :statement).failure_count).to eq(1)
+      end
+
+      it "calls FailureManager with correct params" do
+        expect_any_instance_of(Migration::FailureManager).to receive(:record_failure).with(ecf_migration_statement, "Validation failed: Output fee is not included in the list").and_call_original
+
+        subject
+      end
+    end
+  end
+end

--- a/spec/services/migration/migrators/user_spec.rb
+++ b/spec/services/migration/migrators/user_spec.rb
@@ -42,5 +42,26 @@ RSpec.describe Migration::Migrators::User do
         subject
       end
     end
+
+    context "when there are multiple TRNs from NPQ applications" do
+      let!(:ecf_migration_user) { create(:ecf_migration_user, :npq) }
+
+      before do
+        create(:ecf_migration_npq_application, teacher_reference_number: "123456", participant_identity: ecf_migration_user.participant_identities.first)
+      end
+
+      it "increments the failure count " do
+        subject
+
+        expect(Migration::DataMigration.find_by(model: :user).processed_count).to eq(3)
+        expect(Migration::DataMigration.find_by(model: :user).failure_count).to eq(1)
+      end
+
+      it "calls FailureManager with correct params" do
+        expect_any_instance_of(Migration::FailureManager).to receive(:record_failure).with(ecf_migration_user, "Validation failed: There are multiple different TRNs from NPQ applications").and_call_original
+
+        subject
+      end
+    end
   end
 end

--- a/spec/services/migration/migrators/user_spec.rb
+++ b/spec/services/migration/migrators/user_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe Migration::Migrators::User do
   subject { instance.call }
 
   describe "#call" do
+    let(:ecf_user1) { create(:ecf_migration_user, :npq) }
+    let(:ecf_user2) { create(:ecf_migration_user, :npq) }
+
+    let!(:user1) { create(:user, :with_random_name, ecf_id: ecf_user1.id) }
+    let!(:user2) { create(:user, :with_random_name, ecf_id: ecf_user2.id) }
+
     before do
-      ecf_user1 = create(:ecf_migration_user, :npq)
-      ecf_user2 = create(:ecf_migration_user, :npq)
-
-      create(:user, :with_random_name, ecf_id: ecf_user1.id)
-      create(:user, :with_random_name, ecf_id: ecf_user2.id)
-
       create(:data_migration, model: :user)
     end
 
@@ -20,6 +20,36 @@ RSpec.describe Migration::Migrators::User do
       subject
 
       expect(Migration::DataMigration.find_by(model: :user).processed_count).to eq(2)
+    end
+
+    describe "migrated users" do
+      it "sets the TRN correctly" do
+        subject
+
+        expect(user1.reload.trn).to eq(ecf_user1.teacher_profile.trn)
+        expect(user2.reload.trn).to eq(ecf_user2.teacher_profile.trn)
+      end
+
+      it "sets the full name correctly" do
+        subject
+
+        expect(user1.reload.full_name).to eq(ecf_user1.full_name)
+        expect(user2.reload.full_name).to eq(ecf_user2.full_name)
+      end
+
+      it "sets the email correctly" do
+        subject
+
+        expect(user1.reload.email).to eq(ecf_user1.email)
+        expect(user2.reload.email).to eq(ecf_user2.email)
+      end
+
+      it "sets the UID correctly" do
+        subject
+
+        expect(user1.reload.uid).to eq(ecf_user1.get_an_identity_id)
+        expect(user2.reload.uid).to eq(ecf_user2.get_an_identity_id)
+      end
     end
 
     context "when a user is not correctly created" do

--- a/spec/services/migration/migrators/user_spec.rb
+++ b/spec/services/migration/migrators/user_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe Migration::Migrators::User do
+  let(:instance) { described_class.new }
+
+  subject { instance.call }
+
+  describe "#call" do
+    before do
+      ecf_user1 = create(:ecf_migration_user, :npq)
+      ecf_user2 = create(:ecf_migration_user, :npq)
+
+      create(:user, :with_random_name, ecf_id: ecf_user1.id)
+      create(:user, :with_random_name, ecf_id: ecf_user2.id)
+
+      create(:data_migration, model: :user)
+    end
+
+    it "migrates the users" do
+      subject
+
+      expect(Migration::DataMigration.find_by(model: :user).processed_count).to eq(2)
+    end
+
+    context "when a user is not correctly created" do
+      let!(:ecf_migration_user) { create(:ecf_migration_user, :npq, get_an_identity_id: "123456") }
+
+      before do
+        create(:user, :with_random_name, uid: "123456")
+      end
+
+      it "increments the failure count " do
+        subject
+
+        expect(Migration::DataMigration.find_by(model: :user).processed_count).to eq(3)
+        expect(Migration::DataMigration.find_by(model: :user).failure_count).to eq(1)
+      end
+
+      it "calls FailureManager with correct params" do
+        expect_any_instance_of(Migration::FailureManager).to receive(:record_failure).with(ecf_migration_user, "PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint \"index_users_on_uid\"\nDETAIL:  Key (uid)=(123456) already exists.\n").and_call_original
+
+        subject
+      end
+    end
+  end
+end

--- a/spec/services/migration/migrators/user_spec.rb
+++ b/spec/services/migration/migrators/user_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Migration::Migrators::User do
       end
 
       it "calls FailureManager with correct params" do
-        expect_any_instance_of(Migration::FailureManager).to receive(:record_failure).with(ecf_migration_user, "PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint \"index_users_on_uid\"\nDETAIL:  Key (uid)=(123456) already exists.\n").and_call_original
+        expect_any_instance_of(Migration::FailureManager).to receive(:record_failure).with(ecf_migration_user, "Validation failed: Uid has already been taken").and_call_original
 
         subject
       end


### PR DESCRIPTION
### Context

Ticket: [CPDLP-2898](https://dfedigital.atlassian.net/browse/CPDLP-2898)

We would like to migrate existing user data into NPQ from ECF. There is an existing table in ECF which means there will be conflicts

### Changes proposed in this pull request

 Add logic to migrate ECF user data into NPQ.

![Screenshot 2024-03-26 at 18 40 18](https://github.com/DFE-Digital/npq-registration/assets/3020581/0f77d10a-2958-4514-9683-eb441b522af6)


[CPDLP-2898]: https://dfedigital.atlassian.net/browse/CPDLP-2898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ