### PR TITLE
Preload private_childcare_provider in ReportService

### DIFF
--- a/app/services/report_service.rb
+++ b/app/services/report_service.rb
@@ -72,6 +72,6 @@ private
   end
 
   def applications
-    @applications = Application.includes(:user, :course, :lead_provider, :school)
+    @applications = Application.includes(:user, :course, :lead_provider, :school, :private_childcare_provider)
   end
 end


### PR DESCRIPTION
The `ReportService` runs on a cron every hour. It fetches all applications and puts them into a CSV to be saved in the `reports` table for the analytics dashboard. It is currently running this large query with an n+1 issue due to it not preloading `private_childcare_provider`. This is causing issues with the CPU load on our worker instances.