### PR TITLE
Add GET /app/:version/participants/npq/:id/outcomes endpoints

### DIFF
--- a/app/controllers/api/v1/participants/outcomes_controller.rb
+++ b/app/controllers/api/v1/participants/outcomes_controller.rb
@@ -2,8 +2,32 @@ module API
   module V1
     module Participants
       class OutcomesController < BaseController
-        def index = head(:method_not_allowed)
+        include Pagination
+
+        def index
+          render json: to_json(paginate(outcomes_query.participant_outcomes))
+        end
+
         def create = head(:method_not_allowed)
+
+      private
+
+        def participants_query
+          ::Participants::Query.new(lead_provider: current_lead_provider)
+        end
+
+        def participant
+          participants_query.participant(ecf_id: params[:ecf_id])
+        end
+
+        def outcomes_query
+          conditions = { lead_provider: current_lead_provider, participant_ids: participant.ecf_id }
+          ::ParticipantOutcomes::Query.new(**conditions.compact)
+        end
+
+        def to_json(obj)
+          ParticipantOutcomeSerializer.render(obj, view: :v1, root: "data")
+        end
       end
     end
   end

--- a/app/controllers/api/v2/participants/outcomes_controller.rb
+++ b/app/controllers/api/v2/participants/outcomes_controller.rb
@@ -2,8 +2,32 @@ module API
   module V2
     module Participants
       class OutcomesController < BaseController
-        def index = head(:method_not_allowed)
+        include Pagination
+
+        def index
+          render json: to_json(paginate(outcomes_query.participant_outcomes))
+        end
+
         def create = head(:method_not_allowed)
+
+      private
+
+        def participants_query
+          ::Participants::Query.new(lead_provider: current_lead_provider)
+        end
+
+        def participant
+          participants_query.participant(ecf_id: params[:ecf_id])
+        end
+
+        def outcomes_query
+          conditions = { lead_provider: current_lead_provider, participant_ids: participant.ecf_id }
+          ::ParticipantOutcomes::Query.new(**conditions.compact)
+        end
+
+        def to_json(obj)
+          ParticipantOutcomeSerializer.render(obj, view: :v2, root: "data")
+        end
       end
     end
   end

--- a/app/controllers/api/v3/participants/outcomes_controller.rb
+++ b/app/controllers/api/v3/participants/outcomes_controller.rb
@@ -2,8 +2,32 @@ module API
   module V3
     module Participants
       class OutcomesController < BaseController
-        def index = head(:method_not_allowed)
+        include Pagination
+
+        def index
+          render json: to_json(paginate(outcomes_query.participant_outcomes))
+        end
+
         def create = head(:method_not_allowed)
+
+      private
+
+        def participants_query
+          ::Participants::Query.new(lead_provider: current_lead_provider)
+        end
+
+        def participant
+          participants_query.participant(ecf_id: params[:ecf_id])
+        end
+
+        def outcomes_query
+          conditions = { lead_provider: current_lead_provider, participant_ids: participant.ecf_id }
+          ::ParticipantOutcomes::Query.new(**conditions.compact)
+        end
+
+        def to_json(obj)
+          ParticipantOutcomeSerializer.render(obj, view: :v3, root: "data")
+        end
       end
     end
   end

--- a/app/services/participant_outcomes/query.rb
+++ b/app/services/participant_outcomes/query.rb
@@ -1,12 +1,14 @@
 module ParticipantOutcomes
   class Query
     include API::Concerns::Orderable
+    include Queries::ConditionFormats
 
     attr_reader :scope, :sort
 
-    def initialize(lead_provider: :ignore, created_since: :ignore)
+    def initialize(lead_provider: :ignore, participant_ids: :ignore, created_since: :ignore)
       @scope = all_participant_outcomes
 
+      where_participant_ids_in(participant_ids)
       where_lead_provider_is(lead_provider)
       where_created_since(created_since)
     end
@@ -21,6 +23,12 @@ module ParticipantOutcomes
       return if lead_provider == :ignore
 
       scope.merge!(ParticipantOutcome.where(declaration: { lead_provider: }))
+    end
+
+    def where_participant_ids_in(participant_ids)
+      return if participant_ids == :ignore
+
+      scope.merge!(ParticipantOutcome.where(user: { ecf_id: extract_conditions(participant_ids) }))
     end
 
     def where_created_since(created_since)

--- a/spec/factories/declarations.rb
+++ b/spec/factories/declarations.rb
@@ -1,6 +1,10 @@
 FactoryBot.define do
   factory :declaration do
-    application
+    transient do
+      user { create(:user) }
+    end
+
+    application { create(:application, :accepted, user:) }
     lead_provider { application&.lead_provider || build(:lead_provider) }
     cohort { application&.cohort || build(:cohort, :current) }
 

--- a/spec/requests/api/v1/participants/outcomes_spec.rb
+++ b/spec/requests/api/v1/participants/outcomes_spec.rb
@@ -1,10 +1,37 @@
 require "rails_helper"
 
 RSpec.describe "Participants outcome endpoints", type: :request do
-  describe("index") do
-    before { api_get(api_v1_participants_outcomes_path(123)) }
+  let(:current_lead_provider) { create(:lead_provider) }
+  let(:query) { ParticipantOutcomes::Query }
+  let(:serializer) { API::ParticipantOutcomeSerializer }
+  let(:serializer_version) { :v1 }
+  let(:application) { create(:application, :accepted, lead_provider: current_lead_provider) }
+  let(:user) { application.user }
 
-    specify { expect(response).to(be_method_not_allowed) }
+  def create_resource(**attrs)
+    if attrs[:lead_provider]
+      attrs[:declaration] = create(:declaration, application:, lead_provider: attrs[:lead_provider])
+      attrs.delete(:lead_provider)
+    end
+
+    create(:participant_outcome, **attrs)
+  end
+
+  def create_resource_with_different_parent(**attrs)
+    create_resource(**attrs).tap do |outcome|
+      outcome.declaration.update!(
+        application: create(:application, :accepted, user: create(:user, full_name: "Other User")),
+      )
+    end
+  end
+
+  describe "GET /api/v1/participants/npq/:participant_id/outcomes" do
+    let(:path) { api_v1_participants_outcomes_path(user.ecf_id) }
+    let(:resource_id_key) { :ecf_id }
+
+    it_behaves_like "an API index endpoint"
+    it_behaves_like "an API index endpoint on a parent resource", "participant", "outcome"
+    it_behaves_like "an API index endpoint with pagination"
   end
 
   describe("create") do

--- a/spec/requests/api/v2/participants/outcomes_spec.rb
+++ b/spec/requests/api/v2/participants/outcomes_spec.rb
@@ -1,10 +1,37 @@
 require "rails_helper"
 
 RSpec.describe "Participants outcome endpoints", type: :request do
-  describe("index") do
-    before { api_get(api_v2_participants_outcomes_path(123)) }
+  let(:current_lead_provider) { create(:lead_provider) }
+  let(:query) { ParticipantOutcomes::Query }
+  let(:serializer) { API::ParticipantOutcomeSerializer }
+  let(:serializer_version) { :v2 }
+  let(:application) { create(:application, :accepted, lead_provider: current_lead_provider) }
+  let(:user) { application.user }
 
-    specify { expect(response).to(be_method_not_allowed) }
+  def create_resource(**attrs)
+    if attrs[:lead_provider]
+      attrs[:declaration] = create(:declaration, application:, lead_provider: attrs[:lead_provider])
+      attrs.delete(:lead_provider)
+    end
+
+    create(:participant_outcome, **attrs)
+  end
+
+  def create_resource_with_different_parent(**attrs)
+    create_resource(**attrs).tap do |outcome|
+      outcome.declaration.update!(
+        application: create(:application, :accepted, user: create(:user, full_name: "Other User")),
+      )
+    end
+  end
+
+  describe "GET /api/v2/participants/npq/:participant_id/outcomes" do
+    let(:path) { api_v2_participants_outcomes_path(user.ecf_id) }
+    let(:resource_id_key) { :ecf_id }
+
+    it_behaves_like "an API index endpoint"
+    it_behaves_like "an API index endpoint on a parent resource", "participant", "outcome"
+    it_behaves_like "an API index endpoint with pagination"
   end
 
   describe("create") do

--- a/spec/requests/api/v3/participants/outcomes_spec.rb
+++ b/spec/requests/api/v3/participants/outcomes_spec.rb
@@ -1,10 +1,37 @@
 require "rails_helper"
 
 RSpec.describe "Participants outcome endpoints", type: :request do
-  describe("index") do
-    before { api_get(api_v3_participants_outcomes_path(123)) }
+  let(:current_lead_provider) { create(:lead_provider) }
+  let(:query) { ParticipantOutcomes::Query }
+  let(:serializer) { API::ParticipantOutcomeSerializer }
+  let(:serializer_version) { :v3 }
+  let(:application) { create(:application, :accepted, lead_provider: current_lead_provider) }
+  let(:user) { application.user }
 
-    specify { expect(response).to(be_method_not_allowed) }
+  def create_resource(**attrs)
+    if attrs[:lead_provider]
+      attrs[:declaration] = create(:declaration, application:, lead_provider: attrs[:lead_provider])
+      attrs.delete(:lead_provider)
+    end
+
+    create(:participant_outcome, **attrs)
+  end
+
+  def create_resource_with_different_parent(**attrs)
+    create_resource(**attrs).tap do |outcome|
+      outcome.declaration.update!(
+        application: create(:application, :accepted, user: create(:user, full_name: "Other User")),
+      )
+    end
+  end
+
+  describe "GET /api/v3/participants/npq/:participant_id/outcomes" do
+    let(:path) { api_v3_participants_outcomes_path(user.ecf_id) }
+    let(:resource_id_key) { :ecf_id }
+
+    it_behaves_like "an API index endpoint"
+    it_behaves_like "an API index endpoint on a parent resource", "participant", "outcome"
+    it_behaves_like "an API index endpoint with pagination"
   end
 
   describe("create") do

--- a/spec/support/shared_examples/api_index_endpoint_support.rb
+++ b/spec/support/shared_examples/api_index_endpoint_support.rb
@@ -51,6 +51,24 @@ RSpec.shared_examples "an API index endpoint" do
   end
 end
 
+RSpec.shared_examples "an API index endpoint on a parent resource" do |parent, child|
+  context "when 2 #{child.pluralize} exist for current_lead_provider" do
+    let!(:resource) { create_resource(lead_provider: current_lead_provider) }
+
+    before do
+      create_resource_with_different_parent(lead_provider: current_lead_provider)
+    end
+
+    it "only returns the #{child} nested on the requested #{parent}" do
+      api_get(path)
+
+      expect(response.status).to eq 200
+      expect(response.content_type).to eql("application/json")
+      expect(response_ids).to contain_exactly(resource[resource_id_key])
+    end
+  end
+end
+
 RSpec.shared_examples "an API index endpoint with pagination" do
   context "with pagination" do
     before do


### PR DESCRIPTION
[Jira-3098](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-3098)

### Context

We want to bring across the participant outcomes endpoints from ECF into NPQ reg.

### Changes proposed in this pull request

- Support filtering outcomes by participant ids

Update the `ParticipantOutcomes::Query` service to support filtering outcomes by one or more participant ids.

Add transient `user` to declaration to more easily create an outcome with a certain user (via declaration -> application -> user).

-  Add GET /app/:version/participants/npq/:id/outcomes endpoints

Adds the endpoints to retrieve outcomes for a given participant.

Add shared context for testing `index` actions on a given resource, for example GET `/parent/:id/resources`. Open to suggestions on better naming for this!