### PR TITLE
Add declaration endpoint

### DIFF
--- a/app/controllers/api/v1/declarations_controller.rb
+++ b/app/controllers/api/v1/declarations_controller.rb
@@ -8,8 +8,11 @@ module API
         render json: to_json(paginate(declarations_query.declarations))
       end
 
+      def show
+        render json: to_json(declaration)
+      end
+
       def create = head(:method_not_allowed)
-      def show = head(:method_not_allowed)
       def void = head(:method_not_allowed)
 
     private
@@ -17,6 +20,10 @@ module API
       def declarations_query
         conditions = { lead_provider: current_lead_provider, updated_since:, participant_ids: }
         ::Declarations::Query.new(**conditions.compact)
+      end
+
+      def declaration
+        declarations_query.declaration(ecf_id: params[:ecf_id])
       end
 
       def participant_ids

--- a/app/controllers/api/v2/declarations_controller.rb
+++ b/app/controllers/api/v2/declarations_controller.rb
@@ -8,8 +8,11 @@ module API
         render json: to_json(paginate(declarations_query.declarations))
       end
 
+      def show
+        render json: to_json(declaration)
+      end
+
       def create = head(:method_not_allowed)
-      def show = head(:method_not_allowed)
       def void = head(:method_not_allowed)
 
     private
@@ -17,6 +20,10 @@ module API
       def declarations_query
         conditions = { lead_provider: current_lead_provider, updated_since:, participant_ids: }
         ::Declarations::Query.new(**conditions.compact)
+      end
+
+      def declaration
+        declarations_query.declaration(ecf_id: params[:ecf_id])
       end
 
       def participant_ids

--- a/app/controllers/api/v3/declarations_controller.rb
+++ b/app/controllers/api/v3/declarations_controller.rb
@@ -8,8 +8,11 @@ module API
         render json: to_json(paginate(declarations_query.declarations))
       end
 
+      def show
+        render json: to_json(declaration)
+      end
+
       def create = head(:method_not_allowed)
-      def show = head(:method_not_allowed)
       def void = head(:method_not_allowed)
 
     private
@@ -17,6 +20,10 @@ module API
       def declarations_query
         conditions = { lead_provider: current_lead_provider, updated_since:, participant_ids:, cohort_start_years: }
         ::Declarations::Query.new(**conditions.compact)
+      end
+
+      def declaration
+        declarations_query.declaration(ecf_id: params[:ecf_id])
       end
 
       def participant_ids

--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -71,7 +71,7 @@ class Declaration < ApplicationRecord
     when "duplicate"
       "duplicate_declaration"
     else
-      reason
+      state_reason
     end
   end
 end

--- a/app/services/declarations/query.rb
+++ b/app/services/declarations/query.rb
@@ -18,6 +18,13 @@ module Declarations
       scope.order(created_at: :asc)
     end
 
+    def declaration(id: nil, ecf_id: nil)
+      return scope.find_by!(ecf_id:) if ecf_id.present?
+      return scope.find(id) if id.present?
+
+      fail(ArgumentError, "id or ecf_id needed")
+    end
+
   private
 
     def where_lead_provider_is(lead_provider)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,7 +145,7 @@ Rails.application.routes.draw do
 
           resources :outcomes, only: %i[index]
 
-          resources :declarations, only: %i[create show index], path: "participant-declarations" do
+          resources :declarations, only: %i[create show index], path: "participant-declarations", param: :ecf_id do
             put :void, path: "void"
           end
         end
@@ -178,7 +178,7 @@ Rails.application.routes.draw do
 
       resources :outcomes, only: %i[index]
 
-      resources :declarations, only: %i[create show index], path: "participant-declarations" do
+      resources :declarations, only: %i[create show index], path: "participant-declarations", param: :ecf_id do
         put :void, path: "void"
       end
     end
@@ -207,7 +207,7 @@ Rails.application.routes.draw do
 
       resources :outcomes, only: %i[index]
 
-      resources :declarations, only: %i[create show index], path: "participant-declarations" do
+      resources :declarations, only: %i[create show index], path: "participant-declarations", param: :ecf_id do
         put :void, path: "void"
       end
 

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -84,12 +84,18 @@ RSpec.describe Declaration, type: :model do
 
   describe "#ineligible_for_funding_reason" do
     let(:state) { :ineligible }
-    let(:state_reason) { :duplicate }
+    let(:state_reason) { nil }
     let(:declaration) { build(:declaration, state:, state_reason:) }
 
     subject { declaration.ineligible_for_funding_reason }
 
-    it { is_expected.to eq("duplicate_declaration") }
+    it { is_expected.to be_nil }
+
+    context "when the state_reason is 'duplicate'" do
+      let(:state_reason) { "duplicate" }
+
+      it { is_expected.to eq("duplicate_declaration") }
+    end
 
     described_class.states.keys.excluding("ineligible").each do |ineligible_state|
       context "when the state is #{ineligible_state}" do

--- a/spec/requests/api/v1/declarations_spec.rb
+++ b/spec/requests/api/v1/declarations_spec.rb
@@ -25,10 +25,15 @@ RSpec.describe "Declaration endpoints", type: :request do
     it_behaves_like "an API index endpoint with filter by participant_id"
   end
 
-  describe("show") do
-    before { api_get(api_v1_declaration_path(123)) }
+  describe "GET /api/v1/declarations/:id" do
+    let(:resource) { create(:declaration, lead_provider: current_lead_provider) }
+    let(:resource_id) { resource.ecf_id }
 
-    specify { expect(response).to(be_method_not_allowed) }
+    def path(id = nil)
+      api_v1_declaration_path(id)
+    end
+
+    it_behaves_like "an API show endpoint"
   end
 
   describe("create") do

--- a/spec/requests/api/v2/declarations_spec.rb
+++ b/spec/requests/api/v2/declarations_spec.rb
@@ -25,10 +25,15 @@ RSpec.describe "Declaration endpoints", type: :request do
     it_behaves_like "an API index endpoint with filter by participant_id"
   end
 
-  describe("show") do
-    before { api_get(api_v2_declaration_path(123)) }
+  describe "GET /api/v2/declarations/:id" do
+    let(:resource) { create(:declaration, lead_provider: current_lead_provider) }
+    let(:resource_id) { resource.ecf_id }
 
-    specify { expect(response).to(be_method_not_allowed) }
+    def path(id = nil)
+      api_v2_declaration_path(id)
+    end
+
+    it_behaves_like "an API show endpoint"
   end
 
   describe("void") do

--- a/spec/requests/api/v3/declarations_spec.rb
+++ b/spec/requests/api/v3/declarations_spec.rb
@@ -26,10 +26,15 @@ RSpec.describe "Declaration endpoints", type: :request do
     it_behaves_like "an API index endpoint with filter by cohort"
   end
 
-  describe("show") do
-    before { api_get(api_v3_declaration_path(123)) }
+  describe "GET /api/v3/declarations/:id" do
+    let(:resource) { create(:declaration, lead_provider: current_lead_provider) }
+    let(:resource_id) { resource.ecf_id }
 
-    specify { expect(response).to(be_method_not_allowed) }
+    def path(id = nil)
+      api_v3_declaration_path(id)
+    end
+
+    it_behaves_like "an API show endpoint"
   end
 
   describe("create") do

--- a/spec/services/declarations/query_spec.rb
+++ b/spec/services/declarations/query_spec.rb
@@ -124,4 +124,31 @@ RSpec.describe Declarations::Query do
       end
     end
   end
+
+  describe "#declaration" do
+    let(:declaration) { create(:declaration) }
+    let(:lead_provider) { declaration.lead_provider }
+    let(:query) { Declarations::Query.new(lead_provider:) }
+
+    it "returns a declaration by the given id" do
+      expect(query.declaration(ecf_id: declaration.ecf_id)).to eq(declaration)
+      expect(query.declaration(id: declaration.id)).to eq(declaration)
+    end
+
+    it "raises an error if the declaration does not exist" do
+      expect { query.declaration(ecf_id: "XXX123") }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { query.declaration(id: "XXX123") }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "raises an error if the declaration is not in the filtered query" do
+      other_declaration = create(:declaration)
+
+      expect { query.declaration(ecf_id: other_declaration.ecf_id) }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { query.declaration(id: other_declaration.id) }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "raises an error if neither an ecf_id or id is supplied" do
+      expect { query.declaration }.to raise_error(ArgumentError, "id or ecf_id needed")
+    end
+  end
 end


### PR DESCRIPTION
[Jira-3093](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3093)

### Context

We want to add the GET `/api/:version/declarations/:id` endpoint from ECF, which will return a single declaration by ID for the current lead provider.

### Changes proposed in this pull request

- Add GET /api/:version/declarations/:id endpoint

### Guidance for review

Branches off #1445 