### PR TITLE
Ensure course identifiers are present and unique

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,5 +1,8 @@
 class Course < ApplicationRecord
   validates :name, presence: true
+  validates :identifier,
+            presence: { message: "Enter a identifier" },
+            uniqueness: { message: "Identifier already exists, enter a unique one" }
 
   IDENTIFIERS = %w[
     npq-senior-leadership

--- a/db/migrate/20240517110612_ensure_course_identifiers_are_unique.rb
+++ b/db/migrate/20240517110612_ensure_course_identifiers_are_unique.rb
@@ -1,0 +1,5 @@
+class EnsureCourseIdentifiersAreUnique < ActiveRecord::Migration[7.1]
+  def change
+    add_index :courses, :identifier, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_09_150727) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_17_110612) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -122,6 +122,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_09_150727) do
     t.integer "position", default: 0
     t.boolean "display", default: true
     t.string "identifier"
+    t.index ["identifier"], name: "index_courses_on_identifier", unique: true
   end
 
   create_table "data_migrations", force: :cascade do |t|

--- a/spec/factories/migration/ecf/npq_courses.rb
+++ b/spec/factories/migration/ecf/npq_courses.rb
@@ -3,6 +3,6 @@
 FactoryBot.define do
   factory :ecf_migration_npq_course, class: "Migration::Ecf::NpqCourse" do
     sequence(:name) { |n| "NPQ Course #{n}" }
-    identifier { Course::IDENTIFIERS.sample }
+    sequence(:identifier) { |n| "npq-course-#{n}" }
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe Course do
   describe "validations" do
     it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_uniqueness_of(:identifier).with_message("Identifier already exists, enter a unique one") }
   end
 
   describe ".ehco" do


### PR DESCRIPTION
### Context

I think the application would misbehave quite significantly if we had repeated course identifiers. In the longer term we need to have a think about how to decouple the data from the business logic, but for now let's just ensure they only exist once.
