### PR TITLE
[CPDLP-3080] Add NPQ participant profiles endpoint

### DIFF
--- a/app/controllers/api/v1/participants_controller.rb
+++ b/app/controllers/api/v1/participants_controller.rb
@@ -1,13 +1,35 @@
 module API
   module V1
     class ParticipantsController < BaseController
-      def index = head(:method_not_allowed)
+      include Pagination
+      include ::API::Concerns::FilterByUpdatedSince
+
+      def index
+        render json: to_json(paginate(participants_query.participants))
+      end
+
       def show = head(:method_not_allowed)
       def change_schedule = head(:method_not_allowed)
       def defer = head(:method_not_allowed)
       def withdraw = head(:method_not_allowed)
       def resume = head(:method_not_allowed)
       def outcomes = head(:method_not_allowed)
+
+    private
+
+      def participants_query
+        conditions = { lead_provider: current_lead_provider, updated_since: }
+
+        ::Participants::Query.new(**conditions.compact)
+      end
+
+      def participant_params
+        params.permit(filter: %i[updated_since])
+      end
+
+      def to_json(obj)
+        ParticipantSerializer.render(obj, view: :v1, root: "data", lead_provider: current_lead_provider)
+      end
     end
   end
 end

--- a/app/controllers/api/v2/participants_controller.rb
+++ b/app/controllers/api/v2/participants_controller.rb
@@ -1,13 +1,35 @@
 module API
   module V2
     class ParticipantsController < BaseController
-      def index = head(:method_not_allowed)
+      include Pagination
+      include ::API::Concerns::FilterByUpdatedSince
+
+      def index
+        render json: to_json(paginate(participants_query.participants))
+      end
+
       def show = head(:method_not_allowed)
       def change_schedule = head(:method_not_allowed)
       def defer = head(:method_not_allowed)
       def withdraw = head(:method_not_allowed)
       def resume = head(:method_not_allowed)
       def outcomes = head(:method_not_allowed)
+
+    private
+
+      def participants_query
+        conditions = { lead_provider: current_lead_provider, updated_since: }
+
+        ::Participants::Query.new(**conditions.compact)
+      end
+
+      def participant_params
+        params.permit(filter: %i[updated_since])
+      end
+
+      def to_json(obj)
+        ParticipantSerializer.render(obj, view: :v2, root: "data", lead_provider: current_lead_provider)
+      end
     end
   end
 end

--- a/app/controllers/api/v3/participants_controller.rb
+++ b/app/controllers/api/v3/participants_controller.rb
@@ -1,13 +1,43 @@
 module API
   module V3
     class ParticipantsController < BaseController
-      def index = head(:method_not_allowed)
+      include Pagination
+      include ::API::Concerns::FilterByUpdatedSince
+
+      def index
+        render json: to_json(paginate(participants_query.participants))
+      end
+
       def show = head(:method_not_allowed)
       def change_schedule = head(:method_not_allowed)
       def defer = head(:method_not_allowed)
       def withdraw = head(:method_not_allowed)
       def resume = head(:method_not_allowed)
       def outcomes = head(:method_not_allowed)
+
+    private
+
+      def training_status
+        participant_params.dig(:filter, :training_status)
+      end
+
+      def from_participant_id
+        participant_params.dig(:filter, :from_participant_id)
+      end
+
+      def participants_query
+        conditions = { lead_provider: current_lead_provider, updated_since:, training_status:, from_participant_id: }
+
+        ::Participants::Query.new(**conditions.compact)
+      end
+
+      def participant_params
+        params.permit(:sort, filter: %i[updated_since training_status from_participant_id])
+      end
+
+      def to_json(obj)
+        ParticipantSerializer.render(obj, view: :v3, root: "data", lead_provider: current_lead_provider)
+      end
     end
   end
 end

--- a/app/serializers/api/participant_serializer.rb
+++ b/app/serializers/api/participant_serializer.rb
@@ -1,0 +1,105 @@
+module API
+  class ParticipantSerializer < Blueprinter::Base
+    identifier :ecf_id, name: :id
+    field(:type) { "npq-participant" }
+
+    class AttributesSerializer < Blueprinter::Base
+      exclude :id
+
+      field(:email)
+      field(:full_name)
+      field(:trn, name: :teacher_reference_number)
+      field(:updated_at)
+
+      view :v1 do
+        field(:npq_courses) do |object, options|
+          applications(object, options).map { |application| application.course.identifier }
+        end
+
+        field(:funded_places) do |object, options|
+          applications(object, options).map do |application|
+            {
+              npq_course: application.course.identifier,
+              funded_place: application.funded_place,
+              npq_application_id: application.ecf_id,
+            }
+          end
+        end
+      end
+
+      view :v2 do
+        field(:npq_enrolments) do |object, options|
+          applications(object, options).map do |application|
+            {
+              course_identifier: application.course.identifier,
+              # TODO: Add when schedules are implemented
+              schedule_identifier: nil,
+              cohort: application.cohort&.start_year&.to_s,
+              npq_application_id: application.ecf_id,
+              eligible_for_funding: application.eligible_for_funding,
+              training_status: application.training_status,
+              school_urn: application.school&.urn,
+              targeted_delivery_funding_eligibility: application.targeted_delivery_funding_eligibility,
+              funded_place: application.funded_place,
+            }
+          end
+        end
+      end
+
+      view :v3 do
+        field(:npq_enrolments) do |object, options|
+          applications(object, options).map do |application|
+            {
+              email: object.email,
+              course_identifier: application.course.identifier,
+              # TODO: Add when schedules are implemented
+              schedule_identifier: nil,
+              cohort: application.cohort&.start_year&.to_s,
+              npq_application_id: application.ecf_id,
+              eligible_for_funding: application.eligible_for_funding,
+              training_status: application.training_status,
+              school_urn: application.school&.urn,
+              targeted_delivery_funding_eligibility: application.targeted_delivery_funding_eligibility,
+              withdrawal: nil,
+              deferral: nil,
+              created_at: application.created_at.rfc3339,
+              funded_place: application.funded_place,
+            }
+          end
+        end
+
+        field(:participant_id_changes) do |object, _options|
+          (object.participant_id_changes || []).map do |participant_id_change|
+            {
+              from_participant_id: participant_id_change.from_participant.ecf_id,
+              to_participant_id: participant_id_change.to_participant.ecf_id,
+              changed_at: participant_id_change.created_at.rfc3339,
+            }
+          end
+        end
+      end
+
+      def self.applications(object, options)
+        scope = object.applications
+
+        if options[:lead_provider]
+          scope.where(lead_provider: options[:lead_provider])
+        else
+          Application.none
+        end
+      end
+    end
+
+    association :attributes, blueprint: AttributesSerializer do |participant|
+      participant
+    end
+
+    %i[v1 v2 v3].each do |version|
+      view version do
+        association :attributes, blueprint: AttributesSerializer, view: version do |participant|
+          participant
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/api/participant_serializer.rb
+++ b/app/serializers/api/participant_serializer.rb
@@ -32,8 +32,7 @@ module API
           applications(object, options).map do |application|
             {
               course_identifier: application.course.identifier,
-              # TODO: Add when schedules are implemented
-              schedule_identifier: nil,
+              schedule_identifier: application&.schedule&.identifier,
               cohort: application.cohort&.start_year&.to_s,
               npq_application_id: application.ecf_id,
               eligible_for_funding: application.eligible_for_funding,
@@ -52,8 +51,7 @@ module API
             {
               email: object.email,
               course_identifier: application.course.identifier,
-              # TODO: Add when schedules are implemented
-              schedule_identifier: nil,
+              schedule_identifier: application&.schedule&.identifier,
               cohort: application.cohort&.start_year&.to_s,
               npq_application_id: application.ecf_id,
               eligible_for_funding: application.eligible_for_funding,

--- a/app/services/participants/query.rb
+++ b/app/services/participants/query.rb
@@ -58,6 +58,8 @@ module Participants
             school
             cohort
             lead_provider
+            application_states
+            schedule
           ],
         )
     end

--- a/app/services/participants/query.rb
+++ b/app/services/participants/query.rb
@@ -1,0 +1,65 @@
+module Participants
+  class Query
+    include API::Concerns::Orderable
+
+    attr_reader :scope, :sort
+
+    def initialize(lead_provider: :ignore, updated_since: :ignore, training_status: :ignore, from_participant_id: :ignore, sort: nil)
+      @scope = all_participants
+      @sort = sort
+
+      where_lead_provider_is(lead_provider)
+      where_updated_since(updated_since)
+      where_training_status_is(training_status)
+      where_from_participant_id_is(from_participant_id)
+    end
+
+    def participants
+      scope.order(order_by)
+    end
+
+  private
+
+    def where_lead_provider_is(lead_provider)
+      return if lead_provider == :ignore
+
+      scope.merge!(Application.where(lead_provider:))
+    end
+
+    def where_updated_since(updated_since)
+      return if updated_since == :ignore
+
+      scope.merge!(User.where(updated_at: updated_since..))
+    end
+
+    def where_training_status_is(training_status)
+      return unless Application.training_statuses[training_status]
+
+      scope.merge!(Application.where(training_status:))
+    end
+
+    def where_from_participant_id_is(from_participant_id)
+      return if from_participant_id == :ignore
+
+      scope.merge!(scope.joins(:participant_id_changes).merge(ParticipantIdChange.where(from_participant: User.where(ecf_id: from_participant_id))))
+    end
+
+    def order_by
+      sort_order(sort:, model: User, default: { created_at: :asc })
+    end
+
+    def all_participants
+      User
+        .joins(:applications)
+        .includes(
+          :participant_id_changes,
+          applications: %i[
+            course
+            school
+            cohort
+            lead_provider
+          ],
+        )
+    end
+  end
+end

--- a/app/services/participants/query.rb
+++ b/app/services/participants/query.rb
@@ -50,7 +50,7 @@ module Participants
 
     def all_participants
       User
-        .joins(:applications)
+        .joins(:applications).merge(Application.accepted)
         .includes(
           :participant_id_changes,
           applications: %i[

--- a/app/services/valid_test_data_generators/applications_populater.rb
+++ b/app/services/valid_test_data_generators/applications_populater.rb
@@ -85,8 +85,7 @@ module ValidTestDataGenerators
     end
 
     def accept_application(application)
-      # TODO: replace by Applications::Accept.new(application:).accept when service class is added
-      application.update!(lead_provider_approval_status: "accepted")
+      Applications::Accept.new(application:).accept
       application.reload
     end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,7 @@ module NpqRegistration
 
     # don't use AJAX/XHR to submit forms by default
     config.action_view.form_with_generates_remote_forms = false
+    config.action_controller.always_permitted_parameters = %w( controller action format )
 
     config.action_mailer.delivery_method = :notify
     config.action_mailer.notify_settings = {

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,6 @@ module NpqRegistration
 
     # don't use AJAX/XHR to submit forms by default
     config.action_view.form_with_generates_remote_forms = false
-    config.action_controller.always_permitted_parameters = %w( controller action format )
 
     config.action_mailer.delivery_method = :notify
     config.action_mailer.notify_settings = {

--- a/spec/factories/applications.rb
+++ b/spec/factories/applications.rb
@@ -48,7 +48,7 @@ FactoryBot.define do
 
     trait :accepted do
       lead_provider_approval_status { :accepted }
-      schedule { Schedule.where(cohort:, course_group: course.course_group).sample || create(:schedule, cohort:) }
+      schedule { Schedule.where(cohort:, course_group: course.course_group).sample || create(:schedule, course_group: course.course_group, cohort:) }
     end
 
     trait :rejected do
@@ -64,8 +64,8 @@ FactoryBot.define do
     end
 
     trait :eligible_for_funded_place do
+      accepted
       eligible_for_funding { true }
-      lead_provider_approval_status { :accepted }
 
       after(:create) do |application|
         application.cohort.update!(funding_cap: true)

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
       establishment_type_code do
         %w[1 2 3 5 6 7 8 10 12 14 15 18 24 26 28 31 32 33 34 35 36 38 39 40 41 42 43 44 45 46].sample
       end
+      eyl_funding_eligible { true }
     end
 
     trait :closed do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -23,13 +23,13 @@ FactoryBot.define do
       trn_verified { true }
     end
 
-    trait :with_application do
+    factory :participant do
       transient do
         lead_provider { LeadProvider.all.sample }
       end
 
-      after(:create) do |user, evaluator|
-        create(:application, user:, lead_provider: evaluator.lead_provider)
+      after(:create) do |participant, evaluator|
+        create(:application, :accepted, user: participant, lead_provider: evaluator.lead_provider)
       end
     end
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
       trn_verified { true }
     end
 
-    factory :participant do
+    trait :with_application do
       transient do
         lead_provider { LeadProvider.all.sample }
       end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -22,5 +22,15 @@ FactoryBot.define do
     trait :with_verified_trn do
       trn_verified { true }
     end
+
+    trait :with_application do
+      transient do
+        lead_provider { LeadProvider.all.sample }
+      end
+
+      after(:create) do |user, evaluator|
+        create(:application, user:, lead_provider: evaluator.lead_provider)
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/participants_spec.rb
+++ b/spec/requests/api/v1/participants_spec.rb
@@ -1,10 +1,23 @@
 require "rails_helper"
 
-RSpec.describe API::V1::ParticipantsController, type: "request" do
-  describe("index") do
-    before { api_get(api_v1_participants_path) }
+RSpec.describe "Participant endpoints", type: :request do
+  let(:current_lead_provider) { create(:lead_provider) }
+  let(:query) { Participants::Query }
+  let(:serializer) { API::ParticipantSerializer }
+  let(:serializer_version) { :v1 }
+  let(:serializer_lead_provider) { current_lead_provider }
 
-    specify { expect(response).to(be_method_not_allowed) }
+  describe "GET /api/v1/participants/npq" do
+    let(:path) { api_v1_participants_path }
+    let(:resource_id_key) { :ecf_id }
+
+    def create_resource(**attrs)
+      create(:user, :with_application, **attrs)
+    end
+
+    it_behaves_like "an API index endpoint"
+    it_behaves_like "an API index endpoint with pagination"
+    it_behaves_like "an API index endpoint with filter by updated_since"
   end
 
   describe("show") do

--- a/spec/requests/api/v1/participants_spec.rb
+++ b/spec/requests/api/v1/participants_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Participant endpoints", type: :request do
     let(:resource_id_key) { :ecf_id }
 
     def create_resource(**attrs)
-      create(:user, :with_application, **attrs)
+      create(:participant, **attrs)
     end
 
     it_behaves_like "an API index endpoint"

--- a/spec/requests/api/v1/participants_spec.rb
+++ b/spec/requests/api/v1/participants_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Participant endpoints", type: :request do
     let(:resource_id_key) { :ecf_id }
 
     def create_resource(**attrs)
-      create(:participant, **attrs)
+      create(:user, :with_application, **attrs)
     end
 
     it_behaves_like "an API index endpoint"

--- a/spec/requests/api/v2/participants_spec.rb
+++ b/spec/requests/api/v2/participants_spec.rb
@@ -1,10 +1,23 @@
 require "rails_helper"
 
-RSpec.describe API::V2::ParticipantsController, type: "request" do
-  describe("index") do
-    before { api_get(api_v2_participants_path) }
+RSpec.describe "Participant endpoints", type: :request do
+  let(:current_lead_provider) { create(:lead_provider) }
+  let(:query) { Participants::Query }
+  let(:serializer) { API::ParticipantSerializer }
+  let(:serializer_version) { :v2 }
+  let(:serializer_lead_provider) { current_lead_provider }
 
-    specify { expect(response).to(be_method_not_allowed) }
+  describe "GET /api/v2/participants/npq" do
+    let(:path) { api_v2_participants_path }
+    let(:resource_id_key) { :ecf_id }
+
+    def create_resource(**attrs)
+      create(:user, :with_application, **attrs)
+    end
+
+    it_behaves_like "an API index endpoint"
+    it_behaves_like "an API index endpoint with pagination"
+    it_behaves_like "an API index endpoint with filter by updated_since"
   end
 
   describe("show") do

--- a/spec/requests/api/v2/participants_spec.rb
+++ b/spec/requests/api/v2/participants_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Participant endpoints", type: :request do
     let(:resource_id_key) { :ecf_id }
 
     def create_resource(**attrs)
-      create(:user, :with_application, **attrs)
+      create(:participant, **attrs)
     end
 
     it_behaves_like "an API index endpoint"

--- a/spec/requests/api/v2/participants_spec.rb
+++ b/spec/requests/api/v2/participants_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Participant endpoints", type: :request do
     let(:resource_id_key) { :ecf_id }
 
     def create_resource(**attrs)
-      create(:participant, **attrs)
+      create(:user, :with_application, **attrs)
     end
 
     it_behaves_like "an API index endpoint"

--- a/spec/requests/api/v3/participants_spec.rb
+++ b/spec/requests/api/v3/participants_spec.rb
@@ -1,10 +1,25 @@
 require "rails_helper"
 
-RSpec.describe API::V3::ParticipantsController, type: "request" do
-  describe("index") do
-    before { api_get(api_v3_participants_path) }
+RSpec.describe "Participant endpoints", type: :request do
+  let(:current_lead_provider) { create(:lead_provider) }
+  let(:query) { Participants::Query }
+  let(:serializer) { API::ParticipantSerializer }
+  let(:serializer_version) { :v3 }
+  let(:serializer_lead_provider) { current_lead_provider }
 
-    specify { expect(response).to(be_method_not_allowed) }
+  describe "GET /api/v3/participants/npq" do
+    let(:path) { api_v3_participants_path }
+    let(:resource_id_key) { :ecf_id }
+
+    def create_resource(**attrs)
+      create(:user, :with_application, **attrs)
+    end
+
+    it_behaves_like "an API index endpoint"
+    it_behaves_like "an API index endpoint with pagination"
+    it_behaves_like "an API index endpoint with filter by updated_since"
+    it_behaves_like "an API index endpoint with filter by training_status"
+    it_behaves_like "an API index endpoint with filter by from_participant_id"
   end
 
   describe("show") do

--- a/spec/requests/api/v3/participants_spec.rb
+++ b/spec/requests/api/v3/participants_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Participant endpoints", type: :request do
     let(:resource_id_key) { :ecf_id }
 
     def create_resource(**attrs)
-      create(:user, :with_application, **attrs)
+      create(:participant, **attrs)
     end
 
     it_behaves_like "an API index endpoint"

--- a/spec/requests/api/v3/participants_spec.rb
+++ b/spec/requests/api/v3/participants_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Participant endpoints", type: :request do
     let(:resource_id_key) { :ecf_id }
 
     def create_resource(**attrs)
-      create(:participant, **attrs)
+      create(:user, :with_application, **attrs)
     end
 
     it_behaves_like "an API index endpoint"

--- a/spec/serializers/api/participant_serializer_spec.rb
+++ b/spec/serializers/api/participant_serializer_spec.rb
@@ -1,0 +1,203 @@
+require "rails_helper"
+
+RSpec.describe API::ParticipantSerializer, type: :serializer do
+  let(:lead_provider) { create(:lead_provider) }
+  let(:course) { application.course }
+  let(:school) { application.school }
+  let(:participant_id_change) { application.participant_id_changes.last }
+  let(:cohort) { application.cohort }
+  let(:application) { create(:application, :eligible_for_funded_place, :with_participant_id_change, lead_provider:, funded_place: true) }
+  let(:participant) { application.user }
+
+  describe "core attributes" do
+    subject(:response) { JSON.parse(described_class.render(participant, lead_provider:)) }
+
+    it "serializes the `id`" do
+      participant.ecf_id = "fe1a5280-1b13-4b09-b9c7-e2b01d37e851"
+
+      expect(response["id"]).to eq("fe1a5280-1b13-4b09-b9c7-e2b01d37e851")
+    end
+
+    it "serializes the `type`" do
+      response = JSON.parse(described_class.render(participant))
+
+      expect(response["type"]).to eq("npq-participant")
+    end
+  end
+
+  describe "nested attributes" do
+    context "when serializing the `v1` view" do
+      subject(:attributes) { JSON.parse(described_class.render(participant, lead_provider:, view: :v1))["attributes"] }
+
+      it "serializes the `participant_id`" do
+        expect(attributes["participant_id"]).to eq(participant.ecf_id)
+      end
+
+      it "serializes the `full_name`" do
+        expect(attributes["full_name"]).to eq(participant.full_name)
+      end
+
+      it "serializes the `email`" do
+        expect(attributes["email"]).to eq(participant.email)
+      end
+
+      it "serializes the `npq_courses`" do
+        expect(attributes["npq_courses"]).to eq([course.identifier])
+      end
+
+      it "serializes the `funded_places`" do
+        expect(attributes["funded_places"]).to eq([
+          {
+            npq_course: application.course.identifier,
+            funded_place: application.funded_place,
+            npq_application_id: application.ecf_id,
+          }.stringify_keys,
+        ])
+      end
+
+      it "serializes the `teacher_reference_number`" do
+        expect(attributes["teacher_reference_number"]).to eq(participant.trn)
+      end
+
+      it "serializes the `updated_at`" do
+        expect(attributes["updated_at"]).to eq(participant.updated_at.rfc3339)
+      end
+    end
+
+    context "when serializing the `v2` view" do
+      subject(:attributes) { JSON.parse(described_class.render(participant, lead_provider:, view: :v2))["attributes"] }
+
+      it "serializes the `email`" do
+        expect(attributes["email"]).to eq(participant.email)
+      end
+
+      it "serializes the `full_name`" do
+        expect(attributes["full_name"]).to eq(participant.full_name)
+      end
+
+      it "serializes the `teacher_reference_number`" do
+        expect(attributes["teacher_reference_number"]).to eq(participant.trn)
+      end
+
+      it "serializes the `updated_at`" do
+        expect(attributes["updated_at"]).to eq(participant.updated_at.rfc3339)
+      end
+
+      it "serializes the `npq_enrolments`" do
+        expect(attributes["npq_enrolments"]).to eq([
+          {
+            course_identifier: application.course.identifier,
+            schedule_identifier: application.schedule.identifier,
+            cohort: application.cohort.start_year.to_s,
+            npq_application_id: application.ecf_id,
+            eligible_for_funding: application.eligible_for_funding,
+            training_status: application.training_status,
+            school_urn: application.school.urn,
+            targeted_delivery_funding_eligibility: application.targeted_delivery_funding_eligibility,
+            funded_place: application.funded_place,
+          }.stringify_keys,
+        ])
+      end
+    end
+
+    context "when serializing the `v3` view" do
+      subject(:attributes) { JSON.parse(described_class.render(participant, lead_provider:, view: :v3))["attributes"] }
+
+      it "serializes the `full_name`" do
+        expect(attributes["full_name"]).to eq(participant.full_name)
+      end
+
+      it "serializes the `teacher_reference_number`" do
+        expect(attributes["teacher_reference_number"]).to eq(participant.trn)
+      end
+
+      it "serializes the `updated_at`" do
+        expect(attributes["updated_at"]).to eq(participant.updated_at.rfc3339)
+      end
+
+      it "serializes the `npq_enrolments`" do
+        expect(attributes["npq_enrolments"]).to eq([
+          {
+            email: participant.email,
+            course_identifier: application.course.identifier,
+            schedule_identifier: application.schedule.identifier,
+            cohort: application.cohort.start_year.to_s,
+            npq_application_id: application.ecf_id,
+            eligible_for_funding: application.eligible_for_funding,
+            training_status: application.training_status,
+            school_urn: application.school.urn,
+            targeted_delivery_funding_eligibility: application.targeted_delivery_funding_eligibility,
+            withdrawal: nil,
+            deferral: nil,
+            created_at: application.created_at.rfc3339,
+            funded_place: application.funded_place,
+          }.stringify_keys,
+        ])
+      end
+
+      context "when application has been withdrawn" do
+        let(:application) { create(:application, :withdrawn, :eligible_for_funded_place, lead_provider:) }
+
+        it "serializes the `npq_enrolments`" do
+          expect(attributes["npq_enrolments"]).to eq([
+            {
+              email: participant.email,
+              course_identifier: application.course.identifier,
+              schedule_identifier: application.schedule.identifier,
+              cohort: application.cohort.start_year.to_s,
+              npq_application_id: application.ecf_id,
+              eligible_for_funding: application.eligible_for_funding,
+              training_status: application.training_status,
+              school_urn: application.school.urn,
+              targeted_delivery_funding_eligibility: application.targeted_delivery_funding_eligibility,
+              withdrawal: {
+                reason: application.application_states.last.reason,
+                date: application.application_states.last.created_at.rfc3339,
+              },
+              deferral: nil,
+              created_at: application.created_at.rfc3339,
+              funded_place: application.funded_place,
+            }.deep_stringify_keys,
+          ])
+        end
+      end
+
+      context "when application has been deferred" do
+        let(:application) { create(:application, :deferred, :eligible_for_funded_place, lead_provider:) }
+
+        it "serializes the `npq_enrolments`" do
+          expect(attributes["npq_enrolments"]).to eq([
+            {
+              email: participant.email,
+              course_identifier: application.course.identifier,
+              schedule_identifier: application.schedule.identifier,
+              cohort: application.cohort.start_year.to_s,
+              npq_application_id: application.ecf_id,
+              eligible_for_funding: application.eligible_for_funding,
+              training_status: application.training_status,
+              school_urn: application.school.urn,
+              targeted_delivery_funding_eligibility: application.targeted_delivery_funding_eligibility,
+              withdrawal: nil,
+              deferral: {
+                reason: application.application_states.last.reason,
+                date: application.application_states.last.created_at.rfc3339,
+              },
+              created_at: application.created_at.rfc3339,
+              funded_place: application.funded_place,
+            }.deep_stringify_keys,
+          ])
+        end
+      end
+
+      it "serializes the `participant_id_changes`" do
+        expect(attributes["participant_id_changes"]).to eq([
+          {
+            from_participant_id: participant.participant_id_changes.last.from_participant.ecf_id,
+            to_participant_id: participant.participant_id_changes.last.to_participant.ecf_id,
+            changed_at: participant.participant_id_changes.last.created_at.rfc3339,
+          }.stringify_keys,
+        ])
+      end
+    end
+  end
+end

--- a/spec/services/participants/query_spec.rb
+++ b/spec/services/participants/query_spec.rb
@@ -1,0 +1,168 @@
+require "rails_helper"
+
+RSpec.describe Participants::Query do
+  subject(:query) { described_class.new(**params) }
+
+  let(:params) { {} }
+
+  describe "#participants" do
+    let(:lead_provider) { create(:lead_provider) }
+    let!(:participant1) { create(:user, :with_application, lead_provider:) }
+    let!(:participant2) { create(:user, :with_application, lead_provider:) }
+
+    it "returns all participants" do
+      expect(query.participants).to contain_exactly(participant1, participant2)
+    end
+
+    it "orders participants by created_at in ascending order" do
+      participant3 = travel_to(1.minute.ago) { create(:user, :with_application, lead_provider:) }
+
+      expect(query.participants).to eq([participant3, participant1, participant2])
+    end
+
+    describe "filtering" do
+      describe "lead provider" do
+        context "when a lead provider is supplied" do
+          let(:params) { { lead_provider: } }
+
+          it "filters by lead provider" do
+            create(:user, :with_application, lead_provider: create(:lead_provider))
+
+            expect(query.participants).to contain_exactly(participant1, participant2)
+          end
+        end
+
+        context "when a lead provider is not supplied" do
+          it "does not filter by lead provider" do
+            condition_string = %("applications"."lead_provider_id" =)
+
+            expect(query.scope.to_sql).not_to include(condition_string)
+          end
+        end
+      end
+
+      describe "updated since" do
+        context "when a updated since is supplied" do
+          let(:params) { { updated_since: 1.day.ago } }
+
+          it "filters by updated since" do
+            create(:user, :with_application, lead_provider:, updated_at: 2.days.ago)
+
+            expect(query.participants).to contain_exactly(participant1, participant2)
+          end
+        end
+
+        context "when a updated since is not supplied" do
+          it "does not filter by updated since" do
+            condition_string = %("applications"."updated_at" >=)
+
+            expect(query.scope.to_sql).not_to include(condition_string)
+          end
+        end
+      end
+
+      describe "training status" do
+        context "when a training status is supplied" do
+          let(:params) { { training_status: "withdrawn" } }
+
+          before { participant1.applications.first.update!(training_status: ApplicationState.states[:withdrawn]) }
+
+          it "filters by training status" do
+            expect(query.participants).to contain_exactly(participant1)
+          end
+        end
+
+        context "when a training status is not supplied" do
+          it "does not filter by training status" do
+            condition_string = %("applications"."training_status" =)
+
+            expect(query.scope.to_sql).not_to include(condition_string)
+          end
+        end
+
+        context "when an invalid training status is supplied" do
+          let(:params) { { training_status: "any" } }
+
+          it "does not filter by training status" do
+            condition_string = %("applications"."training_status" =)
+
+            expect(query.scope.to_sql).not_to include(condition_string)
+          end
+        end
+      end
+
+      describe "from participant id" do
+        let(:participant_id_change) { create(:participant_id_change, user: participant1, to_participant: participant1) }
+        let(:from_participant_id) { participant_id_change.from_participant.ecf_id }
+
+        context "when a from participant id is supplied" do
+          let(:params) { { from_participant_id: } }
+
+          it "filters by from participant id" do
+            expect(query.participants).to contain_exactly(participant1)
+          end
+        end
+
+        context "when a from participant id is not supplied" do
+          it "does not filter by from participant id" do
+            condition_string = %("participant_id_changes"."from_participant_id" =)
+
+            expect(query.scope.to_sql).not_to include(condition_string)
+          end
+        end
+
+        context "when an invalid from participant id is supplied" do
+          let(:params) { { from_participant_id: SecureRandom.uuid } }
+
+          it "does not filter by training status" do
+            expect(query.participants).to be_empty
+          end
+        end
+      end
+    end
+
+    describe "sorting" do
+      let(:participant1) { travel_to(1.month.ago) { create(:user, :with_application, lead_provider:) } }
+      let(:participant2) { travel_to(1.week.ago) { create(:user, :with_application, lead_provider:) } }
+      let(:participant3) { create(:user, :with_application, lead_provider:) }
+      let(:sort) { nil }
+      let(:params) { { sort: } }
+
+      subject(:participants) { query.participants }
+
+      it { is_expected.to eq([participant1, participant2, participant3]) }
+
+      context "when sorting by created at, descending" do
+        let(:sort) { "-created_at" }
+
+        it { is_expected.to eq([participant3, participant2, participant1]) }
+      end
+
+      context "when sorting by updated at, ascending" do
+        let(:sort) { "+updated_at" }
+
+        before do
+          participant1.update!(updated_at: 1.day.from_now)
+          participant2.update!(updated_at: 2.days.from_now)
+        end
+
+        it { is_expected.to eq([participant3, participant1, participant2]) }
+      end
+
+      context "when sorting by multiple attributes" do
+        let(:sort) { "+updated_at,-created_at" }
+
+        before do
+          participant1.update!(updated_at: 1.day.from_now)
+          participant2.update!(updated_at: participant1.updated_at)
+          participant3.update!(updated_at: 2.days.from_now)
+
+          participant2.update!(created_at: 1.day.from_now)
+          participant1.update!(created_at: 1.day.ago)
+        end
+
+        it { expect(participants).to eq([participant2, participant1, participant3]) }
+      end
+    end
+  end
+end

--- a/spec/services/participants/query_spec.rb
+++ b/spec/services/participants/query_spec.rb
@@ -7,15 +7,15 @@ RSpec.describe Participants::Query do
 
   describe "#participants" do
     let(:lead_provider) { create(:lead_provider) }
-    let!(:participant1) { create(:user, :with_application, lead_provider:) }
-    let!(:participant2) { create(:user, :with_application, lead_provider:) }
+    let!(:participant1) { create(:participant, lead_provider:) }
+    let!(:participant2) { create(:participant, lead_provider:) }
 
     it "returns all participants" do
       expect(query.participants).to contain_exactly(participant1, participant2)
     end
 
     it "orders participants by created_at in ascending order" do
-      participant3 = travel_to(1.minute.ago) { create(:user, :with_application, lead_provider:) }
+      participant3 = travel_to(1.minute.ago) { create(:participant, lead_provider:) }
 
       expect(query.participants).to eq([participant3, participant1, participant2])
     end
@@ -26,7 +26,7 @@ RSpec.describe Participants::Query do
           let(:params) { { lead_provider: } }
 
           it "filters by lead provider" do
-            create(:user, :with_application, lead_provider: create(:lead_provider))
+            create(:participant, lead_provider: create(:lead_provider))
 
             expect(query.participants).to contain_exactly(participant1, participant2)
           end
@@ -46,7 +46,7 @@ RSpec.describe Participants::Query do
           let(:params) { { updated_since: 1.day.ago } }
 
           it "filters by updated since" do
-            create(:user, :with_application, lead_provider:, updated_at: 2.days.ago)
+            create(:participant, lead_provider:, updated_at: 2.days.ago)
 
             expect(query.participants).to contain_exactly(participant1, participant2)
           end
@@ -122,9 +122,9 @@ RSpec.describe Participants::Query do
     end
 
     describe "sorting" do
-      let(:participant1) { travel_to(1.month.ago) { create(:user, :with_application, lead_provider:) } }
-      let(:participant2) { travel_to(1.week.ago) { create(:user, :with_application, lead_provider:) } }
-      let(:participant3) { create(:user, :with_application, lead_provider:) }
+      let(:participant1) { travel_to(1.month.ago) { create(:participant, lead_provider:) } }
+      let(:participant2) { travel_to(1.week.ago) { create(:participant, lead_provider:) } }
+      let(:participant3) { create(:participant, lead_provider:) }
       let(:sort) { nil }
       let(:params) { { sort: } }
 


### PR DESCRIPTION
### Context

Ticket: [CPDLP-3080](https://dfedigital.atlassian.net/browse/CPDLP-3080)

We would like to add the NPQ participant profiles endpoint to NPQ separation

### Changes proposed in this pull request

- Add new API endpoint for all API versions: `GET api/v{1/2/3}/participants/npq​`.

[CPDLP-3080]: https://dfedigital.atlassian.net/browse/CPDLP-3080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ