### PR TITLE
Add create participant outcomes endpoint/service

### DIFF
--- a/app/controllers/api/v1/participants/outcomes_controller.rb
+++ b/app/controllers/api/v1/participants/outcomes_controller.rb
@@ -2,8 +2,32 @@ module API
   module V1
     module Participants
       class OutcomesController < BaseController
-        def index = head(:method_not_allowed)
+        include Pagination
+
+        def index
+          render json: to_json(paginate(outcomes_query.participant_outcomes))
+        end
+
         def create = head(:method_not_allowed)
+
+      private
+
+        def participants_query
+          ::Participants::Query.new(lead_provider: current_lead_provider)
+        end
+
+        def participant
+          participants_query.participant(ecf_id: params[:ecf_id])
+        end
+
+        def outcomes_query
+          conditions = { lead_provider: current_lead_provider, participant_ids: participant.ecf_id }
+          ::ParticipantOutcomes::Query.new(**conditions.compact)
+        end
+
+        def to_json(obj)
+          ParticipantOutcomeSerializer.render(obj, view: :v1, root: "data")
+        end
       end
     end
   end

--- a/app/controllers/api/v2/participants/outcomes_controller.rb
+++ b/app/controllers/api/v2/participants/outcomes_controller.rb
@@ -2,8 +2,32 @@ module API
   module V2
     module Participants
       class OutcomesController < BaseController
-        def index = head(:method_not_allowed)
+        include Pagination
+
+        def index
+          render json: to_json(paginate(outcomes_query.participant_outcomes))
+        end
+
         def create = head(:method_not_allowed)
+
+      private
+
+        def participants_query
+          ::Participants::Query.new(lead_provider: current_lead_provider)
+        end
+
+        def participant
+          participants_query.participant(ecf_id: params[:ecf_id])
+        end
+
+        def outcomes_query
+          conditions = { lead_provider: current_lead_provider, participant_ids: participant.ecf_id }
+          ::ParticipantOutcomes::Query.new(**conditions.compact)
+        end
+
+        def to_json(obj)
+          ParticipantOutcomeSerializer.render(obj, view: :v2, root: "data")
+        end
       end
     end
   end

--- a/app/controllers/api/v3/participants/outcomes_controller.rb
+++ b/app/controllers/api/v3/participants/outcomes_controller.rb
@@ -2,8 +2,32 @@ module API
   module V3
     module Participants
       class OutcomesController < BaseController
-        def index = head(:method_not_allowed)
+        include Pagination
+
+        def index
+          render json: to_json(paginate(outcomes_query.participant_outcomes))
+        end
+
         def create = head(:method_not_allowed)
+
+      private
+
+        def participants_query
+          ::Participants::Query.new(lead_provider: current_lead_provider)
+        end
+
+        def participant
+          participants_query.participant(ecf_id: params[:ecf_id])
+        end
+
+        def outcomes_query
+          conditions = { lead_provider: current_lead_provider, participant_ids: participant.ecf_id }
+          ::ParticipantOutcomes::Query.new(**conditions.compact)
+        end
+
+        def to_json(obj)
+          ParticipantOutcomeSerializer.render(obj, view: :v3, root: "data")
+        end
       end
     end
   end

--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -1,6 +1,10 @@
 class Declaration < ApplicationRecord
   BILLABLE_STATES = %w[eligible payable paid].freeze
   CHANGEABLE_STATES = %w[eligible submitted].freeze
+  UPLIFT_PAID_STATES = %w[paid awaiting_clawback clawed_back].freeze
+  COURSE_IDENTIFIERS_INELIGIBLE_FOR_UPLIFT = %w[npq-additional-support-offer npq-early-headship-coaching-offer].freeze
+  ELIGIBLE_FOR_PAYMENT_STATES = %w[payable eligible].freeze
+  VOIDABLE_STATES = %w[submitted eligible payable ineligible].freeze
 
   belongs_to :application
   belongs_to :cohort
@@ -9,11 +13,6 @@ class Declaration < ApplicationRecord
   has_many :participant_outcomes, dependent: :destroy
   has_many :statement_items
 
-  UPLIFT_PAID_STATES = %w[paid awaiting_clawback clawed_back].freeze
-  COURSE_IDENTIFIERS_INELIGIBLE_FOR_UPLIFT = %w[npq-additional-support-offer npq-early-headship-coaching-offer].freeze
-  ELIGIBLE_FOR_PAYMENT_STATES = %w[payable eligible].freeze
-  VOIDABLE_STATES = %w[submitted eligible payable ineligible].freeze
-
   delegate :course, :user, to: :application
   delegate :identifier, to: :course, prefix: true
   delegate :name, to: :lead_provider, prefix: true
@@ -21,6 +20,11 @@ class Declaration < ApplicationRecord
   scope :billable, -> { where(state: BILLABLE_STATES) }
   scope :changeable, -> { where(state: CHANGEABLE_STATES) }
   scope :billable_or_changeable, -> { billable.or(changeable) }
+  scope :voidable, -> { where(state: VOIDABLE_STATES) }
+  scope :billable_or_voidable, -> { billable.or(voidable) }
+  scope :with_lead_provider, ->(lead_provider) { where(lead_provider:) }
+  scope :completed, -> { where(declaration_type: "completed") }
+  scope :with_course_identifier, ->(course_identifier) { joins(application: :course).where(course: { identifier: course_identifier }) }
 
   enum state: {
     submitted: "submitted",

--- a/app/models/participant_outcome.rb
+++ b/app/models/participant_outcome.rb
@@ -1,7 +1,7 @@
 class ParticipantOutcome < ApplicationRecord
   belongs_to :declaration
 
-  validates :ecf_id, presence: true, uniqueness: true
+  validates :ecf_id, uniqueness: true
   validates :state, presence: true
   validates :completion_date, presence: true
   validate :completion_date_not_in_the_future

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   devise :omniauthable, omniauth_providers: [:tra_openid_connect]
 
   has_many :applications, dependent: :destroy
+  has_many :declarations, through: :applications
   has_many :ecf_sync_request_logs, as: :syncable, dependent: :destroy
   has_many :participant_id_changes, -> { order("created_at desc") }
 

--- a/app/services/participant_outcomes/create.rb
+++ b/app/services/participant_outcomes/create.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module ParticipantOutcomes
+  class Create
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    STATES = %w[passed failed].freeze
+    COURSE_IDENTIFIERS = %w[npq-early-headship-coaching-offer npq-additional-support-offer].freeze
+    COMPLETION_DATE_FORMAT = /\d{4}-\d{2}-\d{2}/
+
+    attr_reader :created_outcome
+
+    attribute :lead_provider
+    attribute :participant
+    attribute :course_identifier
+    attribute :state
+    attribute :completion_date
+
+    validates :lead_provider, presence: true
+    validates :participant, presence: true
+    validates :course_identifier, inclusion: { in: COURSE_IDENTIFIERS }
+    validates :state, inclusion: { in: STATES }
+    validates :completion_date, presence: true, format: { with: COMPLETION_DATE_FORMAT }
+    validate :participant_has_no_completed_declarations
+    validate :completion_date_not_in_the_future
+
+    def create_outcome
+      return false unless valid?
+
+      ApplicationRecord.transaction do
+        @created_outcome = if outcome_already_exists?
+                             latest_existing_outcome
+                           else
+                             build_outcome.tap(&:save!)
+                           end
+      end
+
+      true
+    end
+
+  private
+
+    def outcome_already_exists?
+      return unless latest_existing_outcome
+
+      latest_existing_outcome.slice(:state, :completion_date) == build_outcome.slice(:state, :completion_date)
+    end
+
+    def build_outcome
+      @build_outcome ||= ParticipantOutcome.new(declaration: latest_completed_declaration, state:, completion_date:)
+    end
+
+    def completed_declarations
+      return Declaration.none unless participant
+
+      @completed_declarations ||= participant.declarations
+        .completed
+        .with_lead_provider(lead_provider)
+        .with_course_identifier(course_identifier)
+        .billable_or_voidable
+    end
+
+    def latest_completed_declaration
+      @latest_completed_declaration ||= completed_declarations.order(created_at: :desc).first
+    end
+
+    def latest_existing_outcome
+      @latest_existing_outcome ||= latest_completed_declaration.participant_outcomes.order(created_at: :desc).first
+    end
+
+    def participant_has_no_completed_declarations
+      errors.add(:base, :no_completed_declarations) unless completed_declarations.exists?
+    end
+
+    def completion_date_not_in_the_future
+      errors.add(:completion_date, :future_date) if completion_date&.to_date&.future?
+    end
+  end
+end

--- a/app/services/participant_outcomes/query.rb
+++ b/app/services/participant_outcomes/query.rb
@@ -1,12 +1,14 @@
 module ParticipantOutcomes
   class Query
     include API::Concerns::Orderable
+    include Queries::ConditionFormats
 
     attr_reader :scope, :sort
 
-    def initialize(lead_provider: :ignore, created_since: :ignore)
+    def initialize(lead_provider: :ignore, participant_ids: :ignore, created_since: :ignore)
       @scope = all_participant_outcomes
 
+      where_participant_ids_in(participant_ids)
       where_lead_provider_is(lead_provider)
       where_created_since(created_since)
     end
@@ -21,6 +23,12 @@ module ParticipantOutcomes
       return if lead_provider == :ignore
 
       scope.merge!(ParticipantOutcome.where(declaration: { lead_provider: }))
+    end
+
+    def where_participant_ids_in(participant_ids)
+      return if participant_ids == :ignore
+
+      scope.merge!(ParticipantOutcome.where(user: { ecf_id: extract_conditions(participant_ids) }))
     end
 
     def where_created_since(created_since)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,11 @@ en:
     cohort_does_not_accept_capping: "Leave the '#/funded_place' field blank. It's only needed for participants starting NPQs from autumn 2024 onwards."
     cannot_change_funded_place: "You must void or claw back your declarations for this participant before being able to set '#/funded_place' to false"
 
+  completion_date: &completion_date
+    future_date: The '#/%{attribute}' value cannot be a future date. Check the date and try again.
+    blank: "The '#/%{attribute}' is missing from your request. Please include a completion_date value and try again."
+    format: "The '#/%{attribute}' value must be in the following format: 'yyyy-mm-dd'"
+
   statement: &statement
     no_output_fee_statement: You cannot submit or void declarations for the %{cohort} cohort. The funding contract for this cohort has ended. Get in touch if you need to discuss this with us.
 
@@ -273,8 +278,20 @@ en:
         participant_outcomes:
           attributes:
             completion_date:
-              future_date: The '#/%{attribute}' value cannot be a future date. Check the date and try again.
-              
+              <<: *completion_date
+        participant_outcomes/create:
+          attributes:
+            base:
+              no_completed_declarations: "The participant has not had a 'completed' declaration submitted for them. Therefore you cannot update their outcome."
+            completion_date:
+              <<: *completion_date
+            course_identifier:
+              inclusion: "The entered '#/course_identifier' is not recognised for the given participant. Check details and try again."
+              invalid_course: "The entered '#/course_identifier' is not recognised for the given participant. Check details and try again."
+            state:
+              inclusion: "The attribute '#/%{attribute}' can only include 'passed' or 'failed' values. If you need to void an outcome, you will need to void the associated 'completed' declaration."
+            
+
   omniauth_providers:
     tra_openid_connect: "Get an Identity"
 

--- a/spec/factories/declarations.rb
+++ b/spec/factories/declarations.rb
@@ -2,9 +2,10 @@ FactoryBot.define do
   factory :declaration do
     transient do
       user { create(:user) }
+      course { create(:course) }
     end
 
-    application { create(:application, :accepted, user:) }
+    application { create(:application, :accepted, user:, course:) }
     lead_provider { application&.lead_provider || build(:lead_provider) }
     cohort { application&.cohort || build(:cohort, :current) }
 

--- a/spec/factories/declarations.rb
+++ b/spec/factories/declarations.rb
@@ -1,6 +1,10 @@
 FactoryBot.define do
   factory :declaration do
-    application
+    transient do
+      user { create(:user) }
+    end
+
+    application { create(:application, :accepted, user:) }
     lead_provider { application&.lead_provider || build(:lead_provider) }
     cohort { application&.cohort || build(:cohort, :current) }
 

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -177,31 +177,84 @@ RSpec.describe Declaration, type: :model do
   end
 
   describe "scopes" do
-    let(:declarations) { Declaration.states.keys.map { |state| create(:declaration, state:) } }
+    describe "declaration states" do
+      let(:declarations) { described_class.states.keys.map { |state| create(:declaration, state:) } }
 
-    describe ".billable" do
-      it "returns declarations with billable states" do
-        billable_declarations = declarations.select { |d| %w[eligible payable paid].include?(d.state) }
+      describe ".billable" do
+        it "returns declarations with billable states" do
+          billable_declarations = declarations.select { |d| %w[eligible payable paid].include?(d.state) }
 
-        expect(Declaration.billable).to match_array(billable_declarations)
+          expect(described_class.billable).to match_array(billable_declarations)
+        end
+      end
+
+      describe ".voidable" do
+        it "returns declarations with voidable states" do
+          voidable_declarations = declarations.select { |d| %w[submitted eligible payable ineligible].include?(d.state) }
+
+          expect(described_class.voidable).to match_array(voidable_declarations)
+        end
+      end
+
+      describe ".changeable" do
+        it "returns declarations with changeable states" do
+          changeable_declarations = declarations.select { |d| %w[eligible submitted].include?(d.state) }
+
+          expect(described_class.changeable).to match_array(changeable_declarations)
+        end
+      end
+
+      describe ".billable_or_changeable" do
+        it "returns declarations with either billable or changeable states" do
+          states = %w[submitted eligible payable paid]
+          billable_or_changeable = declarations.select { |d| states.include?(d.state) }
+
+          expect(described_class.billable_or_changeable).to match_array(billable_or_changeable)
+        end
+      end
+
+      describe ".billable_or_voidable" do
+        it "returns declarations with either billable or voidable states" do
+          states = %w[submitted eligible payable paid ineligible]
+          billable_or_voidable = declarations.select { |d| states.include?(d.state) }
+
+          expect(described_class.billable_or_voidable).to match_array(billable_or_voidable)
+        end
       end
     end
 
-    describe ".changeable" do
-      it "returns declarations with changeable states" do
-        changeable_declarations = declarations.select { |d| %w[eligible submitted].include?(d.state) }
+    describe ".with_lead_provider" do
+      let(:lead_provider) { declaration.lead_provider }
+      let(:declaration) { create(:declaration) }
 
-        expect(Declaration.changeable).to match_array(changeable_declarations)
-      end
+      before { create(:declaration, lead_provider: create(:lead_provider, name: "Other lead provider")) }
+
+      it { expect(described_class.with_lead_provider(lead_provider)).to contain_exactly(declaration) }
     end
 
-    describe ".billable_or_changeable" do
-      it "returns declarations with either billable or changeable states" do
-        states = %w[submitted eligible payable paid]
-        billable_or_changeable = declarations.select { |d| states.include?(d.state) }
+    describe ".completed" do
+      let(:completed_declaration) { create(:declaration, :completed) }
 
-        expect(Declaration.billable_or_changeable).to match_array(billable_or_changeable)
+      before do
+        described_class.declaration_types.keys.excluding("completed").each do |declaration_type|
+          create(:declaration, declaration_type:)
+        end
       end
+
+      it { expect(described_class.completed).to contain_exactly(completed_declaration) }
+    end
+
+    describe ".with_course_identifier" do
+      let(:course_identifier) { declaration.application.course.identifier }
+      let(:declaration) { create(:declaration) }
+
+      before do
+        Course::IDENTIFIERS.excluding(course_identifier).each do |identifier|
+          create(:declaration).application.update!(course: Course.find_by(identifier:))
+        end
+      end
+
+      it { expect(described_class.with_course_identifier(course_identifier)).to contain_exactly(declaration) }
     end
   end
 end

--- a/spec/models/participant_outcome_spec.rb
+++ b/spec/models/participant_outcome_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe ParticipantOutcome, type: :model do
   subject(:instance) { build(:participant_outcome) }
 
   describe "validations" do
-    it { is_expected.to validate_presence_of(:ecf_id) }
     it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive }
     it { is_expected.to validate_presence_of(:state) }
     it { is_expected.to validate_presence_of(:completion_date) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe User do
   describe "relationships" do
     it { is_expected.to have_many(:applications).dependent(:destroy) }
+    it { is_expected.to have_many(:declarations).through(:applications) }
     it { is_expected.to have_many(:ecf_sync_request_logs).dependent(:destroy) }
     it { is_expected.to have_many(:participant_id_changes).order("created_at desc") }
   end

--- a/spec/requests/api/v1/participants/outcomes_spec.rb
+++ b/spec/requests/api/v1/participants/outcomes_spec.rb
@@ -1,10 +1,37 @@
 require "rails_helper"
 
 RSpec.describe "Participants outcome endpoints", type: :request do
-  describe("index") do
-    before { api_get(api_v1_participants_outcomes_path(123)) }
+  let(:current_lead_provider) { create(:lead_provider) }
+  let(:query) { ParticipantOutcomes::Query }
+  let(:serializer) { API::ParticipantOutcomeSerializer }
+  let(:serializer_version) { :v1 }
+  let(:application) { create(:application, :accepted, lead_provider: current_lead_provider) }
+  let(:user) { application.user }
 
-    specify { expect(response).to(be_method_not_allowed) }
+  def create_resource(**attrs)
+    if attrs[:lead_provider]
+      attrs[:declaration] = create(:declaration, application:, lead_provider: attrs[:lead_provider])
+      attrs.delete(:lead_provider)
+    end
+
+    create(:participant_outcome, **attrs)
+  end
+
+  def create_resource_with_different_parent(**attrs)
+    create_resource(**attrs).tap do |outcome|
+      outcome.declaration.update!(
+        application: create(:application, :accepted, user: create(:user, full_name: "Other User")),
+      )
+    end
+  end
+
+  describe "GET /api/v1/participants/npq/:participant_id/outcomes" do
+    let(:path) { api_v1_participants_outcomes_path(user.ecf_id) }
+    let(:resource_id_key) { :ecf_id }
+
+    it_behaves_like "an API index endpoint"
+    it_behaves_like "an API index endpoint on a parent resource", "participant", "outcome"
+    it_behaves_like "an API index endpoint with pagination"
   end
 
   describe("create") do

--- a/spec/requests/api/v1/participants/outcomes_spec.rb
+++ b/spec/requests/api/v1/participants/outcomes_spec.rb
@@ -34,9 +34,22 @@ RSpec.describe "Participants outcome endpoints", type: :request do
     it_behaves_like "an API index endpoint with pagination"
   end
 
-  describe("create") do
-    before { api_post(api_v1_participants_outcomes_path(123)) }
+  describe "POST /api/v1/participants/npq/:participant_id/outcomes" do
+    let(:path) { api_v1_participants_outcomes_path(user.ecf_id) }
+    let(:attributes) do
+      {
+        state: ParticipantOutcomes::Create::STATES.sample,
+        completion_date: 1.day.ago.strftime("%Y-%m-%d"),
+        course_identifier: ParticipantOutcomes::Create::COURSE_IDENTIFIERS.sample,
+      }
+    end
+    let(:service) { ParticipantOutcomes::Create }
+    let(:action) { :create_outcome }
+    let(:service_args) { { lead_provider: current_lead_provider, participant: user }.merge!(attributes) }
+    let(:resource) { build(:participant_outcome) }
+    let(:resource_id) { resource.ecf_id }
+    let(:resource_name) { :created_outcome }
 
-    specify { expect(response).to(be_method_not_allowed) }
+    it_behaves_like "an API create endpoint"
   end
 end

--- a/spec/requests/api/v2/participants/outcomes_spec.rb
+++ b/spec/requests/api/v2/participants/outcomes_spec.rb
@@ -34,9 +34,22 @@ RSpec.describe "Participants outcome endpoints", type: :request do
     it_behaves_like "an API index endpoint with pagination"
   end
 
-  describe("create") do
-    before { api_post(api_v2_participants_outcomes_path(123)) }
+  describe "POST /api/v2/participants/npq/:participant_id/outcomes" do
+    let(:path) { api_v2_participants_outcomes_path(user.ecf_id) }
+    let(:attributes) do
+      {
+        state: ParticipantOutcomes::Create::STATES.sample,
+        completion_date: 1.day.ago.strftime("%Y-%m-%d"),
+        course_identifier: ParticipantOutcomes::Create::COURSE_IDENTIFIERS.sample,
+      }
+    end
+    let(:service) { ParticipantOutcomes::Create }
+    let(:action) { :create_outcome }
+    let(:service_args) { { lead_provider: current_lead_provider, participant: user }.merge!(attributes) }
+    let(:resource) { build(:participant_outcome) }
+    let(:resource_id) { resource.ecf_id }
+    let(:resource_name) { :created_outcome }
 
-    specify { expect(response).to(be_method_not_allowed) }
+    it_behaves_like "an API create endpoint"
   end
 end

--- a/spec/requests/api/v2/participants/outcomes_spec.rb
+++ b/spec/requests/api/v2/participants/outcomes_spec.rb
@@ -1,10 +1,37 @@
 require "rails_helper"
 
 RSpec.describe "Participants outcome endpoints", type: :request do
-  describe("index") do
-    before { api_get(api_v2_participants_outcomes_path(123)) }
+  let(:current_lead_provider) { create(:lead_provider) }
+  let(:query) { ParticipantOutcomes::Query }
+  let(:serializer) { API::ParticipantOutcomeSerializer }
+  let(:serializer_version) { :v2 }
+  let(:application) { create(:application, :accepted, lead_provider: current_lead_provider) }
+  let(:user) { application.user }
 
-    specify { expect(response).to(be_method_not_allowed) }
+  def create_resource(**attrs)
+    if attrs[:lead_provider]
+      attrs[:declaration] = create(:declaration, application:, lead_provider: attrs[:lead_provider])
+      attrs.delete(:lead_provider)
+    end
+
+    create(:participant_outcome, **attrs)
+  end
+
+  def create_resource_with_different_parent(**attrs)
+    create_resource(**attrs).tap do |outcome|
+      outcome.declaration.update!(
+        application: create(:application, :accepted, user: create(:user, full_name: "Other User")),
+      )
+    end
+  end
+
+  describe "GET /api/v2/participants/npq/:participant_id/outcomes" do
+    let(:path) { api_v2_participants_outcomes_path(user.ecf_id) }
+    let(:resource_id_key) { :ecf_id }
+
+    it_behaves_like "an API index endpoint"
+    it_behaves_like "an API index endpoint on a parent resource", "participant", "outcome"
+    it_behaves_like "an API index endpoint with pagination"
   end
 
   describe("create") do

--- a/spec/requests/api/v3/participants/outcomes_spec.rb
+++ b/spec/requests/api/v3/participants/outcomes_spec.rb
@@ -34,9 +34,22 @@ RSpec.describe "Participants outcome endpoints", type: :request do
     it_behaves_like "an API index endpoint with pagination"
   end
 
-  describe("create") do
-    before { api_post(api_v3_participants_outcomes_path(123)) }
+  describe "POST /api/v3/participants/npq/:participant_id/outcomes" do
+    let(:path) { api_v3_participants_outcomes_path(user.ecf_id) }
+    let(:attributes) do
+      {
+        state: ParticipantOutcomes::Create::STATES.sample,
+        completion_date: 1.day.ago.strftime("%Y-%m-%d"),
+        course_identifier: ParticipantOutcomes::Create::COURSE_IDENTIFIERS.sample,
+      }
+    end
+    let(:service) { ParticipantOutcomes::Create }
+    let(:action) { :create_outcome }
+    let(:service_args) { { lead_provider: current_lead_provider, participant: user }.merge!(attributes) }
+    let(:resource) { build(:participant_outcome) }
+    let(:resource_id) { resource.ecf_id }
+    let(:resource_name) { :created_outcome }
 
-    specify { expect(response).to(be_method_not_allowed) }
+    it_behaves_like "an API create endpoint"
   end
 end

--- a/spec/requests/api/v3/participants/outcomes_spec.rb
+++ b/spec/requests/api/v3/participants/outcomes_spec.rb
@@ -1,10 +1,37 @@
 require "rails_helper"
 
 RSpec.describe "Participants outcome endpoints", type: :request do
-  describe("index") do
-    before { api_get(api_v3_participants_outcomes_path(123)) }
+  let(:current_lead_provider) { create(:lead_provider) }
+  let(:query) { ParticipantOutcomes::Query }
+  let(:serializer) { API::ParticipantOutcomeSerializer }
+  let(:serializer_version) { :v3 }
+  let(:application) { create(:application, :accepted, lead_provider: current_lead_provider) }
+  let(:user) { application.user }
 
-    specify { expect(response).to(be_method_not_allowed) }
+  def create_resource(**attrs)
+    if attrs[:lead_provider]
+      attrs[:declaration] = create(:declaration, application:, lead_provider: attrs[:lead_provider])
+      attrs.delete(:lead_provider)
+    end
+
+    create(:participant_outcome, **attrs)
+  end
+
+  def create_resource_with_different_parent(**attrs)
+    create_resource(**attrs).tap do |outcome|
+      outcome.declaration.update!(
+        application: create(:application, :accepted, user: create(:user, full_name: "Other User")),
+      )
+    end
+  end
+
+  describe "GET /api/v3/participants/npq/:participant_id/outcomes" do
+    let(:path) { api_v3_participants_outcomes_path(user.ecf_id) }
+    let(:resource_id_key) { :ecf_id }
+
+    it_behaves_like "an API index endpoint"
+    it_behaves_like "an API index endpoint on a parent resource", "participant", "outcome"
+    it_behaves_like "an API index endpoint with pagination"
   end
 
   describe("create") do

--- a/spec/services/participant_outcomes/create_spec.rb
+++ b/spec/services/participant_outcomes/create_spec.rb
@@ -1,0 +1,178 @@
+require "rails_helper"
+
+RSpec.describe ParticipantOutcomes::Create, type: :model do
+  let(:date_format) { "%Y-%m-%d" }
+  let(:participant) { completed_declaration.user }
+  let(:lead_provider) { completed_declaration.lead_provider }
+  let(:completion_date) { 1.week.ago.strftime(date_format) }
+  let(:course_identifier) { described_class::COURSE_IDENTIFIERS.sample }
+  let(:course) { Course.find_by(identifier: course_identifier) }
+  let(:state) { described_class::STATES.sample }
+  let(:completed_declaration) { create(:declaration, :completed, :payable, course:) }
+  let(:instance) { described_class.new(lead_provider:, participant:, completion_date:, state:, course_identifier:) }
+
+  describe "validations" do
+    it { expect(instance).to be_valid }
+    it { is_expected.to validate_presence_of(:lead_provider) }
+    it { is_expected.to validate_presence_of(:participant) }
+    it { is_expected.to validate_presence_of(:completion_date) }
+    it { is_expected.to allow_values(1.day.ago.strftime(date_format)).for(:completion_date) }
+    it { is_expected.not_to allow_values(nil, "", 1.day.from_now.strftime(date_format), 1.day.ago.strftime("%d-%m-%Y")).for(:completion_date) }
+    it { is_expected.to validate_inclusion_of(:course_identifier).in_array(described_class::COURSE_IDENTIFIERS) }
+    it { is_expected.to validate_inclusion_of(:state).in_array(described_class::STATES) }
+
+    describe "completed declarations" do
+      context "when the participant has no completed declarations" do
+        before { completed_declaration.destroy! }
+
+        it "adds an error to the base attribute" do
+          expect(instance).to be_invalid
+          expect(instance.errors.first).to have_attributes(attribute: :base, type: :no_completed_declarations)
+        end
+      end
+
+      context "when the participant has completed declarations on another lead provider" do
+        let(:lead_provider) { create(:lead_provider, name: "Other lead provider") }
+
+        it "adds an error to the base attribute" do
+          expect(instance).to be_invalid
+          expect(instance.errors.first).to have_attributes(attribute: :base, type: :no_completed_declarations)
+        end
+      end
+
+      context "when the participant has completed declarations with a different course identifier" do
+        let(:other_course) { Course.find_by(identifier: described_class::COURSE_IDENTIFIERS.excluding(course_identifier).sample) }
+
+        before { completed_declaration.application.update!(course: other_course) }
+
+        it "adds an error to the base attribute" do
+          expect(instance).to be_invalid
+          expect(instance.errors.first).to have_attributes(attribute: :base, type: :no_completed_declarations)
+        end
+      end
+
+      Declaration.states.keys.excluding(Declaration::BILLABLE_STATES + Declaration::VOIDABLE_STATES).each do |state|
+        context "when the participant has completed declarations for the same lead provider and course that are #{state}" do
+          before { completed_declaration.update!(state:) }
+
+          it "adds an error to the base attribute" do
+            expect(instance).to be_invalid
+            expect(instance.errors.first).to have_attributes(attribute: :base, type: :no_completed_declarations)
+          end
+        end
+      end
+    end
+  end
+
+  describe "#create_outcome" do
+    subject(:create_outcome) { instance.create_outcome }
+
+    let(:created_outcome) { instance.created_outcome }
+
+    context "when an existing participant outcome already exists" do
+      context "when it matches the state and completion_date passed into the service" do
+        let!(:existing_outcome) { create(:participant_outcome, state:, completion_date:, declaration: completed_declaration) }
+
+        it { is_expected.to be(true) }
+        it { expect { create_outcome }.not_to change(ParticipantOutcome, :count) }
+
+        it "sets the created_outcome to the existing outcome" do
+          create_outcome
+          expect(created_outcome).to eq(existing_outcome)
+        end
+      end
+
+      context "when it matches the state but not the completion_date passed into the service" do
+        let!(:existing_outcome) { create(:participant_outcome, state:, completion_date: 1.month.ago, declaration: completed_declaration) }
+
+        it { is_expected.to be(true) }
+        it { expect { create_outcome }.to change(ParticipantOutcome, :count) }
+
+        it "sets the created_outcome to the newly created outcome" do
+          create_outcome
+          expect(created_outcome).not_to eq(existing_outcome)
+          expect(created_outcome).to have_attributes({
+            declaration: completed_declaration,
+            state:,
+            completion_date: completion_date.to_date,
+          })
+        end
+      end
+
+      context "when it matches the completion_date but not the state passed into the service" do
+        let(:other_state) { described_class::STATES.excluding(state).sample }
+        let!(:existing_outcome) { create(:participant_outcome, state: other_state, completion_date:, declaration: completed_declaration) }
+
+        it { is_expected.to be(true) }
+        it { expect { create_outcome }.to change(ParticipantOutcome, :count) }
+
+        it "sets the created_outcome to the newly created outcome" do
+          create_outcome
+          expect(created_outcome).not_to eq(existing_outcome)
+          expect(created_outcome).to have_attributes({
+            declaration: completed_declaration,
+            state:,
+            completion_date: completion_date.to_date,
+          })
+        end
+      end
+
+      context "when there are multiple existing participant outcomes that both match and do not match the state and completion_date passed into the service" do
+        let!(:matching_outcome) { create(:participant_outcome, state:, completion_date:, declaration: completed_declaration) }
+        let!(:not_matching_outcome) { create(:participant_outcome, completion_date: 1.month.ago, declaration: completed_declaration) }
+
+        context "when the matching outcome is the latest" do
+          before { matching_outcome.update!(created_at: not_matching_outcome.created_at + 1.day) }
+
+          it { is_expected.to be(true) }
+          it { expect { create_outcome }.not_to change(ParticipantOutcome, :count) }
+
+          it "sets the created_outcome to the latest existing outcome" do
+            create_outcome
+            expect(created_outcome).to eq(matching_outcome)
+          end
+        end
+
+        context "when the matching outcome is not the latest latest" do
+          before { matching_outcome.update!(created_at: not_matching_outcome.created_at - 1.day) }
+
+          it { is_expected.to be(true) }
+          it { expect { create_outcome }.to change(ParticipantOutcome, :count) }
+
+          it "sets the created_outcome to the newly created outcome" do
+            create_outcome
+            expect(created_outcome).not_to eq(matching_outcome)
+            expect(created_outcome).to have_attributes({
+              declaration: completed_declaration,
+              state:,
+              completion_date: completion_date.to_date,
+            })
+          end
+        end
+      end
+    end
+
+    context "when an existing participant outcome does not exist" do
+      it { is_expected.to be(true) }
+
+      it "creates a new participant outcome, assigning it to created_outcome" do
+        expect { create_outcome }.to change(ParticipantOutcome, :count).by(1)
+
+        expect(created_outcome).to have_attributes({
+          declaration: completed_declaration,
+          state:,
+          completion_date: completion_date.to_date,
+        })
+
+        expect(created_outcome.ecf_id).to be_present
+      end
+    end
+
+    context "when not valid" do
+      let(:state) { "invalid" }
+
+      it { is_expected.to be(false) }
+      it { expect { create_outcome }.not_to change(ParticipantOutcome, :count) }
+    end
+  end
+end

--- a/spec/support/shared_examples/api_create_endpoint_support.rb
+++ b/spec/support/shared_examples/api_create_endpoint_support.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "an API create endpoint" do
+  let(:params) { defined?(attributes) ? { data: { attributes: } } : nil }
+  let(:stub_service) do
+    service_double = instance_double(service, "#{action}": true, **service_args)
+    allow(service).to receive(:new) { |args|
+      expect(args.to_hash.symbolize_keys).to eq(service_args)
+    }.and_return(service_double)
+    allow(service_double).to receive(resource_name).and_return(resource) if defined?(resource_name)
+    service_double
+  end
+
+  context "when authorized" do
+    it "returns the resource" do
+      stub_service
+
+      api_post(path, params:)
+
+      expect(response.status).to eq 200
+      expect(response.content_type).to eql("application/json")
+      expect(parsed_response["data"]["id"]).to eq(resource_id)
+    end
+
+    it "calls the correct service" do
+      service_double = stub_service
+
+      api_post(path, params:)
+
+      expect(service_double).to have_received(action)
+    end
+
+    it "calls the correct serializer" do
+      stub_service
+
+      serializer_params = { root: "data" }
+      serializer_params[:view] = serializer_version if defined?(serializer_version)
+      serializer_params[:lead_provider] = serializer_lead_provider if defined?(serializer_lead_provider)
+
+      expect(serializer).to receive(:render).with(resource, **serializer_params).and_call_original
+
+      api_post(path, params:)
+    end
+
+    context "when the service has errors", exceptions_app: true do
+      it "returns 422 - unprocessable entity" do
+        errors = instance_double("errors", messages: { attr: %w[error] })
+        service_double = instance_double(service, "#{action}": false, errors:)
+        allow(service).to receive(:new) { |args|
+          expect(args.to_hash.symbolize_keys).to eq(service_args)
+        }.and_return(service_double)
+
+        api_post(path, params:)
+
+        expect(response.status).to eq(422)
+      end
+    end
+  end
+
+  context "when unauthorized" do
+    it "returns 401 - unauthorized" do
+      api_post(path, params:, token: "incorrect-token")
+
+      expect(response.status).to eq 401
+      expect(parsed_response["error"]).to eql("HTTP Token: Access denied")
+      expect(response.content_type).to eql("application/json")
+    end
+  end
+end

--- a/spec/support/shared_examples/api_index_endpoint_support.rb
+++ b/spec/support/shared_examples/api_index_endpoint_support.rb
@@ -51,6 +51,24 @@ RSpec.shared_examples "an API index endpoint" do
   end
 end
 
+RSpec.shared_examples "an API index endpoint on a parent resource" do |parent, child|
+  context "when 2 #{child.pluralize} exist for current_lead_provider" do
+    let!(:resource) { create_resource(lead_provider: current_lead_provider) }
+
+    before do
+      create_resource_with_different_parent(lead_provider: current_lead_provider)
+    end
+
+    it "only returns the #{child} nested on the requested #{parent}" do
+      api_get(path)
+
+      expect(response.status).to eq 200
+      expect(response.content_type).to eql("application/json")
+      expect(response_ids).to contain_exactly(resource[resource_id_key])
+    end
+  end
+end
+
 RSpec.shared_examples "an API index endpoint with pagination" do
   context "with pagination" do
     before do


### PR DESCRIPTION
[Jira-3099](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3099)

### Context

We want to bring across the create participant outcomes functionality from ECF into NPQ reg. This will not include posting updates to the qualified teachers API when outcomes are created.

### Changes proposed in this pull request

-  Add ParticipantOutcomes::Create service

Port the service to create a `ParticipantOutcome` from ECF, replicating the functionality.

The `course_for_participant` validator has been omitted as its redundant; we require a completed declaration for the given `course_identifier` to submit the outcome which implies the participant has an application with the relevant course.

Add transient `course` to declarations factory to more easily create a declaration with a given course.

- Remove presence validation from ecf_id

We generate this at the database level, but if we don't omit the validation here it will prevent us from creating a new `ParticipantOutcome` without specifying an `ecf_id` upfront.

- Add POST api/:version/npq/participants/:id/outcomes endpoints

Add the endpoints to create a `ParticipantOutcome` for a given participant. Calls the `ParticipantOutcomes::Create` service.
