### PR TITLE
Fix missing translations

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -52,7 +52,7 @@ Rails.application.configure do
   config.active_support.disallowed_deprecation_warnings = []
 
   # Raises error for missing translations.
-  # config.action_view.raise_on_missing_translations = true
+  config.i18n.raise_on_missing_translations = true
 
   config.active_job.queue_adapter = :test
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -179,6 +179,13 @@ en:
       pural_title: "Your NPQ registrations"
 
   admin:
+    application_submissions:
+      ecf_sync_request_log:
+        sync_type:
+          user_creation: "User Creation"
+          application_creation: "Application Creation"
+        success: "Success"
+        failed: "Failed"
     layout:
       title: "Admin"
       dashboard: "Dashboard"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,10 @@ en:
   invalid_updated_since_filter: "The filter '#/updated_since' must be a valid ISO 8601 date"
   invalid_page_parameters: "The '#/page[page]' and '#/page[per_page]' parameter values must be a valid positive number"
 
+  errors:
+    email:
+      invalid: Enter a valid email address
+
   time:
     formats:
       admin: "%R on %d/%m/%Y"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -506,3 +506,5 @@ en:
         trn: "Teacher reference number (TRN)"
         full_name: "Full name"
         national_insurance_number: "National Insurance number (optional)"
+
+        date_of_birth: What is your date of birth?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -186,6 +186,7 @@ en:
       webhook_messages: "Webhook Messages"
       admins: "Admin Users"
       feature_flags: "Feature Flags"
+      settings: "Settings"
 
     super_admins:
       update:


### PR DESCRIPTION
### Context

Some translations are missing and we're unaware. Hopefully running through the entire test suite with `config.i18n.raise_on_missing_translations` enabled should highlight a few.
