### PR TITLE
Fix flakey specs with cohort factories

### DIFF
--- a/spec/factories/cohorts.rb
+++ b/spec/factories/cohorts.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     registration_start_date { Date.new(start_year, 4, 3) }
 
     initialize_with do
-      Cohort.find_by(start_year:) || new(**attributes)
+      Cohort.find_or_create_by(start_year:)
     end
 
     trait :current do


### PR DESCRIPTION
We're seeing flakey specs:

```
     #   ERROR:  null value in column "cohort_id" of relation "statements" violates not-null constraint
```

I think this happens if the cohort does not exist and we are creating a statement; it will end up initializing (but not persisting) the associated cohort as its created with `new` and the `belongs_to :cohort` won't chain the persistence by default.
