### PR TITLE
[CPDLP-3015] Improve application endpoint performance (`previously_funded?` N+1)

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -56,6 +56,10 @@ class Application < ApplicationRecord
   }
 
   def previously_funded?
+    # This is an optimization used by the API Applications::Query in order
+    # to speed up the bulk-retrieval of Applications.
+    return transient_previously_funded if respond_to?(:transient_previously_funded)
+
     @previously_funded ||= user.applications
       .where.not(id:)
       .where(course: course.rebranded_alternative_courses)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -13,6 +13,7 @@ class Course < ApplicationRecord
     npq-leading-primary-mathematics
     npq-additional-support-offer
     npq-early-headship-coaching-offer
+    npq-senco
   ].freeze
 
   class << self

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,6 +1,20 @@
 class Course < ApplicationRecord
   validates :name, presence: true
 
+  IDENTIFIERS = %w[
+    npq-senior-leadership
+    npq-headship
+    npq-executive-leadership
+    npq-early-years-leadership
+    npq-leading-teaching
+    npq-leading-behaviour-culture
+    npq-leading-teaching-development
+    npq-leading-literacy
+    npq-leading-primary-mathematics
+    npq-additional-support-offer
+    npq-early-headship-coaching-offer
+  ].freeze
+
   class << self
     def npqeyl
       find_by(identifier: NPQ_EARLY_YEARS_LEADERSHIP)
@@ -21,10 +35,6 @@ class Course < ApplicationRecord
 
   def npqh?
     identifier == NPQ_HEADSHIP
-  end
-
-  def npqsl?
-    identifier == NPQ_SENIOR_LEADERSHIP
   end
 
   def ehco?
@@ -63,7 +73,6 @@ class Course < ApplicationRecord
   end
 
   NPQ_HEADSHIP = "npq-headship".freeze
-  NPQ_SENIOR_LEADERSHIP = "npq-senior-leadership".freeze
   NPQ_EARLY_HEADSHIP_COACHING_OFFER = "npq-early-headship-coaching-offer".freeze
   NPQ_EARLY_YEARS_LEADERSHIP = "npq-early-years-leadership".freeze
   NPQ_LEADING_TEACHING_DEVELOPMENT = "npq-leading-teaching-development".freeze

--- a/public/api/docs/v1/swagger.yaml
+++ b/public/api/docs/v1/swagger.yaml
@@ -177,6 +177,7 @@ components:
               - npq-additional-support-offer
               - npq-early-headship-coaching-offer
               - npq-leading-primary-mathematics
+              - npq-senco
             email:
               description: The email address registered for this NPQ participant
               type: string

--- a/public/api/docs/v2/swagger.yaml
+++ b/public/api/docs/v2/swagger.yaml
@@ -177,6 +177,7 @@ components:
               - npq-additional-support-offer
               - npq-early-headship-coaching-offer
               - npq-leading-primary-mathematics
+              - npq-senco
             email:
               description: The email address registered for this NPQ participant
               type: string

--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -345,6 +345,7 @@ components:
               - npq-additional-support-offer
               - npq-early-headship-coaching-offer
               - npq-leading-primary-mathematics
+              - npq-senco
             status:
               description: The current state of the NPQ application
               type: string

--- a/spec/factories/applications.rb
+++ b/spec/factories/applications.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     application_for_school
 
     user
-    course { Course.all.sample }
+    course
     lead_provider { LeadProvider.all.sample }
     headteacher_status { "no" }
     ecf_id { SecureRandom.uuid }
@@ -55,6 +55,7 @@ FactoryBot.define do
     trait :previously_funded do
       after(:create) do |application|
         course = application.course.rebranded_alternative_courses.sample
+
         create(:application, :accepted, :eligible_for_funding, user: application.user, course:)
       end
     end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -64,6 +64,11 @@ FactoryBot.define do
       identifier { "npq-leading-primary-mathematics" }
     end
 
+    trait :senco do
+      sequence(:name) { |n| "NPQ for Senco #{n}" }
+      identifier { "npq-senco" }
+    end
+
     factory :"npq-executive-leadership", traits: [:el]
     factory :"npq-leading-behaviour-culture", traits: [:lbc]
     factory :"npq-headship", traits: [:hs]
@@ -75,5 +80,6 @@ FactoryBot.define do
     factory :"npq-additional-support-offer", traits: [:aso]
     factory :"npq-early-headship-coaching-offer", traits: [:ehco]
     factory :"npq-leading-primary-mathematics", traits: [:lpm]
+    factory :"npq-senco", traits: [:senco]
   end
 end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -1,0 +1,79 @@
+FactoryBot.define do
+  factory :course do
+    sequence(:name) { |n| "NPQ Course #{n}" }
+    identifier { Course::IDENTIFIERS.sample }
+    ecf_id { SecureRandom.uuid }
+
+    initialize_with do
+      Course.find_by(identifier:) || new(**attributes)
+    end
+
+    trait :ehco do
+      sequence(:name) { |n| "NPQ Early Headship Coaching Offer Course #{n}" }
+      identifier { "npq-early-headship-coaching-offer" }
+    end
+
+    trait :aso do
+      sequence(:name) { |n| "NPQ Additional Support Offer Course #{n}" }
+      identifier { "npq-additional-support-offer" }
+      display { false }
+    end
+
+    trait :eyl do
+      sequence(:name) { |n| "NPQ Early Years Leadership Course #{n}" }
+      identifier { "npq-early-years-leadership" }
+    end
+
+    trait :sl do
+      sequence(:name) { |n| "NPQ Senior Leadership Course #{n}" }
+      identifier { "npq-senior-leadership" }
+    end
+
+    trait :ll do
+      sequence(:name) { |n| "NPQ Leading Literacy Course #{n}" }
+      identifier { "npq-leading-literacy" }
+    end
+
+    trait :ltd do
+      sequence(:name) { |n| "NPQ Leading Teaching Development Course #{n}" }
+      identifier { "npq-leading-teaching-development" }
+    end
+
+    trait :lt do
+      sequence(:name) { |n| "NPQ Leading Teaching Course #{n}" }
+      identifier { "npq-leading-teaching" }
+    end
+
+    trait :hs do
+      sequence(:name) { |n| "NPQ Headship Course #{n}" }
+      identifier { "npq-headship" }
+    end
+
+    trait :el do
+      sequence(:name) { |n| "NPQ Executive Leadership Course #{n}" }
+      identifier { "npq-executive-leadership" }
+    end
+
+    trait :lbc do
+      sequence(:name) { |n| "NPQ Leading Behaviour Culture Course #{n}" }
+      identifier { "npq-leading-behaviour-culture" }
+    end
+
+    trait :lpm do
+      sequence(:name) { |n| "NPQ Leading Primary Mathematics Course #{n}" }
+      identifier { "npq-leading-primary-mathematics" }
+    end
+
+    factory :"npq-executive-leadership", traits: [:el]
+    factory :"npq-leading-behaviour-culture", traits: [:lbc]
+    factory :"npq-headship", traits: [:hs]
+    factory :"npq-leading-teaching", traits: [:lt]
+    factory :"npq-leading-teaching-development", traits: [:ltd]
+    factory :"npq-leading-literacy", traits: [:ll]
+    factory :"npq-senior-leadership", traits: [:sl]
+    factory :"npq-early-years-leadership", traits: [:eyl]
+    factory :"npq-additional-support-offer", traits: [:aso]
+    factory :"npq-early-headship-coaching-offer", traits: [:ehco]
+    factory :"npq-leading-primary-mathematics", traits: [:lpm]
+  end
+end

--- a/spec/factories/migration/ecf/finance/schedules.rb
+++ b/spec/factories/migration/ecf/finance/schedules.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :ecf_migration_schedule, class: "Migration::Ecf::Finance::Schedule" do
-    name { Course.all.sample.name }
+    sequence(:name) { |n| "NPQ Finance Schedule #{n}" }
     cohort { create(:ecf_migration_cohort) }
     sequence(:schedule_identifier) { |n| "schedule-identifier-#{n}" }
     type { "Finance::Schedule::NPQ" }

--- a/spec/factories/migration/ecf/npq_courses.rb
+++ b/spec/factories/migration/ecf/npq_courses.rb
@@ -3,6 +3,6 @@
 FactoryBot.define do
   factory :ecf_migration_npq_course, class: "Migration::Ecf::NpqCourse" do
     sequence(:name) { |n| "NPQ Course #{n}" }
-    identifier { Course.all.sample.identifier }
+    identifier { Course::IDENTIFIERS.sample }
   end
 end

--- a/spec/lib/questionnaires/check_answers_spec.rb
+++ b/spec/lib/questionnaires/check_answers_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Questionnaires::CheckAnswers do
   let(:user_record_trn) { "7654321" }
   let(:user) { create(:user, trn: user_record_trn) }
   let(:load_provider) { LeadProvider.all.sample }
-  let(:course) { Course.all.sample }
+  let(:course) { create(:course) }
   let(:school) { create(:school) }
   let(:verified_trn) { rand(1_000_000..9_999_999).to_s }
   let(:store_trn) { "1234567" }

--- a/spec/lib/questionnaires/choose_school_spec.rb
+++ b/spec/lib/questionnaires/choose_school_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Questionnaires::ChooseSchool, type: :model do
   describe "#next_step" do
     subject { described_class.new(institution_identifier: "School-#{school.urn}", wizard:) }
 
-    let(:course) { Course.all.sample }
+    let(:course) { create(:course) }
     let(:store) do
       {
         "course_identifier" => course.identifier.to_s,

--- a/spec/lib/questionnaires/possible_funding_spec.rb
+++ b/spec/lib/questionnaires/possible_funding_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Questionnaires::PossibleFunding do
   end
 
   describe "#course" do
-    let(:course) { Course.all.sample }
+    let(:course) { create(:course, :eyl) }
     let(:store) { { "course_identifier" => course.identifier } }
     let(:request) { nil }
     let(:wizard) do

--- a/spec/lib/services/ecf/npq_profile_creator_spec.rb
+++ b/spec/lib/services/ecf/npq_profile_creator_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Ecf::NpqProfileCreator do
       national_insurance_number: "AB123456C",
     )
   end
-  let(:course) { Course.create!(name: "Some course", ecf_id: "c8c9c80b-375b-48fc-92ea-670c2cb4da5c") }
+  let(:course) { create(:course, name: "Some course", ecf_id: "c8c9c80b-375b-48fc-92ea-670c2cb4da5c") }
   let(:lead_provider) { LeadProvider.create!(name: "Some lead provider", ecf_id: "0d2ac426-e67c-47ad-b53b-a214ec7f999a") }
   let(:itt_provider) { create :itt_provider }
   let(:school) { create(:school) }

--- a/spec/lib/services/ecf/npq_profile_updater_spec.rb
+++ b/spec/lib/services/ecf/npq_profile_updater_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Ecf::NpqProfileUpdater do
           },
         )
   end
-  let(:course) { Course.create!(name: "Some course", ecf_id: "d182edb5-2f5a-4ad3-a897-8cce0650ae93") }
+  let(:course) { create(:course, name: "Some course", ecf_id: "d182edb5-2f5a-4ad3-a897-8cce0650ae93") }
   let(:lead_provider) { LeadProvider.create!(name: "Some lead provider", ecf_id: "73ab3215-0403-4de1-a537-066dae9ded60") }
   let(:school) { create(:school) }
 

--- a/spec/lib/services/eligibility/targeted_delivery_funding_spec.rb
+++ b/spec/lib/services/eligibility/targeted_delivery_funding_spec.rb
@@ -1,13 +1,12 @@
 require "rails_helper"
 
 RSpec.describe Eligibility::TargetedDeliveryFunding do
-  CourseService::DefinitionLoader.call
-  unsupported_course_codes = %w[npq-early-headship-coaching-offer].freeze
-  supported_course_codes = Course.pluck(:identifier) - unsupported_course_codes
-
   subject { described_class.call(institution:, course:) }
 
   describe ".call" do
+    unsupported_course_codes = %w[npq-early-headship-coaching-offer].freeze
+    supported_course_codes = Course::IDENTIFIERS - unsupported_course_codes
+
     let(:course) { Course.find_by!(identifier: supported_course_codes.sample) }
 
     context "when eligible" do

--- a/spec/lib/services/funding_eligibility_spec.rb
+++ b/spec/lib/services/funding_eligibility_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe FundingEligibility do
                         lead_mentor:)
   end
 
-  let(:course) { Course.all.find { |c| !c.ehco? } }
+  let(:course) { create(:course, :aso) }
   let(:inside_catchment) { true }
   let(:trn) { "1234567" }
   let(:get_an_identity_id) { SecureRandom.uuid }
@@ -69,7 +69,7 @@ RSpec.describe FundingEligibility do
             let(:eyl_funding_eligible) { true }
 
             context "when user has selected the NPQEYL course" do
-              let(:course) { Course.all.find(&:eyl?) }
+              let(:course) { create(:course, :eyl) }
 
               it "returns true" do
                 expect(subject).to be_funded
@@ -77,7 +77,7 @@ RSpec.describe FundingEligibility do
             end
 
             context "when user has not selected the NPQEYL course" do
-              let(:course) { Course.all.find(&:npqsl?) }
+              let(:course) { create(:course, :sl) }
 
               it "returns true" do
                 expect(subject).to be_funded
@@ -96,41 +96,11 @@ RSpec.describe FundingEligibility do
             expect(subject.funding_eligiblity_status_code).to eq :ineligible_establishment_type
           end
 
-          # context "when undertaking ASO" do
-          #   let(:course) { Course.all.find(&:aso?) }
-
-          #   context "new headteacher" do
-          #     subject do
-          #       described_class.new(
-          #         institution:,
-          #         course:,
-          #         inside_catchment:,
-          #         new_headteacher: true,
-          #         get_an_identity_id:,
-          #         trn:,
-          #         approved_itt_provider:,
-          #         lead_mentor:,
-          #       )
-          #     end
-
-          #     it "returns false" do
-          #       expect(subject).not_to be_funded
-          #       expect(subject.funding_eligiblity_status_code).to eq :ineligible_establishment_type
-          #     end
-          #   end
-
-          #   context "not a new headteacher" do
-          #     it "returns false" do
-          #       expect(subject).not_to be_funded
-          #       expect(subject.funding_eligiblity_status_code).to eq :ineligible_establishment_type
-          #     end
-          #   end
-
           context "when school offering funding for the NPQEYL course" do
             let(:eyl_funding_eligible) { true }
 
             context "when user has selected the NPQEYL course" do
-              let(:course) { Course.all.find(&:eyl?) }
+              let(:course) { create(:course, :eyl) }
 
               it "returns true" do
                 expect(subject).to be_funded
@@ -138,7 +108,7 @@ RSpec.describe FundingEligibility do
             end
 
             context "when user has not selected the NPQEYL course" do
-              let(:course) { Course.all.find(&:npqsl?) }
+              let(:course) { create(:course, :aso) }
 
               it "returns false" do
                 expect(subject).not_to be_funded
@@ -155,7 +125,7 @@ RSpec.describe FundingEligibility do
       let(:lead_mentor) { true }
 
       context "and the course is NPQLTD" do
-        let(:course) { Course.all.find(&:npqltd?) }
+        let(:course) { create(:course, :ltd) }
 
         it "is eligible" do
           expect(subject).to be_funded
@@ -196,7 +166,7 @@ RSpec.describe FundingEligibility do
     context "when institution is a PrivateChildcareProvider" do
       context "when meets all the funding criteria" do
         let(:institution) { build(:private_childcare_provider, :on_early_years_register) }
-        let(:course) { Course.all.find(&:eyl?) }
+        let(:course) { create(:course, :eyl) }
         let(:inside_catchment) { true }
 
         it "is eligible" do
@@ -207,7 +177,7 @@ RSpec.describe FundingEligibility do
 
       context "when does not meets all the funding criteria" do
         let(:institution) { build(:private_childcare_provider, :on_early_years_register) }
-        let(:course) { Course.all.find(&:eyl?) }
+        let(:course) { create(:course, :eyl) }
         let(:inside_catchment) { true }
 
         context "when previously funded" do
@@ -232,7 +202,7 @@ RSpec.describe FundingEligibility do
         end
 
         context "when NPQ course is not Early Year Leadership" do
-          let(:course) { Course.all.find { |c| !c.eyl? } }
+          let(:course) { create(:course, :aso) }
 
           it "returns status code :early_years_invalid_npq" do
             expect(subject.funding_eligiblity_status_code).to eq :early_years_invalid_npq

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -27,11 +27,6 @@ RSpec.describe Course do
     it { expect(described_class.new(identifier: "other")).not_to be_npqh }
   end
 
-  describe "#npqsl?" do
-    it { expect(described_class.new(identifier: "npq-senior-leadership")).to be_npqsl }
-    it { expect(described_class.new(identifier: "other")).not_to be_npqsl }
-  end
-
   describe "#ehco?" do
     it { expect(described_class.new(identifier: "npq-early-headship-coaching-offer")).to be_ehco }
     it { expect(described_class.new(identifier: "other")).not_to be_ehco }

--- a/spec/models/lead_provider_spec.rb
+++ b/spec/models/lead_provider_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe LeadProvider do
   describe "#for" do
     subject { described_class.for(course:).map(&:name) }
 
-    let(:course) { Course.find_by!(identifier: course_identifier) }
+    let(:course) { create(:course, identifier: course_identifier) }
 
     before { LeadProviders::Updater.call }
 

--- a/spec/models/registration_wizard_spec.rb
+++ b/spec/models/registration_wizard_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe RegistrationWizard do
   let(:user) { create(:user) }
   let(:current_step) { "share_provider" }
 
+  before { create(:course, :aso) }
+
   describe "#current_step" do
     it "returns current step" do
       expect(subject.current_step).to be(:share_provider)
@@ -35,52 +37,6 @@ RSpec.describe RegistrationWizard do
         response: ecf_funding_lookup_response(previously_funded: false),
       )
     end
-
-    # context "when ASO is selected course and is eligible for funding" do
-    #   let(:store) do
-    #     {
-    #       "date_of_birth" => 30.years.ago,
-    #       "works_in_school" => "yes",
-    #       "institution_identifier" => "School-#{school.urn}",
-    #       "teacher_catchment" => "england",
-    #       "course_identifier" => "npq-additional-support-offer",
-    #       "lead_provider_id" => LeadProvider.all.sample.id,
-    #       "funding_choice" => "school",
-    #       "ehco_headteacher" => "yes",
-    #       "ehco_new_headteacher" => "yes",
-    #       "ehco_funding" => "yes",
-    #       "ehco_funding_choice" => "another",
-    #       "trn" => "123456",
-    #     }
-    #   end
-
-    #   it "does not show Course funding" do
-    #     expect(subject.answers.map(&:key)).not_to include("Course funding")
-    #   end
-
-    #   it "does not show ASO funding option" do
-    #     expect(subject.answers.map(&:key)).not_to include("How is the Additional Support Offer being paid for?")
-    #   end
-    # end
-
-    # context "when ASO and not eligible for funding" do
-    #   let(:store) do
-    #     {
-    #       "date_of_birth" => 30.years.ago,
-    #       "works_in_school" => "yes",
-    #       "institution_identifier" => "School-#{school.urn}",
-    #       "course_identifier" => "npq-additional-support-offer",
-    #       "lead_provider_id" => LeadProvider.all.sample.id,
-    #       "ehco_funding" => "yes",
-    #       "ehco_funding_choice" => "another",
-    #       "trn" => "123456",
-    #     }
-    #   end
-
-    #   it "shows ASO funding option" do
-    #     expect(subject.answers.find { |el| el.key == "How is the Additional Support Offer being paid for?" }.value).to eql("The Early headship coaching offer is being paid in another way")
-    #   end
-    # end
 
     context "when working in Local authority maintained nursery" do
       let(:store) do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -113,6 +113,12 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
+  config.before(:suite) do
+    Course::IDENTIFIERS.each do |identifier|
+      FactoryBot.create(identifier)
+    end
+  end
+
   config.before do
     Flipper.enable(Feature::REGISTRATION_OPEN)
   end

--- a/spec/requests/npq_separation/admin/courses_controller_spec.rb
+++ b/spec/requests/npq_separation/admin/courses_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe NpqSeparation::Admin::CoursesController, type: :request do
   end
 
   describe "/npq_separation/admin/courses/{id}" do
-    let(:course_id) { Course.all.sample.id }
+    let(:course_id) { create(:course).id }
 
     subject do
       get npq_separation_admin_course_path(course_id)

--- a/spec/serializers/api/application_serializer_spec.rb
+++ b/spec/serializers/api/application_serializer_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe API::ApplicationSerializer, type: :serializer do
   let(:user) { application.user }
-  let(:course) { Course.all.sample }
+  let(:course) { create(:course) }
   let(:cohort) { build(:cohort) }
   let(:private_childcare_provider) { build(:private_childcare_provider) }
   let(:school) { build(:school) }

--- a/spec/services/applications/query_spec.rb
+++ b/spec/services/applications/query_spec.rb
@@ -168,6 +168,92 @@ RSpec.describe Applications::Query do
         it { expect(applications).to eq([application2, application1, application3]) }
       end
     end
+
+    describe "transient_previously_funded" do
+      let(:course) { create(:course, :sl) }
+      let!(:application) { create(:application, lead_provider:, course:) }
+      let(:query_applications) { Applications::Query.new(lead_provider:).applications }
+      let(:returned_application) { query_applications.find(application.id) }
+
+      it { expect(returned_application).not_to be_transient_previously_funded }
+
+      context "when there is a previous, rejected application that was eligible for funding" do
+        before do
+          create(
+            :application,
+            :rejected,
+            lead_provider:,
+            user_id: application.user_id,
+            eligible_for_funding: true,
+            course: application.course,
+          )
+        end
+
+        it { expect(returned_application).not_to be_transient_previously_funded }
+      end
+
+      context "when there is a previous, accepted application that was not eligible for funding" do
+        before do
+          create(
+            :application,
+            :accepted,
+            lead_provider:,
+            user_id: application.user_id,
+            eligible_for_funding: false,
+            course: application.course,
+          )
+        end
+
+        it { expect(returned_application).not_to be_transient_previously_funded }
+      end
+
+      context "when there is a previous, accepted application that was eligible for funding in a different (not rebranded) course" do
+        before do
+          create(
+            :application,
+            :accepted,
+            lead_provider:,
+            user_id: application.user_id,
+            eligible_for_funding: true,
+            course: Course.find_by(identifier: Course::NPQ_LEADING_TEACHING_DEVELOPMENT),
+          )
+        end
+
+        it { expect(returned_application).not_to be_transient_previously_funded }
+      end
+
+      context "when there is a previous, accepted application that was eligible for funding" do
+        before do
+          create(
+            :application,
+            :accepted,
+            lead_provider:,
+            user_id: application.user_id,
+            eligible_for_funding: true,
+            course: application.course,
+          )
+        end
+
+        it { expect(returned_application).to be_transient_previously_funded }
+      end
+
+      context "when there is a previous, accepted application that was eligible for funding on a rebranded course" do
+        let(:course) { Course.find_by(identifier: Course::NPQ_ADDITIONAL_SUPPORT_OFFER) }
+
+        before do
+          create(
+            :application,
+            :accepted,
+            lead_provider:,
+            user_id: application.user_id,
+            eligible_for_funding: true,
+            course:,
+          )
+        end
+
+        it { expect(returned_application).to be_transient_previously_funded }
+      end
+    end
   end
 
   describe "#application" do

--- a/spec/services/courses/query_spec.rb
+++ b/spec/services/courses/query_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Courses::Query do
 
   describe "#course" do
     it "returns the course" do
-      course = Course.all.sample
+      course = create(:course)
       query = Courses::Query.new
       expect(query.course(id: course.id)).to eq(course)
     end

--- a/spec/services/migration/migrators/course_spec.rb
+++ b/spec/services/migration/migrators/course_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Migration::Migrators::Course do
 
     context "when a courses is not correctly created" do
       let!(:ecf_migration_npq_course) { create(:ecf_migration_npq_course) }
-      let(:course) { Course.all.sample }
+      let(:course) { create(:course) }
 
       before do
         course.update!(ecf_id: ecf_migration_npq_course.id)

--- a/spec/support/database_seeds.rb
+++ b/spec/support/database_seeds.rb
@@ -1,6 +1,5 @@
 RSpec.configure do |config|
   config.before(:suite) do
-    CourseService::DefinitionLoader.call(silent: true)
     LeadProviders::Updater.call
 
     file_name = "lib/approved_itt_providers/24-11-2022/approved_itt_providers.csv"

--- a/spec/swagger_schemas/models/application.rb
+++ b/spec/swagger_schemas/models/application.rb
@@ -34,6 +34,7 @@ APPLICATION = {
               npq-additional-support-offer
               npq-early-headship-coaching-offer
               npq-leading-primary-mathematics
+              npq-senco
             ],
           },
           email: {
@@ -353,6 +354,7 @@ APPLICATION = {
               npq-additional-support-offer
               npq-early-headship-coaching-offer
               npq-leading-primary-mathematics
+              npq-senco
             ],
           },
           status: {


### PR DESCRIPTION
### Context

Ticket: [CPDLP-3015](https://dfedigital.atlassian.net/browse/CPDLP-3015)

In the current ECF implementation of `ineligible_for_funding_reason` to surface the value `previously_funded?` we had to optimise in the API applications endpoint [here in ECF](https://github.com/DFE-Digital/early-careers-framework/blob/main/app/services/api/v3/npq_applications_query.rb#L34).

### Changes proposed in this pull request

Fix `previously_funded?` N+1 query then improving the application endpoint performance.

[CPDLP-3015]: https://dfedigital.atlassian.net/browse/CPDLP-3015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ