### PR TITLE
[CPDNPQ-1834] Updated senco course name

### DIFF
--- a/config/initializers/courses.rb
+++ b/config/initializers/courses.rb
@@ -73,7 +73,7 @@ module Courses
     },
     {
       position: 9,
-      name: "NPQ for Senco(NPQS)",
+      name: "NPQ for Senco (NPQSENCO)",
       ecf_id: "84b7ffd9-c726-4915-bcac-05901d9629b8",
       identifier: "npq-senco",
       display: true,


### PR DESCRIPTION
The NPQ Senco course identifier has been changed from NPQS to NPQSENCO. This needs to be changed in the course name.