### PR TITLE
Add `bullet` gem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,7 @@ RUN yarn install --frozen-lockfile
 COPY . /app/
 
 # Compile assets and run webpack
-# Run in rails test environment to avoid loading development gems
-RUN RAILS_ENV=test bundle exec rails assets:precompile
+RUN RAILS_ENV=production SECRET_KEY_BASE=key bundle exec rails assets:precompile
 
 # Cleanup to save space in the production image
 RUN rm -rf node_modules log tmp && \

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ gem "net-smtp", "~> 0.5.0", require: false
 
 group :development, :test do
   gem "amazing_print"
+  gem "bullet"
   gem "byebug", platforms: %i[mri mingw x64_mingw]
   gem "capybara"
   gem "capybara-screenshot"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,9 @@ GEM
     brakeman (6.1.2)
       racc
     builder (3.3.0)
+    bullet (7.2.0)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (11.1.3)
     canonical-rails (0.2.15)
       actionview (>= 4.1, <= 7.2)
@@ -598,6 +601,7 @@ GEM
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
     unicode-display_width (2.5.0)
+    uniform_notifier (1.16.0)
     uri (0.13.0)
     version_gem (1.1.1)
     view_component (3.12.1)
@@ -655,6 +659,7 @@ DEPENDENCIES
   blueprinter
   bootsnap (>= 1.1.0)
   brakeman
+  bullet
   byebug
   canonical-rails
   capybara

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,16 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable                       = true
+    Bullet.alert                        = true
+    Bullet.bullet_logger                = true
+    Bullet.console                      = true
+    Bullet.rails_logger                 = true
+    Bullet.add_footer                   = true
+    Bullet.unused_eager_loading_enable  = false # Disabled due to the way our queries are structured
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -6,6 +6,19 @@ require "active_support/core_ext/integer/time"
 # and recreated between test runs. Don't rely on the data there!
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable                       = true
+    Bullet.bullet_logger                = true
+    Bullet.raise                        = true # Raise an error if n+1 query occurs
+    Bullet.unused_eager_loading_enable  = false # Disabled due to the way our queries are structured
+    Bullet.stacktrace_excludes          = [
+      "app/controllers/api", # Ignore as request spec factories cause false positives (excluding controllers as we use shared examples so can't target spec/requests/api here), see: https://github.com/flyerhzm/bullet/issues/435
+      "spec/features/admin", # Ignore until they are fixed
+      "spec/features/migration_spec.rb", # Ignore until they are fixed
+      "npq_separation/admin", # Ignore until they are fixed
+    ]
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   config.cache_classes = false


### PR DESCRIPTION
### Context

We want to use `bullet` to identify and alert on N+1 queries, so that we don't have to manually check for them.

### Changes proposed in this pull request

- Add `bullet` gem

Add `bullet` to identify and report N+1 queries. Enabled in `development` and will raise an error in `test` if an N+1 is detected.

- Precompile assets using prod environment

We bundle the production assets and run the precompile using the test env, which doesn't make sense. It causes an issue now that we have `bullet` referenced in the `test.rb` as it installed installed with the production gems.

Switch to compiling assets using the prod environment. We need to specify a `SECRET_KEY_BASE` for this to complete, but it doesn't matter what it is.

### Guidance to review

Awkwardly due to the way we are mocking out the underlying services in our request specs and the way our queries are structured (to perform the includes), `bullet` won't actually catch many N+1s from the API 😞 we may want to rethink if we want a robust way to detect them, but there's no harm in adding it in.

Off the top of my head we could hit the query services as part of the serializer specs and that would cover _most_ N+1's we're likely to see.