### PR TITLE
Add `Participant::Resume` service and endpoints

### DIFF
--- a/app/controllers/api/v1/participants_controller.rb
+++ b/app/controllers/api/v1/participants_controller.rb
@@ -12,10 +12,19 @@ module API
         render json: to_json(participant)
       end
 
+      def resume
+        service = ::Participants::Resume.new(participant_action_params)
+
+        if service.resume
+          render json: to_json(service.participant)
+        else
+          render json: API::Errors::Response.from(service), status: :unprocessable_entity
+        end
+      end
+
       def change_schedule = head(:method_not_allowed)
       def defer = head(:method_not_allowed)
       def withdraw = head(:method_not_allowed)
-      def resume = head(:method_not_allowed)
       def outcomes = head(:method_not_allowed)
 
     private
@@ -27,7 +36,18 @@ module API
       end
 
       def participant_params
-        params.permit(:ecf_id, filter: %i[updated_since])
+        params.permit(:ecf_id)
+      end
+
+      def participant_action_params
+        params
+          .require(:data)
+          .require(:attributes)
+          .permit(:course_identifier)
+          .merge(
+            participant:,
+            lead_provider: current_lead_provider,
+          )
       end
 
       def to_json(obj)

--- a/app/controllers/api/v2/participants_controller.rb
+++ b/app/controllers/api/v2/participants_controller.rb
@@ -12,10 +12,19 @@ module API
         render json: to_json(participant)
       end
 
+      def resume
+        service = ::Participants::Resume.new(participant_action_params)
+
+        if service.resume
+          render json: to_json(service.participant)
+        else
+          render json: API::Errors::Response.from(service), status: :unprocessable_entity
+        end
+      end
+
       def change_schedule = head(:method_not_allowed)
       def defer = head(:method_not_allowed)
       def withdraw = head(:method_not_allowed)
-      def resume = head(:method_not_allowed)
       def outcomes = head(:method_not_allowed)
 
     private
@@ -27,7 +36,18 @@ module API
       end
 
       def participant_params
-        params.permit(:ecf_id, filter: %i[updated_since])
+        params.permit(:ecf_id)
+      end
+
+      def participant_action_params
+        params
+          .require(:data)
+          .require(:attributes)
+          .permit(:course_identifier)
+          .merge(
+            participant:,
+            lead_provider: current_lead_provider,
+          )
       end
 
       def to_json(obj)

--- a/app/controllers/api/v3/participants_controller.rb
+++ b/app/controllers/api/v3/participants_controller.rb
@@ -12,10 +12,19 @@ module API
         render json: to_json(participant)
       end
 
+      def resume
+        service = ::Participants::Resume.new(participant_action_params)
+
+        if service.resume
+          render json: to_json(service.participant)
+        else
+          render json: API::Errors::Response.from(service), status: :unprocessable_entity
+        end
+      end
+
       def change_schedule = head(:method_not_allowed)
       def defer = head(:method_not_allowed)
       def withdraw = head(:method_not_allowed)
-      def resume = head(:method_not_allowed)
       def outcomes = head(:method_not_allowed)
 
     private
@@ -35,7 +44,18 @@ module API
       end
 
       def participant_params
-        params.permit(:ecf_id, :sort, filter: %i[updated_since training_status from_participant_id])
+        params.permit(:ecf_id, filter: %i[training_status from_participant_id])
+      end
+
+      def participant_action_params
+        params
+          .require(:data)
+          .require(:attributes)
+          .permit(:course_identifier)
+          .merge(
+            participant:,
+            lead_provider: current_lead_provider,
+          )
       end
 
       def to_json(obj)

--- a/app/services/participants/resume.rb
+++ b/app/services/participants/resume.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Participants
+  class Resume
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :lead_provider
+    attribute :participant
+    attribute :course_identifier
+
+    validates :lead_provider, presence: true
+    validates :participant, presence: true
+    validates :course_identifier, inclusion: { in: Course::IDENTIFIERS }, allow_blank: false
+    validate :application_exists
+    validate :not_already_active
+
+    def resume
+      return false if invalid?
+
+      ActiveRecord::Base.transaction do
+        create_application_state!
+        application.active!
+        participant.reload
+      end
+
+      true
+    end
+
+  private
+
+    def create_application_state!
+      ApplicationState.create!(application:, lead_provider:)
+    end
+
+    def application
+      @application ||= participant
+        &.applications
+        &.accepted
+        &.includes(:course)
+        &.find_by(lead_provider:, course: { identifier: course_identifier })
+    end
+
+    def application_exists
+      errors.add(:participant, :blank) if application.blank?
+    end
+
+    def not_already_active
+      errors.add(:participant, :already_active) if application&.active?
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -194,7 +194,14 @@ en:
               blank: Enter the date you became a SENCO to continue
               in_future: The date you became a SENCO must be in the past
               invalid: The date you became a SENCO must be a real date
-
+        participants/resume:
+          attributes:
+            course_identifier:
+              blank: "Enter a '#/course_identifier' value for this participant."
+              inclusion: The entered '#/course_identifier' is not recognised for the given participant. Check details and try again.
+            participant:
+              blank: "Your update cannot be made as the '#/participant_id' is not recognised. Check participant details and try again."
+              already_active: The participant is already active
   omniauth_providers:
     tra_openid_connect: "Get an Identity"
 

--- a/spec/requests/api/v1/participants_spec.rb
+++ b/spec/requests/api/v1/participants_spec.rb
@@ -31,6 +31,19 @@ RSpec.describe "Participant endpoints", type: :request do
     it_behaves_like "an API show endpoint"
   end
 
+  describe "PUT /api/v1/participants/:ecf_id/resume" do
+    let(:course_identifier) { application.course.identifier }
+    let(:application) { create(:application, :accepted, :withdrawn, lead_provider: current_lead_provider) }
+    let(:participant) { application.user }
+    let(:participant_id) { participant.ecf_id }
+
+    def path(id = nil)
+      resume_api_v1_participant_path(id)
+    end
+
+    it_behaves_like "an API resume participant endpoint"
+  end
+
   describe("change_schedule") do
     before { api_put(change_schedule_api_v1_participant_path(123)) }
 
@@ -45,12 +58,6 @@ RSpec.describe "Participant endpoints", type: :request do
 
   describe("withdraw") do
     before { api_put(withdraw_api_v1_participant_path(123)) }
-
-    specify { expect(response).to(be_method_not_allowed) }
-  end
-
-  describe("resume") do
-    before { api_put(resume_api_v1_participant_path(123)) }
 
     specify { expect(response).to(be_method_not_allowed) }
   end

--- a/spec/requests/api/v2/participants_spec.rb
+++ b/spec/requests/api/v2/participants_spec.rb
@@ -31,6 +31,23 @@ RSpec.describe "Participant endpoints", type: :request do
     it_behaves_like "an API show endpoint"
   end
 
+  describe "PUT /api/v2/participants/:ecf_id/resume" do
+    let(:course_identifier) { application.course.identifier }
+    let(:application) { create(:application, :accepted, :withdrawn, lead_provider: current_lead_provider) }
+    let(:participant) { application.user }
+    let(:participant_id) { participant.ecf_id }
+
+    def path(id = nil)
+      resume_api_v2_participant_path(id)
+    end
+
+    it_behaves_like "an API resume participant endpoint" do
+      def assert_on_successful_response(parsed_response)
+        expect(parsed_response["data"]["attributes"]["npq_enrolments"][0]["training_status"]).to eq("active")
+      end
+    end
+  end
+
   describe("change_schedule") do
     before { api_put(change_schedule_api_v2_participant_path(123)) }
 
@@ -45,12 +62,6 @@ RSpec.describe "Participant endpoints", type: :request do
 
   describe("withdraw") do
     before { api_put(withdraw_api_v2_participant_path(123)) }
-
-    specify { expect(response).to(be_method_not_allowed) }
-  end
-
-  describe("resume") do
-    before { api_put(resume_api_v2_participant_path(123)) }
 
     specify { expect(response).to(be_method_not_allowed) }
   end

--- a/spec/requests/api/v3/participants_spec.rb
+++ b/spec/requests/api/v3/participants_spec.rb
@@ -33,6 +33,23 @@ RSpec.describe "Participant endpoints", type: :request do
     it_behaves_like "an API show endpoint"
   end
 
+  describe "PUT /api/v3/participants/:ecf_id/resume" do
+    let(:course_identifier) { application.course.identifier }
+    let(:application) { create(:application, :accepted, :withdrawn, lead_provider: current_lead_provider) }
+    let(:participant) { application.user }
+    let(:participant_id) { participant.ecf_id }
+
+    def path(id = nil)
+      resume_api_v3_participant_path(id)
+    end
+
+    it_behaves_like "an API resume participant endpoint" do
+      def assert_on_successful_response(parsed_response)
+        expect(parsed_response["data"]["attributes"]["npq_enrolments"][0]["training_status"]).to eq("active")
+      end
+    end
+  end
+
   describe("change_schedule") do
     before { api_put(change_schedule_api_v2_participant_path(123)) }
 
@@ -47,12 +64,6 @@ RSpec.describe "Participant endpoints", type: :request do
 
   describe("withdraw") do
     before { api_put(withdraw_api_v2_participant_path(123)) }
-
-    specify { expect(response).to(be_method_not_allowed) }
-  end
-
-  describe("resume") do
-    before { api_put(resume_api_v2_participant_path(123)) }
 
     specify { expect(response).to(be_method_not_allowed) }
   end

--- a/spec/services/participants/resume_spec.rb
+++ b/spec/services/participants/resume_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Participants::Resume, type: :model do
+  let(:lead_provider) { application.lead_provider }
+  let(:participant) { application.user }
+  let(:application) { create(:application, :accepted, :withdrawn) }
+  let(:course_identifier) { application.course.identifier }
+  let!(:instance) { described_class.new(lead_provider:, participant:, course_identifier:) }
+
+  it { expect(instance).to be_valid }
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:lead_provider) }
+    it { is_expected.to validate_presence_of(:participant) }
+    it { is_expected.to validate_inclusion_of(:course_identifier).in_array(Course::IDENTIFIERS) }
+
+    context "when the application is already active" do
+      let(:application) { create(:application, :accepted) }
+
+      it "adds an error to the participant attribute" do
+        expect(instance).to be_invalid
+        expect(instance.errors.first).to have_attributes(attribute: :participant, type: :already_active)
+      end
+    end
+
+    context "when a matching application does not exist (different course identifier)" do
+      let(:course_identifier) { Course::IDENTIFIERS.excluding(application.course.identifier).sample }
+
+      it "adds an error to the participant attribute" do
+        expect(instance).to be_invalid
+        expect(instance.errors.first).to have_attributes(attribute: :participant, type: :blank)
+      end
+    end
+
+    context "when a matching application does not exist (different lead provider)" do
+      let(:lead_provider) { create(:lead_provider) }
+
+      it "adds an error to the participant attribute" do
+        expect(instance).to be_invalid
+        expect(instance.errors.first).to have_attributes(attribute: :participant, type: :blank)
+      end
+    end
+
+    context "when there is a matching application, but it is not accepted" do
+      let(:application) { create(:application, :withdrawn) }
+
+      it "adds an error to the participant attribute" do
+        expect(instance).to be_invalid
+        expect(instance.errors.first).to have_attributes(attribute: :participant, type: :blank)
+      end
+    end
+  end
+
+  describe "#resume" do
+    subject(:resume) { instance.resume }
+
+    it { is_expected.to be(true) }
+
+    it "creates an active application state" do
+      expect { resume }.to change(ApplicationState, :count).by(1)
+
+      expect(application.application_states.last).to have_attributes(
+        lead_provider:,
+        application:,
+        state: "active",
+      )
+    end
+
+    it "updates the application training status to active" do
+      expect { resume }.to change { application.reload.training_status }.from("withdrawn").to("active")
+    end
+
+    context "when the instance is invalid" do
+      let(:lead_provider) { nil }
+
+      it "returns false and sets errors" do
+        expect(resume).to be(false)
+        expect(instance.errors).to be_present
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/api_resume_participant_endpoint_support.rb
+++ b/spec/support/shared_examples/api_resume_participant_endpoint_support.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "an API resume participant endpoint" do
+  let(:params) { { data: { attributes: { course_identifier: } } } }
+
+  context "when authorized" do
+    context "when the participant exists" do
+      it "returns the participant" do
+        api_put(path(participant_id), params:)
+
+        expect(response.status).to eq 200
+        expect(response.content_type).to eql("application/json")
+        expect(parsed_response["data"]["id"]).to eq(participant_id)
+
+        assert_on_successful_response(parsed_response) if defined?(assert_on_successful_response)
+      end
+
+      it "calls the correct service" do
+        resume_double = instance_double(Participants::Resume, resume: true, participant:)
+
+        allow(Participants::Resume).to receive(:new) { |args|
+          expect(args[:participant]).to eq(participant)
+          expect(args[:lead_provider]).to eq(current_lead_provider)
+          expect(args[:course_identifier]).to eq(course_identifier)
+        }.and_return(resume_double)
+
+        api_put(path(participant_id), params:)
+
+        expect(resume_double).to have_received(:resume)
+      end
+
+      it "calls the correct service/serializer" do
+        serializer_params = { root: "data" }
+        serializer_params[:view] = serializer_version if defined?(serializer_version)
+        serializer_params[:lead_provider] = serializer_lead_provider if defined?(serializer_lead_provider)
+
+        expect(serializer).to receive(:render).with(participant, **serializer_params).and_call_original
+
+        api_put(path(participant_id), params:)
+      end
+    end
+
+    context "when the participant does not exist", exceptions_app: true do
+      it "returns not found" do
+        api_put(path("123XXX"), params:)
+
+        expect(response.status).to eq(404)
+      end
+    end
+  end
+
+  context "when unauthorized" do
+    it "returns 401 - unauthorized" do
+      api_put(path(participant_id), params:, token: "incorrect-token")
+
+      expect(response.status).to eq 401
+      expect(parsed_response["error"]).to eql("HTTP Token: Access denied")
+      expect(response.content_type).to eql("application/json")
+    end
+  end
+end


### PR DESCRIPTION
[Jira-3088](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3088)

### Context

We want to add the participant resume endpoint from ECF, bringing across anything relevant to NPQ.

### Changes proposed in this pull request

- Add Participant::Resume service

Add the service to move a participant back to the `active` state. This is lifted from ECF; instead of looking for the matching profile we find the matching application.

- Add /participants/npq/:id/resume endpoint

Adds the endpoint to enable providers to resume the training status of a participant.
