### PR TITLE
Events

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -63,6 +63,7 @@ Rails/SaveBang:
     - "app/services/ecf/ecf_user_creator.rb"
     - "app/services/ecf/npq_profile_creator.rb"
     - "app/services/ecf/npq_profile_updater.rb"
+    - "app/services/events/*"
 
 Rails/Output:
   Exclude:

--- a/app/components/npq_separation/timeline_component.rb
+++ b/app/components/npq_separation/timeline_component.rb
@@ -1,0 +1,61 @@
+module NpqSeparation
+  class TimelineComponent < ViewComponent::Base
+    renders_many :items, "ItemComponent"
+
+    attr_reader :events
+
+    def initialize(events)
+      @events = events.sort_by(&:created_at)
+
+      @events.each { |event| with_item(event) }
+    end
+
+    def call
+      tag.div(class: "app-timeline") do
+        safe_join(items)
+      end
+    end
+
+    class ItemComponent < ViewComponent::Base
+      attr_reader :event
+
+      def initialize(event)
+        @event = event
+      end
+
+      def call
+        tag.div(class: "app-timeline__item") do
+          safe_join([header, timestamp, description])
+        end
+      end
+
+    private
+
+      def header
+        tag.div(class: "app-timeline__header") do
+          safe_join([title, byline], " ")
+        end
+      end
+
+      def title
+        tag.h2(event.title, class: "app-timeline__title")
+      end
+
+      def timestamp
+        tag.p(class: "app-timeline__date") do
+          tag.time(event.created_at.to_fs(:govuk_short), datetime: event.created_at.to_fs(:iso8601))
+        end
+      end
+
+      def description
+        tag.div(class: "app-timeline__description") { event.description }
+      end
+
+      def byline
+        return if event.byline.blank?
+
+        tag.p("by #{event.byline}", class: "app-timeline__byline")
+      end
+    end
+  end
+end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -7,6 +7,8 @@ class Admin < ApplicationRecord
             presence: { message: "Enter an email address" },
             length: { maximum: 64, message: "Email must be shorter than 64 characters" }
 
+  has_many :events, dependent: :nullify
+
   # Whether this user has admin access to the feature flagging interface
   def flipper_access?
     super_admin?

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -21,6 +21,7 @@ class Application < ApplicationRecord
   has_many :ecf_sync_request_logs, as: :syncable, dependent: :destroy
   has_many :participant_id_changes, through: :user
   has_many :application_states
+  has_many :events, dependent: :nullify
 
   scope :unsynced, -> { where(ecf_id: nil) }
   scope :expired_applications, -> { where(lead_provider_approval_status: "rejected").where("created_at < ?", cut_off_date_for_expired_applications) }

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -1,4 +1,6 @@
 class Cohort < ApplicationRecord
+  has_many :events, dependent: :nullify
+
   validates :start_year,
             presence: true,
             numericality: {

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,5 +1,6 @@
 class Course < ApplicationRecord
   belongs_to :course_group, optional: true
+  has_many :events, dependent: :nullify
 
   validates :name, presence: true
   validates :identifier,

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,10 +1,12 @@
 class Event < ApplicationRecord
+  EVENT_TYPES = %w[ApplicationAcceptance].freeze
+
   validates :title,
             presence: { message: "Enter a title" },
             length: { maximum: 256, message: "Title must be shorter than 256 characters" }
 
   validates :event_type,
-            presence: { message: "Choose an event type" }
+            inclusion: { in: EVENT_TYPES, message: "Event type must be in the list of valid event types" }
 
   belongs_to :admin, optional: true
   belongs_to :application, optional: true

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,19 @@
+class Event < ApplicationRecord
+  validates :title,
+            presence: { message: "Enter a title" },
+            length: { maximum: 256, message: "Title must be shorter than 256 characters" }
+
+  validates :event_type,
+            presence: { message: "Choose an event type" }
+
+  belongs_to :admin, optional: true
+  belongs_to :application, optional: true
+  belongs_to :cohort, optional: true
+  belongs_to :course, optional: true
+  belongs_to :lead_provider, optional: true
+  belongs_to :private_childcare_provider, optional: true
+  belongs_to :school, optional: true
+  belongs_to :statement, optional: true
+  belongs_to :statement_item, optional: true
+  belongs_to :user, optional: true
+end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -3,6 +3,8 @@ class School < ApplicationRecord
   PRIMARY_PHASE = "Primary".freeze
   MIDDLE_DEEMED_PRIMARY_PHASE = "Middle deemed primary".freeze
 
+  has_many :events, dependent: :nullify
+
   pg_search_scope :search_by_name,
                   against: [:name],
                   using: {

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -2,6 +2,7 @@ class Statement < ApplicationRecord
   belongs_to :cohort
   belongs_to :lead_provider
   has_many :statement_items
+  has_many :events, dependent: :nullify
 
   validates :output_fee,
             inclusion: {

--- a/app/models/statement_item.rb
+++ b/app/models/statement_item.rb
@@ -4,6 +4,7 @@ class StatementItem < ApplicationRecord
 
   belongs_to :statement
   # belongs_to :declaration
+  has_many :events, dependent: :nullify
 
   scope :billable, -> { where(state: BILLABLE_STATES) }
   scope :refundable, -> { where(state: REFUNDABLE_STATES) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   has_many :applications, dependent: :destroy
   has_many :ecf_sync_request_logs, as: :syncable, dependent: :destroy
   has_many :participant_id_changes, -> { order("created_at desc") }
+  has_many :events, dependent: :nullify
 
   validates :full_name, presence: { message: "Enter a full name" }
 

--- a/app/services/events/application_acceptance.rb
+++ b/app/services/events/application_acceptance.rb
@@ -44,7 +44,7 @@ module Events
   private
 
     def event_type
-      "Application accepted"
+      "ApplicationAcceptance"
     end
   end
 end

--- a/app/services/events/application_acceptance.rb
+++ b/app/services/events/application_acceptance.rb
@@ -1,0 +1,50 @@
+module Events
+  class ApplicationAcceptance
+    attr_accessor :description
+    attr_reader :application, :user, :school, :private_childcare_provider, :course, :cohort, :lead_provider
+
+    def initialize(application:, user:, course:, cohort:, lead_provider:, school: nil, private_childcare_provider: nil, title: nil, description: nil, byline: nil)
+      @application = application
+      @user = user
+      @school = school
+      @private_childcare_provider = private_childcare_provider
+      @cohort = cohort
+      @course = course
+      @lead_provider = lead_provider
+
+      @override_title = title
+      @override_description = description
+      @override_byline = byline
+    end
+
+    def self.create_event_from_application(application)
+      new(
+        application:,
+        user: application.user,
+        school: application.school,
+        private_childcare_provider: application.private_childcare_provider,
+        cohort: application.cohort,
+        course: application.course,
+        lead_provider: application.lead_provider,
+      ).create_event
+    end
+
+    def title
+      @override_title || "Application #{application.id} accepted"
+    end
+
+    def byline
+      @override_byline || lead_provider.name
+    end
+
+    def create_event
+      Event.create!(event_type:, application:, user:, school:, private_childcare_provider:, course:, cohort:, lead_provider:, title:, description:, byline:)
+    end
+
+  private
+
+    def event_type
+      "Application accepted"
+    end
+  end
+end

--- a/app/views/npq_separation/admin/applications/show.html.erb
+++ b/app/views/npq_separation/admin/applications/show.html.erb
@@ -83,3 +83,7 @@
     end
   end
 %>
+
+<h2 class="govuk-heading-m govuk-!-margin-top-9">Timeline</h2>
+
+<%= render NpqSeparation::TimelineComponent.new(@application.events) %>

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -21,6 +21,7 @@ $govuk-image-url-function: frontend-image-url;
 @import "big-number";
 @import "admin";
 @import "api_guidance";
+@import "timeline";
 
 h1.govuk-fieldset__heading {
   margin-bottom: 10px;

--- a/app/webpacker/styles/timeline.scss
+++ b/app/webpacker/styles/timeline.scss
@@ -1,0 +1,107 @@
+// timeline
+//
+// borrowed from the MoJ frontend library, moj- replaced with app- as
+// we will likely customise this to suit our needs
+//
+// https://design-patterns.service.justice.gov.uk/components/timeline/
+.app-timeline {
+  margin-bottom: govuk-spacing(4);
+  overflow: hidden;
+  position: relative;
+
+  &:before {
+    background-color: $govuk-brand-colour;
+    content: "";
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: govuk-spacing(2);
+    width: 5px;
+  }
+
+}
+
+.app-timeline--full {
+  margin-bottom: 0;
+  &:before {
+    height: calc(100% - 75px);
+  }
+}
+
+.app-timeline__item {
+  padding-bottom: govuk-spacing(6);
+  padding-left: govuk-spacing(4);
+  position: relative;
+
+  &:before {
+    background-color: $govuk-brand-colour;
+    content: "";
+    height: 5px;
+    left: 0;
+    position: absolute;
+    top: govuk-spacing(2);
+    width: 15px;
+  }
+
+}
+
+.app-timeline__title {
+  @include govuk-font($size: 19, $weight: bold);
+  display: inline;
+}
+
+.app-timeline__byline {
+  @include govuk-font($size: 19);
+  color: $govuk-secondary-text-colour;
+  display: inline;
+  margin: 0;
+}
+
+.app-timeline__date {
+  @include govuk-font($size: 16);
+  margin-top: govuk-spacing(1);
+  margin-bottom: 0;
+}
+
+.app-timeline__description {
+  @include govuk-font($size: 19);
+  margin-top: govuk-spacing(4);
+}
+
+.app-timeline__documents {
+  list-style: none;
+  margin-bottom: 0;
+  padding-left: 0;
+}
+
+.app-timeline__document-item {
+  margin-bottom: govuk-spacing(1);
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+
+}
+
+.app-timeline__document-icon {
+  float: left;
+  margin-top: 4px;
+  margin-right: 4px;
+  fill: currentColor;
+
+  @media screen and (forced-colors: active) {
+    fill: linkText;
+  }
+}
+
+.app-timeline__document-link {
+  // background-image: url(#{$app-images-path}icon-document.svg);
+  background-repeat: no-repeat;
+  background-size: 20px 16px;
+  background-position: 0 50%;
+  padding-left: govuk-spacing(5);
+
+  &:focus {
+    color: govuk-colour("black"); // Focus colour on yellow should really be black.
+  }
+}

--- a/db/migrate/20240430103919_create_events.rb
+++ b/db/migrate/20240430103919_create_events.rb
@@ -1,0 +1,37 @@
+class CreateEvents < ActiveRecord::Migration[7.1]
+  def change
+    create_table :events do |t|
+      t.timestamps
+
+      t.string :title, limit: 256, null: false
+      t.string :byline, limit: 128
+      t.text :event_type, null: false
+      t.text :description
+
+      # indexed with high cardinality
+      t.integer :admin_id, index: true
+      t.integer :application_id, index: true
+      t.integer :user_id, index: true
+      t.integer :school_id, index: true
+      t.integer :private_childcare_provider_id, index: true
+      t.integer :statement_id, index: true
+      t.integer :statement_item_id, index: true
+      t.integer :lead_provider_id, index: true
+
+      # unindexed with low cardinality
+      t.integer :cohort_id
+      t.integer :course_id
+    end
+
+    add_foreign_key :events, :admins, on_delete: :nullify
+    add_foreign_key :events, :applications, on_delete: :nullify
+    add_foreign_key :events, :users, on_delete: :nullify
+    add_foreign_key :events, :schools, on_delete: :nullify
+    add_foreign_key :events, :private_childcare_providers, on_delete: :nullify
+    add_foreign_key :events, :statements, on_delete: :nullify
+    add_foreign_key :events, :statement_items, on_delete: :nullify
+    add_foreign_key :events, :cohorts, on_delete: :nullify
+    add_foreign_key :events, :courses, on_delete: :nullify
+    add_foreign_key :events, :lead_providers, on_delete: :nullify
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -189,6 +189,33 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_31_090547) do
     t.index ["syncable_id", "syncable_type"], name: "index_ecf_sync_request_logs_on_syncable_id_and_syncable_type"
   end
 
+  create_table "events", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "title", limit: 256, null: false
+    t.string "byline", limit: 128
+    t.text "event_type", null: false
+    t.text "description"
+    t.integer "admin_id"
+    t.integer "application_id"
+    t.integer "user_id"
+    t.integer "school_id"
+    t.integer "private_childcare_provider_id"
+    t.integer "statement_id"
+    t.integer "statement_item_id"
+    t.integer "lead_provider_id"
+    t.integer "cohort_id"
+    t.integer "course_id"
+    t.index ["admin_id"], name: "index_events_on_admin_id"
+    t.index ["application_id"], name: "index_events_on_application_id"
+    t.index ["lead_provider_id"], name: "index_events_on_lead_provider_id"
+    t.index ["private_childcare_provider_id"], name: "index_events_on_private_childcare_provider_id"
+    t.index ["school_id"], name: "index_events_on_school_id"
+    t.index ["statement_id"], name: "index_events_on_statement_id"
+    t.index ["statement_item_id"], name: "index_events_on_statement_item_id"
+    t.index ["user_id"], name: "index_events_on_user_id"
+  end
+
   create_table "flipper_features", force: :cascade do |t|
     t.string "key", null: false
     t.datetime "created_at", null: false
@@ -448,6 +475,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_31_090547) do
   add_foreign_key "participant_id_changes", "users"
   add_foreign_key "participant_id_changes", "users", column: "from_participant_id"
   add_foreign_key "participant_id_changes", "users", column: "to_participant_id"
+  add_foreign_key "events", "admins", on_delete: :nullify
+  add_foreign_key "events", "applications", on_delete: :nullify
+  add_foreign_key "events", "cohorts", on_delete: :nullify
+  add_foreign_key "events", "courses", on_delete: :nullify
+  add_foreign_key "events", "lead_providers", on_delete: :nullify
+  add_foreign_key "events", "private_childcare_providers", on_delete: :nullify
+  add_foreign_key "events", "schools", on_delete: :nullify
+  add_foreign_key "events", "statement_items", on_delete: :nullify
+  add_foreign_key "events", "statements", on_delete: :nullify
+  add_foreign_key "events", "users", on_delete: :nullify
   add_foreign_key "schedules", "cohorts"
   add_foreign_key "schedules", "course_groups"
   add_foreign_key "statement_items", "statements"

--- a/spec/components/npq_separation/timeline_component_spec.rb
+++ b/spec/components/npq_separation/timeline_component_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe NpqSeparation::TimelineComponent, type: :component do
+  let(:one_day_ago) { FactoryBot.build(:event, :with_byline, created_at: 1.day.ago) }
+  let(:two_days_ago) { FactoryBot.build(:event, :with_byline, created_at: 2.days.ago) }
+  let(:three_days_ago) { FactoryBot.build(:event, :with_byline, created_at: 3.days.ago) }
+  let(:events) { [two_days_ago, one_day_ago, three_days_ago] }
+
+  subject { NpqSeparation::TimelineComponent.new(events) }
+
+  before { render_inline(subject) }
+
+  context "when the events aren't in choronological order" do
+    it "orders the events by created_at on initialization" do
+      expect(subject.events).to eql(events.sort_by(&:created_at))
+    end
+  end
+
+  it "displays all of the events in a timeline" do
+    expect(rendered_content).to have_css(".app-timeline__item", count: events.size)
+  end
+
+  it "shows a timestamp for each event" do
+    events.each do |event|
+      expect(rendered_content).to have_css("time", text: event.created_at.to_fs(:govuk_short))
+      expect(rendered_content).to have_css("time[datetime='#{event.created_at.to_fs(:iso8601)}']")
+    end
+  end
+
+  it "shows the title and byline in the header" do
+    events.each do |event|
+      expect(rendered_content).to have_css(".app-timeline__header > .app-timeline__title", text: event.title)
+      expect(rendered_content).to have_css(".app-timeline__header > .app-timeline__byline", text: event.byline)
+    end
+  end
+end

--- a/spec/factories/applications.rb
+++ b/spec/factories/applications.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
     trait :application_for_school do
       school { build(:school) }
       private_childcare_provider_id { nil }
-      DEPRECATED_private_childcare_provider_urn { nil }
+      private_childcare_provider { nil }
 
       works_in_school { true }
       works_in_childcare { false }
@@ -29,7 +29,8 @@ FactoryBot.define do
     end
 
     trait :application_for_private_childcare_provider do
-      school_urn { nil }
+      school { nil }
+      school_id { nil }
       private_childcare_provider { build(:private_childcare_provider) }
 
       works_in_school { false }

--- a/spec/factories/event.rb
+++ b/spec/factories/event.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :event do
+    sequence(:title) { |n| "Event #{n}" }
+    sequence(:description) { |n| "Event #{n} description goes here" }
+    created_at { Time.zone.now }
+
+    trait(:with_random_description) { description { Faker::Lorem.paragraph } }
+    trait(:with_byline) { byline { Faker::Name.name } }
+  end
+end

--- a/spec/models/admin_spec.rb
+++ b/spec/models/admin_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe Admin, type: :model do
     end
   end
 
+  describe "relationships" do
+    it { is_expected.to have_many(:events).dependent(:nullify) }
+  end
+
   describe "defaults" do
     specify "super_admin defaults to false" do
       expect(Admin.new.super_admin?).to be false

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Application do
     it { is_expected.to belong_to(:itt_provider).optional }
     it { is_expected.to belong_to(:cohort).optional }
     it { is_expected.to belong_to(:schedule).optional }
+    it { is_expected.to have_many(:events).dependent(:nullify) }
     it { is_expected.to have_many(:ecf_sync_request_logs).dependent(:destroy) }
     it { is_expected.to have_many(:participant_id_changes).through(:user) }
     it { is_expected.to have_many(:application_states) }

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -3,6 +3,10 @@ require "rails_helper"
 RSpec.describe Cohort, type: :model do
   subject(:statement) { build(:cohort) }
 
+  describe "relationships" do
+    it { is_expected.to have_many(:events).dependent(:nullify) }
+  end
+
   describe "validations" do
     it { is_expected.to validate_presence_of(:registration_start_date) }
     it { is_expected.to allow_value(%w[true false]).for(:funding_cap).with_message("Choose true or false for funding cap") }

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.describe Course do
+  describe "relationships" do
+    it { is_expected.to have_many(:events).dependent(:nullify) }
+  end
+
   describe "validations" do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_uniqueness_of(:identifier).with_message("Identifier already exists, enter a unique one") }

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Event do
     end
 
     describe "event_type" do
-      it { is_expected.to validate_presence_of(:event_type).with_message("Choose an event type") }
+      it { is_expected.to validate_inclusion_of(:event_type).in_array(Event::EVENT_TYPES).with_message("Event type must be in the list of valid event types") }
     end
   end
 

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe Event do
+  describe "validation" do
+    describe "title" do
+      it { is_expected.to validate_presence_of(:title).with_message("Enter a title") }
+      it { is_expected.to validate_length_of(:title).is_at_most(256).with_message("Title must be shorter than 256 characters") }
+    end
+
+    describe "event_type" do
+      it { is_expected.to validate_presence_of(:event_type).with_message("Choose an event type") }
+    end
+  end
+
+  describe "relationships" do
+    it { is_expected.to belong_to(:admin).optional }
+    it { is_expected.to belong_to(:application).optional }
+    it { is_expected.to belong_to(:cohort).optional }
+    it { is_expected.to belong_to(:course).optional }
+    it { is_expected.to belong_to(:lead_provider).optional }
+    it { is_expected.to belong_to(:private_childcare_provider).optional }
+    it { is_expected.to belong_to(:school).optional }
+    it { is_expected.to belong_to(:statement).optional }
+    it { is_expected.to belong_to(:statement_item).optional }
+    it { is_expected.to belong_to(:user).optional }
+  end
+end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.describe School do
+  describe "relationships" do
+    it { is_expected.to have_many(:events).dependent(:nullify) }
+  end
+
   describe ".primary_education_phase?" do
     let(:school) do
       build(:school,

--- a/spec/models/statement_item_spec.rb
+++ b/spec/models/statement_item_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe StatementItem, type: :model do
   describe "relationships" do
     it { is_expected.to belong_to(:statement).required }
     # it { is_expected.to belong_to(:declaration).required }
+    it { is_expected.to have_many(:events).dependent(:nullify) }
   end
 
   describe "validations" do

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Statement, type: :model do
     it { is_expected.to belong_to(:cohort).required }
     it { is_expected.to belong_to(:lead_provider).required }
     it { is_expected.to have_many(:statement_items) }
+    it { is_expected.to have_many(:events).dependent(:nullify) }
   end
 
   describe "validations" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe User do
     it { is_expected.to have_many(:applications).dependent(:destroy) }
     it { is_expected.to have_many(:ecf_sync_request_logs).dependent(:destroy) }
     it { is_expected.to have_many(:participant_id_changes).order("created_at desc") }
+    it { is_expected.to have_many(:events).dependent(:nullify) }
   end
 
   describe "validations" do

--- a/spec/services/events/application_acceptance_spec.rb
+++ b/spec/services/events/application_acceptance_spec.rb
@@ -39,10 +39,10 @@ RSpec.describe Events::ApplicationAcceptance do
       expect(event.lead_provider).to eql(lead_provider)
     end
 
-    it "sets application type to 'Application accepted'" do
+    it "sets application type to 'ApplicationAcceptance'" do
       event = application_acceptance.create_event
 
-      expect(event.event_type).to eql("Application accepted")
+      expect(event.event_type).to eql("ApplicationAcceptance")
     end
   end
 

--- a/spec/services/events/application_acceptance_spec.rb
+++ b/spec/services/events/application_acceptance_spec.rb
@@ -1,0 +1,90 @@
+require "rails_helper"
+
+RSpec.describe Events::ApplicationAcceptance do
+  let(:application) { FactoryBot.create(:application) }
+
+  let(:user) { application.user }
+  let(:school) { application.school }
+  let(:private_childcare_provider) { application.private_childcare_provider }
+  let(:cohort) { application.cohort }
+  let(:course) { application.course }
+  let(:lead_provider) { application.lead_provider }
+
+  describe "#initialize" do
+    let(:application_acceptance) { Events::ApplicationAcceptance.new(application:, user:, school:, private_childcare_provider:, cohort:, course:, lead_provider:) }
+
+    it("correctly assigns the user") { expect(application_acceptance.user).to eq(application.user) }
+    it("correctly assigns the school") { expect(application_acceptance.school).to eq(application.school) }
+    it("correctly assigns the cohort") { expect(application_acceptance.cohort).to eq(application.cohort) }
+    it("correctly assigns the course") { expect(application_acceptance.course).to eq(application.course) }
+    it("correctly assigns the lead_provider") { expect(application_acceptance.lead_provider).to eq(application.lead_provider) }
+
+    it("doesn't assign the private childcare provider") { expect(application_acceptance.private_childcare_provider).to be_nil }
+  end
+
+  describe "#create_event" do
+    let(:application_acceptance) { Events::ApplicationAcceptance.new(application:, user:, school:, private_childcare_provider:, cohort:, course:, lead_provider:) }
+
+    it "creates one event record" do
+      expect { application_acceptance.create_event }.to change(Event, :count).by(1)
+    end
+
+    it "creates the event record with the right values" do
+      event = application_acceptance.create_event
+
+      expect(event.user).to eql(user)
+      expect(event.school).to eql(school)
+      expect(event.cohort).to eql(cohort)
+      expect(event.course).to eql(course)
+      expect(event.lead_provider).to eql(lead_provider)
+    end
+
+    it "sets application type to 'Application accepted'" do
+      event = application_acceptance.create_event
+
+      expect(event.event_type).to eql("Application accepted")
+    end
+  end
+
+  describe "#title" do
+    let(:title) { nil }
+    let(:application_acceptance) { Events::ApplicationAcceptance.new(title:, application:, user:, school:, private_childcare_provider:, cohort:, course:, lead_provider:) }
+
+    it "defaults to 'Application [id] accepted" do
+      expect(application_acceptance.title).to eql("Application #{application.id} accepted")
+    end
+
+    context "when title is overridden" do
+      let(:title) { "New title" }
+
+      it "uses the supplied title text" do
+        expect(application_acceptance.title).to eql("New title")
+      end
+    end
+  end
+
+  describe "#byline" do
+    let(:byline) { nil }
+    let(:application_acceptance) { Events::ApplicationAcceptance.new(byline:, application:, user:, school:, private_childcare_provider:, cohort:, course:, lead_provider:) }
+
+    it "defaults to 'Application [id] accepted" do
+      expect(application_acceptance.title).to eql("Application #{application.id} accepted")
+    end
+
+    context "when byline is overridden" do
+      it "uses the lead provider's name" do
+        expect(application_acceptance.byline).to eql(lead_provider.name)
+      end
+    end
+  end
+
+  describe ".create_event_from_appliction" do
+    before { allow(Events::ApplicationAcceptance).to receive(:new).and_call_original }
+
+    it "calls .new with arguments from the event" do
+      Events::ApplicationAcceptance.create_event_from_application(application)
+
+      expect(Events::ApplicationAcceptance).to have_received(:new).with(application:, user:, school:, private_childcare_provider:, cohort:, course:, lead_provider:).once
+    end
+  end
+end


### PR DESCRIPTION
### Context

User research has shown repeatedly that admins in both ECF and NPQ have struggled to piece together what happened chonologically. This meant time had to be spent by devs piecing things together using [the audit log](https://github.com/paper-trail-gem/paper_trail). A disadvantage of using record-level audit data for events is that events are often related to multiple records.

For example, when a participant registers for an NPQ, we might want to see that event when looking at the participant, the school, the course, etc.

This PR proposes a new, better way of recording that information.

The record at the centre is an `Event`. Events are linked by foreign keys to all the 'domain' models in the app but the foreign keys default to `NULL`. As we will be organising all of our business logic in the service layer, we will have objects that perform the creation/update/deletion. The intended use is that we wrap the operation in a transaction and write an event at the same time.

The foreign keys are all set to `on_delete: :nullify` so objects in the application can be deleted at will. The events will no longer be linked to any object so at that point we'd be reliant on the `title`/`description` for context. Really deletion should also happen through a service object so we can record a deletion event (that won't be accessible through the originating object but will be through the other related ones).

```ruby
# pseudocode in app/services/widgets/create_widget.rb
class Widgets::CreateWidget
  def create_widget
    Widget.transaction do
      widget = Widget.create(widget_params)

      Events::WidgetCreation.new(widget:, author: current_user, title: "Widget #{widget.name} was created by #{current_user}")

      # or

      Events::WidgetCreation.create_from_widget(widget, title: "Widget #{widget.name} was created by #{current_user}")
    end
  end
end
```

In addition to the foreign key colums the event has:

* `title` - (required) a short string of text describing what happened. It should make sense regardless of where it's displayed in the admin UI
* `description` - (optional) more text if required, this might be useful in some circumstances but I'm not sure exactly how yet

I decided not to add any metadata columns to events yet, but dropping in a `hstore` or `jsonb` is an option.

### Changes proposed in this pull request

- Add events model with validation and relationships
- Add sample event creation service

### Overview/preview of how the UI might look

![image](https://github.com/DFE-Digital/npq-registration/assets/128088/bbe9f20c-9648-4d8e-8b04-0348fae274c0)

### Remaining tasks

* [x] work out how to mark the importance of an event type - this will vary by context (an application raised by a participant is important and should be given prominence but when looking at it from the course's point of view it's less important)
  I think the solution here is to not try and predict how we want to display events, just make sure they're easy to identify and categorise. I've switched over the `event_type` column validation from presence/length to inclusion and defined a list of event types in the `Event` model. I think it's sufficient for now.
* [x] add a timeline component based on [MoJ's timeline](https://design-patterns.service.justice.gov.uk/components/timeline/) or [HMRC's  timeline](https://design.tax.service.gov.uk/hmrc-design-patterns/timeline/) that takes and displays an array of events. Here's a preview of how it looks, note that the data is all smoke and mirrors at the moment:
  
  ![Screenshot from 2024-05-14 14-40-03](https://github.com/DFE-Digital/npq-registration/assets/128088/4448ca22-6a0b-4324-90d0-1269221bd2ce)
