### PR TITLE
Require FactoryBot gem in separation environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,7 +86,7 @@ group :test do
   gem "with_model", "~> 2.1", ">= 2.1.7"
 end
 
-group :development, :test, :review do
+group :development, :test, :review, :separation do
   gem "factory_bot_rails"
   gem "faker", "~> 3.4"
 end


### PR DESCRIPTION
### Context

Ticket: N/A

We are using FactoryBot to generate good test data in separation environment so we need to install/require it on Gemfile.

### Changes proposed in this pull request

Require/Install `FactoryBot` gem in the separation environment.