### PR TITLE
Prevent funded place change with applicable declarations

### DIFF
--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -16,6 +16,8 @@ class Declaration < ApplicationRecord
   delegate :identifier, to: :course, prefix: true
   delegate :name, to: :lead_provider, prefix: true
 
+  scope :billable, -> { where(state: BILLABLE_STATES) }
+
   enum state: {
     submitted: "submitted",
     eligible: "eligible",

--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -1,6 +1,6 @@
 class Declaration < ApplicationRecord
-  BILLABLE_STATES = %w[submitted eligible payable paid].freeze
-  NON_BILLABLE_STATES = %w[voided ineligible awaiting_clawback clawed_back].freeze
+  BILLABLE_STATES = %w[eligible payable paid].freeze
+  CHANGEABLE_STATES = %w[eligible submitted].freeze
 
   belongs_to :application
   belongs_to :cohort
@@ -17,6 +17,8 @@ class Declaration < ApplicationRecord
   delegate :name, to: :lead_provider, prefix: true
 
   scope :billable, -> { where(state: BILLABLE_STATES) }
+  scope :changeable, -> { where(state: CHANGEABLE_STATES) }
+  scope :billable_or_changeable, -> { billable.or(changeable) }
 
   enum state: {
     submitted: "submitted",

--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -1,4 +1,7 @@
 class Declaration < ApplicationRecord
+  BILLABLE_STATES = %w[submitted eligible payable paid].freeze
+  NON_BILLABLE_STATES = %w[voided ineligible awaiting_clawback clawed_back].freeze
+
   belongs_to :application
   belongs_to :cohort
   belongs_to :lead_provider

--- a/app/services/applications/change_funded_place.rb
+++ b/app/services/applications/change_funded_place.rb
@@ -17,6 +17,7 @@ module Applications
     validate :accepted_application
     validate :eligible_for_funding
     validate :cohort_has_funding_cap
+    validate :eligible_for_removing_funding_place
 
     def change
       return false unless valid?
@@ -46,6 +47,18 @@ module Applications
       return if cohort&.funding_cap?
 
       errors.add(:application, I18n.t("application.cohort_does_not_accept_capping"))
+    end
+
+    def eligible_for_removing_funding_place
+      return if funded_place
+
+      errors.add(:application, I18n.t("application.cannot_change_funded_place")) if applicable_declarations.any?
+    end
+
+    def applicable_declarations
+      application
+        .declarations
+        .where(state: %w[submitted eligible payable paid])
     end
   end
 end

--- a/app/services/applications/change_funded_place.rb
+++ b/app/services/applications/change_funded_place.rb
@@ -51,7 +51,7 @@ module Applications
 
     def eligible_for_removing_funding_place
       return if funded_place
-      return unless application.declarations.billable.any?
+      return unless application.declarations.billable_or_changeable.any?
 
       errors.add(:application, I18n.t("application.cannot_change_funded_place"))
     end

--- a/app/services/applications/change_funded_place.rb
+++ b/app/services/applications/change_funded_place.rb
@@ -51,14 +51,9 @@ module Applications
 
     def eligible_for_removing_funding_place
       return if funded_place
+      return unless application.declarations.billable.any?
 
-      errors.add(:application, I18n.t("application.cannot_change_funded_place")) if applicable_declarations.any?
-    end
-
-    def applicable_declarations
-      application
-        .declarations
-        .where(state: %w[submitted eligible payable paid])
+      errors.add(:application, I18n.t("application.cannot_change_funded_place"))
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,7 +26,7 @@ en:
     cannot_change_funded_status_non_eligible: This participant is not eligible for funding. Contact us if you think this is wrong.
     missing_funded_place: "The entered '#/funded_place' is missing from your request. Check details and try again."
     cohort_does_not_accept_capping: "Leave the '#/funded_place' field blank. It's only needed for participants starting NPQs from autumn 2024 onwards."
-
+    cannot_change_funded_place: "You must void or claw back your declarations for this participant before being able to set '#/funded_place' to false"
   participant: &participant
     blank: Your update cannot be made as the '#/participant_id' is not recognised. Check participant details and try again.
     already_active: The participant is already active

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -150,17 +150,30 @@ RSpec.describe Declaration, type: :model do
   end
 
   describe "scopes" do
+    let(:declarations) { Declaration.states.keys.map { |state| create(:declaration, state:) } }
+
     describe ".billable" do
       it "returns declarations with billable states" do
-        billable_declarations = Declaration::BILLABLE_STATES.map do |state|
-          create(:declaration, state:)
-        end
-
-        Declaration::NON_BILLABLE_STATES.map do |state|
-          create(:declaration, state:)
-        end
+        billable_declarations = declarations.select { |d| %w[eligible payable paid].include?(d.state) }
 
         expect(Declaration.billable).to match_array(billable_declarations)
+      end
+    end
+
+    describe ".changeable" do
+      it "returns declarations with changeable states" do
+        changeable_declarations = declarations.select { |d| %w[eligible submitted].include?(d.state) }
+
+        expect(Declaration.changeable).to match_array(changeable_declarations)
+      end
+    end
+
+    describe ".billable_or_changeable" do
+      it "returns declarations with either billable or changeable states" do
+        states = %w[submitted eligible payable paid]
+        billable_or_changeable = declarations.select { |d| states.include?(d.state) }
+
+        expect(Declaration.billable_or_changeable).to match_array(billable_or_changeable)
       end
     end
   end

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -148,4 +148,20 @@ RSpec.describe Declaration, type: :model do
       it { is_expected.to be_nil }
     end
   end
+
+  describe "scopes" do
+    describe ".billable" do
+      it "returns declarations with billable states" do
+        billable_declarations = Declaration::BILLABLE_STATES.map do |state|
+          create(:declaration, state:)
+        end
+
+        Declaration::NON_BILLABLE_STATES.map do |state|
+          create(:declaration, state:)
+        end
+
+        expect(Declaration.billable).to match_array(billable_declarations)
+      end
+    end
+  end
 end

--- a/spec/services/applications/change_funded_place_spec.rb
+++ b/spec/services/applications/change_funded_place_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Applications::ChangeFundedPlace do
               params.merge!(funded_place: true)
             end
 
-            (Declaration::BILLABLE_STATES + Declaration::NON_BILLABLE_STATES).each do |state|
+            Declaration.states.each_key do |state|
               it "is valid if the application has #{state} declarations" do
                 create(:declaration, application:, state:)
                 service.change
@@ -114,7 +114,8 @@ RSpec.describe Applications::ChangeFundedPlace do
               params.merge!(funded_place: false)
             end
 
-            Declaration::BILLABLE_STATES.each do |applicable_state|
+            applicable = %w[submitted eligible payable paid]
+            applicable.each do |applicable_state|
               it "is invalid if the application has #{applicable_state} declarations" do
                 create(:declaration, application:, state: applicable_state)
 
@@ -124,10 +125,10 @@ RSpec.describe Applications::ChangeFundedPlace do
               end
             end
 
-            Declaration::NON_BILLABLE_STATES.each do |non_applicable_state|
+            (Declaration.states.keys - applicable).each do |non_applicable_state|
               it "is valid if the application has #{non_applicable_state} declarations" do
                 create(:declaration, application:, state: non_applicable_state)
-                application.reload
+
                 service.change
 
                 expect(service.errors.messages_for(:application)).to be_empty

--- a/spec/services/applications/change_funded_place_spec.rb
+++ b/spec/services/applications/change_funded_place_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Applications::ChangeFundedPlace do
               params.merge!(funded_place: true)
             end
 
-            %w[submitted eligible payable paid voided ineligible awaiting_clawback clawed_back].each do |state|
+            (Declaration::BILLABLE_STATES + Declaration::NON_BILLABLE_STATES).each do |state|
               it "is valid if the application has #{state} declarations" do
                 create(:declaration, application:, state:)
                 service.change
@@ -114,7 +114,7 @@ RSpec.describe Applications::ChangeFundedPlace do
               params.merge!(funded_place: false)
             end
 
-            %w[submitted eligible payable paid].each do |applicable_state|
+            Declaration::BILLABLE_STATES.each do |applicable_state|
               it "is invalid if the application has #{applicable_state} declarations" do
                 create(:declaration, application:, state: applicable_state)
 
@@ -124,7 +124,7 @@ RSpec.describe Applications::ChangeFundedPlace do
               end
             end
 
-            %w[voided ineligible awaiting_clawback clawed_back].each do |non_applicable_state|
+            Declaration::NON_BILLABLE_STATES.each do |non_applicable_state|
               it "is valid if the application has #{non_applicable_state} declarations" do
                 create(:declaration, application:, state: non_applicable_state)
                 application.reload


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-3086

### Description

Add logic to check for `applicable_declarations` declarations before removing the `funded_place` in an application.
The API endpoint, as the validation returns `false`, will trigger a 422 with the error message from the validator.