### PR TITLE
Add `Participant::Defer` service and endpoints

### DIFF
--- a/app/controllers/api/v1/participants_controller.rb
+++ b/app/controllers/api/v1/participants_controller.rb
@@ -22,8 +22,17 @@ module API
         end
       end
 
+      def defer
+        service = ::Participants::Defer.new(participant_action_params)
+
+        if service.defer
+          render json: to_json(service.participant)
+        else
+          render json: API::Errors::Response.from(service), status: :unprocessable_entity
+        end
+      end
+
       def change_schedule = head(:method_not_allowed)
-      def defer = head(:method_not_allowed)
       def withdraw = head(:method_not_allowed)
       def outcomes = head(:method_not_allowed)
 
@@ -43,7 +52,7 @@ module API
         params
           .require(:data)
           .require(:attributes)
-          .permit(:course_identifier)
+          .permit(:course_identifier, :reason)
           .merge(
             participant:,
             lead_provider: current_lead_provider,

--- a/app/controllers/api/v2/participants_controller.rb
+++ b/app/controllers/api/v2/participants_controller.rb
@@ -22,8 +22,17 @@ module API
         end
       end
 
+      def defer
+        service = ::Participants::Defer.new(participant_action_params)
+
+        if service.defer
+          render json: to_json(service.participant)
+        else
+          render json: API::Errors::Response.from(service), status: :unprocessable_entity
+        end
+      end
+
       def change_schedule = head(:method_not_allowed)
-      def defer = head(:method_not_allowed)
       def withdraw = head(:method_not_allowed)
       def outcomes = head(:method_not_allowed)
 
@@ -43,7 +52,7 @@ module API
         params
           .require(:data)
           .require(:attributes)
-          .permit(:course_identifier)
+          .permit(:course_identifier, :reason)
           .merge(
             participant:,
             lead_provider: current_lead_provider,

--- a/app/controllers/api/v3/participants_controller.rb
+++ b/app/controllers/api/v3/participants_controller.rb
@@ -22,8 +22,17 @@ module API
         end
       end
 
+      def defer
+        service = ::Participants::Defer.new(participant_action_params)
+
+        if service.defer
+          render json: to_json(service.participant)
+        else
+          render json: API::Errors::Response.from(service), status: :unprocessable_entity
+        end
+      end
+
       def change_schedule = head(:method_not_allowed)
-      def defer = head(:method_not_allowed)
       def withdraw = head(:method_not_allowed)
       def outcomes = head(:method_not_allowed)
 
@@ -51,7 +60,7 @@ module API
         params
           .require(:data)
           .require(:attributes)
-          .permit(:course_identifier)
+          .permit(:course_identifier, :reason)
           .merge(
             participant:,
             lead_provider: current_lead_provider,

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -21,6 +21,7 @@ class Application < ApplicationRecord
   has_many :ecf_sync_request_logs, as: :syncable, dependent: :destroy
   has_many :participant_id_changes, through: :user
   has_many :application_states
+  has_many :declarations
 
   scope :unsynced, -> { where(ecf_id: nil) }
   scope :expired_applications, -> { where(lead_provider_approval_status: "rejected").where("created_at < ?", cut_off_date_for_expired_applications) }

--- a/app/services/participants/defer.rb
+++ b/app/services/participants/defer.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module Participants
+  class Defer
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    DEFERRAL_REASONS = %w[
+      bereavement
+      long-term-sickness
+      parental-leave
+      career-break
+      other
+    ].freeze
+
+    attribute :lead_provider
+    attribute :participant
+    attribute :course_identifier
+    attribute :reason
+
+    validates :lead_provider, presence: true
+    validates :participant, presence: true
+    validates :course_identifier, inclusion: { in: Course::IDENTIFIERS }, allow_blank: false
+    validates :reason, inclusion: { in: DEFERRAL_REASONS }, allow_blank: false
+    validate :application_exists
+    validate :not_already_deferred
+    validate :not_withdrawn
+    validate :has_declarations
+
+    def defer
+      return false if invalid?
+
+      ActiveRecord::Base.transaction do
+        create_application_state!
+        application.deferred!
+        participant.reload
+      end
+
+      true
+    end
+
+  private
+
+    def create_application_state!
+      ApplicationState.create!(application:, lead_provider:, reason:, state: :deferred)
+    end
+
+    def application
+      @application ||= participant
+        &.applications
+        &.accepted
+        &.includes(:course)
+        &.find_by(lead_provider:, course: { identifier: course_identifier })
+    end
+
+    def application_exists
+      errors.add(:participant, :blank) if application.blank?
+    end
+
+    def not_withdrawn
+      errors.add(:participant, :withdrawn) if application&.withdrawn?
+    end
+
+    def not_already_deferred
+      errors.add(:participant, :already_deferred) if application&.deferred?
+    end
+
+    def has_declarations
+      errors.add(:participant, :no_declarations) if application&.declarations&.none?
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,13 @@ en:
     missing_funded_place: "The entered '#/funded_place' is missing from your request. Check details and try again."
     cohort_does_not_accept_capping: "Leave the '#/funded_place' field blank. It's only needed for participants starting NPQs from autumn 2024 onwards."
 
+  participant: &participant
+    blank: Your update cannot be made as the '#/participant_id' is not recognised. Check participant details and try again.
+
+  participant_course_identifier: &participant_course_identifier
+    blank: Enter a '#/course_identifier' value for this participant.
+    inclusion: The entered '#/course_identifier' is not recognised for the given participant. Check details and try again.
+
   time:
     formats:
       admin: "%R on %d/%m/%Y"
@@ -197,11 +204,22 @@ en:
         participants/resume:
           attributes:
             course_identifier:
-              blank: "Enter a '#/course_identifier' value for this participant."
-              inclusion: The entered '#/course_identifier' is not recognised for the given participant. Check details and try again.
+              <<: *participant_course_identifier
             participant:
-              blank: "Your update cannot be made as the '#/participant_id' is not recognised. Check participant details and try again."
+              <<: *participant
               already_active: The participant is already active
+        participants/defer:
+          attributes:
+            course_identifier:
+              <<: *participant_course_identifier
+            participant:
+              <<: *participant
+              already_deferred: The participant is already deferred
+              withdrawn: The participant is already withdrawn
+              no_declarations: You cannot defer an NPQ participant that has no declarations
+            reason:
+              blank: The property '#/reason' must be present
+              inclusion: The property '#/reason' must be a valid reason
   omniauth_providers:
     tra_openid_connect: "Get an Identity"
 

--- a/spec/factories/applications.rb
+++ b/spec/factories/applications.rb
@@ -51,6 +51,14 @@ FactoryBot.define do
       schedule { Schedule.where(cohort:, course_group: course.course_group).sample || create(:schedule, course_group: course.course_group, cohort:) }
     end
 
+    trait :with_declaration do
+      accepted
+
+      after(:create) do |application|
+        create(:declaration, application:)
+      end
+    end
+
     trait :rejected do
       lead_provider_approval_status { :rejected }
     end
@@ -69,12 +77,6 @@ FactoryBot.define do
 
       after(:create) do |application|
         application.cohort.update!(funding_cap: true)
-      end
-    end
-
-    trait :with_declaration do
-      after(:create) do |application|
-        create(:declaration, application:)
       end
     end
 

--- a/spec/factories/applications.rb
+++ b/spec/factories/applications.rb
@@ -72,6 +72,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_declaration do
+      after(:create) do |application|
+        create(:declaration, application:)
+      end
+    end
+
     trait :previously_funded do
       after(:create) do |application|
         course = application.course.rebranded_alternative_courses.sample

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Application do
     it { is_expected.to have_many(:ecf_sync_request_logs).dependent(:destroy) }
     it { is_expected.to have_many(:participant_id_changes).through(:user) }
     it { is_expected.to have_many(:application_states) }
+    it { is_expected.to have_many(:declarations) }
   end
 
   describe "enums" do

--- a/spec/requests/api/v1/participants_spec.rb
+++ b/spec/requests/api/v1/participants_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "Participant endpoints", type: :request do
   describe "PUT /api/v1/participants/:ecf_id/defer" do
     let(:course_identifier) { application.course.identifier }
     let(:reason) { Participants::Defer::DEFERRAL_REASONS.sample }
-    let(:application) { create(:application, :accepted, :with_declaration, lead_provider: current_lead_provider) }
+    let(:application) { create(:application, :with_declaration, lead_provider: current_lead_provider) }
     let(:participant) { application.user }
     let(:participant_id) { participant.ecf_id }
 

--- a/spec/requests/api/v1/participants_spec.rb
+++ b/spec/requests/api/v1/participants_spec.rb
@@ -44,14 +44,22 @@ RSpec.describe "Participant endpoints", type: :request do
     it_behaves_like "an API resume participant endpoint"
   end
 
-  describe("change_schedule") do
-    before { api_put(change_schedule_api_v1_participant_path(123)) }
+  describe "PUT /api/v1/participants/:ecf_id/defer" do
+    let(:course_identifier) { application.course.identifier }
+    let(:reason) { Participants::Defer::DEFERRAL_REASONS.sample }
+    let(:application) { create(:application, :accepted, :with_declaration, lead_provider: current_lead_provider) }
+    let(:participant) { application.user }
+    let(:participant_id) { participant.ecf_id }
 
-    specify { expect(response).to(be_method_not_allowed) }
+    def path(id = nil)
+      defer_api_v1_participant_path(id)
+    end
+
+    it_behaves_like "an API defer participant endpoint"
   end
 
-  describe("defer") do
-    before { api_put(defer_api_v1_participant_path(123)) }
+  describe("change_schedule") do
+    before { api_put(change_schedule_api_v1_participant_path(123)) }
 
     specify { expect(response).to(be_method_not_allowed) }
   end

--- a/spec/requests/api/v2/participants_spec.rb
+++ b/spec/requests/api/v2/participants_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Participant endpoints", type: :request do
   describe "PUT /api/v2/participants/:ecf_id/defer" do
     let(:course_identifier) { application.course.identifier }
     let(:reason) { Participants::Defer::DEFERRAL_REASONS.sample }
-    let(:application) { create(:application, :accepted, :with_declaration, lead_provider: current_lead_provider) }
+    let(:application) { create(:application, :with_declaration, lead_provider: current_lead_provider) }
     let(:participant) { application.user }
     let(:participant_id) { participant.ecf_id }
 

--- a/spec/requests/api/v2/participants_spec.rb
+++ b/spec/requests/api/v2/participants_spec.rb
@@ -48,14 +48,26 @@ RSpec.describe "Participant endpoints", type: :request do
     end
   end
 
-  describe("change_schedule") do
-    before { api_put(change_schedule_api_v2_participant_path(123)) }
+  describe "PUT /api/v2/participants/:ecf_id/defer" do
+    let(:course_identifier) { application.course.identifier }
+    let(:reason) { Participants::Defer::DEFERRAL_REASONS.sample }
+    let(:application) { create(:application, :accepted, :with_declaration, lead_provider: current_lead_provider) }
+    let(:participant) { application.user }
+    let(:participant_id) { participant.ecf_id }
 
-    specify { expect(response).to(be_method_not_allowed) }
+    def path(id = nil)
+      defer_api_v2_participant_path(id)
+    end
+
+    it_behaves_like "an API defer participant endpoint" do
+      def assert_on_successful_response(parsed_response)
+        expect(parsed_response["data"]["attributes"]["npq_enrolments"][0]["training_status"]).to eq("deferred")
+      end
+    end
   end
 
-  describe("defer") do
-    before { api_put(defer_api_v2_participant_path(123)) }
+  describe("change_schedule") do
+    before { api_put(change_schedule_api_v2_participant_path(123)) }
 
     specify { expect(response).to(be_method_not_allowed) }
   end

--- a/spec/requests/api/v3/participants_spec.rb
+++ b/spec/requests/api/v3/participants_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Participant endpoints", type: :request do
   describe "PUT /api/v3/participants/:ecf_id/defer" do
     let(:course_identifier) { application.course.identifier }
     let(:reason) { Participants::Defer::DEFERRAL_REASONS.sample }
-    let(:application) { create(:application, :accepted, :with_declaration, lead_provider: current_lead_provider) }
+    let(:application) { create(:application, :with_declaration, lead_provider: current_lead_provider) }
     let(:participant) { application.user }
     let(:participant_id) { participant.ecf_id }
 

--- a/spec/requests/api/v3/participants_spec.rb
+++ b/spec/requests/api/v3/participants_spec.rb
@@ -50,14 +50,26 @@ RSpec.describe "Participant endpoints", type: :request do
     end
   end
 
-  describe("change_schedule") do
-    before { api_put(change_schedule_api_v2_participant_path(123)) }
+  describe "PUT /api/v3/participants/:ecf_id/defer" do
+    let(:course_identifier) { application.course.identifier }
+    let(:reason) { Participants::Defer::DEFERRAL_REASONS.sample }
+    let(:application) { create(:application, :accepted, :with_declaration, lead_provider: current_lead_provider) }
+    let(:participant) { application.user }
+    let(:participant_id) { participant.ecf_id }
 
-    specify { expect(response).to(be_method_not_allowed) }
+    def path(id = nil)
+      defer_api_v3_participant_path(id)
+    end
+
+    it_behaves_like "an API defer participant endpoint" do
+      def assert_on_successful_response(parsed_response)
+        expect(parsed_response["data"]["attributes"]["npq_enrolments"][0]["training_status"]).to eq("deferred")
+      end
+    end
   end
 
-  describe("defer") do
-    before { api_put(defer_api_v2_participant_path(123)) }
+  describe("change_schedule") do
+    before { api_put(change_schedule_api_v2_participant_path(123)) }
 
     specify { expect(response).to(be_method_not_allowed) }
   end

--- a/spec/services/participants/defer_spec.rb
+++ b/spec/services/participants/defer_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Participants::Defer, type: :model do
   let(:lead_provider) { application.lead_provider }
   let(:participant) { application.user }
-  let(:application) { create(:application, :accepted, :with_declaration) }
+  let(:application) { create(:application, :with_declaration) }
   let(:course_identifier) { application.course.identifier }
   let(:reason) { described_class::DEFERRAL_REASONS.sample }
   let!(:instance) { described_class.new(lead_provider:, participant:, course_identifier:, reason:) }
@@ -19,7 +19,7 @@ RSpec.describe Participants::Defer, type: :model do
     it { is_expected.to validate_inclusion_of(:reason).in_array(described_class::DEFERRAL_REASONS) }
 
     context "when the application is already deferred" do
-      let(:application) { create(:application, :accepted, :deferred, :with_declaration) }
+      let(:application) { create(:application, :deferred, :with_declaration) }
 
       it "adds an error to the participant attribute" do
         expect(instance).to be_invalid
@@ -28,7 +28,7 @@ RSpec.describe Participants::Defer, type: :model do
     end
 
     context "when the application is withdrawn" do
-      let(:application) { create(:application, :accepted, :withdrawn, :with_declaration) }
+      let(:application) { create(:application, :withdrawn, :with_declaration) }
 
       it "adds an error to the participant attribute" do
         expect(instance).to be_invalid
@@ -55,7 +55,7 @@ RSpec.describe Participants::Defer, type: :model do
     end
 
     context "when there is a matching application, but it is not accepted" do
-      let(:application) { create(:application, :with_declaration) }
+      let(:application) { create(:application) }
 
       it "adds an error to the participant attribute" do
         expect(instance).to be_invalid

--- a/spec/services/participants/defer_spec.rb
+++ b/spec/services/participants/defer_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Participants::Defer, type: :model do
+  let(:lead_provider) { application.lead_provider }
+  let(:participant) { application.user }
+  let(:application) { create(:application, :accepted, :with_declaration) }
+  let(:course_identifier) { application.course.identifier }
+  let(:reason) { described_class::DEFERRAL_REASONS.sample }
+  let!(:instance) { described_class.new(lead_provider:, participant:, course_identifier:, reason:) }
+
+  it { expect(instance).to be_valid }
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:lead_provider) }
+    it { is_expected.to validate_presence_of(:participant) }
+    it { is_expected.to validate_inclusion_of(:course_identifier).in_array(Course::IDENTIFIERS) }
+    it { is_expected.to validate_inclusion_of(:reason).in_array(described_class::DEFERRAL_REASONS) }
+
+    context "when the application is already deferred" do
+      let(:application) { create(:application, :accepted, :deferred, :with_declaration) }
+
+      it "adds an error to the participant attribute" do
+        expect(instance).to be_invalid
+        expect(instance.errors.first).to have_attributes(attribute: :participant, type: :already_deferred)
+      end
+    end
+
+    context "when the application is withdrawn" do
+      let(:application) { create(:application, :accepted, :withdrawn, :with_declaration) }
+
+      it "adds an error to the participant attribute" do
+        expect(instance).to be_invalid
+        expect(instance.errors.first).to have_attributes(attribute: :participant, type: :withdrawn)
+      end
+    end
+
+    context "when a matching application does not exist (different course identifier)" do
+      let(:course_identifier) { Course::IDENTIFIERS.excluding(application.course.identifier).sample }
+
+      it "adds an error to the participant attribute" do
+        expect(instance).to be_invalid
+        expect(instance.errors.first).to have_attributes(attribute: :participant, type: :blank)
+      end
+    end
+
+    context "when a matching application does not exist (different lead provider)" do
+      let(:lead_provider) { create(:lead_provider) }
+
+      it "adds an error to the participant attribute" do
+        expect(instance).to be_invalid
+        expect(instance.errors.first).to have_attributes(attribute: :participant, type: :blank)
+      end
+    end
+
+    context "when there is a matching application, but it is not accepted" do
+      let(:application) { create(:application, :with_declaration) }
+
+      it "adds an error to the participant attribute" do
+        expect(instance).to be_invalid
+        expect(instance.errors.first).to have_attributes(attribute: :participant, type: :blank)
+      end
+    end
+
+    context "when the participant has no declarations" do
+      let(:application) { create(:application, :accepted) }
+
+      it "adds an error to the participant attribute" do
+        expect(instance).to be_invalid
+        expect(instance.errors.first).to have_attributes(attribute: :participant, type: :no_declarations)
+      end
+    end
+  end
+
+  describe "#defer" do
+    subject(:resume) { instance.defer }
+
+    it { is_expected.to be(true) }
+
+    it "creates a deferred application state" do
+      expect { resume }.to change(ApplicationState, :count).by(1)
+
+      expect(application.application_states.last).to have_attributes(
+        lead_provider:,
+        application:,
+        state: "deferred",
+        reason:,
+      )
+    end
+
+    it "updates the application training status to deferred" do
+      expect { resume }.to change { application.reload.training_status }.from("active").to("deferred")
+    end
+
+    context "when the instance is invalid" do
+      let(:lead_provider) { nil }
+
+      it "returns false and sets errors" do
+        expect(resume).to be(false)
+        expect(instance.errors).to be_present
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/api_defer_participant_endpoint_support.rb
+++ b/spec/support/shared_examples/api_defer_participant_endpoint_support.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples "an API resume participant endpoint" do
-  let(:params) { { data: { attributes: { course_identifier: } } } }
+RSpec.shared_examples "an API defer participant endpoint" do
+  let(:params) { { data: { attributes: { course_identifier:, reason: } } } }
 
   context "when authorized" do
     context "when the participant exists" do
@@ -16,17 +16,18 @@ RSpec.shared_examples "an API resume participant endpoint" do
       end
 
       it "calls the correct service" do
-        resume_double = instance_double(Participants::Resume, resume: true, participant:)
+        defer_double = instance_double(Participants::Defer, defer: true, participant:)
 
-        allow(Participants::Resume).to receive(:new) { |args|
+        allow(Participants::Defer).to receive(:new) { |args|
           expect(args[:participant]).to eq(participant)
           expect(args[:lead_provider]).to eq(current_lead_provider)
           expect(args[:course_identifier]).to eq(course_identifier)
-        }.and_return(resume_double)
+          expect(args[:reason]).to eq(reason)
+        }.and_return(defer_double)
 
         api_put(path(participant_id), params:)
 
-        expect(resume_double).to have_received(:resume)
+        expect(defer_double).to have_received(:defer)
       end
 
       it "calls the correct serializer" do


### PR DESCRIPTION
[Jira-3090](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3090)

### Context

We want to add the participant defer endpoint from ECF, bringing across anything relevant to NPQ.

### Changes proposed in this pull request

- Add Participant::Defer service

Add the service to move a participant to a deferred state. This is lifted from ECF; instead of looking for the matching profile we find the matching application.

- Add /participants/npq/:id/defer endpoint

Adds the endpoint to enable providers to defer the training status of a participant.

### Guidance to review

I DRY up some of the duplication here between resume/defer in the final withdraw PR.