### PR TITLE
Fix the GOV.UK Frontend initialisation error

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
     <%= render partial: "shared/analytics/google_noscript" %>
 
     <script>
-      document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+      document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');
     </script>
 
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>


### PR DESCRIPTION
### Context

Ticket: N/A

The GOV.UK Frontend is complaining about the missing `govuk-frontend-supported` css class in the `<body>` element.

<img src="https://github.com/DFE-Digital/npq-registration/assets/951947/63e11116-39a6-4330-8053-054784b4d3b8" width="300">

### Changes proposed in this pull request

- Add the css class

