### PR TITLE
Add missing test coverage for admin dashboard

### DIFF
--- a/app/views/npq_separation/admin/applications/index.html.erb
+++ b/app/views/npq_separation/admin/applications/index.html.erb
@@ -14,7 +14,7 @@
         body.with_row do |row|
           row.with_cell(text: govuk_link_to(application.ecf_id, npq_separation_admin_application_path(application.id)))
           row.with_cell(text: govuk_link_to(application.user.full_name, npq_separation_admin_user_path(application.user)))
-          row.with_cell(text: govuk_link_to(application.school&.name, "#"))
+          row.with_cell(text: govuk_link_to(application.school&.name, npq_separation_admin_school_path(application.school)))
         end
       end
     end

--- a/app/views/npq_separation/admin/applications/show.html.erb
+++ b/app/views/npq_separation/admin/applications/show.html.erb
@@ -67,7 +67,7 @@
 
     sl.with_row do |row|
       row.with_key(text: "Employer name")
-      row.with_value(text: @application.employer_name&.humanize)
+      row.with_value(text: @application.employer_name)
     end
 
     sl.with_row do |row|

--- a/app/views/npq_separation/admin/courses/show.html.erb
+++ b/app/views/npq_separation/admin/courses/show.html.erb
@@ -25,11 +25,6 @@
     end
 
     sl.with_row do |row|
-      row.with_key(text: "Name")
-      row.with_value(text: @course.name)
-    end
-
-    sl.with_row do |row|
       row.with_key(text: "Description")
       row.with_value(text: @course.description)
     end

--- a/spec/features/npq_separation/admin/applications_spec.rb
+++ b/spec/features/npq_separation/admin/applications_spec.rb
@@ -3,18 +3,95 @@ require "rails_helper"
 RSpec.feature "Listing and viewing applications", type: :feature do
   include Helpers::AdminLogin
 
+  let(:applications_per_page) { Pagy::DEFAULT[:items] }
+  let(:applications_in_order) { Application.order(created_at: :asc) }
+
   before do
-    FactoryBot.create_list(:application, Pagy::DEFAULT[:items] + 1)
+    create_list(:application, applications_per_page + 1)
     sign_in_as(create(:admin))
   end
 
-  scenario "visiting the applications index" do
+  scenario "viewing the list of applications" do
     visit(npq_separation_admin_applications_path)
 
     expect(page).to have_css("h1", text: "All applications")
-    expect(page).to have_css("table.govuk-table")
-    expect(page).to have_css("nav.govuk-pagination")
+
+    applications_in_order.limit(applications_per_page).each do |application|
+      expect(page).to have_link(application.ecf_id, href: npq_separation_admin_application_path(application.id))
+      expect(page).to have_link(application.user.full_name, href: npq_separation_admin_user_path(application.user))
+      expect(page).to have_link(application.school.name, href: npq_separation_admin_school_path(application.school))
+    end
+
+    expect(page).to have_css(".govuk-pagination__item--current", text: 1)
   end
 
-  scenario "viewing a single application"
+  scenario "navigating to the second page of applications" do
+    visit(npq_separation_admin_applications_path)
+
+    click_on("Next")
+
+    expect(page).to have_css("table.govuk-table tbody tr", count: 1)
+    expect(page).to have_css(".govuk-pagination__item--current", text: "2")
+  end
+
+  scenario "viewing application details" do
+    visit(npq_separation_admin_applications_path)
+
+    application = Application.order(created_at: :asc).first
+    application.update!(
+      eligible_for_funding: true,
+      lead_provider_approval_status: :accepted,
+      funding_eligiblity_status_code: 123,
+      employment_type: :full_time,
+      employer_name: "Employer name",
+      employment_role: :headteacher,
+    )
+
+    click_link(application.ecf_id)
+
+    expect(page).to have_css("h1", text: "Application for #{application.user.full_name}")
+
+    summary_lists = all(".govuk-summary-list")
+
+    within(summary_lists[0]) do |summary_list|
+      expect(summary_list).to have_summary_item("Application ID", application.id)
+      expect(summary_list).to have_summary_item("Email", application.user.email)
+      expect(summary_list).to have_summary_item("Course name", application.course.name)
+      expect(summary_list).to have_summary_item("Lead provider name", application.lead_provider.name)
+      expect(summary_list).to have_summary_item("Lead provider approval status", application.lead_provider_approval_status.humanize)
+      expect(summary_list).to have_summary_item("Application submitted date", application.created_at.to_fs(:govuk_short))
+      expect(summary_list).to have_summary_item("Last updated at", application.updated_at.to_fs(:govuk_short))
+    end
+
+    expect(page).to have_css("h2", text: "Scholarship funding")
+
+    within(summary_lists[1]) do |summary_list|
+      expect(summary_list).to have_summary_item("Eligible for funding", "Yes")
+      expect(summary_list).to have_summary_item("Funding eligibility status code", application.funding_eligiblity_status_code.humanize)
+      expect(summary_list).to have_summary_item("Employment type", application.employment_type.humanize)
+      expect(summary_list).to have_summary_item("Employer name", application.employer_name)
+      expect(summary_list).to have_summary_item("Employment role", application.employment_role.humanize)
+      expect(summary_list).to have_summary_item("Notes", "No notes")
+    end
+  end
+
+  scenario "viewing participant details" do
+    visit(npq_separation_admin_applications_path)
+
+    user = applications_in_order.first.user
+
+    click_link(user.full_name)
+
+    expect(page).to have_css("h1", text: user.full_name)
+  end
+
+  scenario "viewing school details" do
+    visit(npq_separation_admin_applications_path)
+
+    school = applications_in_order.first.school
+
+    click_link(school.name)
+
+    expect(page).to have_css("h1", text: school.name)
+  end
 end

--- a/spec/features/npq_separation/admin/courses_spec.rb
+++ b/spec/features/npq_separation/admin/courses_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.feature "Listing and viewing courses", type: :feature do
+  include Helpers::AdminLogin
+
+  let(:courses_per_page) { Pagy::DEFAULT[:items] }
+
+  before do
+    sign_in_as(create(:admin))
+  end
+
+  scenario "viewing the list of courses" do
+    visit(npq_separation_admin_courses_path)
+
+    expect(page).to have_css("h1", text: "All courses")
+
+    Course.order(name: :asc).limit(courses_per_page).each do |course|
+      expect(page).to have_link(course.name, href: npq_separation_admin_course_path(course))
+    end
+
+    expect(page).to have_css(".govuk-pagination__item--current", text: 1)
+  end
+
+  scenario "navigating to the second page of courses" do
+    visit(npq_separation_admin_courses_path)
+
+    click_on("Next")
+
+    expect(page).to have_css("table.govuk-table tbody tr", count: 5)
+    expect(page).to have_css(".govuk-pagination__item--current", text: "2")
+  end
+
+  scenario "viewing course details" do
+    visit(npq_separation_admin_courses_path)
+
+    course = Course.order(name: :asc).first
+
+    click_link(course.name)
+
+    expect(page).to have_css("h1", text: course.name)
+
+    within(".govuk-summary-list") do |summary_list|
+      expect(summary_list).to have_summary_item("ID", course.id)
+      expect(summary_list).to have_summary_item("ECF ID", course.ecf_id)
+      expect(summary_list).to have_summary_item("Identifier", course.identifier)
+      expect(summary_list).to have_summary_item("Position", course.position)
+      expect(summary_list).to have_summary_item("Description", course.description)
+      expect(summary_list).to have_summary_item("Display", "No")
+    end
+  end
+end

--- a/spec/features/npq_separation/admin/finance/statements_spec.rb
+++ b/spec/features/npq_separation/admin/finance/statements_spec.rb
@@ -3,18 +3,49 @@ require "rails_helper"
 RSpec.feature "Listing and viewing statements", type: :feature do
   include Helpers::AdminLogin
 
+  let(:statements_per_page) { Pagy::DEFAULT[:items] }
+
   before do
-    FactoryBot.create_list(:statement, Pagy::DEFAULT[:items] + 1)
+    create_list(:statement, statements_per_page + 1)
     sign_in_as(create(:admin))
   end
 
-  scenario "visiting the statements index" do
+  scenario "viewing the list of statements" do
     visit(npq_separation_admin_finance_statements_path)
 
     expect(page).to have_css("h1", text: "Statements")
-    expect(page).to have_css("table.govuk-table")
-    expect(page).to have_css("nav.govuk-pagination")
+
+    Statement.order(payment_date: :asc).limit(statements_per_page).each do |statement|
+      expect(page).to have_link("View", href: npq_separation_admin_finance_statement_path(statement))
+    end
+
+    expect(page).to have_css(".govuk-pagination__item--current", text: 1)
   end
 
-  scenario "viewing a single statement"
+  scenario "navigating to the second page of statements" do
+    visit(npq_separation_admin_finance_statements_path)
+
+    click_on("Next")
+
+    expect(page).to have_css("table.govuk-table tbody tr", count: 1)
+    expect(page).to have_css(".govuk-pagination__item--current", text: "2")
+  end
+
+  scenario "viewing statement details" do
+    visit(npq_separation_admin_finance_statements_path)
+
+    statement = Statement.order(payment_date: :asc).first
+
+    click_link("View", href: npq_separation_admin_finance_statement_path(statement))
+
+    expect(page).to have_css("h1", text: "Statement #{statement.id}")
+
+    within(".govuk-summary-list") do |summary_list|
+      start_year = statement.cohort.start_year
+      expect(summary_list).to have_summary_item("ID", statement.id)
+      expect(summary_list).to have_summary_item("Lead provider", statement.lead_provider.name)
+      expect(summary_list).to have_summary_item("Cohort", "#{start_year}/#{start_year.next - 2000}")
+      expect(summary_list).to have_summary_item("Status", statement.state.humanize)
+    end
+  end
 end

--- a/spec/features/npq_separation/admin/lead_providers_spec.rb
+++ b/spec/features/npq_separation/admin/lead_providers_spec.rb
@@ -36,4 +36,14 @@ RSpec.feature "Listing and viewing lead providers", type: :feature do
       expect(summary_list).to have_link("View", href: npq_separation_admin_finance_statement_path(statement))
     end
   end
+
+  scenario "viewing all statements" do
+    visit(npq_separation_admin_lead_providers_path)
+
+    click_link(LeadProvider.first.name)
+
+    click_link("View all statements")
+
+    expect(page).to have_css("h1", text: "Statements")
+  end
 end

--- a/spec/features/npq_separation/admin/schools_spec.rb
+++ b/spec/features/npq_separation/admin/schools_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.feature "Listing and viewing schools", type: :feature do
+  include Helpers::AdminLogin
+
+  let(:schools_per_page) { Pagy::DEFAULT[:items] }
+
+  before do
+    create_list(:school, schools_per_page + 1)
+    sign_in_as(create(:admin))
+  end
+
+  scenario "viewing the list of schools" do
+    visit(npq_separation_admin_schools_path)
+
+    expect(page).to have_css("h1", text: "All schools")
+
+    School.order(name: :asc).limit(schools_per_page).each do |school|
+      expect(page).to have_link(school.name, href: npq_separation_admin_school_path(school))
+      expect(page).to have_css("td", text: school.urn)
+    end
+
+    expect(page).to have_css(".govuk-pagination__item--current", text: 1)
+  end
+
+  scenario "navigating to the second page of schools" do
+    visit(npq_separation_admin_schools_path)
+
+    click_on("Next")
+
+    expect(page).to have_css("table.govuk-table tbody tr", count: 1)
+    expect(page).to have_css(".govuk-pagination__item--current", text: "2")
+  end
+
+  scenario "viewing school details" do
+    visit(npq_separation_admin_schools_path)
+
+    school = School.order(name: :asc).first
+
+    click_link(school.name)
+
+    expect(page).to have_css("h1", text: school.name)
+
+    within(".govuk-summary-list") do |summary_list|
+      expect(summary_list).to have_summary_item("ID", school.id)
+      expect(summary_list).to have_summary_item("URN", school.urn)
+      expect(summary_list).to have_summary_item("UKPRN", school.ukprn)
+      expect(summary_list).to have_summary_item("Local authority", school.la_name)
+      expect(summary_list).to have_summary_item("Address", school.address_1)
+    end
+  end
+end

--- a/spec/features/npq_separation/admin/users_spec.rb
+++ b/spec/features/npq_separation/admin/users_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Listing and viewing users", type: :feature do
     expect(page).to have_css("h1", text: "All participants")
 
     User.limit(users_per_page).each do |user|
-      expect(page).to have_css("td a", text: user.full_name)
+      expect(page).to have_link(user.full_name, href: npq_separation_admin_user_path(user))
       expect(page).to have_css("td", text: user.trn)
       expect(page).to have_css("td", text: user.created_at.to_date.to_formatted_s(:govuk))
     end
@@ -43,12 +43,13 @@ RSpec.feature "Listing and viewing users", type: :feature do
     expect(page).to have_css("h1", text: user.full_name)
 
     within(".govuk-summary-list") do |summary_list|
-      expect(summary_list).to have_text(user.id)
-      expect(summary_list).to have_text(user.ecf_id)
-      expect(summary_list).to have_text(user.email)
-      expect(summary_list).to have_text(user.full_name)
-      expect(summary_list).to have_text(user.trn)
-      expect(summary_list).to have_text(user.get_an_identity_id)
+      expect(summary_list).to have_summary_item("ID", user.id)
+      expect(summary_list).to have_summary_item("ECF ID", user.ecf_id)
+      expect(summary_list).to have_summary_item("Email", user.email)
+      expect(summary_list).to have_summary_item("Name", user.full_name)
+      expect(summary_list).to have_summary_item("TRN", user.trn)
+      expect(summary_list).to have_summary_item("TRN validated", "No")
+      expect(summary_list).to have_summary_item("Get an Identity ID", user.get_an_identity_id)
     end
   end
 end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe Application do
   describe "#previously_funded?" do
     let(:user) { create(:user) }
     let(:application) { create(:application, :previously_funded, user:) }
-    let(:previous_application) { user.applications.where.not(id: application.id).first! }
+    let(:previous_applications) { user.applications.where.not(id: application.id) }
 
     subject { application }
 
@@ -164,19 +164,19 @@ RSpec.describe Application do
     end
 
     context "when the application has not been previously funded (previous application not accepted)" do
-      before { previous_application.update!(lead_provider_approval_status: "rejected") }
+      before { previous_applications.update!(lead_provider_approval_status: "rejected") }
 
       it { is_expected.not_to be_previously_funded }
     end
 
     context "when the application has not been previously funded (previous application is not for a rebranded alternative course)" do
-      before { previous_application.update!(course: Course.npqeyl) }
+      before { previous_applications.update!(course: Course.npqeyl) }
 
       it { is_expected.not_to be_previously_funded }
     end
 
     context "when the application has not been previously funded (previous application is not eligible for funding)" do
-      before { previous_application.update!(eligible_for_funding: false) }
+      before { previous_applications.update!(eligible_for_funding: false) }
 
       it { is_expected.not_to be_previously_funded }
     end

--- a/spec/support/matchers/summary_list_matcher.rb
+++ b/spec/support/matchers/summary_list_matcher.rb
@@ -1,0 +1,7 @@
+RSpec::Matchers.define :have_summary_item do |expected_title, expected_value|
+  match do |summary_list|
+    summary_list
+      .find(".govuk-summary-list__key", text: expected_title, exact_text: true)
+      .sibling(".govuk-summary-list__value", text: expected_value.to_s)
+  end
+end


### PR DESCRIPTION
[Jira-3043](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3043)

### Context

Our feature specs for the admin dashboard have mixed coverage (some have full tests, others partial, others none); we want to make them all consistently tested.

### Changes proposed in this pull request

- Add missing test coverage for admin dashboard

Make the feature specs consistent across the admin dashboard. 

### Guidance to review

We may want to rethink this a bit in the future and move some of the views into view components that are tested instead, but this at least makes it all consistent for now.
