### PR TITLE
Ignore ASO courses instead of EHCO

### DIFF
--- a/app/services/valid_test_data_generators/applications_populater.rb
+++ b/app/services/valid_test_data_generators/applications_populater.rb
@@ -34,7 +34,7 @@ module ValidTestDataGenerators
       @cohort = cohort
       @number_of_participants = number_of_participants
       @logger = logger
-      @courses = Course.all.reject { |c| c.identifier == "npq-early-headship-coaching-offer" }
+      @courses = Course.all.reject { |c| c.identifier == "npq-additional-support-offer" }
     end
 
     def create_participants!


### PR DESCRIPTION
### Context

ASO is an old course which we shouldn't create data for anymore

### Changes proposed in this pull request
Ignore ASO courses when creating seed data as they are old courses which we don't create applications for anymore

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
