### PR TITLE
[CPDLP-3085] TS6 - Add declarations table

### DIFF
--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -1,0 +1,30 @@
+class Declaration < ApplicationRecord
+  belongs_to :application
+  belongs_to :cohort
+  belongs_to :lead_provider
+  belongs_to :superseded_by, class_name: "Declaration", optional: true
+
+  enum state: {
+    submitted: "submitted",
+    eligible: "eligible",
+    payable: "payable",
+    paid: "paid",
+    voided: "voided",
+    ineligible: "ineligible",
+    awaiting_clawback: "awaiting_clawback",
+    clawed_back: "clawed_back",
+  }, _suffix: true
+
+  enum declaration_type: {
+    started: "started",
+    "retained-1": "retained-1",
+    "retained-2": "retained-2",
+    completed: "completed",
+  }, _suffix: true
+
+  enum state_reason: {
+    duplicate: "duplicate",
+  }, _suffix: true
+
+  validates :declaration_date, :declaration_type, presence: true
+end

--- a/app/models/statement_item.rb
+++ b/app/models/statement_item.rb
@@ -3,7 +3,7 @@ class StatementItem < ApplicationRecord
   REFUNDABLE_STATES = %w[awaiting_clawback clawed_back].freeze
 
   belongs_to :statement
-  # belongs_to :declaration
+  belongs_to :declaration
 
   scope :billable, -> { where(state: BILLABLE_STATES) }
   scope :refundable, -> { where(state: REFUNDABLE_STATES) }

--- a/db/migrate/20240613151304_create_declarations.rb
+++ b/db/migrate/20240613151304_create_declarations.rb
@@ -1,0 +1,24 @@
+class CreateDeclarations < ActiveRecord::Migration[7.1]
+  def change
+    create_enum :declaration_states, %w[submitted eligible payable paid voided ineligible awaiting_clawback clawed_back]
+    create_enum :declaration_types, %w[started retained-1 retained-2 completed]
+    create_enum :declaration_state_reasons, %w[duplicate]
+
+    create_table :declarations do |t|
+      t.uuid :ecf_id, default: "gen_random_uuid()", null: false, index: true
+
+      t.references :application, null: false, foreign_key: true
+      t.references :superseded_by, null: true, foreign_key: { to_table: :declarations }
+      t.references :lead_provider, null: false, foreign_key: true
+      t.references :cohort, null: false, foreign_key: true
+
+      t.enum :declaration_type, enum_type: "declaration_types"
+      t.date :declaration_date
+
+      t.enum :state, enum_type: "declaration_states", default: "submitted", null: false
+      t.enum :state_reason, enum_type: "declaration_state_reasons"
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240614091519_add_declaration_to_statement_items.rb
+++ b/db/migrate/20240614091519_add_declaration_to_statement_items.rb
@@ -1,0 +1,5 @@
+class AddDeclarationToStatementItems < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :statement_items, :declaration, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_13_151304) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_14_091519) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -395,6 +395,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_13_151304) do
     t.enum "state", default: "eligible", null: false, enum_type: "statement_item_states"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "declaration_id"
+    t.index ["declaration_id"], name: "index_statement_items_on_declaration_id"
     t.index ["statement_id"], name: "index_statement_items_on_statement_id"
   end
 
@@ -476,6 +478,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_13_151304) do
   add_foreign_key "participant_id_changes", "users", column: "to_participant_id"
   add_foreign_key "schedules", "cohorts"
   add_foreign_key "schedules", "course_groups"
+  add_foreign_key "statement_items", "declarations"
   add_foreign_key "statement_items", "statements"
   add_foreign_key "statements", "cohorts"
   add_foreign_key "statements", "lead_providers"

--- a/spec/factories/declarations.rb
+++ b/spec/factories/declarations.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :declaration do
+    application
+    lead_provider { application&.lead_provider || build(:lead_provider) }
+    cohort { application&.cohort || build(:cohort, :current) }
+
+    declaration_type { "started" }
+    declaration_date { Date.current }
+
+    state { "submitted" }
+  end
+end

--- a/spec/factories/statement_items.rb
+++ b/spec/factories/statement_items.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :statement_item do
-    statement { build :statement }
-    # declaration { association :declaration }
+    statement
+    declaration
     state { "eligible" }
 
     trait :eligible do

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe Declaration, type: :model do
+  subject { build(:declaration) }
+
+  describe "associations" do
+    it { is_expected.to belong_to(:application) }
+    it { is_expected.to belong_to(:cohort) }
+    it { is_expected.to belong_to(:lead_provider) }
+    it { is_expected.to belong_to(:superseded_by).optional }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:declaration_type) }
+    it { is_expected.to validate_presence_of(:declaration_date) }
+  end
+end

--- a/spec/models/statement_item_spec.rb
+++ b/spec/models/statement_item_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe StatementItem, type: :model do
   describe "relationships" do
     it { is_expected.to belong_to(:statement).required }
-    # it { is_expected.to belong_to(:declaration).required }
+    it { is_expected.to belong_to(:declaration).required }
   end
 
   describe "validations" do


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-3085

### Changes proposed in this pull request

* `Declaration` model added
* `cohort` and `lead_provider` has been included in declaration as this can change on the `application`
* `state_reason` is now on `Declaration` as its used when state is marked `ineligible`, therefore we do not need the `declaration_states` table. (reason is used for serializer)