### PR TITLE
Add applications endpoint

### DIFF
--- a/app/controllers/api/concerns/filter_by_updated_since.rb
+++ b/app/controllers/api/concerns/filter_by_updated_since.rb
@@ -6,13 +6,11 @@ module API
     protected
 
       def updated_since
-        params.dig(:filter, :updated_since)
-      end
+        updated_since_param = params.dig(:filter, :updated_since)
 
-      def validate_updated_since
-        return if updated_since.blank?
+        return if updated_since_param.blank?
 
-        Time.iso8601(URI.decode_www_form_component(updated_since))
+        Time.iso8601(URI.decode_www_form_component(updated_since_param))
       rescue ArgumentError
         raise ActionController::BadRequest, I18n.t(:invalid_updated_since_filter)
       end

--- a/app/controllers/api/v1/applications_controller.rb
+++ b/app/controllers/api/v1/applications_controller.rb
@@ -1,7 +1,12 @@
 module API
   module V1
     class ApplicationsController < BaseController
-      def index = head(:method_not_allowed)
+      include Pagination
+      include ::API::Concerns::FilterByUpdatedSince
+
+      def index
+        render json: to_json(paginate(applications_query.applications))
+      end
 
       def show
         render json: to_json(applications_query.application(ecf_id: application_params[:ecf_id]))
@@ -15,11 +20,17 @@ module API
       def applications_query
         Applications::Query.new(
           lead_provider: current_lead_provider,
+          cohort_start_years:,
+          updated_since:,
         )
       end
 
+      def cohort_start_years
+        application_params.dig(:filter, :cohort)
+      end
+
       def application_params
-        params.permit(:ecf_id)
+        params.permit(:ecf_id, filter: %i[cohort updated_since])
       end
 
       def to_json(obj)

--- a/app/controllers/api/v2/applications_controller.rb
+++ b/app/controllers/api/v2/applications_controller.rb
@@ -1,7 +1,12 @@
 module API
   module V2
     class ApplicationsController < BaseController
-      def index = head(:method_not_allowed)
+      include Pagination
+      include ::API::Concerns::FilterByUpdatedSince
+
+      def index
+        render json: to_json(paginate(applications_query.applications))
+      end
 
       def show
         render json: to_json(applications_query.application(ecf_id: application_params[:ecf_id]))
@@ -15,11 +20,17 @@ module API
       def applications_query
         Applications::Query.new(
           lead_provider: current_lead_provider,
+          cohort_start_years:,
+          updated_since:,
         )
       end
 
+      def cohort_start_years
+        application_params.dig(:filter, :cohort)
+      end
+
       def application_params
-        params.permit(:ecf_id)
+        params.permit(:ecf_id, filter: %i[cohort updated_since])
       end
 
       def to_json(obj)

--- a/app/controllers/api/v3/applications_controller.rb
+++ b/app/controllers/api/v3/applications_controller.rb
@@ -1,7 +1,12 @@
 module API
   module V3
     class ApplicationsController < BaseController
-      def index = head(:method_not_allowed)
+      include Pagination
+      include ::API::Concerns::FilterByUpdatedSince
+
+      def index
+        render json: to_json(paginate(applications_query.applications))
+      end
 
       def show
         render json: to_json(applications_query.application(ecf_id: application_params[:ecf_id]))
@@ -15,11 +20,22 @@ module API
       def applications_query
         Applications::Query.new(
           lead_provider: current_lead_provider,
+          cohort_start_years:,
+          participant_ids:,
+          updated_since:,
         )
       end
 
+      def cohort_start_years
+        application_params.dig(:filter, :cohort)
+      end
+
+      def participant_ids
+        application_params.dig(:filter, :participant_id)
+      end
+
       def application_params
-        params.permit(:ecf_id)
+        params.permit(:ecf_id, filter: %i[cohort updated_since participant_id])
       end
 
       def to_json(obj)

--- a/app/controllers/api/v3/applications_controller.rb
+++ b/app/controllers/api/v3/applications_controller.rb
@@ -23,6 +23,7 @@ module API
           cohort_start_years:,
           participant_ids:,
           updated_since:,
+          sort: application_params[:sort],
         )
       end
 
@@ -35,7 +36,7 @@ module API
       end
 
       def application_params
-        params.permit(:ecf_id, filter: %i[cohort updated_since participant_id])
+        params.permit(:ecf_id, :sort, filter: %i[cohort updated_since participant_id])
       end
 
       def to_json(obj)

--- a/app/controllers/api/v3/statements_controller.rb
+++ b/app/controllers/api/v3/statements_controller.rb
@@ -4,8 +4,6 @@ module API
       include Pagination
       include ::API::Concerns::FilterByUpdatedSince
 
-      before_action :validate_updated_since, only: %i[index]
-
       def index
         render json: to_json(paginate(statements_query.statements))
       end

--- a/app/services/api/concerns/orderable.rb
+++ b/app/services/api/concerns/orderable.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module API
+  module Concerns
+    module Orderable
+      extend ActiveSupport::Concern
+
+      SORT_ORDER = { "+" => "ASC", "-" => "DESC" }.freeze
+
+      def sort_order(sort:, model:, default: {})
+        return default unless sort
+
+        sort_parts = sort.split(",")
+        sort_parts
+          .map { |sort_part| convert_sort_part_to_active_record_order(sort_part, model) }
+          .compact
+          .join(", ")
+          .presence
+      end
+
+    private
+
+      def convert_sort_part_to_active_record_order(sort_part, model)
+        extracted_sort_sign = sort_part =~ /\A[+-]/ ? sort_part.slice!(0) : "+"
+        sort_order = SORT_ORDER[extracted_sort_sign]
+
+        return unless sort_part.in?(model.attribute_names)
+
+        "#{model.table_name}.#{sort_part} #{sort_order}"
+      end
+    end
+  end
+end

--- a/app/services/applications/query.rb
+++ b/app/services/applications/query.rb
@@ -1,10 +1,13 @@
 module Applications
   class Query
-    def initialize(lead_provider: nil, cohort_start_years: nil, updated_since: nil, participant_ids: nil)
+    include API::Concerns::Orderable
+
+    def initialize(lead_provider: nil, cohort_start_years: nil, updated_since: nil, participant_ids: nil, sort: nil)
       @lead_provider = lead_provider
       @cohort_start_years = cohort_start_years&.split(",")
       @updated_since = updated_since
       @participant_ids = participant_ids&.split(",")
+      @sort = sort
     end
 
     def applications
@@ -23,7 +26,7 @@ module Applications
       scope = scope.where(user: { ecf_id: participant_ids }) if participant_ids.present?
       scope = scope.where(updated_at: updated_since..) if updated_since.present?
 
-      scope.order(created_at: :asc)
+      scope.order(sort_order(sort:, model: Application, default: { created_at: :asc }))
     end
 
     def application(id: nil, ecf_id: nil)
@@ -35,6 +38,6 @@ module Applications
 
   private
 
-    attr_reader :lead_provider, :cohort_start_years, :updated_since, :participant_ids
+    attr_reader :lead_provider, :cohort_start_years, :updated_since, :participant_ids, :sort
   end
 end

--- a/app/services/applications/query.rb
+++ b/app/services/applications/query.rb
@@ -1,7 +1,10 @@
 module Applications
   class Query
-    def initialize(lead_provider: nil)
+    def initialize(lead_provider: nil, cohort_start_years: nil, updated_since: nil, participant_ids: nil)
       @lead_provider = lead_provider
+      @cohort_start_years = cohort_start_years&.split(",")
+      @updated_since = updated_since
+      @participant_ids = participant_ids&.split(",")
     end
 
     def applications
@@ -16,6 +19,9 @@ module Applications
         )
 
       scope = scope.where(lead_provider:) if lead_provider.present?
+      scope = scope.where(cohort: { start_year: cohort_start_years }) if cohort_start_years.present?
+      scope = scope.where(user: { ecf_id: participant_ids }) if participant_ids.present?
+      scope = scope.where(updated_at: updated_since..) if updated_since.present?
 
       scope.order(created_at: :asc)
     end
@@ -29,6 +35,6 @@ module Applications
 
   private
 
-    attr_reader :lead_provider
+    attr_reader :lead_provider, :cohort_start_years, :updated_since, :participant_ids
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,10 +4,7 @@ FactoryBot.define do
     sequence(:email) { |n| "user#{n}@example.com" }
     trn { "1234567" }
     date_of_birth { 30.years.ago }
-
-    trait :with_ecf_id do
-      ecf_id { SecureRandom.uuid }
-    end
+    ecf_id { SecureRandom.uuid }
 
     trait :with_get_an_identity_id do
       transient do

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -170,7 +170,7 @@ RSpec.feature "admin", type: :feature, rack_test_driver: true do
   end
 
   scenario "when logged in as a regular admin, it allows access to the users interface" do
-    users = create_list(:user, 4)
+    users = create_list(:user, 4, ecf_id: nil)
 
     sign_in_as_admin
 
@@ -304,13 +304,13 @@ RSpec.feature "admin", type: :feature, rack_test_driver: true do
     expect(page).to have_content("All users have been successfuly linked with an ECF user.")
 
     # An unsynced user without applications shouldn't appear in the list
-    unsynced_without_application = create(:user)
+    unsynced_without_application = create(:user, ecf_id: nil)
     # A synced user shouldn't appear in the list
-    synced_user = create(:user, :with_ecf_id)
+    synced_user = create(:user)
     create(:application, user: synced_user)
 
     # Unsynced users with applications should appear in the list.
-    unsynced_users = create_list(:user, 2)
+    unsynced_users = create_list(:user, 2, ecf_id: nil)
     unsynced_users.each do |unsynced_user|
       create_list(:application, 2, user: unsynced_user)
     end

--- a/spec/features/npq_separation/admin/users_spec.rb
+++ b/spec/features/npq_separation/admin/users_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Listing and viewing users", type: :feature do
   let(:users_per_page) { Pagy::DEFAULT[:items] }
 
   before do
-    create_list(:user, users_per_page + 1, :with_ecf_id, :with_get_an_identity_id)
+    create_list(:user, users_per_page + 1, :with_get_an_identity_id)
     sign_in_as(create(:admin))
   end
 

--- a/spec/jobs/application_submission_job_spec.rb
+++ b/spec/jobs/application_submission_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ApplicationSubmissionJob do
 
   describe "#perform" do
     let!(:application) { create(:application, user:, school:, ecf_id: nil) }
-    let(:user) { create(:user, :with_get_an_identity_id) }
+    let(:user) { create(:user, :with_get_an_identity_id, ecf_id: nil) }
     let(:school) { create(:school) }
 
     it "calls correct services" do
@@ -72,7 +72,7 @@ RSpec.describe ApplicationSubmissionJob do
     end
 
     context "when user already exists in ecf but not npq" do
-      let(:user) { create(:user) }
+      let(:user) { create(:user, ecf_id: nil) }
       let(:ecf_user) { External::EcfAPI::User.new(email: user.email, id: "123") }
 
       it "calls correct services" do

--- a/spec/lib/services/handle_submission_for_store_spec.rb
+++ b/spec/lib/services/handle_submission_for_store_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe HandleSubmissionForStore do
   subject { described_class.new(store:) }
 
   let(:user_record_trn) { "0012345" }
-  let(:user) { create(:user, trn: user_record_trn, full_name: "John Doe") }
+  let(:user) { create(:user, trn: user_record_trn, full_name: "John Doe", ecf_id: nil) }
   let(:school) { create(:school, :funding_eligible_establishment_type_code) }
   let(:private_childcare_provider) { create(:private_childcare_provider, :on_early_years_register) }
 

--- a/spec/requests/api/v1/applications_spec.rb
+++ b/spec/requests/api/v1/applications_spec.rb
@@ -2,8 +2,10 @@ require "rails_helper"
 
 RSpec.describe "Application endpoints", type: :request do
   let(:current_lead_provider) { create(:lead_provider) }
+  let(:query) { Applications::Query }
+  let(:serializer) { API::ApplicationSerializer }
 
-  describe "GET /api/v1/applications/:id" do
+  describe "GET /api/v1/npq-applications/:id" do
     let(:resource) { create(:application, lead_provider: current_lead_provider) }
     let(:resource_id) { resource.ecf_id }
 
@@ -11,13 +13,21 @@ RSpec.describe "Application endpoints", type: :request do
       api_v1_application_path(id)
     end
 
-    it_behaves_like "an API show endpoint", Applications::Query, API::ApplicationSerializer
+    it_behaves_like "an API show endpoint"
   end
 
-  describe("index") do
-    before { api_get(api_v1_applications_path) }
+  describe "GET /api/v1/npq-applications" do
+    let(:path) { api_v1_applications_path }
+    let(:resource_id_key) { :ecf_id }
 
-    specify { expect(response).to(be_method_not_allowed) }
+    def create_resource(**attrs)
+      create(:application, **attrs)
+    end
+
+    it_behaves_like "an API index endpoint"
+    it_behaves_like "an API index endpoint with pagination"
+    it_behaves_like "an API index endpoint with filter by cohort"
+    it_behaves_like "an API index endpoint with filter by updated_since"
   end
 
   describe("accept") do

--- a/spec/requests/api/v2/applications_spec.rb
+++ b/spec/requests/api/v2/applications_spec.rb
@@ -2,6 +2,8 @@ require "rails_helper"
 
 RSpec.describe "Application endpoints", type: :request do
   let(:current_lead_provider) { create(:lead_provider) }
+  let(:query) { Applications::Query }
+  let(:serializer) { API::ApplicationSerializer }
 
   describe "GET /api/v2/applications/:id" do
     let(:resource) { create(:application, lead_provider: current_lead_provider) }
@@ -11,13 +13,21 @@ RSpec.describe "Application endpoints", type: :request do
       api_v2_application_path(id)
     end
 
-    it_behaves_like "an API show endpoint", Applications::Query, API::ApplicationSerializer
+    it_behaves_like "an API show endpoint"
   end
 
-  describe("index") do
-    before { api_get(api_v1_applications_path) }
+  describe "GET /api/v2/npq-applications" do
+    let(:path) { api_v2_applications_path }
+    let(:resource_id_key) { :ecf_id }
 
-    specify { expect(response).to(be_method_not_allowed) }
+    def create_resource(**attrs)
+      create(:application, **attrs)
+    end
+
+    it_behaves_like "an API index endpoint"
+    it_behaves_like "an API index endpoint with pagination"
+    it_behaves_like "an API index endpoint with filter by cohort"
+    it_behaves_like "an API index endpoint with filter by updated_since"
   end
 
   describe("accept") do

--- a/spec/requests/api/v3/applications_spec.rb
+++ b/spec/requests/api/v3/applications_spec.rb
@@ -2,6 +2,9 @@ require "rails_helper"
 
 RSpec.describe "Application endpoints", type: :request do
   let(:current_lead_provider) { create(:lead_provider) }
+  let(:query) { Applications::Query }
+  let(:serializer) { API::ApplicationSerializer }
+  let(:serializer_version) { :v3 }
 
   describe "GET /api/v3/applications/:id" do
     let(:resource) { create(:application, lead_provider: current_lead_provider) }
@@ -11,13 +14,22 @@ RSpec.describe "Application endpoints", type: :request do
       api_v3_application_path(id)
     end
 
-    it_behaves_like "an API show endpoint", Applications::Query, API::ApplicationSerializer, :v3
+    it_behaves_like "an API show endpoint"
   end
 
-  describe("index") do
-    before { api_get(api_v1_applications_path) }
+  describe "GET /api/v3/npq-applications" do
+    let(:path) { api_v3_applications_path }
+    let(:resource_id_key) { :ecf_id }
 
-    specify { expect(response).to(be_method_not_allowed) }
+    def create_resource(**attrs)
+      create(:application, **attrs)
+    end
+
+    it_behaves_like "an API index endpoint"
+    it_behaves_like "an API index endpoint with pagination"
+    it_behaves_like "an API index endpoint with filter by cohort"
+    it_behaves_like "an API index endpoint with filter by updated_since"
+    it_behaves_like "an API index endpoint with filter by participant_id"
   end
 
   describe("accept") do

--- a/spec/requests/api/v3/statements_spec.rb
+++ b/spec/requests/api/v3/statements_spec.rb
@@ -2,134 +2,19 @@ require "rails_helper"
 
 RSpec.describe "Statements endpoint", type: "request" do
   let(:current_lead_provider) { create(:lead_provider) }
+  let(:query) { Statements::Query }
+  let(:serializer) { API::StatementSerializer }
 
   describe "GET /api/v3/statements" do
-    context "when authorized" do
-      context "when 2 statements exist for current_lead_provider" do
-        let!(:statement1) { create(:statement, lead_provider: current_lead_provider) }
-        let!(:statement2) { create(:statement, lead_provider: current_lead_provider) }
+    let(:path) { api_v3_statements_path }
+    let(:resource_id_key) { :ecf_id }
 
-        before do
-          create(:statement, lead_provider: create(:lead_provider, name: "Another lead provider"))
-        end
-
-        it "returns 2 statements" do
-          api_get("/api/v3/statements")
-
-          expect(response.status).to eq 200
-          expect(response.content_type).to eql("application/json")
-          expect(parsed_response["data"].size).to eq(2)
-          expect(response_ids).to match_array([statement1.ecf_id, statement2.ecf_id])
-        end
-      end
-
-      context "when no statements exist" do
-        it "returns empty" do
-          api_get("/api/v3/statements")
-
-          expect(response.status).to eq 200
-          expect(parsed_response["data"].size).to eq(0)
-        end
-      end
-
-      describe "filtering" do
-        describe "by cohort" do
-          let(:cohort_2023) { create(:cohort, start_year: 2023) }
-          let(:cohort_2024) { create(:cohort, start_year: 2024) }
-          let(:cohort_2025) { create(:cohort, start_year: 2025) }
-
-          it "returns statements for the specified cohort" do
-            create(:statement, lead_provider: current_lead_provider, cohort: cohort_2023)
-            create(:statement, lead_provider: current_lead_provider, cohort: cohort_2024)
-            create(:statement, lead_provider: current_lead_provider, cohort: cohort_2025)
-
-            api_get("/api/v3/statements", params: { filter: { cohort: "2023,2024" } })
-
-            expect(parsed_response["data"].size).to eq(2)
-          end
-        end
-
-        describe "by updated_since" do
-          it "returns statements updated since the specified date" do
-            create(:statement, lead_provider: current_lead_provider, updated_at: 2.hours.ago)
-
-            api_get("/api/v3/statements", params: { filter: { updated_since: 1.hour.ago.iso8601 } })
-
-            expect(parsed_response["data"].size).to be_zero
-          end
-
-          it "returns 400 - bad request for invalid updated_since" do
-            api_get("/api/v3/statements", params: { filter: { updated_since: "invalid" } })
-
-            expect(response.status).to eq 400
-            expect(parsed_response["errors"]).to eq([
-              {
-                "detail" => "The filter '#/updated_since' must be a valid ISO 8601 date",
-                "title" => "Bad request",
-              },
-            ])
-          end
-        end
-      end
-
-      context "with pagination" do
-        before do
-          create_list(:statement, 8, lead_provider: current_lead_provider)
-        end
-
-        it "returns 5 statements on page 1" do
-          api_get("/api/v3/statements", params: { page: { per_page: 5, page: 1 } })
-
-          expect(response.status).to eq 200
-          expect(parsed_response["data"].size).to eq(5)
-        end
-
-        it "returns 3 statements on page 2" do
-          api_get("/api/v3/statements", params: { page: { per_page: 5, page: 2 } })
-
-          expect(response.status).to eq 200
-          expect(parsed_response["data"].size).to eq(3)
-        end
-
-        it "returns empty for page 3" do
-          api_get("/api/v3/statements", params: { page: { per_page: 5, page: 3 } })
-
-          expect(response.status).to eq 200
-          expect(parsed_response["data"].size).to eq(0)
-        end
-
-        it "returns error when requesting page -1" do
-          api_get("/api/v3/statements", params: { page: { per_page: 5, page: -1 } })
-
-          expect(response.status).to eq 400
-          expect(parsed_response["errors"].size).to eq(1)
-          expect(parsed_response["errors"][0]["title"]).to eql("Bad request")
-          expect(parsed_response["errors"][0]["detail"]).to eql("The '#/page[page]' and '#/page[per_page]' parameter values must be a valid positive number")
-        end
-      end
+    def create_resource(**attrs)
+      create(:statement, **attrs)
     end
 
-    context "when unauthorized" do
-      it "returns 401 - unauthorized" do
-        api_get("/api/v3/statements", token: "incorrect-token")
-
-        expect(response.status).to eq 401
-        expect(parsed_response["error"]).to eql("HTTP Token: Access denied")
-        expect(response.content_type).to eql("application/json")
-      end
-    end
-  end
-
-  describe "GET /api/v3/statements/:id" do
-    describe "GET /api/v1/applications/:id" do
-      let(:resource) { create(:statement, lead_provider: current_lead_provider) }
-      let(:resource_id) { resource.ecf_id }
-
-      def path(id = nil)
-        api_v3_statement_path(id)
-      end
-
-      it_behaves_like "an API show endpoint", Statements::Query, API::StatementSerializer
-    end
+    it_behaves_like "an API index endpoint with pagination"
+    it_behaves_like "an API index endpoint with filter by cohort"
+    it_behaves_like "an API index endpoint with filter by updated_since"
   end
 end

--- a/spec/services/api/concerns/orderable_spec.rb
+++ b/spec/services/api/concerns/orderable_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+class TestQuery
+  include API::Concerns::Orderable
+end
+
+class Test < ApplicationRecord
+  include ActiveModel::Attributes
+
+  attribute :foo
+  attribute :bar
+end
+
+RSpec.describe API::Concerns::Orderable do
+  let(:query) { TestQuery.new }
+
+  describe "#sort_order" do
+    it "returns a formatted sort order relative to the model" do
+      sort_order = query.sort_order(sort: "-foo,bar,invalid", model: Test, default: { id: :asc })
+      expect(sort_order).to eq("tests.foo DESC, tests.bar ASC")
+    end
+
+    it "returns nil when there is no sort" do
+      expect(query.sort_order(sort: " ", model: Test)).to be_nil
+    end
+
+    it "returns the default sort order when there is no sort" do
+      default = { created_at: :asc }
+      sort_order = query.sort_order(sort: nil, default:, model: Test)
+      expect(sort_order).to eq(default)
+    end
+  end
+end

--- a/spec/support/shared_examples/api_index_endpoint_support.rb
+++ b/spec/support/shared_examples/api_index_endpoint_support.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "an API index endpoint" do
+  context "when authorized" do
+    context "when 2 resources exist for current_lead_provider" do
+      let!(:resource1) { create_resource(lead_provider: current_lead_provider) }
+      let!(:resource2) { create_resource(lead_provider: current_lead_provider) }
+
+      before do
+        create_resource(lead_provider: create(:lead_provider, name: "Another lead provider"))
+      end
+
+      it "returns 2 resources" do
+        api_get(path)
+
+        expect(response.status).to eq 200
+        expect(response.content_type).to eql("application/json")
+        expect(response_ids).to contain_exactly(resource1[resource_id_key], resource2[resource_id_key])
+      end
+
+      it "calls the correct query/serializer" do
+        serializer_params = { root: "data" }
+        serializer_params[:view] = serializer_version if defined?(serializer_version)
+
+        expect(serializer).to receive(:render).with([resource1, resource2], **serializer_params).and_call_original
+        expect(query).to receive(:new).with(a_hash_including(lead_provider: current_lead_provider)).and_call_original
+
+        api_get(path)
+      end
+    end
+
+    context "when no resources exist" do
+      it "returns empty" do
+        api_get(path)
+
+        expect(response.status).to eq 200
+        expect(parsed_response["data"]).to be_empty
+      end
+    end
+  end
+
+  context "when unauthorized" do
+    it "returns 401 - unauthorized" do
+      api_get(path, token: "incorrect-token")
+
+      expect(response.status).to eq 401
+      expect(parsed_response["error"]).to eql("HTTP Token: Access denied")
+      expect(response.content_type).to eql("application/json")
+    end
+  end
+end
+
+RSpec.shared_examples "an API index endpoint with pagination" do
+  context "with pagination" do
+    before do
+      8.times { create_resource(lead_provider: current_lead_provider) }
+    end
+
+    it "returns 5 resources on page 1" do
+      api_get(path, params: { page: { per_page: 5, page: 1 } })
+
+      expect(response.status).to eq 200
+      expect(parsed_response["data"].size).to eq(5)
+    end
+
+    it "returns 3 resources on page 2" do
+      api_get(path, params: { page: { per_page: 5, page: 2 } })
+
+      expect(response.status).to eq 200
+      expect(parsed_response["data"].size).to eq(3)
+    end
+
+    it "returns empty for page 3" do
+      api_get(path, params: { page: { per_page: 5, page: 3 } })
+
+      expect(response.status).to eq 200
+      expect(parsed_response["data"].size).to eq(0)
+    end
+
+    it "returns error when requesting page -1" do
+      api_get(path, params: { page: { per_page: 5, page: -1 } })
+
+      expect(response.status).to eq 400
+      expect(parsed_response["errors"].size).to eq(1)
+      expect(parsed_response["errors"][0]["title"]).to eql("Bad request")
+      expect(parsed_response["errors"][0]["detail"]).to eql("The '#/page[page]' and '#/page[per_page]' parameter values must be a valid positive number")
+    end
+  end
+end
+
+RSpec.shared_examples "an API index endpoint with filter by cohort" do
+  context "when fitlering by cohort" do
+    let(:cohort_2023) { create(:cohort, start_year: 2023) }
+    let(:cohort_2024) { create(:cohort, start_year: 2024) }
+    let(:cohort_2025) { create(:cohort, start_year: 2025) }
+
+    it "returns resources for the specified cohorts" do
+      create_resource(lead_provider: current_lead_provider, cohort: cohort_2023)
+      create_resource(lead_provider: current_lead_provider, cohort: cohort_2024)
+      create_resource(lead_provider: current_lead_provider, cohort: cohort_2025)
+
+      api_get(path, params: { filter: { cohort: "2023,2024" } })
+
+      expect(parsed_response["data"].size).to eq(2)
+    end
+
+    it "calls the correct query" do
+      expect(query).to receive(:new).with(a_hash_including(lead_provider: current_lead_provider, cohort_start_years: "2023,2024")).and_call_original
+
+      api_get(path, params: { filter: { cohort: "2023,2024" } })
+    end
+  end
+end
+
+RSpec.shared_examples "an API index endpoint with filter by updated_since" do
+  context "when fitlering by updated_since" do
+    it "returns resources updated since the specified date" do
+      create_resource(lead_provider: current_lead_provider, updated_at: 2.hours.ago)
+      create_resource(lead_provider: current_lead_provider, updated_at: 1.minute.ago)
+
+      api_get(path, params: { filter: { updated_since: 1.hour.ago.iso8601 } })
+
+      expect(parsed_response["data"].size).to eq(1)
+    end
+
+    it "calls the correct query" do
+      updated_since = 1.hour.ago.iso8601
+      expect(query).to receive(:new).with(a_hash_including(lead_provider: current_lead_provider, updated_since: Time.iso8601(updated_since))).and_call_original
+
+      api_get(path, params: { filter: { updated_since: } })
+    end
+
+    it "returns 400 - bad request for invalid updated_since" do
+      api_get(path, params: { filter: { updated_since: "invalid" } })
+
+      expect(response.status).to eq 400
+      expect(parsed_response["errors"]).to eq([
+        {
+          "detail" => "The filter '#/updated_since' must be a valid ISO 8601 date",
+          "title" => "Bad request",
+        },
+      ])
+    end
+  end
+end
+
+RSpec.shared_examples "an API index endpoint with filter by participant_id" do
+  context "when fitlering by participant_id" do
+    it "returns resources with the given participant_id" do
+      resource1 = create_resource(lead_provider: current_lead_provider, user: create(:user))
+      resource2 = create_resource(lead_provider: current_lead_provider, user: create(:user))
+      create_resource(lead_provider: current_lead_provider, user: create(:user))
+
+      api_get(path, params: { filter: { participant_id: [resource1.user.ecf_id, resource2.user.ecf_id].join(",") } })
+
+      expect(parsed_response["data"].size).to eq(2)
+    end
+
+    it "calls the correct query" do
+      participant_id = [SecureRandom.uuid, SecureRandom.uuid].join(",")
+      expect(query).to receive(:new).with(a_hash_including(lead_provider: current_lead_provider, participant_ids: participant_id)).and_call_original
+
+      api_get(path, params: { filter: { participant_id: } })
+    end
+  end
+end

--- a/spec/support/shared_examples/api_show_endpoint_support.rb
+++ b/spec/support/shared_examples/api_show_endpoint_support.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples "an API show endpoint" do |query, serializer, serializer_version|
+RSpec.shared_examples "an API show endpoint" do
   context "when authorized" do
     context "when the resource exists" do
       it "returns the resource" do
@@ -13,10 +13,10 @@ RSpec.shared_examples "an API show endpoint" do |query, serializer, serializer_v
 
       it "calls the correct query/serializer" do
         serializer_params = { root: "data" }
-        serializer_params[:view] = serializer_version if serializer_version
+        serializer_params[:view] = serializer_version if defined?(serializer_version)
 
         expect(serializer).to receive(:render).with(resource, **serializer_params).and_call_original
-        expect(query).to receive(:new).and_call_original
+        expect(query).to receive(:new).with(a_hash_including(lead_provider: current_lead_provider)).and_call_original
 
         api_get(path(resource_id))
       end


### PR DESCRIPTION
### Context

Follow on PR from #1305 to add the implementation for the GET `/applications` endpoint across all API versions.

### Changes proposed in this pull request

- Add filtering to Applications::Query

We need to support filtering by cohort and updated since for the GET `/applications` endpoint.

- Add applications endpoint

Update the `Applications::Query` to support filtering. 
Add GET `/applications` actions to each version of the `ApplicationsController`. 
Extract index tests into shared examples to DRY up. 
Update users factory to set `ecf_id` by default as this is the default state.