### PR TITLE
Refactor tag helpers

### DIFF
--- a/app/helpers/admin_management_helper.rb
+++ b/app/helpers/admin_management_helper.rb
@@ -1,9 +1,9 @@
 module AdminManagementHelper
   def admin_type_cell_contents(admin)
     if admin.super_admin?
-      content_tag(:strong, t(".admin_type.super_admin"), class: "govuk-tag govuk-tag--blue")
+      govuk_tag(text: t(".admin_type.super_admin"), colour: "blue")
     else
-      content_tag(:strong, t(".admin_type.admin"), class: "govuk-tag govuk-tag--green")
+      govuk_tag(text: t(".admin_type.admin"), colour: "green")
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,10 +18,10 @@ module ApplicationHelper
   end
 
   def boolean_red_green_tag(bool, text = nil)
-    text ||= bool ? "YES" : "NO"
+    text ||= bool ? "Yes" : "No"
     colour = bool ? "green" : "red"
 
-    content_tag(:strong, text, class: "govuk-tag govuk-tag--#{colour}")
+    govuk_tag(text:, colour:)
   end
 
   def boolean_tag(bool)

--- a/app/helpers/webhook_messages_helper.rb
+++ b/app/helpers/webhook_messages_helper.rb
@@ -1,6 +1,6 @@
 module WebhookMessagesHelper
   def webhook_message_status_tag(webhook_message)
-    status = webhook_message.status
+    text = webhook_message.status
 
     colour = case status
              when "pending"
@@ -13,10 +13,10 @@ module WebhookMessagesHelper
                "grey"
              end
 
-    content_tag(:span, status, class: "govuk-tag govuk-tag--#{colour}")
+    govuk_tag(text:, colour:)
   end
 
   def pre_tagged_pretty_json(json)
-    content_tag(:pre, JSON.pretty_generate(json))
+    tag.pre(JSON.pretty_generate(json))
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 RSpec.describe ApplicationHelper, type: :helper do
+  include GovukComponentsHelper
   describe "#show_tracking_pixels?" do
     let(:cookie_name) { "consented-to-cookies" }
 
@@ -37,6 +38,20 @@ RSpec.describe ApplicationHelper, type: :helper do
       specify "#{environment}: #{expected_result}" do
         expect(show_otp_code_in_ui(environment, admin)).to eq(expected_result)
       end
+    end
+  end
+
+  describe "#boolean_red_green_tag" do
+    it "is a red tag with 'No' when bool is false" do
+      expect(boolean_red_green_tag(false)).to have_css("strong.govuk-tag.govuk-tag--red", text: "No")
+    end
+
+    it "is a green tag with 'Yes' when bool is true" do
+      expect(boolean_red_green_tag(true)).to have_css("strong.govuk-tag.govuk-tag--green", text: "Yes")
+    end
+
+    it "allows custom text to be set" do
+      expect(boolean_red_green_tag(true, "Totally")).to have_css("strong.govuk-tag", text: "Totally")
     end
   end
 end

--- a/spec/views/admin/applications/show.html.erb_spec.rb
+++ b/spec/views/admin/applications/show.html.erb_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "admin/applications/show.html.erb", type: :view do
 
     render
 
-    expect(rendered).to match(/Targeted delivery funding eligibility.*YES/m)
+    expect(rendered).to match(/Targeted delivery funding eligibility.*Yes/m)
   end
 
   it "displays application created_at" do


### PR DESCRIPTION
### Context

We have a couple of spots where we're manually doing things which are already covered by govuk-components.

### Changes proposed in this pull request

- **Capitalise 'Yes' and 'No' and use govuk_tag helper**
- **Replace other manual tag building with component**
