### PR TITLE
Change Senco from specialist to leadership course

### DIFF
--- a/config/initializers/courses.rb
+++ b/config/initializers/courses.rb
@@ -86,7 +86,7 @@ module Courses
       name: "NPQ for Senco (NPQSENCO)",
       ecf_id: "84b7ffd9-c726-4915-bcac-05901d9629b8",
       identifier: "npq-senco",
-      course_group_name: "specialist",
+      course_group_name: "leadership",
       display: true,
     },
     {

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -79,7 +79,7 @@ FactoryBot.define do
     trait :senco do
       sequence(:name) { |n| "NPQ for Senco #{n}" }
       identifier { "npq-senco" }
-      course_group { CourseGroup.find_by(name: "specialist") || create(:course_group, name: "specialist") }
+      course_group { CourseGroup.find_by(name: "leadership") || create(:course_group, name: "leadership") }
     end
 
     factory :"npq-executive-leadership", traits: [:el]


### PR DESCRIPTION
### Context

Senco is a leadership course, and should belong to the leadership course group.


Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-000

[Why are we making this change?]

### Changes proposed in this pull request

Change seed data for Senco point to leadership rather than specialist

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
