### PR TITLE
Add Senco to API docs

### DIFF
--- a/public/api/docs/v1/swagger.yaml
+++ b/public/api/docs/v1/swagger.yaml
@@ -177,6 +177,7 @@ components:
               - npq-additional-support-offer
               - npq-early-headship-coaching-offer
               - npq-leading-primary-mathematics
+              - npq-senco
             email:
               description: The email address registered for this NPQ participant
               type: string

--- a/public/api/docs/v2/swagger.yaml
+++ b/public/api/docs/v2/swagger.yaml
@@ -177,6 +177,7 @@ components:
               - npq-additional-support-offer
               - npq-early-headship-coaching-offer
               - npq-leading-primary-mathematics
+              - npq-senco
             email:
               description: The email address registered for this NPQ participant
               type: string

--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -345,6 +345,7 @@ components:
               - npq-additional-support-offer
               - npq-early-headship-coaching-offer
               - npq-leading-primary-mathematics
+              - npq-senco
             status:
               description: The current state of the NPQ application
               type: string

--- a/spec/swagger_schemas/models/application.rb
+++ b/spec/swagger_schemas/models/application.rb
@@ -34,6 +34,7 @@ APPLICATION = {
               npq-additional-support-offer
               npq-early-headship-coaching-offer
               npq-leading-primary-mathematics
+              npq-senco
             ],
           },
           email: {
@@ -353,6 +354,7 @@ APPLICATION = {
               npq-additional-support-offer
               npq-early-headship-coaching-offer
               npq-leading-primary-mathematics
+              npq-senco
             ],
           },
           status: {


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-000
Failure on main after adding Senco course

[Why are we making this change?]

### Changes proposed in this pull request

Add new Senco course to swagger docs

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
