### PR TITLE
[CPDLP-3102] Add outcomes seed data to separation

### DIFF
--- a/app/services/valid_test_data_generators/applications_populater.rb
+++ b/app/services/valid_test_data_generators/applications_populater.rb
@@ -45,6 +45,7 @@ module ValidTestDataGenerators
 
       accept_application(application)
       create_declarations(application)
+      create_outcomes(application)
 
       return if Faker::Boolean.boolean(true_ratio: 0.3)
 
@@ -104,6 +105,21 @@ module ValidTestDataGenerators
           application:,
           declaration_type:,
         )
+      end
+    end
+
+    def create_outcomes(application)
+      completed_declaration = application.declarations.eligible_for_outcomes(lead_provider, application.course.identifier).first
+      return unless completed_declaration
+
+      ParticipantOutcomes::Create::STATES.reverse.each do |state|
+        ParticipantOutcomes::Create.new(lead_provider:,
+                                        participant: application.user,
+                                        course_identifier: application.course.identifier,
+                                        state:,
+                                        completion_date: completed_declaration.declaration_date.to_s).create_outcome
+
+        break if Faker::Boolean.boolean(true_ratio: 0.3)
       end
     end
   end

--- a/spec/services/valid_test_data_generators/applications_populater_spec.rb
+++ b/spec/services/valid_test_data_generators/applications_populater_spec.rb
@@ -71,6 +71,14 @@ RSpec.describe ValidTestDataGenerators::ApplicationsPopulater, :with_default_sch
           subject.populate
         }.to(change(Declaration, :count))
       end
+
+      it "creates outcomes" do
+        allow(Faker::Boolean).to receive(:boolean).and_return(false)
+
+        expect {
+          subject.populate
+        }.to(change(ParticipantOutcome, :count))
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-3102

We have a service to create seed data for providers in separation which we need to keep up to date.

### Changes proposed in this pull request

Add outcomes to some accepted applications with completed declarations in the seed data.