### PR TITLE
Make logger injectable so we can disable logging in tests (targeted_delivery_funding_eligibility_updater_spec)

### DIFF
--- a/app/services/ehco/targeted_delivery_funding_eligibility_updater.rb
+++ b/app/services/ehco/targeted_delivery_funding_eligibility_updater.rb
@@ -6,8 +6,7 @@ module Ehco
       delegate :run, to: :new
     end
 
-    def run
-      logger = Logger.new($stdout)
+    def run(logger: Logger.new($stdout))
       logger.info "Updating EHCO NPQ Applications, this may take a couple of minutes..."
 
       ehco_course = Course.ehco

--- a/spec/lib/services/ehco/targeted_delivery_funding_eligibility_updater_spec.rb
+++ b/spec/lib/services/ehco/targeted_delivery_funding_eligibility_updater_spec.rb
@@ -3,9 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Ehco::TargetedDeliveryFundingEligibilityUpdater do
-  subject { described_class.run }
+  subject { described_class.run(logger:) }
 
   let(:ehco_course) { Course.ehco }
+  let(:logger) { object_double("logger", info: nil) }
 
   let(:applicable_application_hash) do
     {


### PR DESCRIPTION
### Context

Ticket: N/A

When running tests, logger is outputting texts in screen.

`rspec spec/lib/services/ehco/targeted_delivery_funding_eligibility_updater_spec.rb`

### Changes proposed in this pull request

Make the logger injectable so we can inject a fake logger in tests so it doesn't spit out text when running the tests.
