### PR TITLE
Add human readable messages for validations

### DIFF
--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,5 +1,8 @@
 class Admin < ApplicationRecord
-  validates :full_name, presence: true, length: { maximum: 64 }
+  validates :full_name,
+            presence: { message: "Enter a full name" },
+            length: { maximum: 64, message: "Full name must be shorter than 64 characters" }
+
   validates :email, presence: true, length: { maximum: 64 }
 
   # Whether this user has admin access to the feature flagging interface

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -3,7 +3,9 @@ class Admin < ApplicationRecord
             presence: { message: "Enter a full name" },
             length: { maximum: 64, message: "Full name must be shorter than 64 characters" }
 
-  validates :email, presence: true, length: { maximum: 64 }
+  validates :email,
+            presence: { message: "Enter an email address" },
+            length: { maximum: 64, message: "Email must be shorter than 64 characters" }
 
   # Whether this user has admin access to the feature flagging interface
   def flipper_access?

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -4,7 +4,12 @@ class Statement < ApplicationRecord
   has_many :statement_items
 
   validates :output_fee, inclusion: [true, false]
-  validates :month, numericality: { in: 1..12, only_integer: true }
+  validates :month,
+            numericality: {
+              in: 1..12,
+              only_integer: true,
+              message: "Month must be a number between 1 and 12",
+            }
   validates :year, numericality: { in: 2020..2050, only_integer: true }
   validates :ecf_id, presence: true, uniqueness: { case_sensitive: false }
 

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -10,7 +10,12 @@ class Statement < ApplicationRecord
               only_integer: true,
               message: "Month must be a number between 1 and 12",
             }
-  validates :year, numericality: { in: 2020..2050, only_integer: true }
+  validates :year,
+            numericality: {
+              in: 2020..2050,
+              only_integer: true,
+              message: "Year must be a 4 digit number",
+            }
   validates :ecf_id, presence: true, uniqueness: { case_sensitive: false }
 
   validate :validate_max_statement_items_count

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -52,7 +52,7 @@ private
 
   def validate_max_statement_items_count
     if statement_items.count > 2
-      errors.add(:statement_items, "cannot have more than two items")
+      errors.add(:statement_items, "There cannot be more than two items per statement")
     end
   end
 end

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -3,7 +3,12 @@ class Statement < ApplicationRecord
   belongs_to :lead_provider
   has_many :statement_items
 
-  validates :output_fee, inclusion: [true, false]
+  validates :output_fee,
+            inclusion: {
+              in: [true, false],
+              message: "Choose yes or no for output fee",
+            }
+
   validates :month,
             numericality: {
               in: 1..12,

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -16,7 +16,12 @@ class Statement < ApplicationRecord
               only_integer: true,
               message: "Year must be a 4 digit number",
             }
-  validates :ecf_id, presence: true, uniqueness: { case_sensitive: false }
+  validates :ecf_id,
+            presence: { message: "Enter an ECF ID" },
+            uniqueness: {
+              case_sensitive: false,
+              message: "ECF ID must be unique",
+            }
 
   validate :validate_max_statement_items_count
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,15 @@ class User < ApplicationRecord
   has_many :ecf_sync_request_logs, as: :syncable, dependent: :destroy
 
   validates :full_name, presence: { message: "Enter a full name" }
-  validates :email, presence: true, uniqueness: true, notify_email: true, on: :npq_separation # rubocop:disable Rails/UniqueValidationWithoutIndex
+
+  # rubocop:disable Rails/UniqueValidationWithoutIndex
+  validates :email,
+            presence: { message: "Enter an email address" },
+            uniqueness: { message: "Email address must be unique" },
+            notify_email: true,
+            on: :npq_separation
+  # rubocop:enable Rails/UniqueValidationWithoutIndex
+
   validates :uid, uniqueness: { allow_blank: true }
   validates :uid, inclusion: { in: ->(user) { [user.uid_was] } }, on: :npq_separation, if: -> { uid_was.present? }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   has_many :applications, dependent: :destroy
   has_many :ecf_sync_request_logs, as: :syncable, dependent: :destroy
 
-  validates :full_name, presence: true
+  validates :full_name, presence: { message: "Enter a full name" }
   validates :email, presence: true, uniqueness: true, notify_email: true, on: :npq_separation # rubocop:disable Rails/UniqueValidationWithoutIndex
   validates :uid, uniqueness: { allow_blank: true }
   validates :uid, inclusion: { in: ->(user) { [user.uid_was] } }, on: :npq_separation, if: -> { uid_was.present? }

--- a/spec/models/admin_spec.rb
+++ b/spec/models/admin_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Admin, type: :model do
     end
 
     describe "email" do
-      it { is_expected.to validate_presence_of(:email) }
-      it { is_expected.to validate_length_of(:email).is_at_most(64) }
+      it { is_expected.to validate_presence_of(:email).with_message("Enter an email address") }
+      it { is_expected.to validate_length_of(:email).is_at_most(64).with_message("Email must be shorter than 64 characters") }
     end
   end
 

--- a/spec/models/admin_spec.rb
+++ b/spec/models/admin_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 RSpec.describe Admin, type: :model do
   describe "validation" do
     describe "full_name" do
-      it { is_expected.to validate_presence_of(:full_name) }
-      it { is_expected.to validate_length_of(:full_name).is_at_most(64) }
+      it { is_expected.to validate_presence_of(:full_name).with_message("Enter a full name") }
+      it { is_expected.to validate_length_of(:full_name).is_at_most(64).with_message("Full name must be shorter than 64 characters") }
     end
 
     describe "email" do

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Statement, type: :model do
           create_list(:statement_item, 3, statement:)
 
           expect(statement.valid?).to be false
-          expect(statement.errors[:statement_items]).to include("cannot have more than two items")
+          expect(statement.errors[:statement_items]).to include("There cannot be more than two items per statement")
         end
       end
     end

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Statement, type: :model do
 
   describe "validations" do
     it { is_expected.to validate_numericality_of(:month).is_in(1..12).only_integer.with_message("Month must be a number between 1 and 12") }
-    it { is_expected.to validate_numericality_of(:year).only_integer.is_in(2020..2050) }
+    it { is_expected.to validate_numericality_of(:year).only_integer.is_in(2020..2050).with_message("Year must be a 4 digit number") }
     it { is_expected.to allow_value(%w[true false]).for(:output_fee) }
     it { is_expected.not_to allow_value(nil).for(:output_fee) }
     it { is_expected.to validate_presence_of(:ecf_id) }

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe Statement, type: :model do
     it { is_expected.to validate_numericality_of(:year).only_integer.is_in(2020..2050).with_message("Year must be a 4 digit number") }
     it { is_expected.to allow_value(%w[true false]).for(:output_fee) }
     it { is_expected.not_to allow_value(nil).for(:output_fee) }
-    it { is_expected.to validate_presence_of(:ecf_id) }
-    it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive }
+    it { is_expected.to validate_presence_of(:ecf_id).with_message("Enter an ECF ID") }
+    it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique") }
 
     describe "Validation for statement items count" do
       context "when the statement has two or fewer statement items" do

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Statement, type: :model do
   end
 
   describe "validations" do
-    it { is_expected.to validate_numericality_of(:month).is_in(1..12).only_integer }
+    it { is_expected.to validate_numericality_of(:month).is_in(1..12).only_integer.with_message("Month must be a number between 1 and 12") }
     it { is_expected.to validate_numericality_of(:year).only_integer.is_in(2020..2050) }
     it { is_expected.to allow_value(%w[true false]).for(:output_fee) }
     it { is_expected.not_to allow_value(nil).for(:output_fee) }

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe Statement, type: :model do
   describe "validations" do
     it { is_expected.to validate_numericality_of(:month).is_in(1..12).only_integer.with_message("Month must be a number between 1 and 12") }
     it { is_expected.to validate_numericality_of(:year).only_integer.is_in(2020..2050).with_message("Year must be a 4 digit number") }
-    it { is_expected.to allow_value(%w[true false]).for(:output_fee) }
-    it { is_expected.not_to allow_value(nil).for(:output_fee) }
+    it { is_expected.to allow_value(%w[true false]).for(:output_fee).with_message("Output fee must be true or false") }
+    it { is_expected.not_to allow_value(nil).for(:output_fee).with_message("Choose yes or no for output fee") }
     it { is_expected.to validate_presence_of(:ecf_id).with_message("Enter an ECF ID") }
     it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique") }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe User do
   end
 
   describe "validations" do
-    it { is_expected.to validate_presence_of(:full_name) }
+    it { is_expected.to validate_presence_of(:full_name).with_message("Enter a full name") }
 
     it { is_expected.to validate_presence_of(:email).on(:npq_separation) }
     it { is_expected.to validate_uniqueness_of(:email).on(:npq_separation).case_insensitive }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe User do
   describe "validations" do
     it { is_expected.to validate_presence_of(:full_name).with_message("Enter a full name") }
 
-    it { is_expected.to validate_presence_of(:email).on(:npq_separation) }
-    it { is_expected.to validate_uniqueness_of(:email).on(:npq_separation).case_insensitive }
+    it { is_expected.to validate_presence_of(:email).on(:npq_separation).with_message("Enter an email address") }
+    it { is_expected.to validate_uniqueness_of(:email).on(:npq_separation).case_insensitive.with_message("Email address must be unique") }
     it { is_expected.not_to allow_value("invalid-email").for(:email).on(:npq_separation) }
 
     it { is_expected.to validate_uniqueness_of(:uid).allow_blank }

--- a/spec/services/migration/migrators/statement_spec.rb
+++ b/spec/services/migration/migrators/statement_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Migration::Migrators::Statement do
       end
 
       it "calls FailureManager with correct params" do
-        expect_any_instance_of(Migration::FailureManager).to receive(:record_failure).with(ecf_migration_statement, "Validation failed: Output fee is not included in the list").and_call_original
+        expect_any_instance_of(Migration::FailureManager).to receive(:record_failure).with(ecf_migration_statement, "Validation failed: Output fee Choose yes or no for output fee").and_call_original
 
         subject
       end


### PR DESCRIPTION
### Context

This change adds validation messages that will make sense in the user interface (when we build it). Setting the trend early should encourage developers to continue adding them as we implement more validation rules. This prevents Rails' default error messages from unintentionally appearing in the UI, and they don't work with the GOV.UK error summary because they don't include the field name and aren't very helpful to users.

### Changes proposed in this pull request

- **Add validation messages for Statement month**
- **Add validation messages for Statement year**
- **Add validation messages for Statement ecf_id**
- **Add validation messages for Statement output_fee**
- **Make statement items validation message friendlier**
- **Add validation message for User full_name**
- **Add validation message for User email**
- **Add validation message for Admin full_name**
- **Add validation message for Admin email**

