### PR TITLE
Add X-With-Server-Date header support

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -34,5 +34,9 @@ module NpqRegistration
     config.action_mailer.notify_settings = {
       api_key: ENV["GOVUK_NOTIFY_API_KEY"]
     }
+
+    # Used to handle HTTP_X_WITH_SERVER_DATE header for server side datetime overwrite
+    require "middleware/time_traveler"
+    config.middleware.use Middleware::TimeTraveler
   end
 end

--- a/lib/middleware/time_traveler.rb
+++ b/lib/middleware/time_traveler.rb
@@ -1,0 +1,19 @@
+require "active_support/testing/time_helpers"
+
+module Middleware
+  class TimeTraveler
+    include ActiveSupport::Testing::TimeHelpers
+
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      return @app.call(env) unless env.key?("HTTP_X_WITH_SERVER_DATE") && !Rails.env.production?
+
+      travel_to(Time.zone.parse(env["HTTP_X_WITH_SERVER_DATE"])) do
+        @app.call(env)
+      end
+    end
+  end
+end

--- a/spec/lib/middleware/time_traveler_spec.rb
+++ b/spec/lib/middleware/time_traveler_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+require "middleware/time_traveler"
+
+RSpec.describe Middleware::TimeTraveler, type: :request do
+  let(:app) { proc { [200, {}, Time.zone.now.to_s] } }
+  let(:middleware) { described_class.new(app) }
+  let(:request) { Rack::MockRequest.new(middleware) }
+  let(:headers) { {} }
+
+  subject do
+    response = request.get("/", headers)
+    Time.zone.parse(response.body)
+  end
+
+  it { is_expected.to be_within(1.minute).of(Time.zone.now) }
+
+  context "when the HTTP_X_WITH_SERVER_DATE header is present" do
+    let(:travelled_time) { Time.zone.local(2021, 8, 8, 10, 10, 0) }
+    let(:headers) { { "HTTP_X_WITH_SERVER_DATE" => travelled_time.iso8601 } }
+
+    it { is_expected.to be_within(1.minute).of(travelled_time) }
+
+    context "when in the production environment" do
+      before { allow(Rails).to receive(:env) { "production".inquiry } }
+
+      it { is_expected.to be_within(1.minute).of(Time.zone.now) }
+    end
+  end
+end


### PR DESCRIPTION
### Context

In ECF we allow the server-time to be changed per-request by specifying an `X-With-Server-Header` header.

We want to replicate this functionality in NPQ for all environments apart from production.

### Changes proposed in this pull request

- Add X-With-Server-Date header support

In ECF we allow the server-time to be changed per-request by specifying an `X-With-Server-Header` header.

We want to replicate this functionality in NPQ for all environments apart from production.

Add `time_traveler` middleware from ECF and update it to use `ActiveSupport::Testing::TimeHelpers` instead of `TimeCop`. Load middleware into all environments, but disable in production.

### Guidance to review

I opted to load the middleware in all environments by default to avoid having to manually include it into new environments individually. The middleware itself will only run if its in a non-production environment.