### PR TITLE
Add funded place logic to previously funded and eligibility

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -65,6 +65,19 @@ class Application < ApplicationRecord
     withdrawn: "withdrawn",
   }
 
+  # `eligible_for_dfe_funding?`  takes into consideration what we know
+  # about user eligibility plus if it has been previously funded. We need
+  # to keep this method in place to keep consistency during the split between
+  # ECF and NPQ. In the mid term we will perform this calculation on NPQ and
+  # store the value in the `eligible_for_funding` attribute.
+  def eligible_for_dfe_funding?
+    if previously_funded?
+      false
+    else
+      eligible_for_funding
+    end
+  end
+
   def previously_funded?
     # This is an optimization used by the API Applications::Query in order
     # to speed up the bulk-retrieval of Applications.

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -75,6 +75,7 @@ class Application < ApplicationRecord
       .where(course: course.rebranded_alternative_courses)
       .accepted
       .eligible_for_funding
+      .where(funded_place: [nil, true])
       .exists?
   end
 

--- a/app/serializers/api/application_serializer.rb
+++ b/app/serializers/api/application_serializer.rb
@@ -24,7 +24,7 @@ module API
       field(:lead_provider_approval_status, name: :status)
       field(:works_in_school)
       field(:cohort) { |a| a.cohort&.start_year&.to_s }
-      field(:eligible_for_funding)
+      field(:eligible_for_dfe_funding?, name: :eligible_for_funding)
       field(:targeted_delivery_funding_eligibility)
       field(:inside_uk_catchment?, name: :teacher_catchment)
       field(:teacher_catchment_country)

--- a/app/services/applications/query.rb
+++ b/app/services/applications/query.rb
@@ -16,6 +16,7 @@ module Applications
             WHERE a.id != applications.id AND
                   a.user_id = applications.user_id AND
                   a.eligible_for_funding = true AND
+                  (a.funded_place is null OR a.funded_place = true) AND
                   a.lead_provider_approval_status = 'accepted' AND
                   a.course_id IN (
                     SELECT jsonb_array_elements_text(alt_courses->(applications.course_id::text))::bigint

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -163,6 +163,34 @@ RSpec.describe Application do
     end
   end
 
+  describe "#eligible_for_dfe_funding?" do
+    let(:user) { create(:user) }
+
+    subject { application }
+
+    context "when application has been previously funded" do
+      let(:application) { create(:application, :previously_funded, user:, course: Course.ehco) }
+
+      it { is_expected.not_to be_eligible_for_dfe_funding }
+    end
+
+    context "when application has not been previously funded" do
+      let(:application) { create(:application, user:, course: Course.ehco) }
+
+      it "is not eligible for DfE funding if not eligible for funding" do
+        application.update!(eligible_for_funding: false)
+
+        expect(application).not_to be_eligible_for_dfe_funding
+      end
+
+      it "is eligible for DfE funding if the application is eligible for funding" do
+        application.update!(eligible_for_funding: true)
+
+        expect(application).to be_eligible_for_dfe_funding
+      end
+    end
+  end
+
   describe "#previously_funded?" do
     let(:user) { create(:user) }
     let(:application) { create(:application, :previously_funded, user:, course: Course.ehco) }
@@ -182,7 +210,7 @@ RSpec.describe Application do
       context "when funded place is `false`" do
         before { previous_application.update!(funded_place: false) }
 
-        it { is_expected.to_not be_previously_funded }
+        it { is_expected.not_to be_previously_funded }
       end
 
       context "when funded place is `true`" do

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -172,6 +172,24 @@ RSpec.describe Application do
 
     context "when the application has been previously funded" do
       it { is_expected.to be_previously_funded }
+
+      context "when funded place is `nil`" do
+        before { previous_application.update!(funded_place: nil) }
+
+        it { is_expected.to be_previously_funded }
+      end
+
+      context "when funded place is `false`" do
+        before { previous_application.update!(funded_place: false) }
+
+        it { is_expected.to_not be_previously_funded }
+      end
+
+      context "when funded place is `true`" do
+        before { previous_application.update!(funded_place: true) }
+
+        it { is_expected.to be_previously_funded }
+      end
     end
 
     context "when the application has not been previously funded (previous application not accepted)" do

--- a/spec/serializers/api/application_serializer_spec.rb
+++ b/spec/serializers/api/application_serializer_spec.rb
@@ -69,9 +69,11 @@ RSpec.describe API::ApplicationSerializer, type: :serializer do
       expect(attributes["targeted_delivery_funding_eligibility"]).to eq(application.targeted_delivery_funding_eligibility)
     end
 
-    it "serializes the `eligible_for_funding`" do
+    it "serializes the `eligible_for_funding` (previously funded)" do
       application.eligible_for_funding = true
-      expect(attributes["eligible_for_funding"]).to eq(application.eligible_for_funding)
+      allow(application).to receive(:previously_funded?).and_return(true)
+
+      expect(attributes["eligible_for_funding"]).to eq(false)
     end
 
     it "serializes the `teacher_catchment`" do

--- a/spec/services/applications/query_spec.rb
+++ b/spec/services/applications/query_spec.rb
@@ -210,7 +210,6 @@ RSpec.describe Applications::Query do
 
       it { expect(returned_application).not_to be_transient_previously_funded }
 
-
       context "when there is a previous, rejected application that was eligible for funding" do
         before do
           create(
@@ -316,8 +315,9 @@ RSpec.describe Applications::Query do
           )
         end
 
-        it { expect(returned_application).to_not be_transient_previously_funded }
+        it { expect(returned_application).not_to be_transient_previously_funded }
       end
+
       context "when there is a previous, accepted application that was eligible for funding on a rebranded course" do
         let(:course) { Course.find_by(identifier: Course::NPQ_ADDITIONAL_SUPPORT_OFFER) }
 

--- a/spec/services/applications/query_spec.rb
+++ b/spec/services/applications/query_spec.rb
@@ -210,6 +210,7 @@ RSpec.describe Applications::Query do
 
       it { expect(returned_application).not_to be_transient_previously_funded }
 
+
       context "when there is a previous, rejected application that was eligible for funding" do
         before do
           create(
@@ -270,6 +271,53 @@ RSpec.describe Applications::Query do
         it { expect(returned_application).to be_transient_previously_funded }
       end
 
+      context "when there is a previous, accepted application that was eligible for funding and funded place is `nil`" do
+        before do
+          create(
+            :application,
+            :accepted,
+            lead_provider:,
+            user_id: application.user_id,
+            eligible_for_funding: true,
+            funded_place: nil,
+            course: application.course,
+          )
+        end
+
+        it { expect(returned_application).to be_transient_previously_funded }
+      end
+
+      context "when there is a previous, accepted application that was eligible for funding and funded place is `true`" do
+        before do
+          create(
+            :application,
+            :accepted,
+            lead_provider:,
+            user_id: application.user_id,
+            eligible_for_funding: true,
+            funded_place: true,
+            course: application.course,
+          )
+        end
+
+        it { expect(returned_application).to be_transient_previously_funded }
+      end
+
+      context "when there is a previous, accepted application that was eligible for funding and funded place is `false`" do
+        before do
+          create(
+            :application,
+            :accepted,
+            lead_provider:,
+            user_id: application.user_id,
+            eligible_for_funding: true,
+            funded_place: false,
+            course: application.course,
+          )
+        end
+
+        it { expect(returned_application).to_not be_transient_previously_funded }
+      end
       context "when there is a previous, accepted application that was eligible for funding on a rebranded course" do
         let(:course) { Course.find_by(identifier: Course::NPQ_ADDITIONAL_SUPPORT_OFFER) }
 


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-3150

### Description

Add support for `eligible_for_dfe_funding?` in applications, so we take into consideration
the `funded_place` attribute for capping.

Related to this PR (https://github.com/DFE-Digital/early-careers-framework/pull/4871).

