### PR TITLE
[CPDLP-3269] Add data required to support NPQ MVP testing

### DIFF
--- a/app/services/valid_test_data_generators/applications_populater.rb
+++ b/app/services/valid_test_data_generators/applications_populater.rb
@@ -47,7 +47,7 @@ module ValidTestDataGenerators
 
     def prepare_cohort!
       cohort.tap do |c|
-        c.funding_cap = cohort.start_year >= 2024
+        c.funding_cap = cohort.start_year >= Cohort.current.start_year
         c.save!
       end
     end
@@ -62,6 +62,7 @@ module ValidTestDataGenerators
       accept_application(application)
       create_declarations(application)
       create_outcomes(application)
+      void_completed_declaration_for(application)
 
       return if Faker::Boolean.boolean(true_ratio: 0.3)
 
@@ -161,6 +162,13 @@ module ValidTestDataGenerators
 
         break if Faker::Boolean.boolean(true_ratio: 0.2)
       end
+    end
+
+    def void_completed_declaration_for(application)
+      return if Faker::Boolean.boolean(true_ratio: 0.3)
+
+      completed_declaration = application.declarations.eligible_for_outcomes(lead_provider, application.course.identifier).first
+      Declarations::Void.new(declaration: completed_declaration).void
     end
   end
 end

--- a/app/services/valid_test_data_generators/applications_populater.rb
+++ b/app/services/valid_test_data_generators/applications_populater.rb
@@ -143,7 +143,7 @@ module ValidTestDataGenerators
       return unless completed_declaration
       return unless CourseGroup.joins(:courses).leadership_or_specialist.where(courses: { identifier: application.course.identifier }).exists?
 
-      %i[passed voided failed].each do |state_trait|
+      ParticipantOutcome.states.keys.sort.each do |state_trait|
         FactoryBot.create(
           :participant_outcome,
           state_trait,

--- a/lib/tasks/valid_test_data_generators/separation_data.rake
+++ b/lib/tasks/valid_test_data_generators/separation_data.rake
@@ -12,7 +12,7 @@ namespace :lead_providers do
     raise "Cohort not found: #{args[:cohort_start_year]}" if args[:cohort_start_year] && !cohort
 
     Array.wrap(lead_provider || LeadProvider.all).each do |lp|
-      Array.wrap(cohort || Cohort.all).each do |c|
+      Array.wrap(cohort || Cohort.where(start_year: ..Cohort.current.start_year)).each do |c|
         ValidTestDataGenerators::ApplicationsPopulater.populate(lead_provider: lp, cohort: c, number_of_participants: args[:number_of_participants]&.to_i || 100)
         ValidTestDataGenerators::StatementsPopulater.populate(lead_provider: lp, cohort: c)
       end

--- a/spec/services/valid_test_data_generators/applications_populater_spec.rb
+++ b/spec/services/valid_test_data_generators/applications_populater_spec.rb
@@ -79,6 +79,14 @@ RSpec.describe ValidTestDataGenerators::ApplicationsPopulater, :with_default_sch
           subject.populate
         }.to(change(ParticipantOutcome, :count))
       end
+
+      it "voids some declarations" do
+        allow(Faker::Boolean).to receive(:boolean).and_return(false)
+
+        expect {
+          subject.populate
+        }.to(change(Declaration.voided_state, :count).and(change(ParticipantOutcome.voided_state, :count)))
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

Ticket: [CPDLP-3269](https://dfedigital.atlassian.net/browse/CPDLP-3269)

We need to revisit the rake task to setup seed data to cover all the set up specs below.

### Changes proposed in this pull request

New data needs to be set up to support NPQ testing, some of which has already been set up in the rake task, but we’d like to beef up the scripts as per in the ticket description.

[CPDLP-3269]: https://dfedigital.atlassian.net/browse/CPDLP-3269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ