### PR TITLE
Add `has_passed` to `DeclarationSerializer`

### DIFF
--- a/app/models/participant_outcome.rb
+++ b/app/models/participant_outcome.rb
@@ -8,8 +8,20 @@ class ParticipantOutcome < ApplicationRecord
 
   delegate :user, :lead_provider, :course, to: :declaration
 
+  enum state: {
+    passed: "passed",
+    failed: "failed",
+    voided: "voided",
+  }, _suffix: true
+
   def self.latest
     order(created_at: :desc).first
+  end
+
+  def has_passed?
+    return nil if voided_state?
+
+    passed_state?
   end
 
 private

--- a/app/serializers/api/declaration_serializer.rb
+++ b/app/serializers/api/declaration_serializer.rb
@@ -11,8 +11,7 @@ module API
       field(:course_identifier)
       field(:declaration_date)
       field(:state) { |declaration| declaration.state.dasherize }
-      # TODO: implement once we have outcomes
-      field(:has_passed) { "TODO" }
+      field(:has_passed) { |declaration| declaration.participant_outcomes.latest&.has_passed? }
 
       view :v1 do
         field(:voided_state?, name: :voided)

--- a/spec/models/participant_outcome_spec.rb
+++ b/spec/models/participant_outcome_spec.rb
@@ -54,4 +54,26 @@ RSpec.describe ParticipantOutcome, type: :model do
   describe "associations" do
     it { is_expected.to belong_to(:declaration) }
   end
+
+  describe "#has_passed?" do
+    context "when the outcome is voided" do
+      before { instance.state = :voided }
+
+      it { expect(instance.has_passed?).to be_nil }
+    end
+
+    context "when the outcome is passed" do
+      before { instance.state = :passed }
+
+      it { is_expected.to be_has_passed }
+    end
+
+    described_class.states.keys.excluding("passed", "voided").each do |state|
+      context "when the outcome is #{state}" do
+        before { instance.state = state }
+
+        it { is_expected.not_to be_has_passed }
+      end
+    end
+  end
 end

--- a/spec/models/participant_outcome_spec.rb
+++ b/spec/models/participant_outcome_spec.rb
@@ -3,6 +3,16 @@ require "rails_helper"
 RSpec.describe ParticipantOutcome, type: :model do
   subject(:instance) { build(:participant_outcome) }
 
+  describe "enums" do
+    it {
+      expect(subject).to define_enum_for(:state).with_values(
+        passed: "passed",
+        failed: "failed",
+        voided: "voided",
+      ).backed_by_column_of_type(:enum).with_suffix
+    }
+  end
+
   describe ".latest" do
     subject { described_class.latest }
 

--- a/spec/serializers/api/declaration_serializer_spec.rb
+++ b/spec/serializers/api/declaration_serializer_spec.rb
@@ -48,8 +48,34 @@ RSpec.describe API::DeclarationSerializer, type: :serializer do
           expect(attributes["state"]).to eq(declaration.state)
         end
 
-        it "serializes `has_passed`" do
-          expect(attributes["has_passed"]).to eq("TODO")
+        context "when there is no participant outcome" do
+          it "serializes `has_passed`" do
+            expect(attributes["has_passed"]).to be_nil
+          end
+        end
+
+        context "when the latest outcome is voided" do
+          before { create(:participant_outcome, :voided, declaration:) }
+
+          it "serializes `has_passed`" do
+            expect(attributes["has_passed"]).to be_nil
+          end
+        end
+
+        context "when the latest outcome has passed" do
+          before { create(:participant_outcome, :passed, declaration:) }
+
+          it "serializes `has_passed`" do
+            expect(attributes["has_passed"]).to be(true)
+          end
+        end
+
+        context "when the latest outcome has failed" do
+          before { create(:participant_outcome, :failed, declaration:) }
+
+          it "serializes `has_passed`" do
+            expect(attributes["has_passed"]).to be(false)
+          end
         end
       end
     end

--- a/spec/serializers/api/declarations_csv_serializer_spec.rb
+++ b/spec/serializers/api/declarations_csv_serializer_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe API::DeclarationsCsvSerializer, type: :serializer do
   describe "#serialize" do
     subject(:csv) { instance.serialize }
 
-    let(:declarations) { create_list(:declaration, 2) }
+    let(:declarations) { create_list(:declaration, 2, :started) }
     let(:rows) { CSV.parse(csv, headers: true) }
     let(:first_declaration) { declarations.first }
     let(:first_row) { rows.first.to_hash.symbolize_keys }
 
     it { expect(rows.count).to eq(declarations.count) }
-    it { expect(first_row.values).to all(be_present) }
+    it { expect(first_row.except(:has_passed).values).to all(be_present) }
 
     it "returns expected data", :aggregate_failures do
       expect(first_row).to include({
@@ -26,7 +26,7 @@ RSpec.describe API::DeclarationsCsvSerializer, type: :serializer do
         declaration_date: first_declaration.declaration_date.rfc3339,
         updated_at: first_declaration.updated_at.rfc3339,
         state: first_declaration.state,
-        has_passed: "TODO",
+        has_passed: nil,
         voided: first_declaration.voided_state?.to_s,
         eligible_for_payment: first_declaration.eligible_for_payment?.to_s,
       })


### PR DESCRIPTION
[Jira-3236](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-3236)

### Context

We want to bring the `has_passed?` logic from ECF into `ParticipantOutcome` and expose in the `DeclarationSerializer`. The `has_passed` will be `nil` if the outcome does not exist or is `voided`, otherwise `true`/`false` for `passed` and `failed`.

### Changes proposed in this pull request

- Add has_passed to DeclarationSerializer