### PR TITLE
Add schools/courses to admin dashboard

### DIFF
--- a/app/components/npq_separation/navigation_structures/admin_navigation_structure.rb
+++ b/app/components/npq_separation/navigation_structures/admin_navigation_structure.rb
@@ -53,7 +53,7 @@ module NpqSeparation
           ],
           Node.new(
             name: "Schools",
-            href: "#",
+            href: npq_separation_admin_schools_path,
             prefix: "/npq-separation/admin/schools",
           ) => [],
           Node.new(

--- a/app/components/npq_separation/navigation_structures/admin_navigation_structure.rb
+++ b/app/components/npq_separation/navigation_structures/admin_navigation_structure.rb
@@ -30,6 +30,11 @@ module NpqSeparation
             prefix: "/npq-separation/admin/applications",
           ) => [],
           Node.new(
+            name: "Courses",
+            href: npq_separation_admin_courses_path,
+            prefix: "/npq-separation/admin/courses",
+          ) => [],
+          Node.new(
             name: "Participants",
             href: npq_separation_admin_users_path,
             prefix: "/npq-separation/admin/users",

--- a/app/controllers/npq_separation/admin/courses_controller.rb
+++ b/app/controllers/npq_separation/admin/courses_controller.rb
@@ -1,0 +1,15 @@
+class NpqSeparation::Admin::CoursesController < NpqSeparation::AdminController
+  def index
+    @pagy, @courses = pagy(courses_query.courses)
+  end
+
+  def show
+    @course = courses_query.course(id: params[:id])
+  end
+
+private
+
+  def courses_query
+    @courses_query ||= Courses::Query.new
+  end
+end

--- a/app/controllers/npq_separation/admin/schools_controller.rb
+++ b/app/controllers/npq_separation/admin/schools_controller.rb
@@ -1,0 +1,15 @@
+class NpqSeparation::Admin::SchoolsController < NpqSeparation::AdminController
+  def index
+    @pagy, @schools = pagy(schools_query.schools)
+  end
+
+  def show
+    @school = schools_query.school(id: params[:id])
+  end
+
+private
+
+  def schools_query
+    @schools_query ||= Schools::Query.new
+  end
+end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -6,6 +6,15 @@ module AdminHelper
     "#{start_year}/#{end_year}"
   end
 
+  def format_address(school)
+    keys = %i[address_1 address_2 address_3 town county postcode]
+    parts = keys.map { |k| school[k] }.compact_blank
+
+    return if parts.blank?
+
+    safe_join(parts, tag.br)
+  end
+
   def admin_navigation_structure
     @admin_navigation_structure ||= NpqSeparation::NavigationStructures::AdminNavigationStructure.new
   end

--- a/app/services/courses/query.rb
+++ b/app/services/courses/query.rb
@@ -1,0 +1,11 @@
+module Courses
+  class Query
+    def courses
+      Course.all.order(name: :asc)
+    end
+
+    def course(id:)
+      courses.find_by!(id:)
+    end
+  end
+end

--- a/app/services/schools/query.rb
+++ b/app/services/schools/query.rb
@@ -1,0 +1,11 @@
+module Schools
+  class Query
+    def schools
+      School.all.order(name: :asc)
+    end
+
+    def school(id:)
+      schools.find_by!(id:)
+    end
+  end
+end

--- a/app/views/npq_separation/admin/courses/index.html.erb
+++ b/app/views/npq_separation/admin/courses/index.html.erb
@@ -1,0 +1,20 @@
+<h1 class="govuk-heading-l">All courses</h1>
+<%=
+  govuk_table do |table|
+    table.with_head do |header|
+      header.with_row do |row|
+        row.with_cell(text: "Name")
+      end
+    end
+  
+    table.with_body do |body|
+      @courses.each do |course|
+        body.with_row do |row|
+          row.with_cell(text: govuk_link_to(course.name, npq_separation_admin_course_path(course)))
+        end
+      end
+    end
+  end
+%>
+
+<%= govuk_pagination(pagy: @pagy) %>

--- a/app/views/npq_separation/admin/courses/show.html.erb
+++ b/app/views/npq_separation/admin/courses/show.html.erb
@@ -15,6 +15,11 @@
     end
 
     sl.with_row do |row|
+      row.with_key(text: "Identifier")
+      row.with_value(text: @course.identifier)
+    end
+
+    sl.with_row do |row|
       row.with_key(text: "Position")
       row.with_value(text: @course.position)
     end

--- a/app/views/npq_separation/admin/courses/show.html.erb
+++ b/app/views/npq_separation/admin/courses/show.html.erb
@@ -1,0 +1,37 @@
+<%= govuk_back_link(href: url_for(:back)) %>
+
+<h1 class="govuk-heading-l"><%= @course.name %></h1>
+
+<%=
+  govuk_summary_list do |sl|
+    sl.with_row do |row|
+      row.with_key(text: "ID")
+      row.with_value(text: @course.id)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "ECF ID")
+      row.with_value(text: @course.ecf_id)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Position")
+      row.with_value(text: @course.position)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Name")
+      row.with_value(text: @course.name)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Description")
+      row.with_value(text: @course.description)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Display")
+      row.with_value(text: boolean_red_green_tag(@course.display?))
+    end
+  end
+%>

--- a/app/views/npq_separation/admin/schools/index.html.erb
+++ b/app/views/npq_separation/admin/schools/index.html.erb
@@ -3,16 +3,16 @@
   govuk_table do |table|
     table.with_head do |header|
       header.with_row do |row|
-        row.with_cell(text: "URN")
         row.with_cell(text: "School")
+        row.with_cell(text: "URN")
       end
     end
 
     table.with_body do |body|
       @schools.each do |school|
         body.with_row do |row|
-          row.with_cell(text: school.urn)
           row.with_cell(text: govuk_link_to(school.name, npq_separation_admin_school_path(school)))
+          row.with_cell(text: school.urn)
         end
       end
     end

--- a/app/views/npq_separation/admin/schools/index.html.erb
+++ b/app/views/npq_separation/admin/schools/index.html.erb
@@ -1,0 +1,22 @@
+<h1 class="govuk-heading-l">All schools</h1>
+<%=
+  govuk_table do |table|
+    table.with_head do |header|
+      header.with_row do |row|
+        row.with_cell(text: "URN")
+        row.with_cell(text: "School")
+      end
+    end
+
+    table.with_body do |body|
+      @schools.each do |school|
+        body.with_row do |row|
+          row.with_cell(text: school.urn)
+          row.with_cell(text: govuk_link_to(school.name, npq_separation_admin_school_path(school)))
+        end
+      end
+    end
+  end
+%>
+
+<%= govuk_pagination(pagy: @pagy) %>

--- a/app/views/npq_separation/admin/schools/show.html.erb
+++ b/app/views/npq_separation/admin/schools/show.html.erb
@@ -1,0 +1,32 @@
+<%= govuk_back_link(href: url_for(:back)) %>
+
+<h1 class="govuk-heading-l"><%= @school.name %></h1>
+
+<%=
+  govuk_summary_list do |sl|
+    sl.with_row do |row|
+      row.with_key(text: "ID")
+      row.with_value(text: @school.id)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "URN")
+      row.with_value(text: @school.urn)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "UKPRN")
+      row.with_value(text: @school.ukprn)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Local authority")
+      row.with_value(text: @school.la_name)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Address")
+      row.with_value(text: format_address(@school))
+    end
+  end
+%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -191,6 +191,7 @@ Rails.application.routes.draw do
 
         resources :applications, only: %i[index]
         resources :schools, only: %i[index show]
+        resources :courses, only: %i[index show]
         resources :users, only: %i[index show]
 
         namespace :finance do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -190,6 +190,7 @@ Rails.application.routes.draw do
         end
 
         resources :applications, only: %i[index]
+        resources :schools, only: %i[index show]
         resources :users, only: %i[index show]
 
         namespace :finance do

--- a/spec/components/npq_separation/navigation_structures/admin_navigation_structure_spec.rb
+++ b/spec/components/npq_separation/navigation_structures/admin_navigation_structure_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe NpqSeparation::NavigationStructures::AdminNavigationStructure, ty
     {
       "Dashboard" => "/npq-separation/admin",
       "Applications" => "/npq-separation/admin/applications",
+      "Courses" => "/npq-separation/admin/courses",
       "Participants" => "/npq-separation/admin/users",
       "Finance" => "/npq-separation/admin/finance/statements",
       "Schools" => "/npq-separation/admin/schools",

--- a/spec/components/npq_separation/navigation_structures/admin_navigation_structure_spec.rb
+++ b/spec/components/npq_separation/navigation_structures/admin_navigation_structure_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe NpqSeparation::NavigationStructures::AdminNavigationStructure, ty
       "Applications" => "/npq-separation/admin/applications",
       "Participants" => "/npq-separation/admin/users",
       "Finance" => "/npq-separation/admin/finance/statements",
-      "Schools" => "#",
+      "Schools" => "/npq-separation/admin/schools",
       "Lead providers" => "/npq-separation/admin/lead-providers",
       "Settings" => "#",
     }.each_with_index do |(name, href), i|

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -13,5 +13,14 @@ FactoryBot.define do
     trait :closed do
       establishment_status_code { 2 }
     end
+
+    trait :with_address do
+      address_1 { Faker::Address.building_number }
+      address_2 { Faker::Address.street_address }
+      address_3 { Faker::Address.community }
+      town { "town" }
+      county { "county" }
+      postcode { Faker::Address.postcode }
+    end
   end
 end

--- a/spec/helpers/admin_helper_spec.rb
+++ b/spec/helpers/admin_helper_spec.rb
@@ -13,4 +13,24 @@ RSpec.describe AdminHelper, type: :helper do
       expect(subject).to include("2019/20")
     end
   end
+
+  describe "format_address" do
+    subject { format_address(school) }
+
+    let(:school) { build(:school, :with_address) }
+
+    it { is_expected.to eq("#{school.address_1}<br>#{school.address_2}<br>#{school.address_3}<br>#{school.town}<br>#{school.county}<br>#{school.postcode}") }
+
+    context "when the school has no address" do
+      let(:school) { build(:school) }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when the school has a partial address" do
+      let(:school) { build(:school, :with_address, address_2: nil, address_3: " ") }
+
+      it { is_expected.to eq("#{school.address_1}<br>#{school.town}<br>#{school.county}<br>#{school.postcode}") }
+    end
+  end
 end

--- a/spec/requests/npq_separation/admin/courses_controller_spec.rb
+++ b/spec/requests/npq_separation/admin/courses_controller_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe NpqSeparation::Admin::CoursesController, type: :request do
+  include Helpers::NPQSeparationAdminLogin
+
+  before { sign_in_as_admin }
+
+  describe "/npq_separation/admin/courses" do
+    subject do
+      get npq_separation_admin_courses_path
+      response
+    end
+
+    it { is_expected.to have_http_status(:ok) }
+  end
+
+  describe "/npq_separation/admin/courses/{id}" do
+    let(:course_id) { Course.all.sample.id }
+
+    subject do
+      get npq_separation_admin_course_path(course_id)
+      response
+    end
+
+    it { is_expected.to have_http_status(:ok) }
+
+    context "when the course cannot be found", exceptions_app: true do
+      let(:course_id) { -1 }
+
+      it { is_expected.to have_http_status(:not_found) }
+    end
+  end
+end

--- a/spec/requests/npq_separation/admin/schools_controller_spec.rb
+++ b/spec/requests/npq_separation/admin/schools_controller_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe NpqSeparation::Admin::SchoolsController, type: :request do
+  include Helpers::NPQSeparationAdminLogin
+
+  before { sign_in_as_admin }
+
+  describe "/npq_separation/admin/schools" do
+    subject do
+      get npq_separation_admin_schools_path
+      response
+    end
+
+    it { is_expected.to have_http_status(:ok) }
+  end
+
+  describe "/npq_separation/admin/schools/{id}" do
+    let(:school_id) { create(:school).id }
+
+    subject do
+      get npq_separation_admin_school_path(school_id)
+      response
+    end
+
+    it { is_expected.to have_http_status(:ok) }
+
+    context "when the school cannot be found", exceptions_app: true do
+      let(:school_id) { -1 }
+
+      it { is_expected.to have_http_status(:not_found) }
+    end
+  end
+end

--- a/spec/services/courses/query_spec.rb
+++ b/spec/services/courses/query_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe Courses::Query do
+  describe "#courses" do
+    it "returns all courses" do
+      query = Courses::Query.new
+
+      expect(query.courses).not_to be_empty
+      expect(query.courses).to contain_exactly(*Course.all)
+    end
+
+    it "orders courses by name in ascending order" do
+      query = Courses::Query.new
+      course_names = query.courses.map(&:name)
+      expect(course_names).to eq(course_names.sort)
+    end
+  end
+
+  describe "#course" do
+    it "returns the course" do
+      course = Course.all.sample
+      query = Courses::Query.new
+      expect(query.course(id: course.id)).to eq(course)
+    end
+
+    it "raises an error if the course does not exist" do
+      query = Courses::Query.new
+      expect { query.course(id: "XXX123") }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end

--- a/spec/services/schools/query_spec.rb
+++ b/spec/services/schools/query_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe Schools::Query do
+  describe "#schools" do
+    it "returns all schools" do
+      school1 = create(:school)
+      school2 = create(:school)
+
+      query = Schools::Query.new
+      expect(query.schools).to contain_exactly(school1, school2)
+    end
+
+    it "orders schools by name in ascending order" do
+      school1 = create(:school, name: "C School")
+      school2 = create(:school, name: "A school")
+      school3 = create(:school, name: "B school")
+
+      query = Schools::Query.new
+      expect(query.schools).to eq([school2, school3, school1])
+    end
+  end
+
+  describe "#school" do
+    it "returns the school" do
+      school = create(:school)
+
+      query = Schools::Query.new
+      expect(query.school(id: school.id)).to eq(school)
+    end
+
+    it "raises an error if the school does not exist" do
+      query = Schools::Query.new
+      expect { query.school(id: "XXX123") }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end


### PR DESCRIPTION
[Jira-2968](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-2968)

### Context

We want to add a list of schools and courses to the new admin dashboard in NPQ reg, along with detail pages that contain the details of a course/school.

### Changes proposed in this pull request

- Add schools to the admin dashboard

Add a page to list schools and show details of a school in the admin dashboard.

- Add courses to the admin dashboard

Add a page to list courses and show details of a course in the admin dashboard.

### Guidance for review

For some reason the Faker town/county translations are missing and it complains, so I've hardecoded these values in the factory for now.

| All courses    | Course | All schools | School |
| -------- | ------- | -------- | ------- |
| ![all-courses](https://github.com/DFE-Digital/npq-registration/assets/29867726/947f04e2-ea7f-4213-9b07-2c6a764a4ac5)  | ![course](https://github.com/DFE-Digital/npq-registration/assets/29867726/618bad06-4bb0-4392-b0f7-87f79cf49e50)   | ![all-schools](https://github.com/DFE-Digital/npq-registration/assets/29867726/27d47472-a0ec-4599-8248-94cbbd9a34ea)  | ![school](https://github.com/DFE-Digital/npq-registration/assets/29867726/83042004-4865-4595-a79e-deb451ec509e)   |




