### PR TITLE
Get Flipper working in review apps

### DIFF
--- a/db/migrate/20240422135109_change_flipper_gates_value_to_text.rb
+++ b/db/migrate/20240422135109_change_flipper_gates_value_to_text.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class ChangeFlipperGatesValueToText < ActiveRecord::Migration[7.1]
+  def up
+    # Ensure this incremental update migration is idempotent
+    return unless connection.column_exists? :flipper_gates, :value, :string
+
+    if index_exists? :flipper_gates, [:feature_key, :key, :value]
+      remove_index :flipper_gates, [:feature_key, :key, :value]
+    end
+    change_column :flipper_gates, :value, :text
+    add_index :flipper_gates, [:feature_key, :key, :value], unique: true, length: { value: 255 }
+  end
+
+  def down
+    change_column :flipper_gates, :value, :string
+  end
+end

--- a/db/migrate/20240422135109_change_flipper_gates_value_to_text.rb
+++ b/db/migrate/20240422135109_change_flipper_gates_value_to_text.rb
@@ -5,11 +5,11 @@ class ChangeFlipperGatesValueToText < ActiveRecord::Migration[7.1]
     # Ensure this incremental update migration is idempotent
     return unless connection.column_exists? :flipper_gates, :value, :string
 
-    if index_exists? :flipper_gates, [:feature_key, :key, :value]
-      remove_index :flipper_gates, [:feature_key, :key, :value]
+    if index_exists? :flipper_gates, %i[feature_key key value]
+      remove_index :flipper_gates, %i[feature_key key value]
     end
     change_column :flipper_gates, :value, :text
-    add_index :flipper_gates, [:feature_key, :key, :value], unique: true, length: { value: 255 }
+    add_index :flipper_gates, %i[feature_key key value], unique: true, length: { value: 255 }
   end
 
   def down

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_15_104534) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_22_135109) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -171,7 +171,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_15_104534) do
   create_table "flipper_gates", force: :cascade do |t|
     t.string "feature_key", null: false
     t.string "key", null: false
-    t.string "value"
+    t.text "value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -27,6 +27,7 @@ Rails.logger.info("Seeding database")
   "add_cohorts.rb",
   "add_statements.rb",
   "add_api_tokens.rb",
+  "add_feature_flags.rb",
 ].each do |seed_file|
   Rails.logger.info("seeding #{seed_file}")
   load_base_file(seed_file)

--- a/db/seeds/base/add_feature_flags.rb
+++ b/db/seeds/base/add_feature_flags.rb
@@ -1,0 +1,1 @@
+Feature.initialize_feature_flags


### PR DESCRIPTION
### Context

Flipper wasn't working in review apps because we weren't initializing the config when seeding the database.

In order to initialize properly we had to switch Flipper's `value` column from `varchar` to `text`, [see here](https://github.com/flippercloud/flipper/pull/790).

### Changes proposed in this pull request

- **Change flipper value column from varchar to text**
- **Initialize feature flags during seeding**
