### PR TITLE
Migrate schools data from ECF to NPQ reg

### DIFF
--- a/app/models/migration/ecf/npq_application.rb
+++ b/app/models/migration/ecf/npq_application.rb
@@ -6,5 +6,6 @@ module Migration::Ecf
     belongs_to :cohort, optional: true
     has_one :profile, class_name: "ParticipantProfile", foreign_key: :id
     has_one :user, through: :participant_identity
+    has_one :school, class_name: "School", foreign_key: :urn, primary_key: :school_urn
   end
 end

--- a/app/models/migration/ecf/school.rb
+++ b/app/models/migration/ecf/school.rb
@@ -1,0 +1,5 @@
+module Migration::Ecf
+  class School < BaseRecord
+    has_many :npq_applications, primary_key: :urn, foreign_key: :school_urn, class_name: "NpqApplication"
+  end
+end

--- a/app/services/migration/migrator.rb
+++ b/app/services/migration/migrator.rb
@@ -10,6 +10,7 @@ module Migration
       Migration::Migrators::Cohort,
       Migration::Migrators::Statement,
       Migration::Migrators::User,
+      Migration::Migrators::School,
     ].freeze
 
     class << self

--- a/app/services/migration/migrators/school.rb
+++ b/app/services/migration/migrators/school.rb
@@ -1,0 +1,17 @@
+module Migration::Migrators
+  class School < Base
+    def call
+      migrate(ecf_schools, :school) do |ecf_school|
+        ::School.find_by!(urn: ecf_school.urn, name: ecf_school.name)
+      end
+    end
+
+  private
+
+    def ecf_schools
+      @ecf_schools ||= Migration::Ecf::School
+        .includes(:npq_applications)
+        .where.not(npq_applications: { id: nil })
+    end
+  end
+end

--- a/spec/factories/migration/ecf/schools.rb
+++ b/spec/factories/migration/ecf/schools.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :ecf_migration_school, class: "Migration::Ecf::School" do
+    sequence(:name) { |n| "School #{n}" }
+    urn { Faker::Number.unique.decimal_part(digits: 7) }
+    address_line1 { Faker::Address.street_address }
+    postcode { Faker::Address.postcode }
+
+    trait :with_applications do
+      after(:create) do |school|
+        create_list(:ecf_migration_npq_application, 1, school_urn: school.urn, user: create(:ecf_migration_user))
+      end
+    end
+  end
+end

--- a/spec/models/migration/ecf/npq_application_spec.rb
+++ b/spec/models/migration/ecf/npq_application_spec.rb
@@ -8,5 +8,6 @@ RSpec.describe Migration::Ecf::NpqApplication, type: :model do
     it { is_expected.to belong_to(:cohort).optional }
     it { is_expected.to have_one(:profile).class_name("ParticipantProfile").with_foreign_key(:id) }
     it { is_expected.to have_one(:user).through(:participant_identity) }
+    it { is_expected.to have_one(:school).class_name("School").with_foreign_key(:urn).with_primary_key(:school_urn) }
   end
 end

--- a/spec/models/migration/ecf/school_spec.rb
+++ b/spec/models/migration/ecf/school_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+RSpec.describe Migration::Ecf::School, type: :model do
+  describe "associations" do
+    it { is_expected.to have_many(:npq_applications).class_name("NpqApplication").with_foreign_key(:school_urn).with_primary_key(:urn) }
+  end
+end

--- a/spec/services/migration/migrator_spec.rb
+++ b/spec/services/migration/migrator_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Migration::Migrator do
   describe ".prepare_for_migration" do
     subject(:prepare) { described_class.prepare_for_migration }
 
-    it { expect { prepare }.to change(Migration::DataMigration, :count).by(4) }
+    it { expect { prepare }.to change(Migration::DataMigration, :count).by(5) }
 
     context "when attempting to prepare multiple times" do
       before { described_class.prepare_for_migration }
@@ -46,6 +46,12 @@ RSpec.describe Migration::Migrator do
 
       it "calls Migration::Migrators::User correctly" do
         expect(Migration::Migrators::User).to receive(:call)
+
+        migrate
+      end
+
+      it "calls Migration::Migrators::School correctly" do
+        expect(Migration::Migrators::School).to receive(:call)
 
         migrate
       end

--- a/spec/services/migration/migrators/school_spec.rb
+++ b/spec/services/migration/migrators/school_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe Migration::Migrators::School do
+  let(:instance) { described_class.new }
+  let(:find_data_migration) { Migration::DataMigration.find_by(model: :school) }
+
+  subject(:migrate) { instance.call }
+
+  describe "#call" do
+    let(:failure_manager) { instance_double(Migration::FailureManager, record_failure: nil) }
+
+    before do
+      allow(Migration::FailureManager).to receive(:new) { failure_manager }
+
+      described_class.prepare!
+    end
+
+    it "migrates schools that have applications" do
+      ecf_school_1 = create(:ecf_migration_school, :with_applications)
+      create(:school, urn: ecf_school_1.urn, name: ecf_school_1.name)
+
+      ecf_school_2 = create(:ecf_migration_school, :with_applications)
+      create(:school, urn: ecf_school_2.urn, name: ecf_school_2.name)
+
+      migrate
+
+      expect(find_data_migration.reload).to have_attributes(processed_count: 2, failure_count: 0)
+    end
+
+    it "does not migrate schools that do not have applications" do
+      create(:ecf_migration_school)
+
+      migrate
+
+      expect(find_data_migration.reload).to have_attributes(processed_count: 0)
+    end
+
+    it "records a failure when a matching school cannot be found" do
+      ecf_school = create(:ecf_migration_school, :with_applications)
+
+      migrate
+
+      expect(find_data_migration.reload).to have_attributes(processed_count: 1, failure_count: 1)
+
+      expect(failure_manager).to have_received(:record_failure).with(
+        ecf_school,
+        "Couldn't find School with [WHERE \"schools\".\"urn\" = $1 AND \"schools\".\"name\" = $2]",
+      )
+    end
+
+    it "records a failure when the school matches on URN but not name" do
+      ecf_school = create(:ecf_migration_school, :with_applications)
+      create(:school, urn: ecf_school.urn, name: "Different Name")
+
+      migrate
+
+      expect(find_data_migration.reload).to have_attributes(processed_count: 1, failure_count: 1)
+
+      expect(failure_manager).to have_received(:record_failure).with(
+        ecf_school,
+        "Couldn't find School with [WHERE \"schools\".\"urn\" = $1 AND \"schools\".\"name\" = $2]",
+      )
+    end
+  end
+end


### PR DESCRIPTION
### Context

Add migrator to migrate school data from ECF to NPQ reg. Initially we are only performing an integrity check to ensure a corresponding school with the same URN/name exists. We are also only looking at schools in ECF that have NPQ applications associated with them.

### Changes proposed in this pull request

- Migrate schools data from ECF to NPQ reg

### Guidance for review

I ran this manually on the migration environment:

```
 id: 16,
 model: "school",
 processed_count: 21026,
 failure_count: 3,
 started_at: Tue, 16 Apr 2024 09:39:15.366959000 UTC +00:00,
 completed_at: Tue, 16 Apr 2024 10:07:33.029796000 UTC +00:00,
 created_at: Tue, 16 Apr 2024 09:34:15.669314000 UTC +00:00,
 updated_at: Tue, 16 Apr 2024 10:07:33.031010000 UTC +00:00,
 total_count: 21026
```