### PR TITLE
Fix query scopes for `show` actions

### DIFF
--- a/app/controllers/api/v1/applications_controller.rb
+++ b/app/controllers/api/v1/applications_controller.rb
@@ -5,13 +5,16 @@ module API
       include FilterByDate
 
       def index
+        conditions = { cohort_start_years:, updated_since: }
+        applications = applications_query(conditions:).applications
+
         respond_to do |format|
           format.json do
-            render json: to_json(paginate(applications_query.applications))
+            render json: to_json(paginate(applications))
           end
 
           format.csv do
-            render body: to_csv(applications_query.applications)
+            render body: to_csv(applications)
           end
         end
       end
@@ -52,9 +55,8 @@ module API
 
     private
 
-      def applications_query
-        conditions = { lead_provider: current_lead_provider, cohort_start_years:, updated_since: }
-
+      def applications_query(conditions: {})
+        conditions.merge!(lead_provider: current_lead_provider)
         Applications::Query.new(**conditions.compact)
       end
 

--- a/app/controllers/api/v1/declarations_controller.rb
+++ b/app/controllers/api/v1/declarations_controller.rb
@@ -5,13 +5,16 @@ module API
       include FilterByDate
 
       def index
+        conditions = { updated_since:, participant_ids: }
+        declarations = declarations_query(conditions:).declarations
+
         respond_to do |format|
           format.json do
-            render json: to_json(paginate(declarations_query.declarations))
+            render json: to_json(paginate(declarations))
           end
 
           format.csv do
-            render body: to_csv(declarations_query.declarations)
+            render body: to_csv(declarations)
           end
         end
       end
@@ -42,10 +45,9 @@ module API
 
     private
 
-      def declarations_query
-        conditions = { lead_provider: current_lead_provider, updated_since:, participant_ids: }
-
-        ::Declarations::Query.new(**conditions.compact)
+      def declarations_query(conditions: {})
+        conditions.merge!(lead_provider: current_lead_provider)
+        Declarations::Query.new(**conditions.compact)
       end
 
       def declaration

--- a/app/controllers/api/v1/participant_outcomes_controller.rb
+++ b/app/controllers/api/v1/participant_outcomes_controller.rb
@@ -5,14 +5,17 @@ module API
       include FilterByDate
 
       def index
-        render json: to_json(paginate(outcomes_query.participant_outcomes))
+        conditions = { created_since: }
+        outcomes = outcomes_query(conditions:).participant_outcomes
+
+        render json: to_json(paginate(outcomes))
       end
 
     private
 
-      def outcomes_query
-        conditions = { lead_provider: current_lead_provider, created_since: }
-        ::ParticipantOutcomes::Query.new(**conditions.compact)
+      def outcomes_query(conditions: {})
+        conditions.merge!(lead_provider: current_lead_provider)
+        ParticipantOutcomes::Query.new(**conditions.compact)
       end
 
       def to_json(obj)

--- a/app/controllers/api/v1/participants/outcomes_controller.rb
+++ b/app/controllers/api/v1/participants/outcomes_controller.rb
@@ -5,7 +5,10 @@ module API
         include Pagination
 
         def index
-          render json: to_json(paginate(outcomes_query.participant_outcomes))
+          conditions = { participant_ids: participant.ecf_id }
+          outcomes = outcomes_query(conditions:).participant_outcomes
+
+          render json: to_json(paginate(outcomes))
         end
 
         def create
@@ -41,9 +44,9 @@ module API
           participants_query.participant(ecf_id: params[:ecf_id])
         end
 
-        def outcomes_query
-          conditions = { lead_provider: current_lead_provider, participant_ids: participant.ecf_id }
-          ::ParticipantOutcomes::Query.new(**conditions.compact)
+        def outcomes_query(conditions: {})
+          conditions.merge!(lead_provider: current_lead_provider)
+          ParticipantOutcomes::Query.new(**conditions.compact)
         end
 
         def to_json(obj)

--- a/app/controllers/api/v1/participants_controller.rb
+++ b/app/controllers/api/v1/participants_controller.rb
@@ -5,7 +5,10 @@ module API
       include FilterByDate
 
       def index
-        render json: to_json(paginate(participants_query.participants))
+        conditions = { updated_since: }
+        participants = participants_query(conditions:).participants
+
+        render json: to_json(paginate(participants))
       end
 
       def show
@@ -56,9 +59,8 @@ module API
 
     private
 
-      def participants_query
-        conditions = { lead_provider: current_lead_provider, updated_since: }
-
+      def participants_query(conditions: {})
+        conditions.merge!(lead_provider: current_lead_provider)
         ::Participants::Query.new(**conditions.compact)
       end
 

--- a/app/controllers/api/v2/applications_controller.rb
+++ b/app/controllers/api/v2/applications_controller.rb
@@ -5,13 +5,16 @@ module API
       include FilterByDate
 
       def index
+        conditions = { cohort_start_years:, updated_since: }
+        applications = applications_query(conditions:).applications
+
         respond_to do |format|
           format.json do
-            render json: to_json(paginate(applications_query.applications))
+            render json: to_json(paginate(applications))
           end
 
           format.csv do
-            render body: to_csv(applications_query.applications)
+            render body: to_csv(applications)
           end
         end
       end
@@ -52,9 +55,8 @@ module API
 
     private
 
-      def applications_query
-        conditions = { lead_provider: current_lead_provider, cohort_start_years:, updated_since: }
-
+      def applications_query(conditions: {})
+        conditions.merge!(lead_provider: current_lead_provider)
         Applications::Query.new(**conditions.compact)
       end
 

--- a/app/controllers/api/v2/declarations_controller.rb
+++ b/app/controllers/api/v2/declarations_controller.rb
@@ -5,13 +5,16 @@ module API
       include FilterByDate
 
       def index
+        conditions = { updated_since:, participant_ids: }
+        declarations = declarations_query(conditions:).declarations
+
         respond_to do |format|
           format.json do
-            render json: to_json(paginate(declarations_query.declarations))
+            render json: to_json(paginate(declarations))
           end
 
           format.csv do
-            render body: to_csv(declarations_query.declarations)
+            render body: to_csv(declarations)
           end
         end
       end
@@ -42,9 +45,9 @@ module API
 
     private
 
-      def declarations_query
-        conditions = { lead_provider: current_lead_provider, updated_since:, participant_ids: }
-        ::Declarations::Query.new(**conditions.compact)
+      def declarations_query(conditions: {})
+        conditions.merge!(lead_provider: current_lead_provider)
+        Declarations::Query.new(**conditions.compact)
       end
 
       def declaration

--- a/app/controllers/api/v2/enrolments_controller.rb
+++ b/app/controllers/api/v2/enrolments_controller.rb
@@ -4,9 +4,12 @@ module API
       include FilterByDate
 
       def index
+        conditions = { updated_since:, lead_provider_approval_status: "accepted" }
+        applications = applications_query(conditions:).applications
+
         respond_to do |format|
           format.csv do
-            render body: to_csv(applications_query.applications)
+            render body: to_csv(applications)
           end
         end
       end
@@ -17,9 +20,8 @@ module API
         EnrolmentsCsvSerializer.new(applications).serialize
       end
 
-      def applications_query
-        conditions = { lead_provider: current_lead_provider, updated_since:, lead_provider_approval_status: "accepted" }
-
+      def applications_query(conditions: {})
+        conditions.merge!(lead_provider: current_lead_provider)
         Applications::Query.new(**conditions.compact)
       end
     end

--- a/app/controllers/api/v2/participant_outcomes_controller.rb
+++ b/app/controllers/api/v2/participant_outcomes_controller.rb
@@ -5,14 +5,17 @@ module API
       include FilterByDate
 
       def index
-        render json: to_json(paginate(outcomes_query.participant_outcomes))
+        conditions = { created_since: }
+        outcomes = outcomes_query(conditions:).participant_outcomes
+
+        render json: to_json(paginate(outcomes))
       end
 
     private
 
-      def outcomes_query
-        conditions = { lead_provider: current_lead_provider, created_since: }
-        ::ParticipantOutcomes::Query.new(**conditions.compact)
+      def outcomes_query(conditions: {})
+        conditions.merge!(lead_provider: current_lead_provider)
+        ParticipantOutcomes::Query.new(**conditions.compact)
       end
 
       def to_json(obj)

--- a/app/controllers/api/v2/participants/outcomes_controller.rb
+++ b/app/controllers/api/v2/participants/outcomes_controller.rb
@@ -5,7 +5,10 @@ module API
         include Pagination
 
         def index
-          render json: to_json(paginate(outcomes_query.participant_outcomes))
+          conditions = { participant_ids: participant.ecf_id }
+          outcomes = outcomes_query(conditions:).participant_outcomes
+
+          render json: to_json(paginate(outcomes))
         end
 
         def create
@@ -41,9 +44,9 @@ module API
           participants_query.participant(ecf_id: params[:ecf_id])
         end
 
-        def outcomes_query
-          conditions = { lead_provider: current_lead_provider, participant_ids: participant.ecf_id }
-          ::ParticipantOutcomes::Query.new(**conditions.compact)
+        def outcomes_query(conditions: {})
+          conditions.merge!(lead_provider: current_lead_provider)
+          ParticipantOutcomes::Query.new(**conditions.compact)
         end
 
         def to_json(obj)

--- a/app/controllers/api/v2/participants_controller.rb
+++ b/app/controllers/api/v2/participants_controller.rb
@@ -5,7 +5,10 @@ module API
       include FilterByDate
 
       def index
-        render json: to_json(paginate(participants_query.participants))
+        conditions = { updated_since: }
+        participants = participants_query(conditions:).participants
+
+        render json: to_json(paginate(participants))
       end
 
       def show
@@ -56,9 +59,8 @@ module API
 
     private
 
-      def participants_query
-        conditions = { lead_provider: current_lead_provider, updated_since: }
-
+      def participants_query(conditions: {})
+        conditions.merge!(lead_provider: current_lead_provider)
         ::Participants::Query.new(**conditions.compact)
       end
 

--- a/app/controllers/api/v3/applications_controller.rb
+++ b/app/controllers/api/v3/applications_controller.rb
@@ -5,7 +5,10 @@ module API
       include FilterByDate
 
       def index
-        render json: to_json(paginate(applications_query.applications))
+        conditions = { cohort_start_years:, participant_ids:, updated_since: }
+        applications = applications_query(conditions:).applications
+
+        render json: to_json(paginate(applications))
       end
 
       def show
@@ -44,10 +47,9 @@ module API
 
     private
 
-      def applications_query
-        conditions = { lead_provider: current_lead_provider, cohort_start_years:, participant_ids:, updated_since: }
-
-        Applications::Query.new(**conditions.compact, sort: application_params[:sort])
+      def applications_query(conditions: {})
+        conditions.merge!(lead_provider: current_lead_provider)
+        Applications::Query.new(**conditions.compact)
       end
 
       def application

--- a/app/controllers/api/v3/declarations_controller.rb
+++ b/app/controllers/api/v3/declarations_controller.rb
@@ -5,7 +5,10 @@ module API
       include FilterByDate
 
       def index
-        render json: to_json(paginate(declarations_query.declarations))
+        conditions = { updated_since:, participant_ids:, cohort_start_years: }
+        declarations = declarations_query(conditions:).declarations
+
+        render json: to_json(paginate(declarations))
       end
 
       def show
@@ -34,9 +37,9 @@ module API
 
     private
 
-      def declarations_query
-        conditions = { lead_provider: current_lead_provider, updated_since:, participant_ids:, cohort_start_years: }
-        ::Declarations::Query.new(**conditions.compact)
+      def declarations_query(conditions: {})
+        conditions.merge!(lead_provider: current_lead_provider)
+        Declarations::Query.new(**conditions.compact)
       end
 
       def declaration

--- a/app/controllers/api/v3/participant_outcomes_controller.rb
+++ b/app/controllers/api/v3/participant_outcomes_controller.rb
@@ -5,14 +5,17 @@ module API
       include FilterByDate
 
       def index
-        render json: to_json(paginate(outcomes_query.participant_outcomes))
+        conditions = { created_since: }
+        outcomes = outcomes_query(conditions:).participant_outcomes
+
+        render json: to_json(paginate(outcomes))
       end
 
     private
 
-      def outcomes_query
-        conditions = { lead_provider: current_lead_provider, created_since: }
-        ::ParticipantOutcomes::Query.new(**conditions.compact)
+      def outcomes_query(conditions: {})
+        conditions.merge!(lead_provider: current_lead_provider)
+        ParticipantOutcomes::Query.new(**conditions.compact)
       end
 
       def to_json(obj)

--- a/app/controllers/api/v3/participants/outcomes_controller.rb
+++ b/app/controllers/api/v3/participants/outcomes_controller.rb
@@ -5,7 +5,10 @@ module API
         include Pagination
 
         def index
-          render json: to_json(paginate(outcomes_query.participant_outcomes))
+          conditions = { participant_ids: participant.ecf_id }
+          outcomes = outcomes_query(conditions:).participant_outcomes
+
+          render json: to_json(paginate(outcomes))
         end
 
         def create
@@ -41,9 +44,9 @@ module API
           participants_query.participant(ecf_id: params[:ecf_id])
         end
 
-        def outcomes_query
-          conditions = { lead_provider: current_lead_provider, participant_ids: participant.ecf_id }
-          ::ParticipantOutcomes::Query.new(**conditions.compact)
+        def outcomes_query(conditions: {})
+          conditions.merge!(lead_provider: current_lead_provider)
+          ParticipantOutcomes::Query.new(**conditions.compact)
         end
 
         def to_json(obj)

--- a/app/controllers/api/v3/participants_controller.rb
+++ b/app/controllers/api/v3/participants_controller.rb
@@ -5,7 +5,10 @@ module API
       include FilterByDate
 
       def index
-        render json: to_json(paginate(participants_query.participants))
+        conditions = { updated_since:, training_status:, from_participant_id: }
+        participants = participants_query(conditions:).participants
+
+        render json: to_json(paginate(participants))
       end
 
       def show
@@ -64,9 +67,8 @@ module API
         participant_params.dig(:filter, :from_participant_id)
       end
 
-      def participants_query
-        conditions = { lead_provider: current_lead_provider, updated_since:, training_status:, from_participant_id: }
-
+      def participants_query(conditions: {})
+        conditions.merge!(lead_provider: current_lead_provider)
         ::Participants::Query.new(**conditions.compact)
       end
 


### PR DESCRIPTION
### Context

We were using the same `Query` instance for both the `index` and `show` actions; this meant the filtering was being applied to the `show` endpoints when it shouldn't be (although this would only happen if a filter parameter was passed in).

### Changes proposed in this pull request

- Fix query scopes for show actions

Extract the query `conditions` so that we only surface them in the `index` actions.
