### PR TITLE
[CPDNPQ-1904] remove deprecated private_childcare_urn

### DIFF
--- a/app/services/ecf/npq_profile_creator.rb
+++ b/app/services/ecf/npq_profile_creator.rb
@@ -25,7 +25,7 @@ module Ecf
         targeted_delivery_funding_eligibility: application.targeted_delivery_funding_eligibility,
         works_in_childcare: application.works_in_childcare,
         kind_of_nursery: application.kind_of_nursery,
-        private_childcare_provider_urn: application.DEPRECATED_private_childcare_provider_urn,
+        private_childcare_provider_urn: application.private_childcare_provider&.provider_urn,
         funding_eligiblity_status_code: application.funding_eligiblity_status_code,
         teacher_catchment: application.teacher_catchment,
         teacher_catchment_country: application.teacher_catchment_country,

--- a/app/services/report_service.rb
+++ b/app/services/report_service.rb
@@ -58,7 +58,7 @@ private
       a.targeted_delivery_funding_eligibility,
       a.works_in_childcare,
       a.kind_of_nursery,
-      a.DEPRECATED_private_childcare_provider_urn,
+      a.private_childcare_provider&.provider_urn,
       a.school_urn,
       a.school&.name,
       a.school&.establishment_type_name,

--- a/app/views/admin/applications/_application_details.html.erb
+++ b/app/views/admin/applications/_application_details.html.erb
@@ -90,7 +90,7 @@
 
     sl.with_row do |row|
       row.with_key(text: 'Private Childcare Provider URN')
-      row.with_value(text: application.DEPRECATED_private_childcare_provider_urn || "-")
+      row.with_value(text: application.private_childcare_provider&.provider_urn || "-")
       row.with_action
     end
 

--- a/spec/views/admin/applications/show.html.erb_spec.rb
+++ b/spec/views/admin/applications/show.html.erb_spec.rb
@@ -1,7 +1,11 @@
 require "rails_helper"
 
 RSpec.describe "admin/applications/show.html.erb", type: :view do
-  let(:application) { create(:application, targeted_delivery_funding_eligibility: true, DEPRECATED_private_childcare_provider_urn: "EY98753") }
+  let(:application) do
+    create(:application,
+           targeted_delivery_funding_eligibility: true,
+           private_childcare_provider: build(:private_childcare_provider, provider_urn: "EY98753"))
+  end
 
   it "displays targeted_delivery_funding_eligibility" do
     assign(:application, application)
@@ -20,7 +24,7 @@ RSpec.describe "admin/applications/show.html.erb", type: :view do
     expect(rendered).to match(/Created at.*#{expected}/m)
   end
 
-  it "displays application DEPRECATED_private_childcare_provider_urn" do
+  it "displays application private_childcare_provider_urn" do
     assign(:application, application)
 
     render


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CPDNPQ-1956

There is an issue with URNs not being passed over to ECF for private nurserys. This is because we are still passing over `DEPRECATED_private_childcare_provider_urn`.

This PR changes use of `DEPRECATED_private_childcare_provider_urn` to `private_childcare_provider&.provider_urn`