### PR TITLE
Clean up service error tests and translations

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -33,6 +33,8 @@ class Application < ApplicationRecord
   scope :accepted, -> { where(lead_provider_approval_status: "accepted") }
   scope :eligible_for_funding, -> { where(eligible_for_funding: true) }
 
+  validate :schedule_cohort_matches
+
   enum kind_of_nursery: {
     local_authority_maintained_nursery: "local_authority_maintained_nursery",
     preschool_class_as_part_of_school: "preschool_class_as_part_of_school",
@@ -175,5 +177,9 @@ private
     return eligible_for_funding unless with_funded_place
 
     eligible_for_funding && (funded_place.nil? || funded_place)
+  end
+
+  def schedule_cohort_matches
+    errors.add(:schedule_identifier, :cohort_mismatch) if schedule && schedule.cohort != cohort
   end
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -180,6 +180,6 @@ private
   end
 
   def schedule_cohort_matches
-    errors.add(:schedule_identifier, :cohort_mismatch) if schedule && schedule.cohort != cohort
+    errors.add(:schedule, :cohort_mismatch) if schedule && schedule.cohort != cohort
   end
 end

--- a/app/services/applications/accept.rb
+++ b/app/services/applications/accept.rb
@@ -9,13 +9,8 @@ module Applications
     attribute :funded_place
     attribute :schedule_identifier, :string
 
-    validates :application, presence: { message: I18n.t("application.missing_application") }
-    validates :funded_place,
-              inclusion: {
-                in: [true, false],
-                if: :validate_funded_place?,
-                message: I18n.t("application.funded_place_required"),
-              }
+    validates :application, presence: true
+    validates :funded_place, inclusion: { in: [true, false], if: :validate_funded_place? }
     validate :not_already_accepted
     validate :cannot_change_from_rejected
     validate :other_accepted_applications_with_same_course?
@@ -43,17 +38,17 @@ module Applications
     def not_already_accepted
       return if application.blank?
 
-      errors.add(:application, I18n.t("application.has_already_been_accepted")) if application.accepted?
+      errors.add(:application, :has_already_been_accepted) if application.accepted?
     end
 
     def cannot_change_from_rejected
       return if application.blank?
 
-      errors.add(:application, I18n.t("application.cannot_change_from_rejected")) if application.rejected?
+      errors.add(:application, :cannot_change_from_rejected) if application.rejected?
     end
 
     def other_accepted_applications_with_same_course?
-      errors.add(:application, I18n.t("application.has_another_accepted_application")) if other_accepted_applications_with_same_course.present?
+      errors.add(:application, :has_another_accepted_application) if other_accepted_applications_with_same_course.present?
     end
 
     def accept_application!
@@ -108,7 +103,7 @@ module Applications
       return unless cohort&.funding_cap?
 
       if funded_place && !application.eligible_for_funding
-        errors.add(:application, I18n.t("application.not_eligible_for_funded_place"))
+        errors.add(:application, :not_eligible_for_funded_place)
       end
     end
 
@@ -130,7 +125,7 @@ module Applications
       return unless schedule
 
       unless schedule.course_group.courses.include?(course)
-        errors.add(:schedule_identifier, I18n.t(:schedule_invalid_for_course))
+        errors.add(:schedule_identifier, :invalid_for_course)
       end
     end
 

--- a/app/services/applications/change_funded_place.rb
+++ b/app/services/applications/change_funded_place.rb
@@ -8,12 +8,8 @@ module Applications
     attribute :application
     attribute :funded_place
 
-    validates :application, presence: { message: I18n.t("application.missing_application") }
-    validates :funded_place,
-              inclusion: {
-                in: [true, false],
-                message: I18n.t("application.missing_funded_place"),
-              }
+    validates :application, presence: true
+    validates :funded_place, inclusion: { in: [true, false] }
     validate :accepted_application
     validate :eligible_for_funding
     validate :cohort_has_funding_cap
@@ -30,30 +26,30 @@ module Applications
     delegate :cohort, to: :application
 
     def accepted_application
-      return if application.accepted?
+      return if application&.accepted?
 
-      errors.add(:application, I18n.t("application.cannot_change_funded_status_from_non_accepted"))
+      errors.add(:application, :cannot_change_funded_status_from_non_accepted)
     end
 
     def eligible_for_funding
       return unless funded_place
       return if application.eligible_for_funding?
 
-      errors.add(:application, I18n.t("application.cannot_change_funded_status_non_eligible"))
+      errors.add(:application, :cannot_change_funded_status_non_eligible)
     end
 
     def cohort_has_funding_cap
       return if errors.any?
       return if cohort&.funding_cap?
 
-      errors.add(:application, I18n.t("application.cohort_does_not_accept_capping"))
+      errors.add(:application, :cohort_does_not_accept_capping)
     end
 
     def eligible_for_removing_funding_place
       return if funded_place
-      return unless application.declarations.billable_or_changeable.any?
+      return unless application&.declarations&.billable_or_changeable&.any?
 
-      errors.add(:application, I18n.t("application.cannot_change_funded_place"))
+      errors.add(:application, :cannot_change_funded_place)
     end
   end
 end

--- a/app/services/applications/reject.rb
+++ b/app/services/applications/reject.rb
@@ -5,7 +5,7 @@ module Applications
 
     attribute :application
 
-    validates :application, presence: { message: I18n.t("application.missing_application") }
+    validates :application, presence: true
     validate :not_already_rejected
     validate :cannot_change_from_accepted
 
@@ -23,14 +23,14 @@ module Applications
       return unless application
       return unless application.rejected?
 
-      errors.add(:application, I18n.t("application.has_already_been_rejected"))
+      errors.add(:application, :has_already_been_rejected)
     end
 
     def cannot_change_from_accepted
       return unless application
       return unless application.accepted?
 
-      errors.add(:application, I18n.t("application.cannot_change_from_accepted"))
+      errors.add(:application, :cannot_change_from_accepted)
     end
   end
 end

--- a/app/services/declarations/statement_attacher.rb
+++ b/app/services/declarations/statement_attacher.rb
@@ -35,7 +35,7 @@ module Declarations
     def next_output_fee_statement_exists
       return unless declaration
 
-      errors.add(:declaration, :no_output_fee_statement, cohort: declaration.cohort) unless next_output_fee_statement
+      errors.add(:declaration, :no_output_fee_statement, cohort: declaration.cohort.start_year) unless next_output_fee_statement
     end
 
     def declaration_has_attachable_state

--- a/app/services/declarations/void.rb
+++ b/app/services/declarations/void.rb
@@ -55,7 +55,7 @@ module Declarations
     end
 
     def output_fee_statement_available
-      errors.add(:declaration, :no_output_fee_statement, cohort: declaration.cohort) unless statement_attacher.valid?
+      errors.add(:declaration, :no_output_fee_statement, cohort: declaration.cohort.start_year) unless statement_attacher.valid?
     end
 
     def declaration_is_paid

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,43 +7,55 @@ en:
   invalid_date_filter: "The filter '#/%{parameterized_attribute}' must be a valid ISO 8601 date"
   invalid_page_parameters: "The '#/page[page]' and '#/page[per_page]' parameter values must be a valid positive number"
   invalid_data_structure: correct json data structure required. See API docs for reference
-  schedule_invalid_for_course: Selected schedule is not valid for the course
   cannot_create_completed_declaration: "Could not create completed declaration. Contact the DfE for support."
 
   errors:
     email:
       invalid: Enter a valid email address
 
-  application:
-    missing_application: "The entered '#/application' is missing from your request. Check details and try again."
-    has_already_been_rejected: This NPQ application has already been rejected
-    cannot_change_from_accepted: Once accepted an application cannot change state
-    has_another_accepted_application: The participant has already had an application accepted for this course.
+  application: &application
+    blank: The entered '#/%{parameterized_attribute}' is missing from your request. Check details and try again.
     has_already_been_accepted: This NPQ application has already been accepted
     cannot_change_from_rejected: Once rejected an application cannot change state
-    not_eligible_for_funded_place: "The participant is not eligible for funding, so '#/funded_place' cannot be set to true."
-    funded_place_required: "Set '#/funded_place' to true or false."
+    has_another_accepted_application: The participant has already had an application accepted for this course.
+    not_eligible_for_funded_place: The participant is not eligible for funding, so '#/funded_place' cannot be set to true.
+    has_already_been_rejected: This NPQ application has already been rejected
+    cannot_change_from_accepted: Once accepted an application cannot change state
     cannot_change_funded_status_from_non_accepted: You must accept the application before attempting to change the '#/funded_place' setting.
     cannot_change_funded_status_non_eligible: This participant is not eligible for funding. Contact us if you think this is wrong.
-    missing_funded_place: "The entered '#/funded_place' is missing from your request. Check details and try again."
-    cohort_does_not_accept_capping: "Leave the '#/funded_place' field blank. It's only needed for participants starting NPQs from autumn 2024 onwards."
-    cannot_change_funded_place: "You must void or claw back your declarations for this participant before being able to set '#/funded_place' to false"
+    cohort_does_not_accept_capping: Leave the '#/funded_place' field blank. It's only needed for participants starting NPQs from autumn 2024 onwards.
+    cannot_change_funded_place: You must void or claw back your declarations for this participant before being able to set '#/funded_place' to false
 
   declaration: &declaration
-    participant_id:
-      blank: "The property '#/participant_id' must be present"
-      declaration_must_be_before_withdrawal_date: "This participant withdrew from this course on %{withdrawal_date}. Enter a '#/declaration_date' that's on or before the withdrawal date."
-      invalid_participant: "Your update cannot be made as the '#/participant_id' is not recognised. Check participant details and try again."
-    declaration_date:
-      blank: "Enter a '#/declaration_date'."
-      invalid: "Enter a valid RCF3339 '#/declaration_date'."
-      declaration_before_schedule_start: "Enter a '#/declaration_date' that's on or after the schedule start."
-      future_declaration_date: "The '#/declaration_date' value cannot be a future date. Check the date and try again."
-    declaration_type:
-      blank: "Enter a '#/declaration_type'."
-      mismatch_declaration_type_for_schedule: "The property '#/declaration_type' does not exist for this schedule."
-    has_passed:
-      invalid: "Enter 'true' or 'false' in the '#/has_passed' field to indicate whether this participant has passed or failed their course."
+    blank: You must specify a declaration
+    not_in_attachable_state: The declaration is not in a state eligible for attachment
+    already_voided: This declaration has already been voided.
+    not_already_refunded: The declaration will or has been be refunded.
+    must_be_paid: The declaration must be paid before it can be clawed back.
+
+  cohort: &cohort
+    cannot_change: "You cannot change the '#/%{parameterized_attribute}' field"
+
+  funded_place: &funded_place
+    inclusion: Set '#/%{parameterized_attribute}' to true or false.
+
+  participant_id: &participant_id
+    blank: "The property '#/participant_id' must be present"
+    declaration_must_be_before_withdrawal_date: "This participant withdrew from this course on %{withdrawal_date}. Enter a '#/declaration_date' that's on or before the withdrawal date."
+    invalid_participant: "Your update cannot be made as the '#/participant_id' is not recognised. Check participant details and try again."
+
+  declaration_date: &declaration_date
+    blank: "Enter a '#/%{parameterized_attribute}'."
+    invalid: "Enter a valid RCF3339 '#/%{parameterized_attribute}'."
+    declaration_before_schedule_start: "Enter a '#/%{parameterized_attribute}' that's on or after the schedule start."
+    future_declaration_date: "The '#/%{parameterized_attribute}' value cannot be a future date. Check the date and try again."
+
+  declaration_type: &declaration_type
+    blank: "Enter a '#/%{parameterized_attribute}'."
+    mismatch_declaration_type_for_schedule: "The property '#/%{parameterized_attribute}' does not exist for this schedule."
+
+  has_passed: &has_passed
+    invalid: "Enter 'true' or 'false' in the '#/%{parameterized_attribute}' field to indicate whether this participant has passed or failed their course."
 
   completion_date: &completion_date
     future_date: The '#/%{parameterized_attribute}' value cannot be a future date. Check the date and try again.
@@ -70,8 +82,19 @@ en:
     invalid: "The entered '#/%{parameterized_attribute}' is not recognised for the given participant. Check details and try again."
 
   participant_reason: &participant_reason
-    blank: The property '#/reason' must be present
-    inclusion: The property '#/reason' must be a valid reason
+    blank: The property '#/%{parameterized_attribute}' must be present
+    inclusion: The property '#/%{parameterized_attribute}' must be a valid reason
+
+  schedule_identifier: &schedule_identifier
+    blank: "The property '#/%{parameterized_attribute}' must be present"
+    invalidates_declaration: Changing schedule would invalidate existing declarations. Please void them first.
+    invalid_schedule: "The property '#/%{parameterized_attribute}' must be present and correspond to a valid schedule"
+    already_on_the_profile: Selected schedule is already on the profile
+    invalid_for_course: Selected schedule is not valid for the course
+
+  state: &state
+    blank: "The '#/%{parameterized_attribute}' is missing from your request. Please include a 'passed' or 'failed' value and try again."
+    inclusion: "The attribute '#/%{parameterized_attribute}' can only include 'passed' or 'failed' values. If you need to void an outcome, you will need to void the associated 'completed' declaration."
 
   time:
     formats:
@@ -253,12 +276,16 @@ en:
               <<: *participant_course_identifier
             participant:
               <<: *participant
+            lead_provider:
+              <<: *lead_provider
         participants/defer:
           attributes:
             course_identifier:
               <<: *participant_course_identifier
             participant:
               <<: *participant
+            lead_provider:
+              <<: *lead_provider
             reason:
               <<: *participant_reason
         participants/withdraw:
@@ -267,6 +294,8 @@ en:
               <<: *participant_course_identifier
             participant:
               <<: *participant
+            lead_provider:
+              <<: *lead_provider
             reason:
               <<: *participant_reason
         participants/change_schedule:
@@ -276,39 +305,43 @@ en:
             participant:
               <<: *participant
             schedule_identifier:
-              blank: "The property '#/schedule_identifier' must be present"
-              invalidates_declaration: Changing schedule would invalidate existing declarations. Please void them first.
-              invalid_schedule: "The property '#/schedule_identifier' must be present and correspond to a valid schedule"
-              already_on_the_profile: Selected schedule is already on the profile
-              invalid_for_course: Selected schedule is not valid for the course
+              <<: *schedule_identifier
             cohort:
-              cannot_change: "You cannot change the '#/cohort' field"
+              <<: *cohort
+            lead_provider:
+              <<: *lead_provider
         declarations/statement_attacher:
           attributes:
             declaration:
               <<: *statement
-              blank: You must specify a declaration
-              not_in_attachable_state: The declaration is not in a state eligible for attachment
+              <<: *declaration
         declarations/void:
           attributes:
             declaration:
               <<: *statement
-              already_voided: This declaration has already been voided.
-              not_already_refunded: The declaration will or has been be refunded.
-              must_be_paid: The declaration must be paid before it can be clawed back.
+              <<: *declaration
         participant_outcomes:
           attributes:
             completion_date:
-              future_date: The '#/%{attribute}' value cannot be a future date. Check the date and try again.
+              <<: *completion_date
         declarations/create:
-          declaration_already_exists: A declaration has already been submitted that will be, or has been, paid for this event
-          <<: *statement
           attributes:
-            <<: *declaration
+            base:
+              declaration_already_exists: A declaration has already been submitted that will be, or has been, paid for this event
+            participant_id:
+              <<: *participant_id
+            declaration_date:
+              <<: *declaration_date
+            declaration_type:
+              <<: *declaration_type
+            has_passed:
+              <<: *has_passed
             course_identifier:
               <<: *participant_course_identifier
             lead_provider:
               <<: *lead_provider
+            cohort:
+              <<: *statement
         participant_outcomes/create:
           attributes:
             base:
@@ -318,13 +351,29 @@ en:
             course_identifier:
               <<: *participant_course_identifier
             state:
-              blank: "The '#/%{parameterized_attribute}' is missing from your request. Please include a 'passed' or 'failed' value and try again."
-              inclusion: "The attribute '#/%{parameterized_attribute}' can only include 'passed' or 'failed' values. If you need to void an outcome, you will need to void the associated 'completed' declaration."
+              <<: *state
             participant:
               <<: *participant
             lead_provider:
               <<: *lead_provider
-            
+        applications/accept:
+          attributes:
+            application:
+              <<: *application
+            schedule_identifier:
+              <<: *schedule_identifier
+            funded_place:
+              <<: *funded_place
+        applications/reject:
+          attributes:
+            application:
+              <<: *application
+        applications/change_funded_place:
+          attributes:
+            application:
+              <<: *application
+            funded_place:
+              <<: *funded_place
 
   omniauth_providers:
     tra_openid_connect: "Get an Identity"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,9 @@ en:
   cohort: &cohort
     cannot_change: "You cannot change the '#/%{parameterized_attribute}' field"
 
+  schedule: &schedule
+    cohort_mismatch: The schedule cohort must match the application cohort
+
   funded_place: &funded_place
     inclusion: Set '#/%{parameterized_attribute}' to true or false.
 
@@ -99,6 +102,13 @@ en:
   time:
     formats:
       admin: "%R on %d/%m/%Y"
+  activerecord:
+    errors:
+      models:
+        application:
+          attributes:
+            schedule:
+              <<: *schedule
   activemodel:
     attributes:
       questionnaires/funding_your_npq:

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -16,6 +16,18 @@ RSpec.describe Application do
     it { is_expected.to have_many(:declarations) }
   end
 
+  describe "validations" do
+    context "when the schedule cohort does not match the application cohort" do
+      subject do
+        build(:application).tap do |application|
+          application.schedule = build(:schedule, cohort: build(:cohort, start_year: application.cohort.start_year + 1))
+        end
+      end
+
+      it { is_expected.to have_error(:schedule, :cohort_mismatch, "The schedule cohort must match the application cohort") }
+    end
+  end
+
   describe "enums" do
     it {
       expect(subject).to define_enum_for(:kind_of_nursery).with_values(

--- a/spec/requests/api/docs/v3/applications_spec.rb
+++ b/spec/requests/api/docs/v3/applications_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe "NPQ Applications endpoint", type: :request, openapi_spec: "v3/sw
 
   let(:course_group) { CourseGroup.find_by(name: "leadership") || create(:course_group, name: "leadership") }
   let(:course) { create(:course, :sl, course_group:) }
-  let(:schedule) { create(:schedule, :npq_leadership_autumn, course_group:, cohort:) }
   let(:cohort) { create(:cohort, :current, funding_cap: true) }
+  let(:schedule) { create(:schedule, :npq_leadership_autumn, course_group:, cohort:) }
   let(:application) do
     create(
       :application,
@@ -79,7 +79,7 @@ RSpec.describe "NPQ Applications endpoint", type: :request, openapi_spec: "v3/sw
                   "The NPQ application after changing the funded place",
                   "#/components/schemas/ApplicationResponse",
                   "#/components/schemas/ApplicationChangeFundedPlaceRequest" do
-    let(:application) { create(:application, :eligible_for_funded_place, lead_provider:, schedule:) }
+    let(:application) { create(:application, :eligible_for_funded_place, lead_provider:, schedule:, cohort:) }
     let(:resource) { application }
     let(:type) { "npq-application-change-funded-place" }
     let(:attributes) { { funded_place: true } }

--- a/spec/services/applications/accept_spec.rb
+++ b/spec/services/applications/accept_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Applications::Accept, :with_default_schedules do
+RSpec.describe Applications::Accept, :with_default_schedules, type: :model do
   let(:params) do
     {
       application:,
@@ -33,34 +33,18 @@ RSpec.describe Applications::Accept, :with_default_schedules do
     end
 
     describe "validations" do
-      context "when the npq application is missing" do
-        let(:application) {}
-
-        it "is invalid and returns an error message" do
-          expect(subject).to be_invalid
-
-          expect(service.errors.messages_for(:application)).to include("The entered '#/application' is missing from your request. Check details and try again.")
-        end
-      end
+      it { is_expected.to validate_presence_of(:application).with_message("The entered '#/application' is missing from your request. Check details and try again.") }
 
       context "when the npq application is already accepted" do
         let(:application) { create(:application, :accepted) }
 
-        it "is invalid and returns an error message" do
-          expect(subject).to be_invalid
-
-          expect(service.errors.messages_for(:application)).to include("This NPQ application has already been accepted")
-        end
+        it { is_expected.to have_error(:application, :has_already_been_accepted, "This NPQ application has already been accepted") }
       end
 
       context "when the npq application is rejected" do
         let(:application) { create(:application, :rejected) }
 
-        it "is invalid and returns an error message" do
-          expect(subject).to be_invalid
-
-          expect(service.errors.messages_for(:application)).to include("Once rejected an application cannot change state")
-        end
+        it { is_expected.to have_error(:application, :cannot_change_from_rejected, "Once rejected an application cannot change state") }
       end
 
       context "when the existing data is invalid" do
@@ -152,8 +136,7 @@ RSpec.describe Applications::Accept, :with_default_schedules do
 
         it "attaches errors to the object" do
           service.accept
-
-          expect(service.errors.messages_for(:application)).to include("The participant has already had an application accepted for this course.")
+          expect(service).to have_error(:application, :has_another_accepted_application, "The participant has already had an application accepted for this course.")
         end
       end
 
@@ -186,8 +169,7 @@ RSpec.describe Applications::Accept, :with_default_schedules do
 
         it "attaches errors to the object" do
           service.accept
-
-          expect(service.errors.messages_for(:application)).to include("The participant has already had an application accepted for this course.")
+          expect(service).to have_error(:application, :has_another_accepted_application, "The participant has already had an application accepted for this course.")
         end
       end
     end
@@ -225,7 +207,7 @@ RSpec.describe Applications::Accept, :with_default_schedules do
       it "cannot then be accepted" do
         service.accept
         expect(application.reload).to be_rejected
-        expect(service.errors.messages_for(:application)).to be_present
+        expect(service).to have_error(:application, :cannot_change_from_rejected, "Once rejected an application cannot change state")
       end
     end
 
@@ -274,9 +256,7 @@ RSpec.describe Applications::Accept, :with_default_schedules do
 
         it "does not set funded place if eligible for funding is false" do
           application.update!(eligible_for_funding: false)
-
-          service.accept
-          expect(service.errors.messages_for(:application)).to include("The participant is not eligible for funding, so '#/funded_place' cannot be set to true.")
+          expect(service).to have_error(:application, :not_eligible_for_funded_place, "The participant is not eligible for funding, so '#/funded_place' cannot be set to true.")
         end
       end
 
@@ -296,7 +276,7 @@ RSpec.describe Applications::Accept, :with_default_schedules do
         context "when funding_cap is true" do
           it "returns funding_place is required error" do
             service.accept
-            expect(service.errors.messages_for(:funded_place)).to include("Set '#/funded_place' to true or false.")
+            expect(service).to have_error(:funded_place, :inclusion, "Set '#/funded_place' to true or false.")
           end
         end
 
@@ -316,7 +296,7 @@ RSpec.describe Applications::Accept, :with_default_schedules do
 
           it "returns funding_place is required error" do
             service.accept
-            expect(service.errors.messages_for(:funded_place)).to include("Set '#/funded_place' to true or false.")
+            expect(service).to have_error(:funded_place, :inclusion, "Set '#/funded_place' to true or false.")
           end
         end
 
@@ -325,7 +305,7 @@ RSpec.describe Applications::Accept, :with_default_schedules do
 
           it "returns funding_place is required error" do
             service.accept
-            expect(service.errors.messages_for(:funded_place)).to include("Set '#/funded_place' to true or false.")
+            expect(service).to have_error(:funded_place, :inclusion, "Set '#/funded_place' to true or false.")
           end
         end
 
@@ -334,7 +314,7 @@ RSpec.describe Applications::Accept, :with_default_schedules do
 
           it "returns funding_place is required error" do
             service.accept
-            expect(service.errors.messages_for(:funded_place)).to include("Set '#/funded_place' to true or false.")
+            expect(service).to have_error(:funded_place, :inclusion, "Set '#/funded_place' to true or false.")
           end
         end
 
@@ -343,7 +323,7 @@ RSpec.describe Applications::Accept, :with_default_schedules do
 
           it "returns funding_place is required error" do
             service.accept
-            expect(service.errors.messages_for(:funded_place)).to include("Set '#/funded_place' to true or false.")
+            expect(service).to have_error(:funded_place, :inclusion, "Set '#/funded_place' to true or false.")
           end
         end
       end
@@ -394,7 +374,7 @@ RSpec.describe Applications::Accept, :with_default_schedules do
 
         it "returns validation error" do
           expect(service.accept).to be_falsey
-          expect(service.errors.messages_for(:schedule_identifier)).to include("Selected schedule is not valid for the course")
+          expect(service).to have_error(:schedule_identifier, :invalid_for_course, "Selected schedule is not valid for the course")
         end
       end
     end

--- a/spec/services/applications/change_funded_place_spec.rb
+++ b/spec/services/applications/change_funded_place_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Applications::ChangeFundedPlace do
+RSpec.describe Applications::ChangeFundedPlace, type: :model do
   let(:params) do
     {
       application:,
@@ -49,6 +49,8 @@ RSpec.describe Applications::ChangeFundedPlace do
     end
 
     describe "validations" do
+      it { is_expected.to validate_presence_of(:application).with_message("The entered '#/application' is missing from your request. Check details and try again.") }
+
       context "when funded_place is present" do
         before { params.merge!(funded_place: true) }
 
@@ -56,21 +58,24 @@ RSpec.describe Applications::ChangeFundedPlace do
           application.update!(lead_provider_approval_status: "pending")
 
           service.change
-          expect(service.errors.messages_for(:application)).to include("You must accept the application before attempting to change the '#/funded_place' setting.")
+
+          expect(service).to have_error(:application, :cannot_change_funded_status_from_non_accepted, "You must accept the application before attempting to change the '#/funded_place' setting.")
         end
 
         it "is invalid if the application is not eligible for funding" do
           application.update!(eligible_for_funding: false)
 
           service.change
-          expect(service.errors.messages_for(:application)).to include("This participant is not eligible for funding. Contact us if you think this is wrong.")
+
+          expect(service).to have_error(:application, :cannot_change_funded_status_non_eligible, "This participant is not eligible for funding. Contact us if you think this is wrong.")
         end
 
         it "is invalid if the cohort does not accept capping and we set a funded place to true" do
           cohort.update!(funding_cap: false)
 
           service.change
-          expect(service.errors.messages_for(:application)).to include("Leave the '#/funded_place' field blank. It's only needed for participants starting NPQs from autumn 2024 onwards.")
+
+          expect(service).to have_error(:application, :cohort_does_not_accept_capping, "Leave the '#/funded_place' field blank. It's only needed for participants starting NPQs from autumn 2024 onwards.")
         end
 
         it "is invalid if the cohort does not accept capping and we set a funded place to false" do
@@ -78,7 +83,8 @@ RSpec.describe Applications::ChangeFundedPlace do
           cohort.update!(funding_cap: false)
 
           service.change
-          expect(service.errors.messages_for(:application)).to include("Leave the '#/funded_place' field blank. It's only needed for participants starting NPQs from autumn 2024 onwards.")
+
+          expect(service).to have_error(:application, :cohort_does_not_accept_capping, "Leave the '#/funded_place' field blank. It's only needed for participants starting NPQs from autumn 2024 onwards.")
         end
 
         context "when the application is not accepted" do
@@ -89,7 +95,7 @@ RSpec.describe Applications::ChangeFundedPlace do
 
             service.change
 
-            expect(service.errors.messages_for(:application)).to include("You must accept the application before attempting to change the '#/funded_place' setting.")
+            expect(service).to have_error(:application, :cannot_change_funded_status_from_non_accepted, "You must accept the application before attempting to change the '#/funded_place' setting.")
           end
         end
 
@@ -121,7 +127,7 @@ RSpec.describe Applications::ChangeFundedPlace do
 
                 service.change
 
-                expect(service.errors.messages_for(:application)).to include("You must void or claw back your declarations for this participant before being able to set '#/funded_place' to false")
+                expect(service).to have_error(:application, :cannot_change_funded_place, "You must void or claw back your declarations for this participant before being able to set '#/funded_place' to false")
               end
             end
 
@@ -143,7 +149,8 @@ RSpec.describe Applications::ChangeFundedPlace do
 
             it "returns funding_place is required error" do
               service.change
-              expect(service.errors.messages_for(:funded_place)).to include("The entered '#/funded_place' is missing from your request. Check details and try again.")
+
+              expect(service).to have_error(:funded_place, :inclusion, "Set '#/funded_place' to true or false.")
             end
           end
 
@@ -152,7 +159,7 @@ RSpec.describe Applications::ChangeFundedPlace do
 
             it "returns funding_place is required error" do
               service.change
-              expect(service.errors.messages_for(:funded_place)).to include("The entered '#/funded_place' is missing from your request. Check details and try again.")
+              expect(service).to have_error(:funded_place, :inclusion, "Set '#/funded_place' to true or false.")
             end
           end
 
@@ -161,7 +168,7 @@ RSpec.describe Applications::ChangeFundedPlace do
 
             it "returns funding_place is required error" do
               service.change
-              expect(service.errors.messages_for(:funded_place)).to include("The entered '#/funded_place' is missing from your request. Check details and try again.")
+              expect(service).to have_error(:funded_place, :inclusion, "Set '#/funded_place' to true or false.")
             end
           end
 
@@ -170,7 +177,7 @@ RSpec.describe Applications::ChangeFundedPlace do
 
             it "returns funding_place is required error" do
               service.change
-              expect(service.errors.messages_for(:funded_place)).to include("The entered '#/funded_place' is missing from your request. Check details and try again.")
+              expect(service).to have_error(:funded_place, :inclusion, "Set '#/funded_place' to true or false.")
             end
           end
         end
@@ -181,8 +188,7 @@ RSpec.describe Applications::ChangeFundedPlace do
 
         it "is invalid if funded_place is `nil`" do
           service.change
-
-          expect(service.errors.messages_for(:funded_place)).to include("The entered '#/funded_place' is missing from your request. Check details and try again.")
+          expect(service).to have_error(:funded_place, :inclusion, "Set '#/funded_place' to true or false.")
         end
       end
     end

--- a/spec/services/applications/reject_spec.rb
+++ b/spec/services/applications/reject_spec.rb
@@ -1,40 +1,24 @@
 require "rails_helper"
 
-RSpec.describe Applications::Reject do
+RSpec.describe Applications::Reject, type: :model do
   let(:application) { create(:application, :pending) }
   let(:params) { { application: } }
 
   subject(:service) { described_class.new(params) }
 
   describe "validations" do
-    context "when the application is missing" do
-      let(:application) { nil }
-
-      it "is invalid and returns an error message" do
-        expect(subject).to be_invalid
-
-        expect(service.errors.messages_for(:application)).to include("The entered '#/application' is missing from your request. Check details and try again.")
-      end
-    end
+    it { is_expected.to validate_presence_of(:application).with_message("The entered '#/application' is missing from your request. Check details and try again.") }
 
     context "when the application is already rejected" do
       let(:application) { create(:application, :rejected) }
 
-      it "is invalid and returns an error message" do
-        expect(subject).to be_invalid
-
-        expect(service.errors.messages_for(:application)).to include("This NPQ application has already been rejected")
-      end
+      it { is_expected.to have_error(:application, :has_already_been_rejected, "This NPQ application has already been rejected") }
     end
 
     context "when the application is accepted" do
       let(:application) { create(:application, :accepted) }
 
-      it "is invalid and returns an error message" do
-        expect(subject).to be_invalid
-
-        expect(service.errors.messages_for(:application)).to include("Once accepted an application cannot change state")
-      end
+      it { is_expected.to have_error(:application, :cannot_change_from_accepted, "Once accepted an application cannot change state") }
     end
   end
 

--- a/spec/services/declarations/statement_attacher_spec.rb
+++ b/spec/services/declarations/statement_attacher_spec.rb
@@ -8,24 +8,18 @@ RSpec.describe Declarations::StatementAttacher, type: :model do
   let(:instance) { described_class.new(declaration:) }
 
   describe "validations" do
-    it { is_expected.to validate_presence_of(:declaration) }
+    it { is_expected.to validate_presence_of(:declaration).with_message("You must specify a declaration") }
 
     context "when the next output fee statement does not exist" do
       before { statement.update!(output_fee: false) }
 
-      it "adds an error to the declaration attribute" do
-        expect(instance).to be_invalid
-        expect(instance.errors.first).to have_attributes(attribute: :declaration, type: :no_output_fee_statement)
-      end
+      it { expect(instance).to have_error(:declaration, :no_output_fee_statement, "You cannot submit or void declarations for the #{declaration.cohort.start_year} cohort. The funding contract for this cohort has ended. Get in touch if you need to discuss this with us.") }
     end
 
     context "when the declaration is not in an attachable state" do
       before { declaration.update!(state: :submitted) }
 
-      it "adds an error to the declaration attribute" do
-        expect(instance).to be_invalid
-        expect(instance.errors.first).to have_attributes(attribute: :declaration, type: :not_in_attachable_state)
-      end
+      it { expect(instance).to have_error(:declaration, :not_in_attachable_state, "The declaration is not in a state eligible for attachment") }
     end
   end
 

--- a/spec/services/declarations/void_spec.rb
+++ b/spec/services/declarations/void_spec.rb
@@ -18,10 +18,7 @@ RSpec.describe Declarations::Void, type: :model do
           context "when the declaration is already voided" do
             before { declaration.update!(state: :voided) }
 
-            it "adds an error to the declaration attribute" do
-              expect(instance).to be_invalid
-              expect(instance.errors.first).to have_attributes(attribute: :declaration, type: :already_voided)
-            end
+            it { expect(instance).to have_error(:declaration, :already_voided, "This declaration has already been voided.") }
           end
         end
       end
@@ -36,20 +33,14 @@ RSpec.describe Declarations::Void, type: :model do
             context "when the declaration already has a #{ineligible_state} statement item" do
               before { create(:statement_item, declaration:, state: ineligible_state) }
 
-              it "adds an error to the declaration attribute" do
-                expect(instance).to be_invalid
-                expect(instance.errors.first).to have_attributes(attribute: :declaration, type: :not_already_refunded)
-              end
+              it { expect(instance).to have_error(:declaration, :not_already_refunded, "The declaration will or has been be refunded.") }
             end
           end
 
           context "when there is no output fee statement" do
             before { statement.update!(output_fee: false) }
 
-            it "adds an error to the declaration attribute" do
-              expect(instance).to be_invalid
-              expect(instance.errors.first).to have_attributes(attribute: :declaration, type: :no_output_fee_statement)
-            end
+            it { expect(instance).to have_error(:declaration, :no_output_fee_statement, "You cannot submit or void declarations for the #{declaration.cohort.start_year} cohort. The funding contract for this cohort has ended. Get in touch if you need to discuss this with us.") }
           end
         end
       end
@@ -58,10 +49,7 @@ RSpec.describe Declarations::Void, type: :model do
         context "when the declaration is #{state}" do
           before { declaration.update!(state:) }
 
-          it "adds an error to the declaration attribute" do
-            expect(instance).to be_invalid
-            expect(instance.errors.first).to have_attributes(attribute: :declaration, type: :must_be_paid)
-          end
+          it { expect(instance).to have_error(:declaration, :must_be_paid, "The declaration must be paid before it can be clawed back.") }
         end
       end
     end

--- a/spec/services/participants/change_schedule_spec.rb
+++ b/spec/services/participants/change_schedule_spec.rb
@@ -47,12 +47,12 @@ RSpec.describe Participants::ChangeSchedule, type: :model do
         let(:application) { create(:application, :accepted, cohort:, course:, schedule:) }
       end
 
-      it { is_expected.to validate_presence_of(:schedule_identifier).with_message(:blank) }
+      it { is_expected.to validate_presence_of(:schedule_identifier).with_message(:blank).with_message("The property '#/schedule_identifier' must be present") }
 
       context "when the schedule is invalid" do
         let(:new_schedule_identifier) { "invalid" }
 
-        it { is_expected.to validate_presence_of(:schedule_identifier).with_message(:invalid_schedule) }
+        it { is_expected.to have_error(:schedule_identifier, :invalid_schedule, "The property '#/schedule_identifier' must be present and correspond to a valid schedule") }
       end
 
       context "when the schedule identifier change of the same type again" do
@@ -62,9 +62,7 @@ RSpec.describe Participants::ChangeSchedule, type: :model do
 
         it "is invalid and returns an error message" do
           expect(subject.change_schedule).to be_truthy
-          expect(subject).to be_invalid
-
-          expect(subject.errors.group_by_attribute[:schedule_identifier].first).to have_attributes(attribute: :schedule_identifier, type: :already_on_the_profile)
+          expect(subject).to have_error(:schedule_identifier, :already_on_the_profile, "Selected schedule is already on the profile")
         end
       end
     end
@@ -76,11 +74,7 @@ RSpec.describe Participants::ChangeSchedule, type: :model do
         application
       end
 
-      it "is invalid and returns an error message" do
-        expect(subject).to be_invalid
-
-        expect(subject.errors.group_by_attribute[:participant].first).to have_attributes(attribute: :participant, type: :already_withdrawn)
-      end
+      it { is_expected.to have_error(:participant, :already_withdrawn, "The participant is already withdrawn") }
     end
 
     context "when the cohort is changing" do
@@ -139,8 +133,8 @@ RSpec.describe Participants::ChangeSchedule, type: :model do
             schedule_identifier: schedule.identifier,
             cohort: cohort.start_year,
           }))
-          expect(second_change_of_schedule).to be_invalid
-          expect(second_change_of_schedule.errors.group_by_attribute[:cohort].first).to have_attributes(attribute: :cohort, type: :cannot_change)
+
+          expect(second_change_of_schedule).to have_error(:cohort, :cannot_change, "You cannot change the '#/cohort' field")
         end
       end
 
@@ -158,11 +152,7 @@ RSpec.describe Participants::ChangeSchedule, type: :model do
           end
 
           context "when changing to another cohort" do
-            it "is invalid and returns an error message" do
-              expect(subject).to be_invalid
-
-              expect(subject.errors.group_by_attribute[:cohort].first).to have_attributes(attribute: :cohort, type: :cannot_change)
-            end
+            it { is_expected.to have_error(:cohort, :cannot_change, "You cannot change the '#/cohort' field") }
           end
         end
       end
@@ -227,7 +217,7 @@ RSpec.describe Participants::ChangeSchedule, type: :model do
         it "does not change the application to the new cohort" do
           expect(subject.change_schedule).to be_falsey
 
-          expect(subject.errors.group_by_attribute[:cohort].first).to have_attributes(attribute: :cohort, type: :cannot_change)
+          expect(subject).to have_error(:cohort, :cannot_change, "You cannot change the '#/cohort' field")
         end
       end
 
@@ -253,7 +243,7 @@ RSpec.describe Participants::ChangeSchedule, type: :model do
 
           it "does not allow a change of schedule" do
             expect(subject.change_schedule).to be_falsey
-            expect(subject.errors.group_by_attribute[:schedule_identifier].first).to have_attributes(attribute: :schedule_identifier, type: :invalidates_declaration)
+            expect(subject).to have_error(:schedule_identifier, :invalidates_declaration, "Changing schedule would invalidate existing declarations. Please void them first.")
           end
         end
 
@@ -262,7 +252,7 @@ RSpec.describe Participants::ChangeSchedule, type: :model do
 
           it "does not allow a change of schedule" do
             expect(subject.change_schedule).to be_falsey
-            expect(subject.errors.group_by_attribute[:schedule_identifier].first).to have_attributes(attribute: :schedule_identifier, type: :invalidates_declaration)
+            expect(subject).to have_error(:schedule_identifier, :invalidates_declaration, "Changing schedule would invalidate existing declarations. Please void them first.")
           end
         end
       end
@@ -276,7 +266,7 @@ RSpec.describe Participants::ChangeSchedule, type: :model do
 
         it "does not allow a change of schedule" do
           expect(subject.change_schedule).to be_falsey
-          expect(subject.errors.group_by_attribute[:schedule_identifier].first).to have_attributes(attribute: :schedule_identifier, type: :invalid_for_course)
+          expect(subject).to have_error(:schedule_identifier, :invalid_for_course, "Selected schedule is not valid for the course")
         end
       end
     end

--- a/spec/services/participants/defer_spec.rb
+++ b/spec/services/participants/defer_spec.rb
@@ -13,33 +13,24 @@ RSpec.describe Participants::Defer, type: :model do
     let(:instance) { described_class.new(lead_provider:, participant:, course_identifier:, reason:) }
 
     describe "validations" do
-      it { is_expected.to validate_inclusion_of(:reason).in_array(described_class::DEFERRAL_REASONS) }
+      it { is_expected.to validate_inclusion_of(:reason).in_array(described_class::DEFERRAL_REASONS).with_message("The property '#/reason' must be a valid reason") }
 
       context "when the application is already deferred" do
         let(:application) { create(:application, :with_declaration, :deferred) }
 
-        it "adds an error to the participant attribute" do
-          expect(instance).to be_invalid
-          expect(instance.errors.first).to have_attributes(attribute: :participant, type: :already_deferred)
-        end
+        it { expect(instance).to have_error(:participant, :already_deferred, "The participant is already deferred") }
       end
 
       context "when the application is withdrawn" do
         let(:application) { create(:application, :with_declaration, :withdrawn) }
 
-        it "adds an error to the participant attribute" do
-          expect(instance).to be_invalid
-          expect(instance.errors.first).to have_attributes(attribute: :participant, type: :already_withdrawn)
-        end
+        it { expect(instance).to have_error(:participant, :already_withdrawn, "The participant is already withdrawn") }
       end
 
       context "when the application has no declarations" do
         let(:application) { create(:application, :accepted) }
 
-        it "adds an error to the participant attribute" do
-          expect(instance).to be_invalid
-          expect(instance.errors.first).to have_attributes(attribute: :participant, type: :no_declarations)
-        end
+        it { expect(instance).to have_error(:participant, :no_declarations, "You cannot defer an NPQ participant that has no declarations") }
       end
     end
   end

--- a/spec/services/participants/resume_spec.rb
+++ b/spec/services/participants/resume_spec.rb
@@ -15,10 +15,7 @@ RSpec.describe Participants::Resume, type: :model do
       context "when the application is already active" do
         let(:application) { create(:application, :accepted) }
 
-        it "adds an error to the participant attribute" do
-          expect(instance).to be_invalid
-          expect(instance.errors.first).to have_attributes(attribute: :participant, type: :already_active)
-        end
+        it { expect(instance).to have_error(:participant, :already_active, "The participant is already active") }
       end
     end
   end

--- a/spec/services/participants/withdraw_spec.rb
+++ b/spec/services/participants/withdraw_spec.rb
@@ -13,24 +13,18 @@ RSpec.describe Participants::Withdraw, type: :model do
     let(:instance) { described_class.new(lead_provider:, participant:, course_identifier:, reason:) }
 
     describe "validations" do
-      it { is_expected.to validate_inclusion_of(:reason).in_array(described_class::WITHDRAWAL_REASONS) }
+      it { is_expected.to validate_inclusion_of(:reason).in_array(described_class::WITHDRAWAL_REASONS).with_message("The property '#/reason' must be a valid reason") }
 
       context "when the application is already withdrawn" do
         let(:application) { create(:application, :accepted, :withdrawn) }
 
-        it "adds an error to the participant attribute" do
-          expect(instance).to be_invalid
-          expect(instance.errors.first).to have_attributes(attribute: :participant, type: :already_withdrawn)
-        end
+        it { expect(instance).to have_error(:participant, :already_withdrawn, "The participant is already withdrawn") }
       end
 
       context "when the application has no declarations" do
         let(:application) { create(:application, :accepted) }
 
-        it "adds an error to the participant attribute" do
-          expect(instance).to be_invalid
-          expect(instance.errors.first).to have_attributes(attribute: :participant, type: :no_started_declarations)
-        end
+        it { expect(instance).to have_error(:participant, :no_started_declarations, "An NPQ participant who has not got a started declaration cannot be withdrawn. Please contact support for assistance") }
       end
 
       context "when the application has no started declarations" do
@@ -38,10 +32,7 @@ RSpec.describe Participants::Withdraw, type: :model do
 
         before { create(:declaration, application:, declaration_type: "retained-1") }
 
-        it "adds an error to the participant attribute" do
-          expect(instance).to be_invalid
-          expect(instance.errors.first).to have_attributes(attribute: :participant, type: :no_started_declarations)
-        end
+        it { expect(instance).to have_error(:participant, :no_started_declarations, "An NPQ participant who has not got a started declaration cannot be withdrawn. Please contact support for assistance") }
       end
     end
   end

--- a/spec/support/shared_examples/participant_action_support.rb
+++ b/spec/support/shared_examples/participant_action_support.rb
@@ -11,35 +11,26 @@ RSpec.shared_examples "a participant action" do
   it { expect(instance).to be_valid }
 
   describe "validations" do
-    it { is_expected.to validate_presence_of(:lead_provider) }
-    it { is_expected.to validate_presence_of(:participant) }
-    it { is_expected.to validate_inclusion_of(:course_identifier).in_array(Course::IDENTIFIERS) }
+    it { is_expected.to validate_presence_of(:lead_provider).with_message("Your update cannot be made as the '#/lead_provider' is not recognised. Check lead provider details and try again.") }
+    it { is_expected.to validate_presence_of(:participant).with_message("Your update cannot be made as the '#/participant' is not recognised. Check participant details and try again.") }
+    it { is_expected.to validate_inclusion_of(:course_identifier).in_array(Course::IDENTIFIERS).with_message("The entered '#/course_identifier' is not recognised for the given participant. Check details and try again.") }
 
     context "when a matching application does not exist (different course identifier)" do
       let(:course_identifier) { Course::IDENTIFIERS.excluding(application.course.identifier).sample }
 
-      it "adds an error to the participant attribute" do
-        expect(instance).to be_invalid
-        expect(instance.errors.first).to have_attributes(attribute: :participant, type: :blank)
-      end
+      it { is_expected.to have_error(:participant, :blank, "Your update cannot be made as the '#/participant' is not recognised. Check participant details and try again.") }
     end
 
     context "when a matching application does not exist (different lead provider)" do
       let(:lead_provider) { create(:lead_provider, name: "Different to #{application.lead_provider.name}") }
 
-      it "adds an error to the participant attribute" do
-        expect(instance).to be_invalid
-        expect(instance.errors.first).to have_attributes(attribute: :participant, type: :blank)
-      end
+      it { is_expected.to have_error(:participant, :blank, "Your update cannot be made as the '#/participant' is not recognised. Check participant details and try again.") }
     end
 
     context "when there is a matching application, but it is not accepted" do
       let(:application) { create(:application) }
 
-      it "adds an error to the participant attribute" do
-        expect(instance).to be_invalid
-        expect(instance.errors.first).to have_attributes(attribute: :participant, type: :blank)
-      end
+      it { is_expected.to have_error(:participant, :blank, "Your update cannot be made as the '#/participant' is not recognised. Check participant details and try again.") }
     end
   end
 end


### PR DESCRIPTION
[Jira-3244](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-3244)

### Context

Update the API service class specs to use the `have_error` matcher.

Clean up the translations file to make it consistent.

### Changes proposed in this pull request

- Clean up service error tests and translations
