### PR TITLE
Switch remaining query objects to format with :ignore

### DIFF
--- a/app/controllers/api/v3/applications_controller.rb
+++ b/app/controllers/api/v3/applications_controller.rb
@@ -18,13 +18,9 @@ module API
     private
 
       def applications_query
-        Applications::Query.new(
-          lead_provider: current_lead_provider,
-          cohort_start_years:,
-          participant_ids:,
-          updated_since:,
-          sort: application_params[:sort],
-        )
+        conditions = { lead_provider: current_lead_provider, cohort_start_years:, participant_ids:, updated_since: }
+
+        Applications::Query.new(**conditions.compact, sort: application_params[:sort])
       end
 
       def cohort_start_years

--- a/app/services/courses/query.rb
+++ b/app/services/courses/query.rb
@@ -1,11 +1,17 @@
 module Courses
   class Query
+    attr_reader :scope
+
+    def initialize
+      @scope = Course.all
+    end
+
     def courses
-      Course.all.order(name: :asc)
+      scope.order(name: :asc)
     end
 
     def course(id:)
-      courses.find_by!(id:)
+      scope.find_by!(id:)
     end
   end
 end

--- a/app/services/schools/query.rb
+++ b/app/services/schools/query.rb
@@ -1,11 +1,19 @@
 module Schools
   class Query
+    include Queries::ConditionFormats
+
+    attr_reader :scope
+
+    def initialize
+      @scope = School.all
+    end
+
     def schools
-      School.all.order(name: :asc)
+      scope.order(name: :asc)
     end
 
     def school(id:)
-      schools.find_by!(id:)
+      scope.find_by!(id:)
     end
   end
 end

--- a/spec/services/applications/query_spec.rb
+++ b/spec/services/applications/query_spec.rb
@@ -22,21 +22,39 @@ RSpec.describe Applications::Query do
     end
 
     describe "filtering" do
-      it "filters by lead provider" do
-        application = create(:application, lead_provider:)
-        create(:application, lead_provider: create(:lead_provider))
+      describe "lead provider" do
+        it "filters by lead provider" do
+          application = create(:application, lead_provider:)
+          create(:application, lead_provider: create(:lead_provider))
 
-        query = Applications::Query.new(lead_provider:)
-        expect(query.applications).to contain_exactly(application)
+          query = Applications::Query.new(lead_provider:)
+          expect(query.applications).to contain_exactly(application)
+        end
+
+        it "doesn't filter by lead provider when none supplied" do
+          condition_string = %("applications"."lead_provider_id" =)
+
+          expect(Applications::Query.new(lead_provider:).scope.to_sql).to include(condition_string)
+          expect(Applications::Query.new.scope.to_sql).not_to include(condition_string)
+        end
       end
 
-      it "filters by updated since" do
-        create(:application, lead_provider:, updated_at: 2.days.ago)
-        application = create(:application, lead_provider:, updated_at: Time.zone.now)
+      describe "updated since" do
+        it "filters by updated since" do
+          create(:application, lead_provider:, updated_at: 2.days.ago)
+          application = create(:application, lead_provider:, updated_at: Time.zone.now)
 
-        query = Applications::Query.new(lead_provider:, updated_since: 1.day.ago)
+          query = Applications::Query.new(lead_provider:, updated_since: 1.day.ago)
 
-        expect(query.applications).to contain_exactly(application)
+          expect(query.applications).to contain_exactly(application)
+        end
+
+        it "doesn't filter by lead provider when none supplied" do
+          condition_string = %("applications"."updated_at" >=)
+
+          expect(Applications::Query.new(updated_since: 2.days.ago).scope.to_sql).to include(condition_string)
+          expect(Applications::Query.new.scope.to_sql).not_to include(condition_string)
+        end
       end
 
       context "when filtering by cohort" do
@@ -66,6 +84,13 @@ RSpec.describe Applications::Query do
 
           expect(query.applications).to be_empty
         end
+
+        it "doesn't filter by cohort when none supplied" do
+          condition_string = %("cohort"."start_year" =)
+
+          expect(Applications::Query.new(cohort_start_years: 2021).scope.to_sql).to include(condition_string)
+          expect(Applications::Query.new.scope.to_sql).not_to include(condition_string)
+        end
       end
 
       context "when filtering by participant_id" do
@@ -90,6 +115,13 @@ RSpec.describe Applications::Query do
           query = Applications::Query.new(participant_ids: SecureRandom.uuid)
 
           expect(query.applications).to be_empty
+        end
+
+        it "doesn't filter by participant_ids when none supplied" do
+          condition_string = %("user"."ecf_id" =)
+
+          expect(Applications::Query.new(participant_ids: SecureRandom.uuid).scope.to_sql).to include(condition_string)
+          expect(Applications::Query.new.scope.to_sql).not_to include(condition_string)
         end
       end
     end


### PR DESCRIPTION
This allows us to query for values that are null as well as skipping adding the condition entirely.

Updated query objects:

* applications
* schools
* courses
