### PR TITLE
[CPDLP-3047] TS4 Add reject applications endpoint

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -23,5 +23,13 @@ module API
       Sentry.capture_exception(exception)
       render json: { errors: API::Errors::Response.new(error: I18n.t(:bad_request), params: exception.message).call }, status: :bad_request
     end
+
+    def render_from_service(service)
+      if service.valid?
+        render json: to_json(service.call)
+      else
+        render json: API::Errors::Response.from(service), status: :unprocessable_entity
+      end
+    end
   end
 end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -23,13 +23,5 @@ module API
       Sentry.capture_exception(exception)
       render json: { errors: API::Errors::Response.new(error: I18n.t(:bad_request), params: exception.message).call }, status: :bad_request
     end
-
-    def render_from_service(service)
-      if service.valid?
-        render json: to_json(service.call)
-      else
-        render json: API::Errors::Response.from(service), status: :unprocessable_entity
-      end
-    end
   end
 end

--- a/app/controllers/api/v1/applications_controller.rb
+++ b/app/controllers/api/v1/applications_controller.rb
@@ -25,7 +25,11 @@ module API
       def reject
         service = Applications::Reject.new(application:)
 
-        render_from_service(service)
+        if service.reject
+          render json: to_json(service.application)
+        else
+          render json: API::Errors::Response.from(service), status: :unprocessable_entity
+        end
       end
 
     private

--- a/app/controllers/api/v1/applications_controller.rb
+++ b/app/controllers/api/v1/applications_controller.rb
@@ -17,11 +17,16 @@ module API
       end
 
       def show
-        render json: to_json(applications_query.application(ecf_id: application_params[:ecf_id]))
+        render json: to_json(application)
       end
 
       def accept = head(:method_not_allowed)
-      def reject = head(:method_not_allowed)
+
+      def reject
+        service = Applications::Reject.new(application:)
+
+        render_from_service(service)
+      end
 
     private
 
@@ -29,6 +34,10 @@ module API
         conditions = { lead_provider: current_lead_provider, cohort_start_years:, updated_since: }
 
         Applications::Query.new(**conditions.compact)
+      end
+
+      def application
+        applications_query.application(ecf_id: application_params[:ecf_id])
       end
 
       def cohort_start_years

--- a/app/controllers/api/v2/applications_controller.rb
+++ b/app/controllers/api/v2/applications_controller.rb
@@ -25,7 +25,11 @@ module API
       def reject
         service = Applications::Reject.new(application:)
 
-        render_from_service(service)
+        if service.reject
+          render json: to_json(service.application)
+        else
+          render json: API::Errors::Response.from(service), status: :unprocessable_entity
+        end
       end
 
     private

--- a/app/controllers/api/v2/applications_controller.rb
+++ b/app/controllers/api/v2/applications_controller.rb
@@ -17,11 +17,16 @@ module API
       end
 
       def show
-        render json: to_json(applications_query.application(ecf_id: application_params[:ecf_id]))
+        render json: to_json(application)
       end
 
       def accept = head(:method_not_allowed)
-      def reject = head(:method_not_allowed)
+
+      def reject
+        service = Applications::Reject.new(application:)
+
+        render_from_service(service)
+      end
 
     private
 
@@ -29,6 +34,10 @@ module API
         conditions = { lead_provider: current_lead_provider, cohort_start_years:, updated_since: }
 
         Applications::Query.new(**conditions.compact)
+      end
+
+      def application
+        applications_query.application(ecf_id: application_params[:ecf_id])
       end
 
       def cohort_start_years

--- a/app/controllers/api/v3/applications_controller.rb
+++ b/app/controllers/api/v3/applications_controller.rb
@@ -9,11 +9,16 @@ module API
       end
 
       def show
-        render json: to_json(applications_query.application(ecf_id: application_params[:ecf_id]))
+        render json: to_json(application)
       end
 
       def accept = head(:method_not_allowed)
-      def reject = head(:method_not_allowed)
+
+      def reject
+        service = Applications::Reject.new(application:)
+
+        render_from_service(service)
+      end
 
     private
 
@@ -21,6 +26,10 @@ module API
         conditions = { lead_provider: current_lead_provider, cohort_start_years:, participant_ids:, updated_since: }
 
         Applications::Query.new(**conditions.compact, sort: application_params[:sort])
+      end
+
+      def application
+        applications_query.application(ecf_id: application_params[:ecf_id])
       end
 
       def cohort_start_years

--- a/app/controllers/api/v3/applications_controller.rb
+++ b/app/controllers/api/v3/applications_controller.rb
@@ -17,7 +17,11 @@ module API
       def reject
         service = Applications::Reject.new(application:)
 
-        render_from_service(service)
+        if service.reject
+          render json: to_json(service.application)
+        else
+          render json: API::Errors::Response.from(service), status: :unprocessable_entity
+        end
       end
 
     private

--- a/app/services/api/errors/response.rb
+++ b/app/services/api/errors/response.rb
@@ -21,6 +21,15 @@ module API
           detail: params,
         }]
       end
+
+      def self.from(service)
+        {
+          errors: service
+            .errors
+            .messages
+            .map { |title, detail| { title:, detail: detail.uniq.join(", ") } },
+        }
+      end
     end
   end
 end

--- a/app/services/applications/reject.rb
+++ b/app/services/applications/reject.rb
@@ -1,0 +1,35 @@
+module Applications
+  class Reject
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :application
+
+    validates :application, presence: { message: I18n.t("application.missing_application") }
+    validate :not_already_rejected
+    validate :cannot_change_from_accepted
+
+    def call
+      return self unless valid?
+
+      application.update!(lead_provider_approval_status: "rejected")
+      application
+    end
+
+  private
+
+    def not_already_rejected
+      return unless application
+      return unless application.rejected?
+
+      errors.add(:application, I18n.t("application.has_already_been_rejected"))
+    end
+
+    def cannot_change_from_accepted
+      return unless application
+      return unless application.accepted?
+
+      errors.add(:application, I18n.t("application.cannot_change_from_accepted"))
+    end
+  end
+end

--- a/app/services/applications/reject.rb
+++ b/app/services/applications/reject.rb
@@ -9,11 +9,12 @@ module Applications
     validate :not_already_rejected
     validate :cannot_change_from_accepted
 
-    def call
-      return self unless valid?
+    def reject
+      return false unless valid?
 
       application.update!(lead_provider_approval_status: "rejected")
-      application
+
+      true
     end
 
   private

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,6 +11,11 @@ en:
     email:
       invalid: Enter a valid email address
 
+  application:
+    missing_application: "The entered '#/application' is missing from your request. Check details and try again."
+    has_already_been_rejected: This NPQ application has already been rejected
+    cannot_change_from_accepted: Once accepted an application cannot change state
+
   time:
     formats:
       admin: "%R on %d/%m/%Y"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -123,8 +123,10 @@ Rails.application.routes.draw do
       constraints -> { Rails.application.config.npq_separation[:api_enabled] } do
         defaults format: :json do
           resources :applications, path: "npq-applications", only: %i[index show], param: :ecf_id do
-            post :reject, path: "reject"
-            post :accept, path: "accept"
+            member do
+              post :reject, path: "reject"
+              post :accept, path: "accept"
+            end
           end
 
           resources :participants, only: %i[index show], path: "participants/npq" do
@@ -146,8 +148,10 @@ Rails.application.routes.draw do
 
     namespace :v2, defaults: { format: :json }, constraints: ->(_request) { Rails.application.config.npq_separation[:api_enabled] } do
       resources :applications, path: "npq-applications", only: %i[index show], param: :ecf_id do
-        post :reject, path: "reject"
-        post :accept, path: "accept"
+        member do
+          post :reject, path: "reject"
+          post :accept, path: "accept"
+        end
       end
 
       resources :enrolments, path: "npq-enrolments", only: %i[index]
@@ -172,8 +176,10 @@ Rails.application.routes.draw do
 
     namespace :v3, defaults: { format: :json }, constraints: ->(_request) { Rails.application.config.npq_separation[:api_enabled] } do
       resources :applications, path: "npq-applications", only: %i[index show], param: :ecf_id do
-        post :reject, path: "reject"
-        post :accept, path: "accept"
+        member do
+          post :reject, path: "reject"
+          post :accept, path: "accept"
+        end
       end
 
       resources :participants, only: %i[index show], path: "participants/npq" do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,6 +16,7 @@ end
 Rails.logger.info("Seeding database")
 
 [
+  "add_cohorts.rb",
   "add_childcare_providers.rb",
   "add_schools.rb",
   "add_courses.rb",
@@ -24,7 +25,6 @@ Rails.logger.info("Seeding database")
   "add_users.rb",
   "add_applications.rb",
   "add_settings.rb",
-  "add_cohorts.rb",
   "add_statements.rb",
   "add_api_tokens.rb",
   "add_feature_flags.rb",

--- a/spec/requests/api/v1/applications_spec.rb
+++ b/spec/requests/api/v1/applications_spec.rb
@@ -52,29 +52,12 @@ RSpec.describe "Application endpoints", type: :request do
   end
 
   describe "POST /api/v1/npq-applications/:ecf_id/reject" do
-    let(:application) { create(:application, lead_provider: current_lead_provider) }
+    let(:service_class) { Applications::Reject }
 
-    context "when application is pending" do
-      it "returns successfully" do
-        api_post "/api/v1/npq-applications/#{application.ecf_id}/reject"
-
-        expect(response).to be_successful
-        expect(parsed_response.dig("data", "attributes", "status")).to eql("rejected")
-      end
+    def path(id = nil)
+      reject_api_v1_application_path(id)
     end
 
-    context "when application is accepted" do
-      let(:application) { create(:application, lead_provider: current_lead_provider, lead_provider_approval_status: "accepted") }
-
-      it "returns error" do
-        api_post "/api/v1/npq-applications/#{application.ecf_id}/reject"
-
-        expect(response).to have_http_status(:unprocessable_entity)
-
-        expect(parsed_response).to be_key("errors")
-        expect(parsed_response["errors"][0]["title"]).to eql("application")
-        expect(parsed_response.dig("errors", 0, "detail")).to eql("Once accepted an application cannot change state")
-      end
-    end
+    it_behaves_like "an API reject application endpoint"
   end
 end

--- a/spec/requests/api/v1/applications_spec.rb
+++ b/spec/requests/api/v1/applications_spec.rb
@@ -46,14 +46,35 @@ RSpec.describe "Application endpoints", type: :request do
   end
 
   describe("accept") do
-    before { api_post(api_v1_application_accept_path(123)) }
+    before { api_post(accept_api_v1_application_path(123)) }
 
     specify { expect(response).to(be_method_not_allowed) }
   end
 
-  describe("reject") do
-    before { api_post(api_v1_application_reject_path(123)) }
+  describe "POST /api/v1/npq-applications/:ecf_id/reject" do
+    let(:application) { create(:application, lead_provider: current_lead_provider) }
 
-    specify { expect(response).to(be_method_not_allowed) }
+    context "when application is pending" do
+      it "returns successfully" do
+        api_post "/api/v1/npq-applications/#{application.ecf_id}/reject"
+
+        expect(response).to be_successful
+        expect(parsed_response.dig("data", "attributes", "status")).to eql("rejected")
+      end
+    end
+
+    context "when application is accepted" do
+      let(:application) { create(:application, lead_provider: current_lead_provider, lead_provider_approval_status: "accepted") }
+
+      it "returns error" do
+        api_post "/api/v1/npq-applications/#{application.ecf_id}/reject"
+
+        expect(response).to have_http_status(:unprocessable_entity)
+
+        expect(parsed_response).to be_key("errors")
+        expect(parsed_response["errors"][0]["title"]).to eql("application")
+        expect(parsed_response.dig("errors", 0, "detail")).to eql("Once accepted an application cannot change state")
+      end
+    end
   end
 end

--- a/spec/requests/api/v2/applications_spec.rb
+++ b/spec/requests/api/v2/applications_spec.rb
@@ -52,29 +52,12 @@ RSpec.describe "Application endpoints", type: :request do
   end
 
   describe "POST /api/v2/npq-applications/:ecf_id/reject" do
-    let(:application) { create(:application, lead_provider: current_lead_provider) }
+    let(:service_class) { Applications::Reject }
 
-    context "when application is pending" do
-      it "returns successfully" do
-        api_post "/api/v2/npq-applications/#{application.ecf_id}/reject"
-
-        expect(response).to be_successful
-        expect(parsed_response.dig("data", "attributes", "status")).to eql("rejected")
-      end
+    def path(id = nil)
+      reject_api_v2_application_path(id)
     end
 
-    context "when application is accepted" do
-      let(:application) { create(:application, lead_provider: current_lead_provider, lead_provider_approval_status: "accepted") }
-
-      it "returns error" do
-        api_post "/api/v2/npq-applications/#{application.ecf_id}/reject"
-
-        expect(response).to have_http_status(:unprocessable_entity)
-
-        expect(parsed_response).to be_key("errors")
-        expect(parsed_response["errors"][0]["title"]).to eql("application")
-        expect(parsed_response.dig("errors", 0, "detail")).to eql("Once accepted an application cannot change state")
-      end
-    end
+    it_behaves_like "an API reject application endpoint"
   end
 end

--- a/spec/requests/api/v2/applications_spec.rb
+++ b/spec/requests/api/v2/applications_spec.rb
@@ -46,14 +46,35 @@ RSpec.describe "Application endpoints", type: :request do
   end
 
   describe("accept") do
-    before { api_post(api_v1_application_accept_path(123)) }
+    before { api_post(accept_api_v2_application_path(123)) }
 
     specify { expect(response).to(be_method_not_allowed) }
   end
 
-  describe("reject") do
-    before { api_post(api_v1_application_reject_path(123)) }
+  describe "POST /api/v2/npq-applications/:ecf_id/reject" do
+    let(:application) { create(:application, lead_provider: current_lead_provider) }
 
-    specify { expect(response).to(be_method_not_allowed) }
+    context "when application is pending" do
+      it "returns successfully" do
+        api_post "/api/v2/npq-applications/#{application.ecf_id}/reject"
+
+        expect(response).to be_successful
+        expect(parsed_response.dig("data", "attributes", "status")).to eql("rejected")
+      end
+    end
+
+    context "when application is accepted" do
+      let(:application) { create(:application, lead_provider: current_lead_provider, lead_provider_approval_status: "accepted") }
+
+      it "returns error" do
+        api_post "/api/v2/npq-applications/#{application.ecf_id}/reject"
+
+        expect(response).to have_http_status(:unprocessable_entity)
+
+        expect(parsed_response).to be_key("errors")
+        expect(parsed_response["errors"][0]["title"]).to eql("application")
+        expect(parsed_response.dig("errors", 0, "detail")).to eql("Once accepted an application cannot change state")
+      end
+    end
   end
 end

--- a/spec/requests/api/v3/applications_spec.rb
+++ b/spec/requests/api/v3/applications_spec.rb
@@ -39,29 +39,12 @@ RSpec.describe "Application endpoints", type: :request do
   end
 
   describe "POST /api/v3/npq-applications/:ecf_id/reject" do
-    let(:application) { create(:application, lead_provider: current_lead_provider) }
+    let(:service_class) { Applications::Reject }
 
-    context "when application is pending" do
-      it "returns successfully" do
-        api_post "/api/v3/npq-applications/#{application.ecf_id}/reject"
-
-        expect(response).to be_successful
-        expect(parsed_response.dig("data", "attributes", "status")).to eql("rejected")
-      end
+    def path(id = nil)
+      reject_api_v3_application_path(id)
     end
 
-    context "when application is accepted" do
-      let(:application) { create(:application, lead_provider: current_lead_provider, lead_provider_approval_status: "accepted") }
-
-      it "returns error" do
-        api_post "/api/v3/npq-applications/#{application.ecf_id}/reject"
-
-        expect(response).to have_http_status(:unprocessable_entity)
-
-        expect(parsed_response).to be_key("errors")
-        expect(parsed_response["errors"][0]["title"]).to eql("application")
-        expect(parsed_response.dig("errors", 0, "detail")).to eql("Once accepted an application cannot change state")
-      end
-    end
+    it_behaves_like "an API reject application endpoint"
   end
 end

--- a/spec/services/applications/reject_spec.rb
+++ b/spec/services/applications/reject_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe Applications::Reject do
+  let(:application) { create(:application, :pending) }
+  let(:params) { { application: } }
+
+  subject(:service) { described_class.new(params) }
+
+  describe "validations" do
+    context "when the application is missing" do
+      let(:application) { nil }
+
+      it "is invalid and returns an error message" do
+        expect(subject).to be_invalid
+
+        expect(service.errors.messages_for(:application)).to include("The entered '#/application' is missing from your request. Check details and try again.")
+      end
+    end
+
+    context "when the application is already rejected" do
+      let(:application) { create(:application, :rejected) }
+
+      it "is invalid and returns an error message" do
+        expect(subject).to be_invalid
+
+        expect(service.errors.messages_for(:application)).to include("This NPQ application has already been rejected")
+      end
+    end
+
+    context "when the application is accepted" do
+      let(:application) { create(:application, :accepted) }
+
+      it "is invalid and returns an error message" do
+        expect(subject).to be_invalid
+
+        expect(service.errors.messages_for(:application)).to include("Once accepted an application cannot change state")
+      end
+    end
+  end
+
+  describe ".call" do
+    it "marks the lead provider approval status as rejected" do
+      expect { service.call }.to change { application.reload.lead_provider_approval_status }.from("pending").to("rejected")
+    end
+  end
+end

--- a/spec/services/applications/reject_spec.rb
+++ b/spec/services/applications/reject_spec.rb
@@ -38,9 +38,9 @@ RSpec.describe Applications::Reject do
     end
   end
 
-  describe ".call" do
+  describe ".reject" do
     it "marks the lead provider approval status as rejected" do
-      expect { service.call }.to change { application.reload.lead_provider_approval_status }.from("pending").to("rejected")
+      expect { service.reject }.to change { application.reload.lead_provider_approval_status }.from("pending").to("rejected")
     end
   end
 end

--- a/spec/support/shared_examples/api_reject_application_endpoint_support.rb
+++ b/spec/support/shared_examples/api_reject_application_endpoint_support.rb
@@ -1,0 +1,56 @@
+RSpec.shared_examples "an API reject application endpoint" do
+  context "when authorized" do
+    context "when application is pending" do
+      let(:application) { create(:application, :pending, lead_provider: current_lead_provider) }
+
+      it "returns successfully" do
+        api_post(path(application.ecf_id))
+
+        expect(response).to be_successful
+        expect(response.content_type).to eql("application/json")
+
+        expect(parsed_response.dig("data", "attributes", "status")).to eql("rejected")
+      end
+
+      it "calls the correct service" do
+        mock_service = instance_double(service_class)
+        allow(service_class).to receive(:new).with(application:).and_return(mock_service)
+        allow(mock_service).to receive(:reject).and_return(true)
+        allow(mock_service).to receive(:application).and_return(application)
+
+        serializer_params = { root: "data" }
+        serializer_params[:view] = serializer_version if defined?(serializer_version)
+        expect(serializer).to receive(:render).with(application, **serializer_params).and_call_original
+
+        api_post(path(application.ecf_id))
+      end
+    end
+
+    context "when application is accepted" do
+      let(:application) { create(:application, :accepted, lead_provider: current_lead_provider) }
+
+      it "returns error" do
+        api_post(path(application.ecf_id))
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.content_type).to eql("application/json")
+
+        expect(parsed_response).to be_key("errors")
+        expect(parsed_response.dig("errors", 0, "title")).to eql("application")
+        expect(parsed_response.dig("errors", 0, "detail")).to eql("Once accepted an application cannot change state")
+      end
+    end
+  end
+
+  context "when unauthorized" do
+    let(:application) { create(:application, lead_provider: current_lead_provider) }
+
+    it "returns 401 - unauthorized" do
+      api_post(path(application.ecf_id), token: "incorrect-token")
+
+      expect(response.status).to eq 401
+      expect(parsed_response["error"]).to eql("HTTP Token: Access denied")
+      expect(response.content_type).to eql("application/json")
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-3047

### Changes proposed in this pull request

* `Applications::Reject` service class added
* Endpoints added:
  * `/api/v1/npq-applications/:ecf_id/reject`
  * `/api/v2/npq-applications/:ecf_id/reject`
  * `/api/v3/npq-applications/:ecf_id/reject`