### PR TITLE
Add separation environmnent

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,6 +116,25 @@ jobs:
           current-commit-sha: ${{ github.sha }}
           statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
 
+  deploy-separation:
+    name: Deploy separation
+    needs: [deploy-staging]
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    environment:
+      name: separation
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/deploy-environment-to-aks
+        id: deploy
+        with:
+          environment: separation
+          docker-image: ${{ needs.deploy-staging.outputs.docker-image }}
+          azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
+          current-commit-sha: ${{ github.sha }}
+          statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
+
   deploy-sandbox:
     name: Deploy sandbox
     needs: [deploy-staging]

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -90,3 +90,5 @@ Rails/UnknownEnv:
     - sandbox
     - staging
     - test
+    - migration
+    - separation

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,9 @@ sandbox: production-cluster
 migration: production-cluster
 	$(eval include global_config/migration.sh)
 
+separation: production-cluster
+	$(eval include global_config/separation.sh)
+
 production: production-cluster
 	$(if $(or ${SKIP_CONFIRM}, ${CONFIRM_PRODUCTION}), , $(error Missing CONFIRM_PRODUCTION=yes))
 	$(eval include global_config/production.sh)

--- a/config/database.yml
+++ b/config/database.yml
@@ -63,6 +63,12 @@ migration:
   ecf:
     <<: *default_ecf
 
+separation:
+  primary:
+    <<: *default_primary
+  ecf:
+    <<: *default_ecf
+
 production:
   primary:
     <<: *default_primary

--- a/config/environments/separation.rb
+++ b/config/environments/separation.rb
@@ -1,0 +1,13 @@
+require Rails.root.join("config/environments/production")
+
+Rails.application.configure do
+  config.log_level = :debug
+  config.ssl_options = { redirect: { exclude: ->(request) { request.path.include?("/healthcheck") } } }
+
+  # Enable/disable aspects of the NPQ separation
+  config.npq_separation = {
+    admin_portal_enabled: true,
+    api_enabled: true,
+    migration_enabled: false,
+  }
+end

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -74,14 +74,159 @@ development:
     watch_options:
       ignored: '**/node_modules/**'
 
+staging:
+  <<: *default
+  compile: true
+
+  # Verifies that versions and hashed value of the package contents in the project's package.json
+  check_yarn_integrity: true
+
+  # Reference: https://webpack.js.org/configuration/dev-server/
+  dev_server:
+    https: false
+    host: localhost
+    port: 3035
+    public: localhost:3035
+    hmr: false
+    # Inline should be set to true if using HMR
+    inline: true
+    overlay: true
+    compress: true
+    disable_host_check: true
+    use_local_ip: false
+    quiet: false
+    headers:
+      "Access-Control-Allow-Origin": "*"
+    watch_options:
+      ignored: '**/node_modules/**'
+
+migration:
+  <<: *default
+  compile: true
+
+  # Verifies that versions and hashed value of the package contents in the project's package.json
+  check_yarn_integrity: true
+
+  # Reference: https://webpack.js.org/configuration/dev-server/
+  dev_server:
+    https: false
+    host: localhost
+    port: 3035
+    public: localhost:3035
+    hmr: false
+    # Inline should be set to true if using HMR
+    inline: true
+    overlay: true
+    compress: true
+    disable_host_check: true
+    use_local_ip: false
+    quiet: false
+    headers:
+      "Access-Control-Allow-Origin": "*"
+    watch_options:
+      ignored: '**/node_modules/**'
+
+separation:
+  <<: *default
+  compile: true
+
+  # Verifies that versions and hashed value of the package contents in the project's package.json
+  check_yarn_integrity: true
+
+  # Reference: https://webpack.js.org/configuration/dev-server/
+  dev_server:
+    https: false
+    host: localhost
+    port: 3035
+    public: localhost:3035
+    hmr: false
+    # Inline should be set to true if using HMR
+    inline: true
+    overlay: true
+    compress: true
+    disable_host_check: true
+    use_local_ip: false
+    quiet: false
+    headers:
+      "Access-Control-Allow-Origin": "*"
+    watch_options:
+      ignored: '**/node_modules/**'
+
+sandbox:
+  <<: *default
+  compile: true
+
+  # Verifies that versions and hashed value of the package contents in the project's package.json
+  check_yarn_integrity: true
+
+  # Reference: https://webpack.js.org/configuration/dev-server/
+  dev_server:
+    https: false
+    host: localhost
+    port: 3035
+    public: localhost:3035
+    hmr: false
+    # Inline should be set to true if using HMR
+    inline: true
+    overlay: true
+    compress: true
+    disable_host_check: true
+    use_local_ip: false
+    quiet: false
+    headers:
+      "Access-Control-Allow-Origin": "*"
+    watch_options:
+      ignored: '**/node_modules/**'
+
+review:
+  <<: *default
+  compile: true
+
+  # Verifies that versions and hashed value of the package contents in the project's package.json
+  check_yarn_integrity: true
+
+  # Reference: https://webpack.js.org/configuration/dev-server/
+  dev_server:
+    https: false
+    host: localhost
+    port: 3035
+    public: localhost:3035
+    hmr: false
+    # Inline should be set to true if using HMR
+    inline: true
+    overlay: true
+    compress: true
+    disable_host_check: true
+    use_local_ip: false
+    quiet: false
+    headers:
+      "Access-Control-Allow-Origin": "*"
+    watch_options:
+      ignored: '**/node_modules/**'
+
 test:
   <<: *default
   compile: true
 
-  # Compile test packs to a separate directory
-  public_output_path: packs-test
+  dev_server:
+    https: false
+    host: localhost
+    port: 3035
+    public: localhost:3035
+    hmr: false
+    # Inline should be set to true if using HMR
+    inline: true
+    overlay: true
+    compress: true
+    disable_host_check: true
+    use_local_ip: false
+    quiet: false
+    headers:
+      "Access-Control-Allow-Origin": "*"
+    watch_options:
+      ignored: '**/node_modules/**'
 
-production: &production
+production:
   <<: *default
 
   # Production depends on precompilation of packs prior to booting for performance.
@@ -89,18 +234,3 @@ production: &production
 
   # Cache manifest.json for performance
   cache_manifest: true
-
-staging:
-  <<: *production
-
-migration:
-  <<: *production
-
-separation:
-  <<: *production
-
-sandbox:
-  <<: *production
-
-review:
-  <<: *production

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -74,133 +74,14 @@ development:
     watch_options:
       ignored: '**/node_modules/**'
 
-staging:
-  <<: *default
-  compile: true
-
-  # Verifies that versions and hashed value of the package contents in the project's package.json
-  check_yarn_integrity: true
-
-  # Reference: https://webpack.js.org/configuration/dev-server/
-  dev_server:
-    https: false
-    host: localhost
-    port: 3035
-    public: localhost:3035
-    hmr: false
-    # Inline should be set to true if using HMR
-    inline: true
-    overlay: true
-    compress: true
-    disable_host_check: true
-    use_local_ip: false
-    quiet: false
-    headers:
-      "Access-Control-Allow-Origin": "*"
-    watch_options:
-      ignored: '**/node_modules/**'
-
-migration:
-  <<: *default
-  compile: true
-
-  # Verifies that versions and hashed value of the package contents in the project's package.json
-  check_yarn_integrity: true
-
-  # Reference: https://webpack.js.org/configuration/dev-server/
-  dev_server:
-    https: false
-    host: localhost
-    port: 3035
-    public: localhost:3035
-    hmr: false
-    # Inline should be set to true if using HMR
-    inline: true
-    overlay: true
-    compress: true
-    disable_host_check: true
-    use_local_ip: false
-    quiet: false
-    headers:
-      "Access-Control-Allow-Origin": "*"
-    watch_options:
-      ignored: '**/node_modules/**'
-
-sandbox:
-  <<: *default
-  compile: true
-
-  # Verifies that versions and hashed value of the package contents in the project's package.json
-  check_yarn_integrity: true
-
-  # Reference: https://webpack.js.org/configuration/dev-server/
-  dev_server:
-    https: false
-    host: localhost
-    port: 3035
-    public: localhost:3035
-    hmr: false
-    # Inline should be set to true if using HMR
-    inline: true
-    overlay: true
-    compress: true
-    disable_host_check: true
-    use_local_ip: false
-    quiet: false
-    headers:
-      "Access-Control-Allow-Origin": "*"
-    watch_options:
-      ignored: '**/node_modules/**'
-
-review:
-  <<: *default
-  compile: true
-
-  # Verifies that versions and hashed value of the package contents in the project's package.json
-  check_yarn_integrity: true
-
-  # Reference: https://webpack.js.org/configuration/dev-server/
-  dev_server:
-    https: false
-    host: localhost
-    port: 3035
-    public: localhost:3035
-    hmr: false
-    # Inline should be set to true if using HMR
-    inline: true
-    overlay: true
-    compress: true
-    disable_host_check: true
-    use_local_ip: false
-    quiet: false
-    headers:
-      "Access-Control-Allow-Origin": "*"
-    watch_options:
-      ignored: '**/node_modules/**'
-
 test:
   <<: *default
   compile: true
 
-  dev_server:
-    https: false
-    host: localhost
-    port: 3035
-    public: localhost:3035
-    hmr: false
-    # Inline should be set to true if using HMR
-    inline: true
-    overlay: true
-    compress: true
-    disable_host_check: true
-    use_local_ip: false
-    quiet: false
-    headers:
-      "Access-Control-Allow-Origin": "*"
-    watch_options:
-      ignored: '**/node_modules/**'
+  # Compile test packs to a separate directory
+  public_output_path: packs-test
 
-production:
+production: &production
   <<: *default
 
   # Production depends on precompilation of packs prior to booting for performance.
@@ -208,3 +89,18 @@ production:
 
   # Cache manifest.json for performance
   cache_manifest: true
+
+staging:
+  <<: *production
+
+migration:
+  <<: *production
+
+separation:
+  <<: *production
+
+sandbox:
+  <<: *production
+
+review:
+  <<: *production

--- a/db/migrate/20221130142333_add_hint_to_lead_providers.rb
+++ b/db/migrate/20221130142333_add_hint_to_lead_providers.rb
@@ -4,7 +4,7 @@ class AddHintToLeadProviders < ActiveRecord::Migration[6.1]
 
     school_led_network_lead_provider = LeadProvider.find_by(ecf_id: LeadProvider::ALL_PROVIDERS["School-Led Network"])
 
-    school_led_network_lead_provider.update!(
+    school_led_network_lead_provider&.update!(
       hint: "You can only register with this provider if you already started your NPQ with them in October 2022.",
     )
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,7 @@
 require "faker"
 require "csv"
 
-return unless Rails.env.in?(%w[development review])
+return unless Rails.env.in?(%w[development review separation])
 
 PaperTrail.enabled = false
 

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -5,48 +5,63 @@
 There are three permanent environments for NPQ and a fourth set of transient environments, the three permanent are sandbox, dev (Staging in Azure) , and production. The fourth transient set are review apps
 
 - [Environments](#environments)
-  - [Sandbox](#sandbox)
-  - [Staging](#staging)
-  - [Migration](#migration)
-  - [Production](#production)
   - [Review Apps](#review-apps)
-
-## Sandbox
-
-The sandbox environment is automatically deployed to in the same way as production, any time anything is merged it will be deployed to the sandbox environment.
-This environment is here for lead providers and other external users to be able to explore the service without putting data into real production systems. Once submitted applications are pushed to the sandbox ECF environment.
-
-You can view the sandbox environment at https://npq-registration-sandbox-web.teacherservices.cloud/
-You can view which commit is deployed to the sandbox environment by going to https://npq-registration-sandbox-web.teacherservices.cloud/healthcheck.json
-
-## Staging
-
-The staging environment is also automatically deployed in the same way as production, any time anything is merged it will be deployed to the staging environment.
-This environment is here for internal members of the team to be able to explore the environment as it is in production without putting data into real production systems.
-
-You can view the dev environment at https://npq-registration-staging-web.test.teacherservices.cloud
-You can view which commit is deployed to the dev environment by going to https://npq-registration-staging-web.test.teacherservices.cloud/healthcheck.json
-
-## Migration
-
-The migration environment is also automatically deployed in the same way as production, any time anything is merged it will be deployed to the migration environment.
-This environment is here specifically for the NPQ separation workstream and will disappear once that work is complete.
-
-You can view the dev environment at https://npq-registration-migration-web.teacherservices.cloud
-You can view which commit is deployed to the dev environment by going to ttps://npq-registration-migration-web.teacherservices.cloud/healthcheck.json
-
-## Production
-
-The production environment is the live system, users that are applying for NPQs fill in the forms in this system. Once submitted applications are pushed to the production ECF environment and then out to lead providers.
-
-You can view the production environment at https://register-national-professional-qualifications.education.gov.uk
-You can view which commit is live on production by going to https://register-national-professional-qualifications.education.gov.uk/healthcheck.json
+  - [Staging](#staging)
+  - [Sandbox](#sandbox)
+  - [Migration](#migration)
+  - [Separation](#separation)
+  - [Production](#production)
 
 ## Review Apps
 
-Review apps are short lived environments that are spun up any time a PR is filed on Github.
-These environments are for us to test features before merging them, so that we can review and approve features on a real environment before they are deployed.
-Please keep in mind that at least for the time being all review apps share a database.
+- Deployed on raising a PR/merging to a branch (branching off `main` only). Destroyed when the PR is merged/closed.
+- Part of the `test` Azure space.
+- Used internally by team members to review changes prior to deploying.
+- https://npq-registration-review-<PR-NUMBER>-web.test.teacherservices.cloud
 
-The URL for these differ but follow the format: https://npq-registration-review-<PR-NUMBER>-web.test.teacherservices.cloud/
+## Staging
+
+- Deployed on merging to `main`.
+- Part of the `test` Azure space.
+- Used internally by team members as a production-like environment.
+- https://npq-registration-staging-web.test.teacherservices.cloud
+- [View deployed commit](https://npq-registration-staging-web.test.teacherservices.cloud/healthcheck.json)
+
+## Sandbox
+
+- Deployed on merging to `main`.
+- Part of the `production` Azure space.
+- Enables lead providers and other external users to explore the service without putting data into our production system.
+- Submitted applications are pushed to the sandbox ECF environment.
+- https://npq-registration-sandbox-web.teacherservices.cloud
+- [View deployed commit](https://npq-registration-sandbox-web.teacherservices.cloud/healthcheck.json)
+
+## Migration
+
+- Deployed on merging to `main`.
+- Part of the `production` Azure space.
+- Temporary environment for NPQ separation work.
+- Used internally by team members as a production-like environment with NPQ separation features enabled.
+- Migration feature (for NPQ separation) will pull from the migration ECF environment.
+- https://npq-registration-migration-web.teacherservices.cloud
+- [View deployed commit](https://npq-registration-migration-web.teacherservices.cloud/healthcheck.json)
+
+## Separation
+
+- Deployed on merging to `main`.
+- Part of the `production` Azure space.
+- Temporary environment for NPQ separation work.
+- Enables lead providers and other external users to explore the NPQ separation endpoints.
+- Migration feature (for NPQ separation) is currently disabled as we have no corresponding environment in ECF to pull from.
+- https://npq-registration-seoaration-web.teacherservices.cloud
+- [View deployed commit](https://npq-registration-seoaration-web.teacherservices.cloud/healthcheck.json)
+
+## Production
+
+- Deployed on merging to `main`.
+- Part of the `production` Azure space.
+- The production environment is the live system, users that are applying for NPQs fill in the forms in this system. Once submitted applications are pushed to the production ECF environment and then out to lead providers.
+- https://register-national-professional-qualifications.education.gov.uk
+- [View deployed commit](https://register-national-professional-qualifications.education.gov.uk/healthcheck.json)
+
 

--- a/global_config/separation.sh
+++ b/global_config/separation.sh
@@ -1,0 +1,7 @@
+CONFIG=separation
+ENVIRONMENT=separation
+CONFIG_SHORT=sp
+AZURE_SUBSCRIPTION=s189-teacher-services-cloud-production
+AZURE_RESOURCE_PREFIX=s189p01
+CONFIG_LONG=separation
+NAMESPACE=cpd-production

--- a/terraform/application/config/separation.tfvars.json
+++ b/terraform/application/config/separation.tfvars.json
@@ -1,0 +1,5 @@
+{
+  "cluster": "production",
+  "namespace": "cpd-production",
+  "environment": "separation"
+}

--- a/terraform/application/config/separation_Terrafile
+++ b/terraform/application/config/separation_Terrafile
@@ -1,0 +1,3 @@
+aks:
+    source:  "https://github.com/DFE-Digital/terraform-modules"
+    version: "testing"


### PR DESCRIPTION
[Jira-2939](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2939)

### Context

We want to add an additional environment for providers to be able to test against the new endpoints added as part of the NPQ separation work.

### Changes proposed in this pull request

- Add new Rails env for separation

Add a new Rails environment for the separation work and enable separation features (apart from migration as there is no corresponding ECF environment to reference yet). Clean up the `webpacker.yml` file.

- Add terraform for separation environment

Adds terraform configuration for separation environment in the production space.

- Deploy to separation environment on merge to main

We want to deploy to the separation environment when merging to `main`, alongside the `sandbox` and `migration` environments.

- Update environment documentation

Add documentation for the separation environment. Clean up docs in general.

- Fix migration if provider does not exist

On a fresh installation the `School-Led Network` provider will not exist and the migrations fail.

- Run seeds on separation environment

- Revert webpacker.yml changes

This isn't right, but its how its currently setup and for some reason asset pre-compilation doesn't work for these environments. One for another day.

### Guidance to review

URL: https://npq-registration-separation-web.teacherservices.cloud/