### PR TITLE
Ignore dependabot prs when requesting reviews from team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,8 @@
 * @DFE-Digital/npq-cpd
+
+# Don't automatically assign reviewers on PRs that only modify these files,
+# as they are dependabot pull requests.
+Gemfile
+Gemfile.lock
+package.json
+yarn.lock


### PR DESCRIPTION
### Context
Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-000

This includes js updates and gem updates. We might get the occasional ruby version update on the actions but it should be less noisy

### Changes proposed in this pull request

Ignore dependabot js and gem updates

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
