### PR TITLE
Fix API sorting

### DIFF
--- a/app/controllers/api/v3/applications_controller.rb
+++ b/app/controllers/api/v3/applications_controller.rb
@@ -5,7 +5,7 @@ module API
       include FilterByDate
 
       def index
-        conditions = { cohort_start_years:, participant_ids:, updated_since: }
+        conditions = { cohort_start_years:, participant_ids:, updated_since:, sort: }
         applications = applications_query(conditions:).applications
 
         render json: to_json(paginate(applications))
@@ -66,6 +66,10 @@ module API
 
       def application_params
         params.permit(:ecf_id, :sort, filter: %i[cohort updated_since participant_id])
+      end
+
+      def sort
+        application_params[:sort]
       end
 
       def to_json(obj)

--- a/app/controllers/api/v3/participants_controller.rb
+++ b/app/controllers/api/v3/participants_controller.rb
@@ -5,7 +5,7 @@ module API
       include FilterByDate
 
       def index
-        conditions = { updated_since:, training_status:, from_participant_id: }
+        conditions = { updated_since:, training_status:, from_participant_id:, sort: }
         participants = participants_query(conditions:).participants
 
         render json: to_json(paginate(participants))
@@ -72,8 +72,12 @@ module API
         ::Participants::Query.new(**conditions.compact)
       end
 
+      def sort
+        participant_params[:sort]
+      end
+
       def participant_params
-        params.permit(:ecf_id, filter: %i[training_status from_participant_id])
+        params.permit(:ecf_id, :sort, filter: %i[training_status from_participant_id])
       end
 
       def participant_action_params

--- a/app/services/participant_outcomes/query.rb
+++ b/app/services/participant_outcomes/query.rb
@@ -1,9 +1,8 @@
 module ParticipantOutcomes
   class Query
-    include API::Concerns::Orderable
     include Queries::ConditionFormats
 
-    attr_reader :scope, :sort
+    attr_reader :scope
 
     def initialize(lead_provider: :ignore, participant_ids: :ignore, created_since: :ignore)
       @scope = all_participant_outcomes
@@ -14,7 +13,7 @@ module ParticipantOutcomes
     end
 
     def participant_outcomes
-      scope.order(order_by)
+      scope.order(:created_at)
     end
 
   private
@@ -35,10 +34,6 @@ module ParticipantOutcomes
       return if created_since == :ignore
 
       scope.merge!(ParticipantOutcome.where(created_at: created_since..))
-    end
-
-    def order_by
-      sort_order(sort:, model: ParticipantOutcome, default: { created_at: :asc })
     end
 
     def all_participant_outcomes

--- a/spec/requests/api/v3/applications_spec.rb
+++ b/spec/requests/api/v3/applications_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe "Application endpoints", type: :request do
     it_behaves_like "an API index endpoint with filter by cohort"
     it_behaves_like "an API index endpoint with filter by updated_since"
     it_behaves_like "an API index endpoint with filter by participant_id"
+    it_behaves_like "an API index endpoint with sorting"
   end
 
   describe "POST /api/v3/npq-applications/:ecf_id/accept" do

--- a/spec/requests/api/v3/participants_spec.rb
+++ b/spec/requests/api/v3/participants_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe "Participant endpoints", type: :request do
     it_behaves_like "an API index endpoint with filter by updated_since"
     it_behaves_like "an API index endpoint with filter by training_status"
     it_behaves_like "an API index endpoint with filter by from_participant_id"
+    it_behaves_like "an API index endpoint with sorting"
   end
 
   describe "GET /api/v3/participants/npq/:id" do

--- a/spec/support/shared_examples/api_index_endpoint_support.rb
+++ b/spec/support/shared_examples/api_index_endpoint_support.rb
@@ -69,6 +69,14 @@ RSpec.shared_examples "an API index endpoint on a parent resource" do |parent, c
   end
 end
 
+RSpec.shared_examples "an API index endpoint with sorting" do
+  it "calls the correct query" do
+    expect(query).to receive(:new).with(a_hash_including(lead_provider: current_lead_provider, sort: "-created_at")).and_call_original
+
+    api_get(path, params: { sort: "-created_at" })
+  end
+end
+
 RSpec.shared_examples "an API index endpoint with pagination" do
   context "with pagination" do
     before do


### PR DESCRIPTION
[Jira-3339](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3339)

### Context

The API sorting was not working correctly due to the `sort` parameter not being passed into the underlying query objects.

### Changes proposed in this pull request

- Fix API sorting

Update `index` actions for applications/participants so that the `sort` parameter tranfers to the underlying query.

Add test coverage to avoid regressions in the future.

Remove unused `sort` attribute from outcomes query.

