### PR TITLE
Fix a bug caused by differences in sorting

### DIFF
--- a/spec/services/courses/query_spec.rb
+++ b/spec/services/courses/query_spec.rb
@@ -12,7 +12,14 @@ RSpec.describe Courses::Query do
     it "orders courses by name in ascending order" do
       query = Courses::Query.new
       course_names = query.courses.map(&:name)
-      expect(course_names).to eq(course_names.sort)
+
+      # Postgres orders alphabetically regardless of case but
+      # Ruby orders by the hex value meaning lowercase entries
+      # come last, so we fix the case before sorting. This is
+      # triggered by 'NPQ for Senco 1'
+      sorted_course_names = course_names.sort_by(&:downcase)
+
+      expect(course_names).to eq(sorted_course_names)
     end
   end
 


### PR DESCRIPTION

### Context

PostgreSQL sorts alphatetically but Ruby sorts by hex value. Fixed this and left a comment explaining _why_ we're sorting this way.
