### PR TITLE
Add prod postgres maintenance window

### DIFF
--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -11,6 +11,11 @@
   "worker_memory_max": "2Gi",
   "enable_monitoring": true,
   "deploy_snapshot_database": true,
+  "azure_maintenance_window": {
+    "day_of_week": 0,
+    "start_hour": 4,
+    "start_minute": 0
+  },
   "external_url": "https://register-national-professional-qualifications.education.gov.uk/healthcheck",
   "enable_logit": true
 }

--- a/terraform/application/database.tf
+++ b/terraform/application/database.tf
@@ -39,6 +39,7 @@ module "postgres" {
   azure_extensions               = ["btree_gin", "citext", "plpgsql", "pg_trgm"]
   azure_enable_high_availability = var.postgres_enable_high_availability
   azure_sku_name                 = var.postgres_flexible_server_sku
+  azure_maintenance_window       = var.azure_maintenance_window
 }
 
 module "postgres-snapshot" {

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -22,6 +22,16 @@ variable "azure_credentials_json" {
 variable "azure_resource_prefix" {
   description = "Standard resource prefix. Usually s189t01 (test) or s189p01 (production)"
 }
+
+variable "azure_maintenance_window" {
+  type = object({
+    day_of_week  = number
+    start_hour   = number
+    start_minute = number
+  })
+  default = null
+}
+
 variable "config_short" {
   description = "Short name of the environment configuration, e.g. dv, st, pd..."
 }


### PR DESCRIPTION
### Context

ECF postgres database don’t have a maintenance window set, so they are upgraded alongside nonprod at a random time

Ticket: https://trello.com/c/4NPqv8MF/1903-add-prod-postgres-maintenance-window

### Changes proposed in this pull request

Add maintenance window to terraform

