### PR TITLE
Amend doc URL to separation rather than sandbox

### DIFF
--- a/public/api/docs/v1/swagger.yaml
+++ b/public/api/docs/v1/swagger.yaml
@@ -254,7 +254,7 @@ paths:
               schema:
                 "$ref": "#/components/schemas/NotFoundResponse"
 servers:
-- url: https://npq-registration-sandbox-web.teacherservices.cloud/
+- url: https://npq-registration-separation-web.teacherservices.cloud/
 components:
   securitySchemes:
     api_key:

--- a/public/api/docs/v2/swagger.yaml
+++ b/public/api/docs/v2/swagger.yaml
@@ -280,7 +280,7 @@ paths:
               schema:
                 "$ref": "#/components/schemas/NotFoundResponse"
 servers:
-- url: https://npq-registration-sandbox-web.teacherservices.cloud/
+- url: https://npq-registration-separation-web.teacherservices.cloud/
 components:
   securitySchemes:
     api_key:

--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -302,7 +302,7 @@ paths:
               schema:
                 "$ref": "#/components/schemas/UnauthorisedResponse"
 servers:
-- url: https://npq-registration-sandbox-web.teacherservices.cloud/
+- url: https://npq-registration-separation-web.teacherservices.cloud/
 components:
   securitySchemes:
     api_key:

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -33,7 +33,7 @@ RSpec.configure do |config|
       paths: {},
       servers: [
         {
-          url: "https://npq-registration-sandbox-web.teacherservices.cloud/",
+          url: "https://npq-registration-separation-web.teacherservices.cloud/",
         },
       ],
       components: {


### PR DESCRIPTION

### Context

To avoid confusing providers and until we make this dynamic, hardcode the url to separation instead of sandbox so providers don't try to test on sandbox.

### Changes proposed in this pull request

Change base url in testing to separation rather than sandbox

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
