### PR TITLE
[CPDLP-3235] Enable sentry on separation env

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -32,6 +32,7 @@ class Application < ApplicationRecord
   scope :active_applications, -> { where.not(id: expired_applications) }
   scope :accepted, -> { where(lead_provider_approval_status: "accepted") }
   scope :eligible_for_funding, -> { where(eligible_for_funding: true) }
+  scope :with_targeted_delivery_funding_eligibility, -> { where(targeted_delivery_funding_eligibility: true) }
 
   validate :schedule_cohort_matches
 

--- a/app/models/external/ecf_api/base.rb
+++ b/app/models/external/ecf_api/base.rb
@@ -2,7 +2,7 @@ module External
   module EcfAPI
     class ConnectionWithAuthHeader < JsonApiClient::Connection
       def run(request_method, path, params: nil, headers: {}, body: nil)
-        raise JsonApiClient::Errors::ServiceUnavailable if Rails.application.config.npq_separation[:ecf_api_disabled]
+        raise JsonApiClient::Errors::ServiceUnavailable.new(@env, "EcfAPI service unavailable") if Rails.application.config.npq_separation[:ecf_api_disabled]
 
         super(
           request_method,

--- a/app/models/external/ecf_api/base.rb
+++ b/app/models/external/ecf_api/base.rb
@@ -2,6 +2,8 @@ module External
   module EcfAPI
     class ConnectionWithAuthHeader < JsonApiClient::Connection
       def run(request_method, path, params: nil, headers: {}, body: nil)
+        raise JsonApiClient::Errors::ServiceUnavailable if Rails.application.config.npq_separation[:ecf_api_disabled]
+
         super(
           request_method,
           path,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -114,7 +114,7 @@ class User < ApplicationRecord
   end
 
   def ecf_user
-    return if ecf_id.blank?
+    return if ecf_id.blank? || Rails.application.config.npq_separation[:ecf_api_disabled]
 
     External::EcfAPI::Npq::User.find(ecf_id).first
   end

--- a/app/services/ecf/base.rb
+++ b/app/services/ecf/base.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Ecf
-  class Base
+  module Base
     def call
       return if Rails.application.config.npq_separation[:ecf_api_disabled]
 

--- a/app/services/ecf/base.rb
+++ b/app/services/ecf/base.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Ecf
+  class Base
+    def call
+      return if Rails.application.config.npq_separation[:ecf_api_disabled]
+
+      super
+    end
+  end
+end

--- a/app/services/ecf/ecf_application_synchronization.rb
+++ b/app/services/ecf/ecf_application_synchronization.rb
@@ -1,5 +1,7 @@
 module Ecf
-  class EcfApplicationSynchronization < Base
+  class EcfApplicationSynchronization
+    prepend Base
+
     def call
       uri = build_uri
       request = build_http_get_request(uri)

--- a/app/services/ecf/ecf_application_synchronization.rb
+++ b/app/services/ecf/ecf_application_synchronization.rb
@@ -1,8 +1,6 @@
 module Ecf
-  class EcfApplicationSynchronization
+  class EcfApplicationSynchronization < Base
     def call
-      return if Rails.application.config.npq_separation[:ecf_api_disabled]
-
       uri = build_uri
       request = build_http_get_request(uri)
       response = send_http_request(uri, request)

--- a/app/services/ecf/ecf_application_synchronization.rb
+++ b/app/services/ecf/ecf_application_synchronization.rb
@@ -1,6 +1,8 @@
 module Ecf
   class EcfApplicationSynchronization
     def call
+      return if Rails.application.config.npq_separation[:ecf_api_disabled]
+
       uri = build_uri
       request = build_http_get_request(uri)
       response = send_http_request(uri, request)

--- a/app/services/ecf/ecf_user_creator.rb
+++ b/app/services/ecf/ecf_user_creator.rb
@@ -1,5 +1,5 @@
 module Ecf
-  class EcfUserCreator
+  class EcfUserCreator < Base
     attr_reader :user
 
     def initialize(user:)
@@ -7,8 +7,6 @@ module Ecf
     end
 
     def call
-      return if Rails.application.config.npq_separation[:ecf_api_disabled]
-
       remote = External::EcfAPI::Npq::User.new(
         email: user.email,
         get_an_identity_id: user.get_an_identity_id,

--- a/app/services/ecf/ecf_user_creator.rb
+++ b/app/services/ecf/ecf_user_creator.rb
@@ -1,5 +1,7 @@
 module Ecf
-  class EcfUserCreator < Base
+  class EcfUserCreator
+    prepend Base
+
     attr_reader :user
 
     def initialize(user:)

--- a/app/services/ecf/ecf_user_creator.rb
+++ b/app/services/ecf/ecf_user_creator.rb
@@ -7,6 +7,8 @@ module Ecf
     end
 
     def call
+      return if Rails.application.config.npq_separation[:ecf_api_disabled]
+
       remote = External::EcfAPI::Npq::User.new(
         email: user.email,
         get_an_identity_id: user.get_an_identity_id,

--- a/app/services/ecf/ecf_user_finder.rb
+++ b/app/services/ecf/ecf_user_finder.rb
@@ -1,5 +1,7 @@
 module Ecf
-  class EcfUserFinder < Base
+  class EcfUserFinder
+    prepend Base
+
     attr_reader :user
 
     def initialize(user:)

--- a/app/services/ecf/ecf_user_finder.rb
+++ b/app/services/ecf/ecf_user_finder.rb
@@ -1,5 +1,5 @@
 module Ecf
-  class EcfUserFinder
+  class EcfUserFinder < Base
     attr_reader :user
 
     def initialize(user:)
@@ -7,8 +7,6 @@ module Ecf
     end
 
     def call
-      return if Rails.application.config.npq_separation[:ecf_api_disabled]
-
       External::EcfAPI::User.where(email: user.email).first
     end
   end

--- a/app/services/ecf/ecf_user_finder.rb
+++ b/app/services/ecf/ecf_user_finder.rb
@@ -7,6 +7,8 @@ module Ecf
     end
 
     def call
+      return if Rails.application.config.npq_separation[:ecf_api_disabled]
+
       External::EcfAPI::User.where(email: user.email).first
     end
   end

--- a/app/services/ecf/ecf_user_updater.rb
+++ b/app/services/ecf/ecf_user_updater.rb
@@ -11,6 +11,8 @@ module Ecf
     end
 
     def call
+      return if Rails.application.config.npq_separation[:ecf_api_disabled]
+
       remote = user.ecf_user
 
       # JsonApiClient::Resource uses errors for flow control, so failed saves

--- a/app/services/ecf/ecf_user_updater.rb
+++ b/app/services/ecf/ecf_user_updater.rb
@@ -1,5 +1,5 @@
 module Ecf
-  class EcfUserUpdater
+  class EcfUserUpdater < Base
     def self.call(user:)
       new(user:).call
     end
@@ -11,8 +11,6 @@ module Ecf
     end
 
     def call
-      return if Rails.application.config.npq_separation[:ecf_api_disabled]
-
       remote = user.ecf_user
 
       # JsonApiClient::Resource uses errors for flow control, so failed saves

--- a/app/services/ecf/ecf_user_updater.rb
+++ b/app/services/ecf/ecf_user_updater.rb
@@ -1,5 +1,7 @@
 module Ecf
-  class EcfUserUpdater < Base
+  class EcfUserUpdater
+    prepend Base
+
     def self.call(user:)
       new(user:).call
     end

--- a/app/services/ecf/npq_profile_creator.rb
+++ b/app/services/ecf/npq_profile_creator.rb
@@ -1,5 +1,5 @@
 module Ecf
-  class NpqProfileCreator
+  class NpqProfileCreator < Base
     attr_reader :application
 
     def initialize(application:)
@@ -7,8 +7,6 @@ module Ecf
     end
 
     def call
-      return if Rails.application.config.npq_separation[:ecf_api_disabled]
-
       profile = External::EcfAPI::NpqProfile.new(
         teacher_reference_number: user.trn,
         teacher_reference_number_verified: user.trn_verified,

--- a/app/services/ecf/npq_profile_creator.rb
+++ b/app/services/ecf/npq_profile_creator.rb
@@ -1,5 +1,7 @@
 module Ecf
-  class NpqProfileCreator < Base
+  class NpqProfileCreator
+    prepend Base
+
     attr_reader :application
 
     def initialize(application:)

--- a/app/services/ecf/npq_profile_creator.rb
+++ b/app/services/ecf/npq_profile_creator.rb
@@ -7,6 +7,8 @@ module Ecf
     end
 
     def call
+      return if Rails.application.config.npq_separation[:ecf_api_disabled]
+
       profile = External::EcfAPI::NpqProfile.new(
         teacher_reference_number: user.trn,
         teacher_reference_number_verified: user.trn_verified,

--- a/app/services/ecf/npq_profile_mass_updater.rb
+++ b/app/services/ecf/npq_profile_mass_updater.rb
@@ -1,13 +1,11 @@
 module Ecf
-  class NpqProfileMassUpdater
+  class NpqProfileMassUpdater < Base
     def initialize(applications:, &after_save)
       @applications = applications
       @after_save = after_save
     end
 
     def call
-      return if Rails.application.config.npq_separation[:ecf_api_disabled]
-
       applications.find_each.with_index do |application, i|
         sleep(0.1) # Ensure that ECF API is not overloaded
 

--- a/app/services/ecf/npq_profile_mass_updater.rb
+++ b/app/services/ecf/npq_profile_mass_updater.rb
@@ -1,5 +1,7 @@
 module Ecf
-  class NpqProfileMassUpdater < Base
+  class NpqProfileMassUpdater
+    prepend Base
+
     def initialize(applications:, &after_save)
       @applications = applications
       @after_save = after_save

--- a/app/services/ecf/npq_profile_mass_updater.rb
+++ b/app/services/ecf/npq_profile_mass_updater.rb
@@ -6,6 +6,8 @@ module Ecf
     end
 
     def call
+      return if Rails.application.config.npq_separation[:ecf_api_disabled]
+
       applications.find_each.with_index do |application, i|
         sleep(0.1) # Ensure that ECF API is not overloaded
 

--- a/app/services/ecf/npq_profile_updater.rb
+++ b/app/services/ecf/npq_profile_updater.rb
@@ -1,5 +1,7 @@
 module Ecf
-  class NpqProfileUpdater < Base
+  class NpqProfileUpdater
+    prepend Base
+
     attr_reader :application
 
     def initialize(application:)

--- a/app/services/ecf/npq_profile_updater.rb
+++ b/app/services/ecf/npq_profile_updater.rb
@@ -7,6 +7,8 @@ module Ecf
     end
 
     def call
+      return if Rails.application.config.npq_separation[:ecf_api_disabled]
+
       profile = External::EcfAPI::NpqProfile.find(application.ecf_id).first
       profile.eligible_for_funding = application.eligible_for_funding
       profile.funding_eligiblity_status_code = application.funding_eligiblity_status_code
@@ -16,6 +18,8 @@ module Ecf
     end
 
     def tsf_data_field_update
+      return if Rails.application.config.npq_separation[:ecf_api_disabled]
+
       profile = External::EcfAPI::NpqProfile.find(application.ecf_id).first
       profile.primary_establishment = application.primary_establishment
       profile.number_of_pupils = application.number_of_pupils

--- a/app/services/ecf/npq_profile_updater.rb
+++ b/app/services/ecf/npq_profile_updater.rb
@@ -1,5 +1,5 @@
 module Ecf
-  class NpqProfileUpdater
+  class NpqProfileUpdater < Base
     attr_reader :application
 
     def initialize(application:)
@@ -7,8 +7,6 @@ module Ecf
     end
 
     def call
-      return if Rails.application.config.npq_separation[:ecf_api_disabled]
-
       profile = External::EcfAPI::NpqProfile.find(application.ecf_id).first
       profile.eligible_for_funding = application.eligible_for_funding
       profile.funding_eligiblity_status_code = application.funding_eligiblity_status_code

--- a/app/services/ecf/tsf_mass_data_field_updater.rb
+++ b/app/services/ecf/tsf_mass_data_field_updater.rb
@@ -1,5 +1,7 @@
 module Ecf
-  class TsfMassDataFieldUpdater < Base
+  class TsfMassDataFieldUpdater
+    prepend Base
+
     def initialize(applications:, &after_save)
       @applications = applications
       @after_save = after_save

--- a/app/services/ecf/tsf_mass_data_field_updater.rb
+++ b/app/services/ecf/tsf_mass_data_field_updater.rb
@@ -1,13 +1,11 @@
 module Ecf
-  class TsfMassDataFieldUpdater
+  class TsfMassDataFieldUpdater < Base
     def initialize(applications:, &after_save)
       @applications = applications
       @after_save = after_save
     end
 
     def call
-      return if Rails.application.config.npq_separation[:ecf_api_disabled]
-
       applications.find_each.with_index do |application, i|
         sleep(0.1) # Ensure that ECF API is not overloaded
 

--- a/app/services/ecf/tsf_mass_data_field_updater.rb
+++ b/app/services/ecf/tsf_mass_data_field_updater.rb
@@ -6,6 +6,8 @@ module Ecf
     end
 
     def call
+      return if Rails.application.config.npq_separation[:ecf_api_disabled]
+
       applications.find_each.with_index do |application, i|
         sleep(0.1) # Ensure that ECF API is not overloaded
 

--- a/app/services/participant_validator.rb
+++ b/app/services/participant_validator.rb
@@ -9,6 +9,8 @@ class ParticipantValidator
   end
 
   def call
+    return if Rails.application.config.npq_separation[:ecf_api_disabled]
+
     request = Net::HTTP::Post.new(uri)
     request["Authorization"] = "Bearer #{config.bearer_token}"
     request.set_form_data(payload)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -87,6 +87,7 @@ Rails.application.configure do
     admin_portal_enabled: true,
     api_enabled: true,
     migration_enabled: true,
+    ecf_api_disabled: false,
   }
 
   # Disable origin check for Cross-Site Request Forgery (CSRF) protection for codespaces.

--- a/config/environments/migration.rb
+++ b/config/environments/migration.rb
@@ -11,6 +11,6 @@ Rails.application.configure do
     admin_portal_enabled: true,
     api_enabled: true,
     migration_enabled: true,
-    ecf_api_disabled: false,
+    ecf_api_disabled: true,
   }
 end

--- a/config/environments/migration.rb
+++ b/config/environments/migration.rb
@@ -11,5 +11,6 @@ Rails.application.configure do
     admin_portal_enabled: true,
     api_enabled: true,
     migration_enabled: true,
+    ecf_api_disabled: false,
   }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -116,5 +116,6 @@ Rails.application.configure do
     admin_portal_enabled: false,
     api_enabled: false,
     migration_enabled: false,
+    ecf_api_disabled: false,
   }
 end

--- a/config/environments/review.rb
+++ b/config/environments/review.rb
@@ -9,5 +9,6 @@ Rails.application.configure do
     admin_portal_enabled: true,
     api_enabled: true,
     migration_enabled: true,
+    ecf_api_disabled: false,
   }
 end

--- a/config/environments/sandbox.rb
+++ b/config/environments/sandbox.rb
@@ -9,5 +9,6 @@ Rails.application.configure do
     admin_portal_enabled: false,
     api_enabled: false,
     migration_enabled: false,
+    ecf_api_disabled: false,
   }
 end

--- a/config/environments/separation.rb
+++ b/config/environments/separation.rb
@@ -9,5 +9,6 @@ Rails.application.configure do
     admin_portal_enabled: true,
     api_enabled: true,
     migration_enabled: false,
+    ecf_api_disabled: true,
   }
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -9,5 +9,6 @@ Rails.application.configure do
     admin_portal_enabled: true,
     api_enabled: true,
     migration_enabled: true,
+    ecf_api_disabled: false,
   }
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -76,6 +76,7 @@ Rails.application.configure do
     admin_portal_enabled: true,
     api_enabled: true,
     migration_enabled: true,
+    ecf_api_disabled: false,
   }
 
   config.dotenv.autorestore = false if config.respond_to?(:dotenv)

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 Sentry.init do |config|
-  config.dsn = Rails.env.production? ? ENV["SENTRY_DSN"] : "disabled"
-  config.release = ENV["GIT_COMMIT_SHA"]
-
+  config.enabled_environments = %w[production separation]
+  config.dsn = config.enabled_environments.include?(Rails.env) ? ENV["SENTRY_DSN"] : "disabled"
   config.breadcrumbs_logger = %i[active_support_logger http_logger]
+  config.release = ENV["GIT_COMMIT_SHA"]
 
   filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
   config.before_send = lambda do |event, _hint|

--- a/docs/merging_deployment_and_env_variables.md
+++ b/docs/merging_deployment_and_env_variables.md
@@ -18,7 +18,7 @@ Deployment is handled by Github Actions, the workflow that handles this can be f
 - [Deploy to Production](../.github/workflows/deploy_to_production.yml)
 - [Deploy to Review App](../.github/workflows/deploy_to_review_app.yml)
 
-See the [environments](docs/environments.md) document for more information on these environments.
+See the [environments](../docs/environments.md) document for more information on these environments.
 
 ## Requirements to merge to main
 
@@ -30,16 +30,16 @@ PRs aimed at the main branch have two mandatory requirements:
 
 Approval from the product owner, testing can be performed using the review app that is deployed automatically for all PRs.
 
-## Environment Variables 
+## Environment Variables
 
 Environment variables are set within the Github repository, these are then passed to CloudFoundry when the application is deployed.
 
-Environment variables can be managed at (https://github.com/DFE-Digital/npq-registration/settings/secrets/actions). 
+Environment variables can be managed at (https://github.com/DFE-Digital/npq-registration/settings/secrets/actions).
 
 These will then be available within the Github Action workflows as `secrets.<secret_name>`. This can be seen in each of the deployment scripts linked above.
 
 Environment variables intended for setting on the CloudFoundry application itself are passed into the `cf push` command as `--var <key>=<value>`.
-They are then set as environment variables on the application's environment manifest: 
+They are then set as environment variables on the application's environment manifest:
 - [Dev environment manifest](../config/manifests/dev-manifest.yml)
 - [Sandbox environment manifest](../config/manifests/sandbox-manifest.yml)
 - [Production environment manifest](../config/manifests/prod-manifest.yml)

--- a/spec/lib/services/ecf/ecf_application_synchronization_spec.rb
+++ b/spec/lib/services/ecf/ecf_application_synchronization_spec.rb
@@ -57,5 +57,13 @@ RSpec.describe Ecf::EcfApplicationSynchronization do
         service.call
       end
     end
+
+    context "when ecf_api_disabled flag is toggled on" do
+      before { allow(Rails.application.config).to receive(:npq_separation).and_return({ ecf_api_disabled: true }) }
+
+      it "returns nil" do
+        expect(service.call).to be_nil
+      end
+    end
   end
 end

--- a/spec/lib/services/ecf/ecf_user_creator_spec.rb
+++ b/spec/lib/services/ecf/ecf_user_creator_spec.rb
@@ -166,5 +166,16 @@ RSpec.describe Ecf::EcfUserCreator do
         )
       end
     end
+
+    context "when ecf_api_disabled flag is toggled on" do
+      let(:response_code) { 201 }
+      let(:response_body) { "anything" }
+
+      before { allow(Rails.application.config).to receive(:npq_separation).and_return({ ecf_api_disabled: true }) }
+
+      it "returns nil" do
+        expect(subject.call).to be_nil
+      end
+    end
   end
 end

--- a/spec/lib/services/ecf/ecf_user_finder_spec.rb
+++ b/spec/lib/services/ecf/ecf_user_finder_spec.rb
@@ -57,5 +57,15 @@ RSpec.describe Ecf::EcfUserFinder do
         expect(subject.call).to be_nil
       end
     end
+
+    context "when ecf_api_disabled flag is toggled on" do
+      let(:response_body) { "anything" }
+
+      before { allow(Rails.application.config).to receive(:npq_separation).and_return({ ecf_api_disabled: true }) }
+
+      it "returns nil" do
+        expect(subject.call).to be_nil
+      end
+    end
   end
 end

--- a/spec/lib/services/ecf/ecf_user_updater_spec.rb
+++ b/spec/lib/services/ecf/ecf_user_updater_spec.rb
@@ -230,5 +230,16 @@ RSpec.describe Ecf::EcfUserUpdater do
         )
       end
     end
+
+    context "when ecf_api_disabled flag is toggled on" do
+      let(:response_code) { 200 }
+      let(:response_body) { "anything" }
+
+      before { allow(Rails.application.config).to receive(:npq_separation).and_return({ ecf_api_disabled: true }) }
+
+      it "returns nil" do
+        expect(subject.call).to be_nil
+      end
+    end
   end
 end

--- a/spec/lib/services/ecf/npq_profile_creator_spec.rb
+++ b/spec/lib/services/ecf/npq_profile_creator_spec.rb
@@ -261,5 +261,15 @@ RSpec.describe Ecf::NpqProfileCreator do
         )
       end
     end
+
+    context "when ecf_api_disabled flag is toggled on" do
+      let(:response_code) { 200 }
+
+      before { allow(Rails.application.config).to receive(:npq_separation).and_return({ ecf_api_disabled: true }) }
+
+      it "returns nil" do
+        expect(subject.call).to be_nil
+      end
+    end
   end
 end

--- a/spec/lib/services/ecf/npq_profile_mass_updater_spec.rb
+++ b/spec/lib/services/ecf/npq_profile_mass_updater_spec.rb
@@ -22,4 +22,12 @@ RSpec.describe Ecf::NpqProfileMassUpdater do
 
     subject.call
   end
+
+  context "when ecf_api_disabled flag is toggled on" do
+    before { allow(Rails.application.config).to receive(:npq_separation).and_return({ ecf_api_disabled: true }) }
+
+    it "returns nil" do
+      expect(subject.call).to be_nil
+    end
+  end
 end

--- a/spec/lib/services/ecf/npq_profile_updater_spec.rb
+++ b/spec/lib/services/ecf/npq_profile_updater_spec.rb
@@ -121,4 +121,12 @@ RSpec.describe Ecf::NpqProfileUpdater do
     subject.call
     expect(update_ecf_stub).to have_been_requested
   end
+
+  context "when ecf_api_disabled flag is toggled on" do
+    before { allow(Rails.application.config).to receive(:npq_separation).and_return({ ecf_api_disabled: true }) }
+
+    it "returns nil" do
+      expect(subject.call).to be_nil
+    end
+  end
 end

--- a/spec/lib/services/ecf/tsf_mass_data_field_updater_spec.rb
+++ b/spec/lib/services/ecf/tsf_mass_data_field_updater_spec.rb
@@ -22,4 +22,12 @@ RSpec.describe Ecf::TsfMassDataFieldUpdater do
 
     subject.call
   end
+
+  context "when ecf_api_disabled flag is toggled on" do
+    before { allow(Rails.application.config).to receive(:npq_separation).and_return({ ecf_api_disabled: true }) }
+
+    it "returns nil" do
+      expect(subject.call).to be_nil
+    end
+  end
 end

--- a/spec/lib/services/participant_validator_spec.rb
+++ b/spec/lib/services/participant_validator_spec.rb
@@ -111,5 +111,13 @@ RSpec.describe ParticipantValidator do
         expect(subject.call).to be_nil
       end
     end
+
+    context "when ecf_api_disabled flag is toggled on" do
+      before { allow(Rails.application.config).to receive(:npq_separation).and_return({ ecf_api_disabled: true }) }
+
+      it "returns nil" do
+        expect(subject.call).to be_nil
+      end
+    end
   end
 end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -134,6 +134,15 @@ RSpec.describe Application do
         expect(described_class.eligible_for_funding).to contain_exactly(application_eligible_for_funding)
       end
     end
+
+    describe ".with_targeted_delivery_funding_eligibility" do
+      it "returns applications with targeted delivery funding eligibility" do
+        application_with_targeted_delivery_funding_eligibility = create(:application, targeted_delivery_funding_eligibility: true)
+        create(:application, targeted_delivery_funding_eligibility: false)
+
+        expect(described_class.with_targeted_delivery_funding_eligibility).to contain_exactly(application_with_targeted_delivery_funding_eligibility)
+      end
+    end
   end
 
   describe "#inside_catchment?" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -119,4 +119,32 @@ RSpec.describe User do
       }.to change { user.reload.email_updates_unsubscribe_key }.from("432").to(nil)
     end
   end
+
+  describe "#ecf_user" do
+    subject(:user) { build(:user) }
+
+    before { allow(External::EcfAPI::Npq::User).to receive(:find).and_return(%w[anything]) }
+
+    it "calls the correct ECF API service" do
+      expect(External::EcfAPI::Npq::User).to receive(:find).with(user.ecf_id)
+
+      user.ecf_user
+    end
+
+    context "when ecf_id is nil" do
+      before { user.update!(ecf_id: nil) }
+
+      it "returns nil" do
+        expect(user.ecf_user).to be_nil
+      end
+    end
+
+    context "when ecf_api_disabled flag is toggled on" do
+      before { allow(Rails.application.config).to receive(:npq_separation).and_return({ ecf_api_disabled: true }) }
+
+      it "returns nil" do
+        expect(user.ecf_user).to be_nil
+      end
+    end
+  end
 end

--- a/terraform/application/config/separation.tfvars.json
+++ b/terraform/application/config/separation.tfvars.json
@@ -1,5 +1,6 @@
 {
   "cluster": "production",
   "namespace": "cpd-production",
-  "environment": "separation"
+  "environment": "separation",
+  "enable_logit": true
 }


### PR DESCRIPTION
### Context

Ticket: [CPDLP-3235](https://dfedigital.atlassian.net/browse/CPDLP-3235)

We need to track logs and debug exceptions on the new separation environment. Also we need to turn off integration with ECF Api.

### Changes proposed in this pull request

- Enable Sentry and Logit on separation environment.
- Disable the ECF API only in separation ENV and remove the keys from the keyvault/setting to nil
- Set NPQ funding eligibility to read from previously funded if ECF API is disabled

[CPDLP-3235]: https://dfedigital.atlassian.net/browse/CPDLP-3235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ