### PR TITLE
[CPDLP-3199] TS8 - Add outcomes logic to void declaration endpoint

### DIFF
--- a/app/services/declarations/void.rb
+++ b/app/services/declarations/void.rb
@@ -22,6 +22,8 @@ module Declarations
 
       ApplicationRecord.transaction do
         clawing_back? ? clawback_declaration : void_declaration
+
+        void_participant_outcome
       end
 
       true
@@ -70,6 +72,10 @@ module Declarations
 
     def voiding?
       !clawing_back?
+    end
+
+    def void_participant_outcome
+      ParticipantOutcomes::Void.new(declaration:).void_outcome
     end
   end
 end

--- a/app/services/participant_outcomes/void.rb
+++ b/app/services/participant_outcomes/void.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module ParticipantOutcomes
+  class Void
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :declaration
+
+    def void_outcome
+      return unless voidable_outcome?
+
+      ParticipantOutcome.create!(
+        declaration:,
+        completion_date: declaration_date,
+        state: "voided",
+      )
+    end
+
+  private
+
+    delegate :user, :lead_provider,
+             :course, :declaration_date,
+             to: :declaration
+
+    def voidable_outcome?
+      declaration.completed_declaration_type? &&
+        valid_course_identifier_for_participant_outcome? &&
+        !latest_existing_outcome&.voided_state?
+    end
+
+    def latest_existing_outcome
+      @latest_existing_outcome ||= user&.latest_participant_outcome(lead_provider, course.identifier)
+    end
+
+    def valid_course_identifier_for_participant_outcome?
+      CourseGroup.joins(:courses).leadership_or_specialist.where(courses: { identifier: course.identifier }).exists?
+    end
+  end
+end

--- a/spec/services/declarations/void_spec.rb
+++ b/spec/services/declarations/void_spec.rb
@@ -85,6 +85,17 @@ RSpec.describe Declarations::Void, type: :model do
             it { expect { void }.to change { statement_item.reload.state }.from(statement_item_state).to("voided") }
           end
         end
+
+        it "calls the void participant outcome service" do
+          service = instance_double(ParticipantOutcomes::Void)
+          allow(service).to receive(:void_outcome)
+          expect(service).to receive(:void_outcome)
+
+          allow(ParticipantOutcomes::Void).to receive(:new).with(declaration:).and_return(service)
+          expect(ParticipantOutcomes::Void).to receive(:new).with(declaration:)
+
+          void
+        end
       end
     end
 
@@ -97,6 +108,17 @@ RSpec.describe Declarations::Void, type: :model do
         expect { void }.to change { statement.reload.statement_items.count }.by(1)
         created_statement_item = statement.statement_items.last
         expect(created_statement_item).to have_attributes(declaration:, state: declaration.reload.state)
+      end
+
+      it "calls the void participant outcome service" do
+        service = instance_double(ParticipantOutcomes::Void)
+        allow(service).to receive(:void_outcome)
+        expect(service).to receive(:void_outcome)
+
+        allow(ParticipantOutcomes::Void).to receive(:new).with(declaration:).and_return(service)
+        expect(ParticipantOutcomes::Void).to receive(:new).with(declaration:)
+
+        void
       end
     end
 

--- a/spec/services/participant_outcomes/void_spec.rb
+++ b/spec/services/participant_outcomes/void_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.describe ParticipantOutcomes::Void, type: :model do
+  let(:course) { create(:course, :sl) }
+  let(:declaration) { create(:declaration, declaration_type, :paid, course:) }
+  let(:declaration_type) { :completed }
+
+  subject(:service) { described_class.new(declaration:) }
+
+  describe "#void_outcome" do
+    context "when completed declaration" do
+      before do
+        create(:participant_outcome, :passed, declaration:)
+      end
+
+      it "creates new participant outcome record" do
+        expect(declaration.participant_outcomes.count).to be(1)
+
+        service.void_outcome
+
+        expect(declaration.participant_outcomes.count).to be(2)
+        outcome = declaration.participant_outcomes.latest
+        expect(outcome).to be_voided_state
+        expect(outcome.completion_date).to eq(declaration.declaration_date)
+      end
+    end
+
+    context "when outcome is already voided" do
+      before do
+        create(:participant_outcome, :voided, declaration:)
+      end
+
+      it "does not create a new participant outcome record" do
+        expect(declaration.participant_outcomes.count).to be(1)
+
+        service.void_outcome
+
+        expect(declaration.participant_outcomes.count).to be(1)
+      end
+    end
+
+    context "when started declaration" do
+      let(:declaration_type) { :started }
+
+      it "does not create participant outcome record" do
+        expect(declaration.participant_outcomes.count).to be(0)
+
+        service.void_outcome
+
+        expect(declaration.participant_outcomes.count).to be(0)
+      end
+    end
+
+    %i[ehco aso].each do |course_trait|
+      context "when the course is #{course_trait}" do
+        let(:course) { create(:course, course_trait) }
+
+        it "does not create participant outcome record" do
+          expect(declaration.participant_outcomes.count).to be(0)
+
+          service.void_outcome
+
+          expect(declaration.participant_outcomes.count).to be(0)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-3199

### Changes proposed in this pull request

* Created `ParticipantOutcomes::Void` service
* Updated `Declarations::Void` to run `ParticipantOutcomes::Void`