### PR TITLE
[CPDLP-3198] Add outcomes logic to create declaration endpoint

### DIFF
--- a/app/models/course_group.rb
+++ b/app/models/course_group.rb
@@ -4,6 +4,8 @@ class CourseGroup < ApplicationRecord
 
   validates :name, presence: { message: "Enter a unique course group name" }, uniqueness: { message: "Course name already exist, enter a unique name" }
 
+  scope :leadership_or_specialist, -> { where(name: %w[leadership specialist]) }
+
   def schedule_for(cohort:, schedule_date:)
     case name
     when "leadership"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,7 @@ en:
   invalid_page_parameters: "The '#/page[page]' and '#/page[per_page]' parameter values must be a valid positive number"
   invalid_data_structure: correct json data structure required. See API docs for reference
   schedule_invalid_for_course: Selected schedule is not valid for the course
+  cannot_create_completed_declaration: "Could not create completed declaration. Contact the DfE for support."
 
   errors:
     email:
@@ -306,6 +307,8 @@ en:
             <<: *declaration
             course_identifier:
               <<: *participant_course_identifier
+            lead_provider:
+              <<: *lead_provider
         participant_outcomes/create:
           attributes:
             base:

--- a/spec/factories/declarations.rb
+++ b/spec/factories/declarations.rb
@@ -27,5 +27,9 @@ FactoryBot.define do
     trait :paid do
       state { :paid }
     end
+
+    trait :completed do
+      declaration_type { :completed }
+    end
   end
 end

--- a/spec/models/course_group_spec.rb
+++ b/spec/models/course_group_spec.rb
@@ -76,4 +76,17 @@ RSpec.describe CourseGroup, type: :model do
       end
     end
   end
+
+  describe "scopes" do
+    describe ".leadership_or_specialist" do
+      let!(:leadership_group) { CourseGroup.find_by(name: "leadership") || create(:course_group, name: "leadership") }
+      let!(:specialist_group) { CourseGroup.find_by(name: "specialist") || create(:course_group, name: "specialist") }
+
+      before { CourseGroup.find_by(name: "support") || create(:course_group, name: "support") }
+
+      it "returns leadership and specialist groups only" do
+        expect(described_class.leadership_or_specialist).to match_array([leadership_group, specialist_group])
+      end
+    end
+  end
 end

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe Declaration, type: :model do
         completed_declaration.dup.update!(declaration_type: "retained-1")
 
         # Declaration on another provider.
-        completed_declaration.dup.update!(lead_provider: create(:lead_provider, name: "Other lead provider"))
+        completed_declaration.dup.update!(lead_provider: LeadProvider.where.not(id: lead_provider.id).first)
 
         # Declaration with different course.
         completed_declaration.dup.update!(application: create(:application, course: create(:course, identifier: "other-course")))
@@ -273,7 +273,7 @@ RSpec.describe Declaration, type: :model do
       let(:lead_provider) { declaration.lead_provider }
       let(:declaration) { create(:declaration) }
 
-      before { create(:declaration, lead_provider: create(:lead_provider, name: "Other lead provider")) }
+      before { create(:declaration, lead_provider: LeadProvider.where.not(id: lead_provider.id).first) }
 
       it { expect(described_class.with_lead_provider(lead_provider)).to contain_exactly(declaration) }
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe User do
         create(:participant_outcome, user:, course:, lead_provider:).declaration.update!(declaration_type: "retained-1")
 
         # Declaration on another provider.
-        create(:participant_outcome, user:, course:, lead_provider: create(:lead_provider, name: "Other lead provider"))
+        create(:participant_outcome, user:, course:, lead_provider: LeadProvider.where.not(id: lead_provider.id).first)
 
         # Declaration with different course.
         create(:participant_outcome, user:, course: create(:course, identifier: "other-course"), lead_provider:)

--- a/spec/services/participant_outcomes/create_spec.rb
+++ b/spec/services/participant_outcomes/create_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe ParticipantOutcomes::Create, type: :model do
       end
 
       context "when the participant has completed declarations on another lead provider" do
-        let(:lead_provider) { create(:lead_provider, name: "Other lead provider") }
+        let(:lead_provider) { LeadProvider.where.not(id: lead_provider.id).first }
 
         it { is_expected.to have_error(:base, :no_completed_declarations, "The participant has not had a 'completed' declaration submitted for them. Therefore you cannot update their outcome.") }
       end

--- a/spec/services/statements/query_spec.rb
+++ b/spec/services/statements/query_spec.rb
@@ -32,8 +32,7 @@ RSpec.describe Statements::Query do
         end
 
         it "does not return statements for other Lead Providers" do
-          other_lead_provider = create(:lead_provider)
-          create(:statement, lead_provider: other_lead_provider)
+          create(:statement, lead_provider: LeadProvider.where.not(id: lead_provider.id).first)
 
           query = Statements::Query.new(lead_provider:)
 


### PR DESCRIPTION
### Context

Ticket: [CPDLP-3198](https://dfedigital.atlassian.net/browse/CPDLP-3198)

When a provider submits a completed declaration we need to capture if they passed in an outcome.

### Changes proposed in this pull request

Similar to ECF if a valid completed declaration has been created, create the outcome for that participant.

[CPDLP-3198]: https://dfedigital.atlassian.net/browse/CPDLP-3198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ