### PR TITLE
[CPDLP-3239] Amend accept and change funding service to only accept funded place booleans only

### DIFF
--- a/app/services/applications/accept.rb
+++ b/app/services/applications/accept.rb
@@ -6,15 +6,20 @@ module Applications
     include ActiveModel::Attributes
 
     attribute :application
-    attribute :funded_place, :boolean
+    attribute :funded_place
     attribute :schedule_identifier, :string
 
     validates :application, presence: { message: I18n.t("application.missing_application") }
+    validates :funded_place,
+              inclusion: {
+                in: [true, false],
+                if: :validate_funded_place?,
+                message: I18n.t("application.funded_place_required"),
+              }
     validate :not_already_accepted
     validate :cannot_change_from_rejected
     validate :other_accepted_applications_with_same_course?
     validate :eligible_for_funded_place
-    validate :validate_funded_place
     validate :validate_permitted_schedule_for_course
 
     def accept
@@ -107,13 +112,8 @@ module Applications
       end
     end
 
-    def validate_funded_place
-      return if errors.any?
-      return unless cohort&.funding_cap?
-
-      if funded_place.nil?
-        errors.add(:application, I18n.t("application.funded_place_required"))
-      end
+    def validate_funded_place?
+      errors.blank? && cohort&.funding_cap?
     end
 
     def schedule

--- a/app/services/applications/change_funded_place.rb
+++ b/app/services/applications/change_funded_place.rb
@@ -6,7 +6,7 @@ module Applications
     include ActiveModel::Attributes
 
     attribute :application
-    attribute :funded_place, :boolean
+    attribute :funded_place
 
     validates :application, presence: { message: I18n.t("application.missing_application") }
     validates :funded_place,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -274,7 +274,7 @@ en:
           attributes:
             completion_date:
               future_date: The '#/%{attribute}' value cannot be a future date. Check the date and try again.
-              
+
   omniauth_providers:
     tra_openid_connect: "Get an Identity"
 

--- a/spec/services/applications/accept_spec.rb
+++ b/spec/services/applications/accept_spec.rb
@@ -296,7 +296,7 @@ RSpec.describe Applications::Accept, :with_default_schedules do
         context "when funding_cap is true" do
           it "returns funding_place is required error" do
             service.accept
-            expect(service.errors.messages_for(:application)).to include("Set '#/funded_place' to true or false.")
+            expect(service.errors.messages_for(:funded_place)).to include("Set '#/funded_place' to true or false.")
           end
         end
 
@@ -305,7 +305,45 @@ RSpec.describe Applications::Accept, :with_default_schedules do
 
           it "does not validate funded_place" do
             service.accept
-            expect(service.errors.messages_for(:application)).to be_empty
+            expect(service.errors.messages_for(:funded_place)).to be_empty
+          end
+        end
+      end
+
+      context "when funded_place is a string" do
+        context "when funded_place is `true`" do
+          let(:params) { { application:, funded_place: "true" } }
+
+          it "returns funding_place is required error" do
+            service.accept
+            expect(service.errors.messages_for(:funded_place)).to include("Set '#/funded_place' to true or false.")
+          end
+        end
+
+        context "when funded_place is `false`" do
+          let(:params) { { application:, funded_place: "false" } }
+
+          it "returns funding_place is required error" do
+            service.accept
+            expect(service.errors.messages_for(:funded_place)).to include("Set '#/funded_place' to true or false.")
+          end
+        end
+
+        context "when funded_place is `null`" do
+          let(:params) { { application:, funded_place: "null" } }
+
+          it "returns funding_place is required error" do
+            service.accept
+            expect(service.errors.messages_for(:funded_place)).to include("Set '#/funded_place' to true or false.")
+          end
+        end
+
+        context "when funded_place is an empty string" do
+          let(:params) { { application:, funded_place: "" } }
+
+          it "returns funding_place is required error" do
+            service.accept
+            expect(service.errors.messages_for(:funded_place)).to include("Set '#/funded_place' to true or false.")
           end
         end
       end

--- a/spec/services/applications/change_funded_place_spec.rb
+++ b/spec/services/applications/change_funded_place_spec.rb
@@ -136,6 +136,44 @@ RSpec.describe Applications::ChangeFundedPlace do
             end
           end
         end
+
+        context "when funded_place is a string" do
+          context "when funded_place is `true`" do
+            before { params.merge!(funded_place: "true") }
+
+            it "returns funding_place is required error" do
+              service.change
+              expect(service.errors.messages_for(:funded_place)).to include("The entered '#/funded_place' is missing from your request. Check details and try again.")
+            end
+          end
+
+          context "when funded_place is `false`" do
+            before { params.merge!(funded_place: "false") }
+
+            it "returns funding_place is required error" do
+              service.change
+              expect(service.errors.messages_for(:funded_place)).to include("The entered '#/funded_place' is missing from your request. Check details and try again.")
+            end
+          end
+
+          context "when funded_place is `null`" do
+            before { params.merge!(funded_place: "null") }
+
+            it "returns funding_place is required error" do
+              service.change
+              expect(service.errors.messages_for(:funded_place)).to include("The entered '#/funded_place' is missing from your request. Check details and try again.")
+            end
+          end
+
+          context "when funded_place is an empty string" do
+            before { params.merge!(funded_place: "") }
+
+            it "returns funding_place is required error" do
+              service.change
+              expect(service.errors.messages_for(:funded_place)).to include("The entered '#/funded_place' is missing from your request. Check details and try again.")
+            end
+          end
+        end
       end
 
       context "when funded_place is not present" do


### PR DESCRIPTION
### Context

We currently validate against the funded place attribute regardless of type. So if a string is passed in we compute it as true.
This confused providers as they were passing values such as `"false"` and `"null"` and this was computed as `true`

- Ticket: [CPDLP-3239](https://dfedigital.atlassian.net/browse/CPDLP-3239)

### Changes proposed in this pull request

Amend the validations in both services to only accept boolean values otherwise returns a validation error, even if it's a string.

### Guidance to review
Maybe we should allow strings and compute those values, but felt better to lock it down to just booleans


[CPDLP-3239]: https://dfedigital.atlassian.net/browse/CPDLP-3239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ