### PR TITLE
[CPDLP-2992] Amend application fields to enums

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -28,6 +28,29 @@ class Application < ApplicationRecord
     another_early_years_setting: "another_early_years_setting",
   }
 
+  enum headteacher_status: {
+    no: "no",
+    yes_when_course_starts: "yes_when_course_starts",
+    yes_in_first_two_years: "yes_in_first_two_years",
+    yes_over_two_years: "yes_over_two_years",
+    yes_in_first_five_years: "yes_in_first_five_years",
+    yes_over_five_years: "yes_over_five_years",
+  }
+
+  enum funding_choice: {
+    school: "school",
+    trust: "trust",
+    self: "self",
+    another: "another",
+    employer: "employer",
+  }
+
+  enum lead_provider_approval_status: {
+    pending: "pending",
+    accepted: "accepted",
+    rejected: "rejected",
+  }
+
   def private_nursery?
     Questionnaires::KindOfNursery::KIND_OF_NURSERY_PRIVATE_OPTIONS.include?(kind_of_nursery)
   end

--- a/db/migrate/20240412131057_create_headteacher_statuses_enum.rb
+++ b/db/migrate/20240412131057_create_headteacher_statuses_enum.rb
@@ -1,0 +1,5 @@
+class CreateHeadteacherStatusesEnum < ActiveRecord::Migration[7.1]
+  def change
+    create_enum :headteacher_statuses, %w[no yes_when_course_starts yes_in_first_two_years yes_over_two_years yes_in_first_five_years yes_over_five_years]
+  end
+end

--- a/db/migrate/20240412131141_change_applications_headteacher_status_to_enum.rb
+++ b/db/migrate/20240412131141_change_applications_headteacher_status_to_enum.rb
@@ -1,0 +1,16 @@
+class ChangeApplicationsHeadteacherStatusToEnum < ActiveRecord::Migration[7.1]
+  def up
+    execute <<-SQL
+      ALTER TABLE applications
+      ALTER COLUMN headteacher_status TYPE headteacher_statuses
+      USING headteacher_status::headteacher_statuses
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      ALTER TABLE applications
+      ALTER COLUMN headteacher_status TYPE text
+    SQL
+  end
+end

--- a/db/migrate/20240415103921_create_funding_choices_enum.rb
+++ b/db/migrate/20240415103921_create_funding_choices_enum.rb
@@ -1,0 +1,5 @@
+class CreateFundingChoicesEnum < ActiveRecord::Migration[7.1]
+  def change
+    create_enum :funding_choices, %w[school trust self another employer]
+  end
+end

--- a/db/migrate/20240415104228_change_applications_funding_choice_to_enum.rb
+++ b/db/migrate/20240415104228_change_applications_funding_choice_to_enum.rb
@@ -1,0 +1,16 @@
+class ChangeApplicationsFundingChoiceToEnum < ActiveRecord::Migration[7.1]
+  def up
+    execute <<-SQL
+      ALTER TABLE applications
+      ALTER COLUMN funding_choice TYPE funding_choices
+      USING funding_choice::funding_choices
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      ALTER TABLE applications
+      ALTER COLUMN funding_choice TYPE text
+    SQL
+  end
+end

--- a/db/migrate/20240415104435_create_lead_provider_approval_statuses_enum.rb
+++ b/db/migrate/20240415104435_create_lead_provider_approval_statuses_enum.rb
@@ -1,0 +1,5 @@
+class CreateLeadProviderApprovalStatusesEnum < ActiveRecord::Migration[7.1]
+  def change
+    create_enum :lead_provider_approval_statuses, %w[pending accepted rejected]
+  end
+end

--- a/db/migrate/20240415104534_change_applications_lead_provider_approval_status_to_enum.rb
+++ b/db/migrate/20240415104534_change_applications_lead_provider_approval_status_to_enum.rb
@@ -1,0 +1,16 @@
+class ChangeApplicationsLeadProviderApprovalStatusToEnum < ActiveRecord::Migration[7.1]
+  def up
+    execute <<-SQL
+      ALTER TABLE applications
+      ALTER COLUMN lead_provider_approval_status TYPE lead_provider_approval_statuses
+      USING lead_provider_approval_status::lead_provider_approval_statuses
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      ALTER TABLE applications
+      ALTER COLUMN lead_provider_approval_status TYPE text
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_12_130037) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_15_104534) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -19,6 +19,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_12_130037) do
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
+  create_enum "funding_choices", ["school", "trust", "self", "another", "employer"]
+  create_enum "headteacher_statuses", ["no", "yes_when_course_starts", "yes_in_first_two_years", "yes_over_two_years", "yes_in_first_five_years", "yes_over_five_years"]
+  create_enum "lead_provider_approval_statuses", ["pending", "accepted", "rejected"]
   create_enum "statement_item_states", ["eligible", "payable", "paid", "voided", "ineligible", "awaiting_clawback", "clawed_back"]
   create_enum "statement_states", ["open", "payable", "paid"]
 
@@ -50,9 +53,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_12_130037) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "ecf_id"
-    t.text "headteacher_status"
+    t.enum "headteacher_status", enum_type: "headteacher_statuses"
     t.boolean "eligible_for_funding", default: false, null: false
-    t.text "funding_choice"
+    t.enum "funding_choice", enum_type: "funding_choices"
     t.text "ukprn"
     t.text "teacher_catchment"
     t.text "teacher_catchment_country"
@@ -76,7 +79,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_12_130037) do
     t.integer "number_of_pupils", default: 0
     t.boolean "tsf_primary_eligibility", default: false
     t.boolean "tsf_primary_plus_eligibility", default: false
-    t.text "lead_provider_approval_status"
+    t.enum "lead_provider_approval_status", enum_type: "lead_provider_approval_statuses"
     t.text "participant_outcome_state"
     t.bigint "private_childcare_provider_id"
     t.bigint "itt_provider_id"

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -13,6 +13,46 @@ RSpec.describe Application do
     it { is_expected.to have_many(:ecf_sync_request_logs).dependent(:destroy) }
   end
 
+  describe "enums" do
+    it {
+      expect(subject).to define_enum_for(:kind_of_nursery).with_values(
+        local_authority_maintained_nursery: "local_authority_maintained_nursery",
+        preschool_class_as_part_of_school: "preschool_class_as_part_of_school",
+        private_nursery: "private_nursery",
+        another_early_years_setting: "another_early_years_setting",
+      ).backed_by_column_of_type(:text)
+    }
+
+    it {
+      expect(subject).to define_enum_for(:headteacher_status).with_values(
+        no: "no",
+        yes_when_course_starts: "yes_when_course_starts",
+        yes_in_first_two_years: "yes_in_first_two_years",
+        yes_over_two_years: "yes_over_two_years",
+        yes_in_first_five_years: "yes_in_first_five_years",
+        yes_over_five_years: "yes_over_five_years",
+      ).backed_by_column_of_type(:enum)
+    }
+
+    it {
+      expect(subject).to define_enum_for(:funding_choice).with_values(
+        school: "school",
+        trust: "trust",
+        self: "self",
+        another: "another",
+        employer: "employer",
+      ).backed_by_column_of_type(:enum)
+    }
+
+    it {
+      expect(subject).to define_enum_for(:lead_provider_approval_status).with_values(
+        pending: "pending",
+        accepted: "accepted",
+        rejected: "rejected",
+      ).backed_by_column_of_type(:enum)
+    }
+  end
+
   describe "scopes" do
     describe ".unsynced" do
       it "returns records where ecf_id is null" do


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-000

After the investigation in https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2932, we've found that a number of fields are enums in ECF but not in NPQ.

We need to change those fields to enums in NPQ.

### Changes proposed in this pull request

Change the following fields to enums in NPQ applications table:

- headteacher_status
- funding_choice
- lead_provider_approval_status

Note: I'm using migrations `up/down` instead of `change` method so migrations can be reversible.