### PR TITLE
[CPDLP-3084] Add seed data for separation environment for participant profiles

### DIFF
--- a/app/services/valid_test_data_generators/applications_populater.rb
+++ b/app/services/valid_test_data_generators/applications_populater.rb
@@ -80,7 +80,11 @@ module ValidTestDataGenerators
     end
 
     def accept_application(application)
-      Applications::Accept.new(application:, funded_place: Faker::Boolean.boolean(true_ratio: 0.7)).accept
+      funded_place = if application.cohort.funding_cap?
+                       application.eligible_for_funding? ? Faker::Boolean.boolean(true_ratio: 0.7) : false
+                     end
+
+      Applications::Accept.new(application:, funded_place:).accept
       application.reload
     end
 

--- a/app/services/valid_test_data_generators/applications_populater.rb
+++ b/app/services/valid_test_data_generators/applications_populater.rb
@@ -38,54 +38,49 @@ module ValidTestDataGenerators
 
     def create_participant(school:)
       course = courses.sample
+      user = create_user
+      application = create_application(user, school, course)
 
-      user = FactoryBot.create(:user,
-                               :with_get_an_identity_id,
-                               :with_random_name,
-                               date_of_birth: Date.new(1990, 1, 1),
-                               trn: Faker::Number.unique.number(digits: 7),
-                               trn_verified: true,
-                               trn_auto_verified: true)
+      return if Faker::Boolean.boolean(true_ratio: 0.3)
 
-      application = FactoryBot.create(:application,
-                                      :pending,
-                                      :with_random_work_setting,
-                                      school:,
-                                      lead_provider:,
-                                      user:,
-                                      cohort:,
-                                      course:,
-                                      headteacher_status: Application.headteacher_statuses.keys.sample,
-                                      eligible_for_funding: Faker::Boolean.boolean,
-                                      itt_provider: IttProvider.currently_approved.order("RANDOM()").first)
+      accept_application(application)
 
-      methods = %i[accept_application reject_application]
+      return if Faker::Boolean.boolean(true_ratio: 0.3)
 
-      return if Faker::Boolean.boolean
+      course = courses.reject { |c| c.identifier == course.identifier }.sample
+      application = create_application(user, school, course)
 
-      send(methods.sample, application)
+      return if Faker::Boolean.boolean(true_ratio: 0.3)
 
-      return if Faker::Boolean.boolean
+      reject_application(application)
+    end
 
-      application = FactoryBot.create(:application,
-                                      :pending,
-                                      :with_random_work_setting,
-                                      school:,
-                                      lead_provider:,
-                                      user:,
-                                      cohort:,
-                                      course: courses.reject { |c| c.identifier == course.identifier }.sample,
-                                      headteacher_status: Application.headteacher_statuses.keys.sample,
-                                      eligible_for_funding: Faker::Boolean.boolean,
-                                      itt_provider: IttProvider.currently_approved.order("RANDOM()").first)
+    def create_user
+      FactoryBot.create(:user,
+                        :with_get_an_identity_id,
+                        :with_random_name,
+                        date_of_birth: Date.new(1990, 1, 1),
+                        trn: Faker::Number.unique.number(digits: 7),
+                        trn_verified: true,
+                        trn_auto_verified: true)
+    end
 
-      return if Faker::Boolean.boolean
-
-      send(methods.sample, application)
+    def create_application(user, school, course)
+      FactoryBot.create(:application,
+                        :pending,
+                        :with_random_work_setting,
+                        school:,
+                        lead_provider:,
+                        user:,
+                        cohort:,
+                        course:,
+                        headteacher_status: Application.headteacher_statuses.keys.sample,
+                        eligible_for_funding: Faker::Boolean.boolean,
+                        itt_provider: IttProvider.currently_approved.order("RANDOM()").first)
     end
 
     def accept_application(application)
-      Applications::Accept.new(application:).accept
+      Applications::Accept.new(application:, funded_place: Faker::Boolean.boolean(true_ratio: 0.7)).accept
       application.reload
     end
 

--- a/lib/tasks/valid_test_data_generators/separation_data.rake
+++ b/lib/tasks/valid_test_data_generators/separation_data.rake
@@ -2,7 +2,7 @@
 
 namespace :lead_providers do
   desc "seed good test data for lead providers for API testing"
-  task :seed_statements_and_applications, %i[lead_provider_name cohort_start_year] => :environment do |_t, args|
+  task :seed_statements_and_applications, %i[lead_provider_name number_of_participants cohort_start_year] => :environment do |_t, args|
     return unless Rails.env.in?(%w[development review separation])
 
     lead_provider = LeadProvider.find_by(name: args[:lead_provider_name])
@@ -13,7 +13,7 @@ namespace :lead_providers do
 
     Array.wrap(lead_provider || LeadProvider.all).each do |lp|
       Array.wrap(cohort || Cohort.all).each do |c|
-        ValidTestDataGenerators::ApplicationsPopulater.populate(lead_provider: lp, cohort: c, number_of_participants: 100)
+        ValidTestDataGenerators::ApplicationsPopulater.populate(lead_provider: lp, cohort: c, number_of_participants: args[:number_of_participants]&.to_i || 100)
         ValidTestDataGenerators::StatementsPopulater.populate(lead_provider: lp, cohort: c)
       end
     end


### PR DESCRIPTION
### Context

Ticket: [CPDLP-3084](https://dfedigital.atlassian.net/browse/CPDLP-3084)

We have a service to create seed data for providers in separation which we need to keep up to date.

### Changes proposed in this pull request

Add seed data for separation environment for participant profiles.

[CPDLP-3084]: https://dfedigital.atlassian.net/browse/CPDLP-3084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ