### PR TITLE
Fix deprecation warning with Rails7 usage of ActiveSupport::Deprecation singleton

### DIFF
--- a/lib/rails_semantic_logger/extensions/action_dispatch/debug_exceptions.rb
+++ b/lib/rails_semantic_logger/extensions/action_dispatch/debug_exceptions.rb
@@ -1,0 +1,15 @@
+# Log actual exceptions, not a string representation
+require "action_dispatch"
+
+module ActionDispatch
+  class DebugExceptions
+  private
+
+    undef_method :log_error
+    def log_error(_request, wrapper)
+      Rails.application.deprecators.silence do
+        ActionController::Base.logger.fatal(wrapper.exception)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: N/A

Rails 7 deprecated ActiveSupport::Deprecation singleton usage.
The gem `rails_semantic_logger`[ is still using it](https://github.com/reidmorrison/rails_semantic_logger/blob/93fed9edd0ba21490044e5fc7474c7b83eb2676c/lib/rails_semantic_logger/extensions/action_dispatch/debug_exceptions.rb#L10). So a warning is displayed when running tests locally.

```Rails -- DEPRECATION WARNING: Calling silence on ActiveSupport::Deprecation is deprecated and will be removed from Rails (use Rails.application.deprecators.silence instead)```

### Changes proposed in this pull request

Create a patch to fix the issue using `Rails.application.deprecators.silence` instead.
