### PR TITLE
Add workflow params to deploy github actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,10 +5,20 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Deploy environment"
+        required: true
+        default: migration
+        type: choice
+        options:
+          - migration
+          - separation
+
   push:
     branches:
       - main
-
   pull_request:
     branches:
       - main


### PR DESCRIPTION
### Context

We need a simpler way of deploying a specific branch/PR to a specific environment.

### Changes proposed in this pull request

Add workflow params to `deploy` Github action like we have in ECF app.

![image](https://github.com/DFE-Digital/npq-registration/assets/3020581/e3beb0ee-0d50-4351-baf0-73e5b36f0366)


