### PR TITLE
[CPDNPQ-1752] Styling fixes after frontend update

### DIFF
--- a/app/forms/email_updates.rb
+++ b/app/forms/email_updates.rb
@@ -10,7 +10,7 @@ class EmailUpdates
       QuestionTypes::RadioButtonGroup.new(
         name: :email_updates_status,
         options:,
-        style_options: { legend: { size: "xl", tag: "h1" } },
+        style_options: { legend: { size: "m", tag: "h2" } },
       ),
     ]
   end

--- a/app/forms/questionnaires/choose_your_npq.rb
+++ b/app/forms/questionnaires/choose_your_npq.rb
@@ -18,7 +18,7 @@ module Questionnaires
         QuestionTypes::RadioButtonGroup.new(
           name: :course_identifier,
           options:,
-          style_options: { legend: { size: "m", tag: "h1" } },
+          style_options: { legend: { size: "m", tag: "h2" } },
         ),
       ]
     end

--- a/app/forms/questionnaires/course_start_date.rb
+++ b/app/forms/questionnaires/course_start_date.rb
@@ -29,7 +29,7 @@ module Questionnaires
         Form.new(
           name: :course_start_date,
           options:,
-          style_options: { legend: { size: "m", tag: "h1" } },
+          style_options: { legend: { size: "m", tag: "h2" } },
         ),
       ]
     end

--- a/app/forms/questionnaires/maths_eligibility_teaching_for_mastery.rb
+++ b/app/forms/questionnaires/maths_eligibility_teaching_for_mastery.rb
@@ -17,7 +17,7 @@ module Questionnaires
         QuestionTypes::RadioButtonGroup.new(
           name: :maths_eligibility_teaching_for_mastery,
           options:,
-          style_options: { legend: { size: "m", tag: "h1" } },
+          style_options: { legend: { size: "m", tag: "h2" } },
         ),
       ]
     end

--- a/app/forms/questionnaires/npqh_status.rb
+++ b/app/forms/questionnaires/npqh_status.rb
@@ -31,7 +31,7 @@ module Questionnaires
         QuestionTypes::RadioButtonGroup.new(
           name: :npqh_status,
           options:,
-          style_options: { legend: { size: "m", tag: "h1" } },
+          style_options: { legend: { size: "m", tag: "h2" } },
         ),
       ]
     end

--- a/app/forms/questionnaires/teacher_reference_number.rb
+++ b/app/forms/questionnaires/teacher_reference_number.rb
@@ -38,7 +38,7 @@ module Questionnaires
         QuestionTypes::RadioButtonGroup.new(
           name: :trn_knowledge,
           options:,
-          style_options: { legend: { size: "m", tag: "h1" } },
+          style_options: { legend: { size: "m", tag: "h2" } },
         ),
       ]
     end

--- a/app/views/accounts/_active_application_table.html.erb
+++ b/app/views/accounts/_active_application_table.html.erb
@@ -27,12 +27,12 @@
         </dt>
         <dd class="govuk-summary-list__value">
           <% if application.lead_provider_approval_status.blank? || pending?(application) %>
-            <strong class="govuk-tag govuk-tag--yellow">APPLY WITH PROVIDER</strong>
+            <strong class="govuk-tag govuk-tag--yellow">Apply with provider</strong>
             <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= I18n.t("provider_details.pending_status")  %></p>
           <% elsif accepted?(application) %>
-            <strong class="govuk-tag govuk-tag--green">SUCCESSFUL</strong>
+            <strong class="govuk-tag govuk-tag--green">Successful</strong>
           <% elsif rejected?(application) %>
-            <strong class="govuk-tag govuk-tag--red">UNSUCCESSFUL</strong>
+            <strong class="govuk-tag govuk-tag--red">Unsuccessful</strong>
           <% end %>
         </dd>
       </div>
@@ -44,10 +44,10 @@
           </dt>
           <dd class="govuk-summary-list__value">
               <% if application.participant_outcome_state.capitalize == "Passed" %>
-                <strong class="govuk-tag govuk-tag--green">PASSED</strong>
+                <strong class="govuk-tag govuk-tag--green">Passed</strong>
                 <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= t("course.outcome.passed_html")  %></p>
               <% elsif application.participant_outcome_state.capitalize == "Failed" %>
-                <strong class="govuk-tag govuk-tag--red">NOT PASSED</strong>
+                <strong class="govuk-tag govuk-tag--red">Not passed</strong>
                 <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= t("course.outcome.failed")  %></p>
               <% end %>
           </dd>

--- a/app/views/accounts/_active_application_table.html.erb
+++ b/app/views/accounts/_active_application_table.html.erb
@@ -27,12 +27,12 @@
         </dt>
         <dd class="govuk-summary-list__value">
           <% if application.lead_provider_approval_status.blank? || pending?(application) %>
-            <strong class="govuk-tag govuk-tag--yellow">Apply with provider</strong>
+            <%= govuk_tag(text: "Apply with provider", colour: "yellow") %>
             <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= I18n.t("provider_details.pending_status")  %></p>
           <% elsif accepted?(application) %>
-            <strong class="govuk-tag govuk-tag--green">Successful</strong>
+            <%= govuk_tag(text: "Successful", colour: "green") %>
           <% elsif rejected?(application) %>
-            <strong class="govuk-tag govuk-tag--red">Unsuccessful</strong>
+            <%= govuk_tag(text: "Unsuccessful", colour: "red") %>
           <% end %>
         </dd>
       </div>
@@ -44,10 +44,10 @@
           </dt>
           <dd class="govuk-summary-list__value">
               <% if application.participant_outcome_state.capitalize == "Passed" %>
-                <strong class="govuk-tag govuk-tag--green">Passed</strong>
+                <%= govuk_tag(text: "Passed", colour: "green") %>
                 <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= t("course.outcome.passed_html")  %></p>
               <% elsif application.participant_outcome_state.capitalize == "Failed" %>
-                <strong class="govuk-tag govuk-tag--red">Not passed</strong>
+                <%= govuk_tag(text: "Not passed", colour: "red") %>
                 <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= t("course.outcome.failed")  %></p>
               <% end %>
           </dd>

--- a/app/views/accounts/_course_details.html.erb
+++ b/app/views/accounts/_course_details.html.erb
@@ -50,12 +50,12 @@
         </dt>
         <dd class="govuk-summary-list__value">
           <% if application.lead_provider_approval_status.blank? || pending?(application) %>
-            <strong class="govuk-tag govuk-tag--yellow">Apply with provider</strong>
+            <%= govuk_tag(text: "Apply with provider", colour: "yellow") %>
             <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= I18n.t("provider_details.pending_status")  %></p>
           <% elsif accepted?(application) %>
-            <strong class="govuk-tag govuk-tag--green">Successful</strong>
+            <%= govuk_tag(text: "Successful", colour: "green") %>
           <% elsif rejected?(application) %>
-            <strong class="govuk-tag govuk-tag--red">Unsuccessful</strong>
+            <%= govuk_tag(text: "Unsuccessful", colour: "red") %>
           <% end %>
         </dd>
         <!-- This code is only written for review apps in order to update the external statuses -->
@@ -89,10 +89,10 @@
           </dt>
           <dd class="govuk-summary-list__value">
               <% if application.participant_outcome_state.capitalize == "Passed" %>
-                <strong class="govuk-tag govuk-tag--green">Passed</strong>
+                <%= govuk_tag(text: "Passed", colour: "green") %>
                 <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= t("course.outcome.passed_html")  %></p>
               <% elsif application.participant_outcome_state.capitalize == "Failed" %>
-                <strong class="govuk-tag govuk-tag--red">Not passed</strong>
+                <%= govuk_tag(text: "Not passed", colour: "red") %>
                 <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= t("course.outcome.failed")  %></p>
               <% end %>
           </dd>
@@ -109,7 +109,7 @@
             Course outcome
           </dt>
           <dd class="govuk-summary-list__value">
-            <strong class="govuk-tag govuk-tag--red">N/A</strong>
+            <%= govuk_tag(text: "N/A", colour: "red") %>
           </dd>
           <% if accepted?(application)%>
             <dd class="govuk-summary-list__actions">

--- a/app/views/accounts/_course_details.html.erb
+++ b/app/views/accounts/_course_details.html.erb
@@ -50,12 +50,12 @@
         </dt>
         <dd class="govuk-summary-list__value">
           <% if application.lead_provider_approval_status.blank? || pending?(application) %>
-            <strong class="govuk-tag govuk-tag--yellow">APPLY WITH PROVIDER</strong>
+            <strong class="govuk-tag govuk-tag--yellow">Apply with provider</strong>
             <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= I18n.t("provider_details.pending_status")  %></p>
           <% elsif accepted?(application) %>
-            <strong class="govuk-tag govuk-tag--green">SUCCESSFUL</strong>
+            <strong class="govuk-tag govuk-tag--green">Successful</strong>
           <% elsif rejected?(application) %>
-            <strong class="govuk-tag govuk-tag--red">UNSUCCESSFUL</strong>
+            <strong class="govuk-tag govuk-tag--red">Unsuccessful</strong>
           <% end %>
         </dd>
         <!-- This code is only written for review apps in order to update the external statuses -->
@@ -89,10 +89,10 @@
           </dt>
           <dd class="govuk-summary-list__value">
               <% if application.participant_outcome_state.capitalize == "Passed" %>
-                <strong class="govuk-tag govuk-tag--green">PASSED</strong>
+                <strong class="govuk-tag govuk-tag--green">Passed</strong>
                 <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= t("course.outcome.passed_html")  %></p>
               <% elsif application.participant_outcome_state.capitalize == "Failed" %>
-                <strong class="govuk-tag govuk-tag--red">NOT PASSED</strong>
+                <strong class="govuk-tag govuk-tag--red">Not passed</strong>
                 <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= t("course.outcome.failed")  %></p>
               <% end %>
           </dd>

--- a/app/views/accounts/_expired_application_table.html.erb
+++ b/app/views/accounts/_expired_application_table.html.erb
@@ -23,7 +23,7 @@
           Provider application
         </dt>
         <dd class="govuk-summary-list__value">
-          <strong class="govuk-tag govuk-tag--grey">Expired</strong>
+          <%= govuk_tag(text: "Expired", colour: "grey") %>
           <% if Feature.registration_closed?(current_user) %>
             <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0">
               Your registration has expired but you can register again for future courses when registrations open.

--- a/app/views/accounts/_expired_application_table.html.erb
+++ b/app/views/accounts/_expired_application_table.html.erb
@@ -23,7 +23,7 @@
           Provider application
         </dt>
         <dd class="govuk-summary-list__value">
-          <strong class="govuk-tag govuk-tag--grey">EXPIRED</strong>
+          <strong class="govuk-tag govuk-tag--grey">Expired</strong>
           <% if Feature.registration_closed?(current_user) %>
             <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0">
               Your registration has expired but you can register again for future courses when registrations open.

--- a/app/views/accounts/_funding_details.html.erb
+++ b/app/views/accounts/_funding_details.html.erb
@@ -6,7 +6,7 @@
     <dd class="govuk-summary-list__value">
       <% unless scholarship_eligibility_in_review?(application) %>
         <strong class="govuk-tag <%= application.eligible_for_funding ? 'govuk-tag--green' : 'govuk-tag--red' %>">
-          <%= application.eligible_for_funding ? 'ELIGIBLE' : 'NOT ELIGIBLE' %>
+          <%= application.eligible_for_funding ? 'Eligible' : 'Not eligible' %>
         </strong>
       <% end %>
       <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= scholarship_funding_eligibility(application) %></p>
@@ -34,7 +34,7 @@
               Targeted support funding
             </dt>
             <dd class="govuk-summary-list__value">
-              <strong class="govuk-tag govuk-tag--green">ELIGIBLE</strong>
+              <strong class="govuk-tag govuk-tag--green">Eligible</strong>
               <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= targeted_support_funding %></p>
             </dd>
           </div>

--- a/app/views/accounts/_funding_details.html.erb
+++ b/app/views/accounts/_funding_details.html.erb
@@ -5,9 +5,11 @@
     </dt>
     <dd class="govuk-summary-list__value">
       <% unless scholarship_eligibility_in_review?(application) %>
-        <strong class="govuk-tag <%= application.eligible_for_funding ? 'govuk-tag--green' : 'govuk-tag--red' %>">
-          <%= application.eligible_for_funding ? 'Eligible' : 'Not eligible' %>
-        </strong>
+        <% if application.eligible_for_funding %>
+          <%= govuk_tag(text: "Eligible", colour: "green") %>
+        <% else %>
+          <%= govuk_tag(text: "Not eligible", colour: "red") %>
+        <% end %>
       <% end %>
       <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= scholarship_funding_eligibility(application) %></p>
       <% unless application.eligible_for_funding || scholarship_eligibility_in_review?(application) %>
@@ -34,7 +36,7 @@
               Targeted support funding
             </dt>
             <dd class="govuk-summary-list__value">
-              <strong class="govuk-tag govuk-tag--green">Eligible</strong>
+              <%= govuk_tag(text: "Eligible", colour: "green") %>
               <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= targeted_support_funding %></p>
             </dd>
           </div>

--- a/app/views/admin/closed_registration_users/index.html.erb
+++ b/app/views/admin/closed_registration_users/index.html.erb
@@ -27,13 +27,9 @@
           <td class="govuk-table__cell">
             <% service_user = User.find_by(email: user.email) %>
             <% if service_user.present? %>
-              <strong class="govuk-tag govuk-tag--green">
-                Yes
-              </strong>
+              <%= govuk_tag(text: "Yes", colour: "green") %>
             <% else %>
-              <strong class="govuk-tag govuk-tag--red">
-                No
-              </strong>
+              <%= govuk_tag(text: "No", colour: "red") %>
             <% end %>
           </td>
           <td class="govuk-table__cell">

--- a/app/views/registration_wizard/shared/questions/_radio_button_group.html.erb
+++ b/app/views/registration_wizard/shared/questions/_radio_button_group.html.erb
@@ -1,4 +1,4 @@
-<%= form.govuk_radio_buttons_fieldset(question.name, legend: { text: question.question_text, tag: "h1", size: "xl" }, **question.fieldset_styles) do %>
+<%= form.govuk_radio_buttons_fieldset(question.name, **{ legend: { text: question.question_text, tag: "h1", size: "xl" }}.deep_merge(question.fieldset_styles)) do %>
   <%= yield :additional_info %>
   <%=
     render(

--- a/app/views/registration_wizard/shared/questions/_radio_button_group.html.erb
+++ b/app/views/registration_wizard/shared/questions/_radio_button_group.html.erb
@@ -1,4 +1,4 @@
-<%= form.govuk_radio_buttons_fieldset(question.name, **question.fieldset_styles, legend: { text: question.question_text, tag: "h1", size: "xl" }) do %>
+<%= form.govuk_radio_buttons_fieldset(question.name, legend: { text: question.question_text, tag: "h1", size: "xl" }, **question.fieldset_styles) do %>
   <%= yield :additional_info %>
   <%=
     render(

--- a/spec/features/journeys/happy_paths/funded_ehco_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/funded_ehco_registration_journey_spec.rb
@@ -59,7 +59,7 @@ RSpec.feature "Happy journeys", type: :feature, rack_test_driver: true do
     end
 
     expect_page_to_have(path: "/registration/npqh-status", submit_form: true) do
-      expect(page).to have_selector "h1", text: "What stage are you at with the Headship NPQ?"
+      expect(page).to have_selector "h2", text: "What stage are you at with the Headship NPQ?"
       page.choose("None of the above", visible: :all)
     end
 
@@ -70,7 +70,7 @@ RSpec.feature "Happy journeys", type: :feature, rack_test_driver: true do
     end
 
     expect_page_to_have(path: "/registration/npqh-status", submit_form: true) do
-      expect(page).to have_selector "h1", text: "What stage are you at with the Headship NPQ?"
+      expect(page).to have_selector "h2", text: "What stage are you at with the Headship NPQ?"
       page.choose("I’ve completed it", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/other_funded_ehco_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/other_funded_ehco_registration_journey_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature "Happy journeys", type: :feature, rack_test_driver: true do
     end
 
     expect_page_to_have(path: "/registration/npqh-status", submit_form: true) do
-      expect(page).to have_selector "h1", text: "What stage are you at with the Headship NPQ?"
+      expect(page).to have_selector "h2", text: "What stage are you at with the Headship NPQ?"
       page.choose("None of the above", visible: :all)
     end
 
@@ -69,7 +69,7 @@ RSpec.feature "Happy journeys", type: :feature, rack_test_driver: true do
     end
 
     expect_page_to_have(path: "/registration/npqh-status", submit_form: true) do
-      expect(page).to have_selector "h1", text: "What stage are you at with the Headship NPQ?"
+      expect(page).to have_selector "h2", text: "What stage are you at with the Headship NPQ?"
       page.choose("I’ve completed it", visible: :all)
     end
 

--- a/spec/features/journeys/sad_paths/applying_for_ehco_but_not_new_headteacher_spec.rb
+++ b/spec/features/journeys/sad_paths/applying_for_ehco_but_not_new_headteacher_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature "Sad journeys", type: :feature do
     end
 
     expect_page_to_have(path: "/registration/npqh-status", submit_form: true) do
-      expect(page).to have_selector "h1", text: "What stage are you at with the Headship NPQ?"
+      expect(page).to have_selector "h2", text: "What stage are you at with the Headship NPQ?"
 
       page.choose "None of the above", visible: :all
     end
@@ -69,7 +69,7 @@ RSpec.feature "Sad journeys", type: :feature do
     end
 
     expect_page_to_have(path: "/registration/npqh-status", submit_form: true) do
-      expect(page).to have_selector "h1", text: "What stage are you at with the Headship NPQ?"
+      expect(page).to have_selector "h2", text: "What stage are you at with the Headship NPQ?"
 
       page.choose "I’ve completed it", visible: :all
     end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-1752

- Tags should be sentence case.
- Questions should be h2.
- Questions should have medium text if there is an XL title above them.

### Changes proposed in this pull request

Question text configuration was already set but was being overridden in `_radio_button_group.html.erb` because of the ordering of arguments. They also needed changing from h1 to h2.

**Before:**
<img width="400" alt="Screenshot 2024-04-22 at 11 36 00" src="https://github.com/DFE-Digital/npq-registration/assets/827432/9e680ba0-a522-4779-aa08-b76d9fa01aba">

**After:**
<img width="400" alt="Screenshot 2024-04-22 at 11 36 13" src="https://github.com/DFE-Digital/npq-registration/assets/827432/41ca4979-7957-49a8-b263-0c939e1e2a6d">

**Before:**
<img width="400" alt="Screenshot 2024-04-22 at 11 36 50" src="https://github.com/DFE-Digital/npq-registration/assets/827432/ebe2f38a-3e03-4d01-b768-cc4958369d44">

**After:**
<img width="400" alt="Screenshot 2024-04-22 at 11 36 38" src="https://github.com/DFE-Digital/npq-registration/assets/827432/871bb02a-00ae-4e18-a24c-561a8a5a0a73">

**Before:**
<img width="400" alt="Screenshot 2024-04-22 at 11 37 23" src="https://github.com/DFE-Digital/npq-registration/assets/827432/abe8bf7a-8b19-4fbb-8c99-3ce4a2b37d4f">

**After:**
<img width="400" alt="Screenshot 2024-04-22 at 11 37 34" src="https://github.com/DFE-Digital/npq-registration/assets/827432/39d4a61d-3104-4029-9fd1-144b1fbedb72">

**Before:**
<img width="400" alt="Screenshot 2024-04-22 at 11 45 27" src="https://github.com/DFE-Digital/npq-registration/assets/827432/43267d47-d0a6-4d64-b7bd-f4b3d817b93c">

**After:**
<img width="400" alt="Screenshot 2024-04-22 at 11 45 06" src="https://github.com/DFE-Digital/npq-registration/assets/827432/44facfee-6919-42d4-a106-be5c8a19c088">

**Before:**
<img width="400" alt="Screenshot 2024-04-22 at 12 35 01" src="https://github.com/DFE-Digital/npq-registration/assets/827432/cd5654a2-435c-4fa7-8b0d-d84e898a88fb">

**After:**
<img width="400" alt="Screenshot 2024-04-22 at 12 05 08" src="https://github.com/DFE-Digital/npq-registration/assets/827432/049b7249-a1f0-49d8-a40d-0f8aab92fa08">
