### PR TITLE
Add missing application/schedule cohort validation

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -33,6 +33,8 @@ class Application < ApplicationRecord
   scope :accepted, -> { where(lead_provider_approval_status: "accepted") }
   scope :eligible_for_funding, -> { where(eligible_for_funding: true) }
 
+  validate :schedule_cohort_matches
+
   enum kind_of_nursery: {
     local_authority_maintained_nursery: "local_authority_maintained_nursery",
     preschool_class_as_part_of_school: "preschool_class_as_part_of_school",
@@ -175,5 +177,9 @@ private
     return eligible_for_funding unless with_funded_place
 
     eligible_for_funding && (funded_place.nil? || funded_place)
+  end
+
+  def schedule_cohort_matches
+    errors.add(:schedule_identifier, :cohort_mismatch) if schedule && schedule.cohort != cohort
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,9 @@ en:
   cohort: &cohort
     cannot_change: "You cannot change the '#/%{parameterized_attribute}' field"
 
+  schedule: &schedule
+    cohort_mismatch: The schedule cohort must match the application cohort
+
   funded_place: &funded_place
     inclusion: Set '#/%{parameterized_attribute}' to true or false.
 
@@ -99,6 +102,13 @@ en:
   time:
     formats:
       admin: "%R on %d/%m/%Y"
+  activerecord:
+    errors:
+      models:
+        application:
+          attributes:
+            schedule:
+              <<: *schedule
   activemodel:
     attributes:
       questionnaires/funding_your_npq:

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -16,6 +16,18 @@ RSpec.describe Application do
     it { is_expected.to have_many(:declarations) }
   end
 
+  describe "validations" do
+    context "when the schedule cohort does not match the application cohort" do
+      subject do
+        build(:application).tap do |application|
+          application.schedule = build(:schedule, cohort: build(:cohort, start_year: application.cohort.start_year + 1))
+        end
+      end
+
+      it { is_expected.to have_error(:schedule, :cohort_mismatch, "The schedule cohort must match the application cohort") }
+    end
+  end
+
   describe "enums" do
     it {
       expect(subject).to define_enum_for(:kind_of_nursery).with_values(


### PR DESCRIPTION
[Jira-3284](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-3284)

### Context

When an application is accepted we attach a schedule. The application has a cohort as does the schedule, so we want to validate that an application can only have a schedule with the same cohort.

The `Accept` service ensures the schedule is picked using the application cohort, so this will always be the case when accepting an application; its more to protect against manual data changes.

### Changes proposed in this pull request

- Add validation to ensure application cohort matches schedule cohort