### PR TITLE
Rename `Outcome` to `ParticipantOutcome`

### DIFF
--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -6,7 +6,7 @@ class Declaration < ApplicationRecord
   belongs_to :cohort
   belongs_to :lead_provider
   belongs_to :superseded_by, class_name: "Declaration", optional: true
-  has_many :outcomes, dependent: :destroy
+  has_many :participant_outcomes, dependent: :destroy
   has_many :statement_items
 
   UPLIFT_PAID_STATES = %w[paid awaiting_clawback clawed_back].freeze

--- a/app/models/participant_outcome.rb
+++ b/app/models/participant_outcome.rb
@@ -1,4 +1,4 @@
-class Outcome < ApplicationRecord
+class ParticipantOutcome < ApplicationRecord
   belongs_to :declaration
 
   validates :state, presence: true

--- a/app/models/participant_outcome.rb
+++ b/app/models/participant_outcome.rb
@@ -8,6 +8,6 @@ class ParticipantOutcome < ApplicationRecord
 private
 
   def completion_date_not_in_the_future
-    errors.add(:completion_date, "must be in the future") if completion_date && completion_date > Time.zone.today
+    errors.add(:completion_date, :future_date) if completion_date&.future?
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -270,6 +270,10 @@ en:
               already_voided: This declaration has already been voided.
               not_already_refunded: The declaration will or has been be refunded.
               must_be_paid: The declaration must be paid before it can be clawed back.
+        participant_outcomes:
+          attributes:
+            completion_date:
+              future_date: The '#/%{attribute}' value cannot be a future date. Check the date and try again.
               
   omniauth_providers:
     tra_openid_connect: "Get an Identity"

--- a/db/migrate/20240628073505_rename_outcome_to_participant_outcome.rb
+++ b/db/migrate/20240628073505_rename_outcome_to_participant_outcome.rb
@@ -1,0 +1,5 @@
+class RenameOutcomeToParticipantOutcome < ActiveRecord::Migration[7.1]
+  def change
+    rename_table :outcomes, :participant_outcomes
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_21_044020) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_28_073505) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -276,18 +276,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_21_044020) do
     t.index ["ukprn"], name: "index_local_authorities_on_ukprn"
   end
 
-  create_table "outcomes", force: :cascade do |t|
-    t.enum "state", null: false, enum_type: "outcome_states"
-    t.date "completion_date", null: false
-    t.bigint "declaration_id", null: false
-    t.boolean "qualified_teachers_api_request_successful"
-    t.datetime "sent_to_qualified_teachers_api_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["declaration_id", "created_at"], name: "index_outcomes_on_declaration_id_and_created_at"
-    t.index ["declaration_id"], name: "index_outcomes_on_declaration_id"
-  end
-
   create_table "participant_id_changes", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "from_participant_id", null: false
@@ -297,6 +285,18 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_21_044020) do
     t.index ["from_participant_id"], name: "index_participant_id_changes_on_from_participant_id"
     t.index ["to_participant_id"], name: "index_participant_id_changes_on_to_participant_id"
     t.index ["user_id"], name: "index_participant_id_changes_on_user_id"
+  end
+
+  create_table "participant_outcomes", force: :cascade do |t|
+    t.enum "state", null: false, enum_type: "outcome_states"
+    t.date "completion_date", null: false
+    t.bigint "declaration_id", null: false
+    t.boolean "qualified_teachers_api_request_successful"
+    t.datetime "sent_to_qualified_teachers_api_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["declaration_id", "created_at"], name: "index_participant_outcomes_on_declaration_id_and_created_at"
+    t.index ["declaration_id"], name: "index_participant_outcomes_on_declaration_id"
   end
 
   create_table "private_childcare_providers", force: :cascade do |t|
@@ -487,10 +487,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_21_044020) do
   add_foreign_key "declarations", "cohorts"
   add_foreign_key "declarations", "declarations", column: "superseded_by_id"
   add_foreign_key "declarations", "lead_providers"
-  add_foreign_key "outcomes", "declarations"
   add_foreign_key "participant_id_changes", "users"
   add_foreign_key "participant_id_changes", "users", column: "from_participant_id"
   add_foreign_key "participant_id_changes", "users", column: "to_participant_id"
+  add_foreign_key "participant_outcomes", "declarations"
   add_foreign_key "schedules", "cohorts"
   add_foreign_key "schedules", "course_groups"
   add_foreign_key "statement_items", "declarations"

--- a/spec/factories/participant_outcomes.rb
+++ b/spec/factories/participant_outcomes.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :outcome do
+  factory :participant_outcome do
     passed
     completion_date { Time.zone.today + 1.week }
 

--- a/spec/factories/participant_outcomes.rb
+++ b/spec/factories/participant_outcomes.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :participant_outcome do
     passed
-    completion_date { Time.zone.today + 1.week }
+    completion_date { 1.week.ago }
 
     declaration { association :declaration }
 

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Declaration, type: :model do
     it { is_expected.to belong_to(:cohort) }
     it { is_expected.to belong_to(:lead_provider) }
     it { is_expected.to belong_to(:superseded_by).optional }
-    it { is_expected.to have_many(:outcomes).dependent(:destroy) }
+    it { is_expected.to have_many(:participant_outcomes).dependent(:destroy) }
     it { is_expected.to have_many(:statement_items) }
   end
 

--- a/spec/models/participant_outcome_spec.rb
+++ b/spec/models/participant_outcome_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
-RSpec.describe Outcome, type: :model do
-  subject { build(:outcome) }
+RSpec.describe ParticipantOutcome, type: :model do
+  subject { build(:participant_outcome) }
 
   describe "validations" do
     it { is_expected.to validate_presence_of(:state) }

--- a/spec/models/participant_outcome_spec.rb
+++ b/spec/models/participant_outcome_spec.rb
@@ -1,38 +1,40 @@
 require "rails_helper"
 
 RSpec.describe ParticipantOutcome, type: :model do
-  subject { build(:participant_outcome) }
+  subject(:instance) { build(:participant_outcome) }
 
   describe "validations" do
     it { is_expected.to validate_presence_of(:state) }
     it { is_expected.to validate_presence_of(:completion_date) }
+
+    describe "completion_date" do
+      context "when the completion_date is in the future" do
+        before { instance.completion_date = 1.day.from_now }
+
+        it "is invalid" do
+          expect(instance).to be_invalid
+          expect(instance.errors.first).to have_attributes(attribute: :completion_date, type: :future_date)
+        end
+      end
+
+      context "when the completion_date is now" do
+        it "is valid" do
+          freeze_time do
+            instance.completion_date = Time.zone.today
+            expect(instance).to be_valid
+          end
+        end
+      end
+
+      context "when the completion_date is in the past" do
+        before { instance.completion_date = 1.day.ago }
+
+        it { is_expected.to be_valid }
+      end
+    end
   end
 
   describe "associations" do
     it { is_expected.to belong_to(:declaration) }
-  end
-
-  describe "completion_date" do
-    context "when the completion_date is in the future" do
-      it "is not valid" do
-        subject.completion_date = 1.day.from_now
-        expect(subject).not_to be_valid
-        expect(subject.errors[:completion_date]).to include("must be in the future")
-      end
-    end
-
-    context "when the completion_date is today" do
-      it "is valid" do
-        subject.completion_date = Time.zone.today
-        expect(subject).to be_valid
-      end
-    end
-
-    context "when the completion_date is in the past" do
-      it "is valid" do
-        subject.completion_date = 1.day.ago
-        expect(subject).to be_valid
-      end
-    end
   end
 end


### PR DESCRIPTION
Using `Outcome` here feels a bit confusing as the controller terminology is 'participant outcome'. Renaming to better align with what you would expect from looking at the controller.