### PR TITLE
Setup Rack::Attack for API requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,6 +80,7 @@ end
 group :test do
   gem "axe-core-capybara", "~> 4.6"
   gem "axe-core-rspec", "~> 4.9"
+  gem "rspec-default_http_header"
   gem "shoulda-matchers", "~> 6.2"
   gem "simplecov", require: false
   gem "site_prism", "~> 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -330,9 +330,9 @@ GEM
     nokogiri (1.16.6)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.16.6-x86_64-darwin)
+    nokogiri (1.16.6-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.6-x86_64-linux)
+    nokogiri (1.16.6-x86_64-darwin)
       racc (~> 1.4)
     notifications-ruby-client (5.4.0)
       jwt (>= 1.5, < 3)
@@ -463,6 +463,8 @@ GEM
     rouge (4.3.0)
     rspec-core (3.13.0)
       rspec-support (~> 3.13.0)
+    rspec-default_http_header (0.0.6)
+      rspec-rails (> 3.0)
     rspec-expectations (3.13.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
@@ -647,6 +649,7 @@ GEM
     zlib (3.1.0)
 
 PLATFORMS
+  arm64-darwin-23
   ruby
   x86_64-darwin-20
   x86_64-linux
@@ -707,6 +710,7 @@ DEPENDENCIES
   rails_semantic_logger
   redis
   rouge
+  rspec-default_http_header
   rspec-rails (~> 6.1.3)
   rswag-specs
   rubocop-govuk

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -9,19 +9,31 @@ class Rack::Attack
     "/session/sign_in_code",
   ].freeze
 
+  PUBLIC_API_PATH_PREFIXES = [
+    "/api/guidance",
+    "/api/docs",
+  ].freeze
+
   # Throttle protected routes by IP (5rpm)
   throttle("protected routes (hitting external services)", limit: 5, period: 1.minute) do |request|
     request.ip if PROTECTED_ROUTES.include?(request.path)
   end
 
   # Throttle /csp_reports requests by IP (5rpm)
-  throttle("csp_reports req/ip", limit: 5, period: 1.minute) do |req|
-    req.ip if req.path == "/csp_reports"
+  throttle("csp_reports req/ip", limit: 5, period: 1.minute) do |request|
+    request.ip if request.path == "/csp_reports"
+  end
+
+  # Throttle /api/v1/get_an_identity/webhook_messages requests by IP (1000 requests per 5 minutes)
+  throttle("API get an identity webhook message requests by ip", limit: 1000, period: 5.minutes) do |request|
+    request.ip if request.path.starts_with?("/api/v1/get_an_identity/webhook_messages")
   end
 
   # Throttle /api requests by auth token (1000 requests per 5 minutes)
   throttle("API requests by auth token", limit: 1000, period: 5.minutes) do |request|
-    if request.path.starts_with?("/api/")
+    public_api_path = PUBLIC_API_PATH_PREFIXES.any? { |prefix| request.path.starts_with?(prefix) }
+
+    if request.path.starts_with?("/api/") && !public_api_path
       request.get_header("HTTP_AUTHORIZATION")
     end
   end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -2,26 +2,32 @@
 
 # Throttle general requests by IP
 class Rack::Attack
-  throttle("General requests by ip", limit: 300, period: 5.minutes, &:ip)
-
-  protected_routes = [
-    "/registration/contact_details",
-    "/registration/contact_details/change",
-    "/registration/confirm_email",
-    "/registration/confirm_email/change",
+  PROTECTED_ROUTES = [
     "/registration/qualified_teacher_check",
     "/registration/qualified_teacher_check/change",
     "/session/sign_in",
     "/session/sign_in_code",
-  ]
-  throttle("Rate limit external APIs", limit: 5, period: 1.minute) do |request|
-    request.ip if protected_routes.include?(request.path)
+  ].freeze
+
+  # Throttle protected routes by IP (5rpm)
+  throttle("protected routes (hitting external services)", limit: 5, period: 1.minute) do |request|
+    request.ip if PROTECTED_ROUTES.include?(request.path)
   end
 
   # Throttle /csp_reports requests by IP (5rpm)
   throttle("csp_reports req/ip", limit: 5, period: 1.minute) do |req|
     req.ip if req.path == "/csp_reports"
   end
+
+  # Throttle /api requests by auth token (1000 requests per 5 minutes)
+  throttle("API requests by auth token", limit: 1000, period: 5.minutes) do |request|
+    if request.path.starts_with?("/api/")
+      request.get_header("HTTP_AUTHORIZATION")
+    end
+  end
+
+  # Throttle all requests by IP (300 requests per 5 minutes)
+  throttle("general requests by ip", limit: 300, period: 5.minutes, &:ip)
 end
 
 ActiveSupport::Notifications.subscribe("throttle.rack_attack") do |_name, _start, _finish, request_id, payload|

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -84,6 +84,7 @@ RSpec.configure do |config|
   config.include Capybara::RSpecMatchers, type: :component
   config.include Helpers::APIHelpers, type: :request
   config.include Helpers::SwaggerExampleParser, type: :request
+  config.include RSpec::DefaultHttpHeader, type: :request
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = [

--- a/spec/requests/csp_reports_controller_spec.rb
+++ b/spec/requests/csp_reports_controller_spec.rb
@@ -37,14 +37,4 @@ RSpec.describe "CSP Reports Controller" do
       it { expect(Rails.logger).to have_received(:error).with({ "csp-report" => expected_report }).once }
     end
   end
-
-  describe "Rate limiting" do
-    let(:ip) { "1.2.3.4" }
-
-    it_behaves_like "an IP-based rate limited endpoint", "POST /csp_reports", 5, 1.minute do
-      def perform_request
-        post csp_reports_path, params: {}.to_json, headers: { "REMOTE_ADDR" => ip }
-      end
-    end
-  end
 end

--- a/spec/requests/rate_limiting_spec.rb
+++ b/spec/requests/rate_limiting_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Rate limiting" do
+  let(:ip) { "1.2.3.4" }
+  let(:other_ip) { "9.8.7.6" }
+
+  before { set_request_ip(ip) }
+
+  it_behaves_like "a rate limited endpoint", "general requests by ip" do
+    def perform_request
+      get root_path
+    end
+
+    def change_condition
+      set_request_ip(other_ip)
+    end
+  end
+
+  Rack::Attack::PROTECTED_ROUTES.each do |protected_path|
+    it_behaves_like "a rate limited endpoint", "protected routes (hitting external services)" do
+      let(:path) { protected_path }
+
+      def perform_request
+        get path
+      end
+
+      def change_condition
+        set_request_ip(other_ip)
+      end
+    end
+  end
+
+  it_behaves_like "a rate limited endpoint", "csp_reports req/ip" do
+    def perform_request
+      post csp_reports_path, params: {}.to_json
+    end
+
+    def change_condition
+      set_request_ip(other_ip)
+    end
+  end
+
+  it_behaves_like "a rate limited endpoint", "API requests by auth token" do
+    let(:lead_provider) { create(:lead_provider) }
+    let(:other_lead_provider) { create(:lead_provider) }
+    let(:auth_token) { APIToken.create_with_random_token!(lead_provider:) }
+    let(:other_auth_token) { APIToken.create_with_random_token!(lead_provider: other_lead_provider) }
+
+    before { set_auth_token(auth_token) }
+
+    def perform_request
+      get api_v3_applications_path
+    end
+
+    def change_condition
+      set_auth_token(other_auth_token)
+    end
+  end
+
+  def set_request_ip(request_ip)
+    default_headers[:REMOTE_ADDR] = request_ip
+  end
+
+  def set_auth_token(token)
+    default_headers[:Authorization] = "Bearer #{token}"
+  end
+end


### PR DESCRIPTION
[Jira-3337](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3337)

### Context

We want to mirror the rate limiting for API requests from ECF.

### Changes proposed in this pull request

- Add rate limiting for `/api` requests that matches the ECF configuration.

Clean up and improve the testing around rate limiting.

Remove redundant protected routes (they no longer appear to exist).
