### PR TITLE
Fix N+1 in DeclarationSerializer

### DIFF
--- a/app/serializers/api/declaration_serializer.rb
+++ b/app/serializers/api/declaration_serializer.rb
@@ -11,7 +11,12 @@ module API
       field(:course_identifier)
       field(:declaration_date)
       field(:state) { |declaration| declaration.state.dasherize }
-      field(:has_passed) { |declaration| declaration.participant_outcomes.latest&.has_passed? }
+      field(:has_passed) do |declaration|
+        declaration
+          .participant_outcomes
+          .max_by(&:created_at)
+          &.has_passed?
+      end
 
       view :v1 do
         field(:voided_state?, name: :voided)

--- a/app/services/declarations/query.rb
+++ b/app/services/declarations/query.rb
@@ -56,6 +56,7 @@ module Declarations
         .includes(
           :cohort,
           :lead_provider,
+          :participant_outcomes,
           application: %i[
             user
             course

--- a/spec/serializers/api/declaration_serializer_spec.rb
+++ b/spec/serializers/api/declaration_serializer_spec.rb
@@ -54,27 +54,33 @@ RSpec.describe API::DeclarationSerializer, type: :serializer do
           end
         end
 
-        context "when the latest outcome is voided" do
-          before { create(:participant_outcome, :voided, declaration:) }
+        context "when there are participant outcomes" do
+          let!(:voided_outcome) { create(:participant_outcome, :voided, declaration:) }
+          let!(:passed_outcome) { create(:participant_outcome, :passed, declaration:) }
+          let!(:failed_outcome) { create(:participant_outcome, :failed, declaration:) }
 
-          it "serializes `has_passed`" do
-            expect(attributes["has_passed"]).to be_nil
+          context "when the latest outcome is voided" do
+            before { voided_outcome.update!(created_at: 1.day.from_now) }
+
+            it "serializes `has_passed`" do
+              expect(attributes["has_passed"]).to be_nil
+            end
           end
-        end
 
-        context "when the latest outcome has passed" do
-          before { create(:participant_outcome, :passed, declaration:) }
+          context "when the latest outcome has passed" do
+            before { passed_outcome.update!(created_at: 1.day.from_now) }
 
-          it "serializes `has_passed`" do
-            expect(attributes["has_passed"]).to be(true)
+            it "serializes `has_passed`" do
+              expect(attributes["has_passed"]).to be(true)
+            end
           end
-        end
 
-        context "when the latest outcome has failed" do
-          before { create(:participant_outcome, :failed, declaration:) }
+          context "when the latest outcome has failed" do
+            before { failed_outcome.update!(created_at: 1.day.from_now) }
 
-          it "serializes `has_passed`" do
-            expect(attributes["has_passed"]).to be(false)
+            it "serializes `has_passed`" do
+              expect(attributes["has_passed"]).to be(false)
+            end
           end
         end
       end


### PR DESCRIPTION
[Jira-3336](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-3336)

### Context

The `DeclarationSerializer` was performing a second query for each declaration in order to find the latest outcome. Instead, we can preload the outomes in the query and perform an in-memory `sort_by` (instead of `order` which triggers another query) to find the latest outcome.

### Changes proposed in this pull request

- Fix N+1 in DeclarationSerializer
