### PR TITLE
Set param to ecf_id for new API routes

### DIFF
--- a/app/controllers/api/v3/statements_controller.rb
+++ b/app/controllers/api/v3/statements_controller.rb
@@ -11,7 +11,7 @@ module API
       end
 
       def show
-        render json: to_json(statements_query.statement(ecf_id: statement_params[:id]))
+        render json: to_json(statements_query.statement(ecf_id: statement_params[:ecf_id]))
       end
 
     private
@@ -25,7 +25,7 @@ module API
       end
 
       def statement_params
-        params.permit(:id, filter: %i[cohort updated_since])
+        params.permit(:ecf_id, filter: %i[cohort updated_since])
       end
 
       def cohort_start_years

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -177,7 +177,7 @@ Rails.application.routes.draw do
         put :void, path: "void"
       end
 
-      resources :statements, only: %i[index show]
+      resources :statements, only: %i[index show], param: :ecf_id
     end
   end
 


### PR DESCRIPTION
There's a source of potential confusion where we're dealing with ecf_id and referring to it as id. I think it's clearer if we override param so it's clear exactly what we're referring to.
