### PR TITLE
Ignore empty filters in queries

### DIFF
--- a/app/services/api/concerns/filter_ignorable.rb
+++ b/app/services/api/concerns/filter_ignorable.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module API
+  module Concerns
+    module FilterIgnorable
+      extend ActiveSupport::Concern
+
+      def ignore?(filter:)
+        filter == :ignore || (!filter.nil? && filter.blank?)
+      end
+    end
+  end
+end

--- a/app/services/applications/query.rb
+++ b/app/services/applications/query.rb
@@ -2,6 +2,7 @@ module Applications
   class Query
     include API::Concerns::Orderable
     include Queries::ConditionFormats
+    include API::Concerns::FilterIgnorable
 
     attr_reader :scope, :sort
 
@@ -48,31 +49,31 @@ module Applications
   private
 
     def where_lead_provider_approval_status_in(lead_provider_approval_status)
-      return if lead_provider_approval_status == :ignore
+      return if ignore?(filter: lead_provider_approval_status)
 
       scope.merge!(Application.where(lead_provider_approval_status: extract_conditions(lead_provider_approval_status, allowlist: Application.lead_provider_approval_statuses.values)))
     end
 
     def where_lead_provider_is(lead_provider)
-      return if lead_provider == :ignore
+      return if ignore?(filter: lead_provider)
 
       scope.merge!(Application.where(lead_provider:))
     end
 
     def where_cohort_start_year_in(cohort_start_years)
-      return if cohort_start_years == :ignore
+      return if ignore?(filter: cohort_start_years)
 
       scope.merge!(Application.where(cohort: { start_year: extract_conditions(cohort_start_years) }))
     end
 
     def where_updated_since(updated_since)
-      return if updated_since == :ignore
+      return if ignore?(filter: updated_since)
 
       scope.merge!(Application.where(updated_at: updated_since..))
     end
 
     def where_participant_ids_in(participant_ids)
-      return if participant_ids == :ignore
+      return if ignore?(filter: participant_ids)
 
       scope.merge!(Application.where(user: { ecf_id: extract_conditions(participant_ids) }))
     end

--- a/app/services/declarations/query.rb
+++ b/app/services/declarations/query.rb
@@ -1,6 +1,7 @@
 module Declarations
   class Query
     include Queries::ConditionFormats
+    include API::Concerns::FilterIgnorable
 
     attr_reader :scope, :sort
 
@@ -28,25 +29,25 @@ module Declarations
   private
 
     def where_lead_provider_is(lead_provider)
-      return if lead_provider == :ignore
+      return if ignore?(filter: lead_provider)
 
       scope.merge!(Declaration.where(lead_provider:))
     end
 
     def where_updated_since(updated_since)
-      return if updated_since == :ignore
+      return if ignore?(filter: updated_since)
 
       scope.merge!(Declaration.where(updated_at: updated_since..))
     end
 
     def where_participant_ids_in(participant_ids)
-      return if participant_ids == :ignore
+      return if ignore?(filter: participant_ids)
 
       scope.merge!(Declaration.where(user: { ecf_id: extract_conditions(participant_ids) }))
     end
 
     def where_cohort_start_year_in(cohort_start_years)
-      return if cohort_start_years == :ignore
+      return if ignore?(filter: cohort_start_years)
 
       scope.merge!(Declaration.where(cohort: { start_year: extract_conditions(cohort_start_years) }))
     end

--- a/app/services/participant_outcomes/query.rb
+++ b/app/services/participant_outcomes/query.rb
@@ -2,6 +2,7 @@ module ParticipantOutcomes
   class Query
     include API::Concerns::Orderable
     include Queries::ConditionFormats
+    include API::Concerns::FilterIgnorable
 
     attr_reader :scope, :sort
 
@@ -20,19 +21,19 @@ module ParticipantOutcomes
   private
 
     def where_lead_provider_is(lead_provider)
-      return if lead_provider == :ignore
+      return if ignore?(filter: lead_provider)
 
       scope.merge!(ParticipantOutcome.where(declaration: { lead_provider: }))
     end
 
     def where_participant_ids_in(participant_ids)
-      return if participant_ids == :ignore
+      return if ignore?(filter: participant_ids)
 
       scope.merge!(ParticipantOutcome.where(user: { ecf_id: extract_conditions(participant_ids) }))
     end
 
     def where_created_since(created_since)
-      return if created_since == :ignore
+      return if ignore?(filter: created_since)
 
       scope.merge!(ParticipantOutcome.where(created_at: created_since..))
     end

--- a/app/services/participants/query.rb
+++ b/app/services/participants/query.rb
@@ -1,6 +1,7 @@
 module Participants
   class Query
     include API::Concerns::Orderable
+    include API::Concerns::FilterIgnorable
 
     attr_reader :scope, :sort
 
@@ -28,25 +29,26 @@ module Participants
   private
 
     def where_lead_provider_is(lead_provider)
-      return if lead_provider == :ignore
+      return if ignore?(filter: lead_provider)
 
       scope.merge!(Application.where(lead_provider:))
     end
 
     def where_updated_since(updated_since)
-      return if updated_since == :ignore
+      return if ignore?(filter: updated_since)
 
       scope.merge!(User.where(updated_at: updated_since..))
     end
 
     def where_training_status_is(training_status)
+      return if ignore?(filter: training_status)
       return unless Application.training_statuses[training_status]
 
       scope.merge!(Application.where(training_status:))
     end
 
     def where_from_participant_id_is(from_participant_id)
-      return if from_participant_id == :ignore
+      return if ignore?(filter: from_participant_id)
 
       scope.merge!(scope.joins(:participant_id_changes).merge(ParticipantIdChange.where(from_participant: User.where(ecf_id: from_participant_id))))
     end

--- a/app/services/statements/query.rb
+++ b/app/services/statements/query.rb
@@ -1,6 +1,7 @@
 module Statements
   class Query
     include Queries::ConditionFormats
+    include API::Concerns::FilterIgnorable
 
     attr_reader :scope
 
@@ -28,31 +29,31 @@ module Statements
   private
 
     def where_lead_provider_is(lead_provider)
-      return if lead_provider == :ignore
+      return if ignore?(filter: lead_provider)
 
       scope.merge!(Statement.where(lead_provider:))
     end
 
     def where_cohort_start_year_in(cohort_start_years)
-      return if cohort_start_years == :ignore
+      return if ignore?(filter: cohort_start_years)
 
       scope.merge!(Statement.where(cohort: { start_year: extract_conditions(cohort_start_years) }))
     end
 
     def where_updated_since(updated_since)
-      return if updated_since == :ignore
+      return if ignore?(filter: updated_since)
 
       scope.merge!(Statement.where(updated_at: updated_since..))
     end
 
     def where_state_is(state)
-      return if state == :ignore
+      return if ignore?(filter: state)
 
       scope.merge!(Statement.with_state(extract_conditions(state)))
     end
 
     def where_output_fee_is(output_fee)
-      return if output_fee == :ignore
+      return if ignore?(filter: output_fee)
 
       scope.merge!(Statement.with_output_fee(output_fee:))
     end

--- a/spec/services/api/concerns/filter_ignorable_spec.rb
+++ b/spec/services/api/concerns/filter_ignorable_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+class TestQuery
+  include API::Concerns::FilterIgnorable
+end
+
+RSpec.describe API::Concerns::FilterIgnorable do
+  let(:query) { TestQuery.new }
+
+  describe "#ignore?" do
+    it { expect(query).to be_ignore(filter: " ") }
+    it { expect(query).to be_ignore(filter: "") }
+    it { expect(query).to be_ignore(filter: :ignore) }
+    it { expect(query).not_to be_ignore(filter: nil) }
+    it { expect(query).not_to be_ignore(filter: "value") }
+  end
+end

--- a/spec/services/declarations/query_spec.rb
+++ b/spec/services/declarations/query_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Declarations::Query do
       declaration1 = create(:declaration)
       declaration2 = create(:declaration)
 
-      query = Declarations::Query.new
+      query = described_class.new
       expect(query.declarations).to contain_exactly(declaration1, declaration2)
     end
 
@@ -15,7 +15,7 @@ RSpec.describe Declarations::Query do
       declaration2 = travel_to(1.hour.ago) { create(:declaration) }
       declaration3 = travel_to(1.minute.ago) { create(:declaration) }
 
-      query = Declarations::Query.new
+      query = described_class.new
       expect(query.declarations).to eq([declaration2, declaration3, declaration1])
     end
 
@@ -25,15 +25,22 @@ RSpec.describe Declarations::Query do
           declaration = create(:declaration)
           create(:declaration, lead_provider: create(:lead_provider))
 
-          query = Declarations::Query.new(lead_provider: declaration.lead_provider)
+          query = described_class.new(lead_provider: declaration.lead_provider)
           expect(query.declarations).to contain_exactly(declaration)
         end
 
         it "doesn't filter by lead provider when none supplied" do
-          condition_string = %("declarations"."lead_provider_id" =)
+          condition_string = %("lead_provider_id")
 
-          expect(Declarations::Query.new(lead_provider: create(:lead_provider)).scope.to_sql).to include(condition_string)
-          expect(Declarations::Query.new.scope.to_sql).not_to include(condition_string)
+          expect(described_class.new(lead_provider: create(:lead_provider)).scope.to_sql).to include(condition_string)
+          expect(described_class.new.scope.to_sql).not_to include(condition_string)
+        end
+
+        it "does not filter by lead provider if an empty string is supplied" do
+          condition_string = %("lead_provider_id")
+          query = described_class.new(lead_provider: " ")
+
+          expect(query.scope.to_sql).not_to include(condition_string)
         end
       end
 
@@ -42,7 +49,7 @@ RSpec.describe Declarations::Query do
           create(:declaration, updated_at: 2.days.ago)
           declaration = create(:declaration, updated_at: Time.zone.now)
 
-          query = Declarations::Query.new(updated_since: 1.day.ago)
+          query = described_class.new(updated_since: 1.day.ago)
 
           expect(query.declarations).to contain_exactly(declaration)
         end
@@ -50,8 +57,15 @@ RSpec.describe Declarations::Query do
         it "doesn't filter by updated since when none supplied" do
           condition_string = %("declarations"."updated_at" >=)
 
-          expect(Declarations::Query.new(updated_since: 2.days.ago).scope.to_sql).to include(condition_string)
-          expect(Declarations::Query.new.scope.to_sql).not_to include(condition_string)
+          expect(described_class.new(updated_since: 2.days.ago).scope.to_sql).to include(condition_string)
+          expect(described_class.new.scope.to_sql).not_to include(condition_string)
+        end
+
+        it "does not filter by updated_since if blank" do
+          condition_string = %("updated_at")
+          query = described_class.new(updated_since: " ")
+
+          expect(query.scope.to_sql).not_to include(condition_string)
         end
       end
 
@@ -63,7 +77,7 @@ RSpec.describe Declarations::Query do
         it "filters by cohort" do
           create(:declaration, cohort: cohort_2023)
           declaration = create(:declaration, cohort: cohort_2024)
-          query = Declarations::Query.new(cohort_start_years: "2024")
+          query = described_class.new(cohort_start_years: "2024")
 
           expect(query.declarations).to contain_exactly(declaration)
         end
@@ -72,13 +86,13 @@ RSpec.describe Declarations::Query do
           declaration1 = create(:declaration, cohort: cohort_2023)
           declaration2 = create(:declaration, cohort: cohort_2024)
           create(:declaration, cohort: cohort_2025)
-          query = Declarations::Query.new(cohort_start_years: "2023,2024")
+          query = described_class.new(cohort_start_years: "2023,2024")
 
           expect(query.declarations).to contain_exactly(declaration1, declaration2)
         end
 
         it "returns no declarations if no cohorts are found" do
-          query = Declarations::Query.new(cohort_start_years: "0000")
+          query = described_class.new(cohort_start_years: "0000")
 
           expect(query.declarations).to be_empty
         end
@@ -86,8 +100,15 @@ RSpec.describe Declarations::Query do
         it "doesn't filter by cohort when none supplied" do
           condition_string = %("cohort"."start_year" =)
 
-          expect(Declarations::Query.new(cohort_start_years: 2021).scope.to_sql).to include(condition_string)
-          expect(Declarations::Query.new.scope.to_sql).not_to include(condition_string)
+          expect(described_class.new(cohort_start_years: 2021).scope.to_sql).to include(condition_string)
+          expect(described_class.new.scope.to_sql).not_to include(condition_string)
+        end
+
+        it "does not filter by cohort if blank" do
+          condition_string = %("start_year")
+          query = described_class.new(cohort_start_years: " ")
+
+          expect(query.scope.to_sql).not_to include(condition_string)
         end
       end
 
@@ -95,7 +116,7 @@ RSpec.describe Declarations::Query do
         it "filters by participant_id" do
           create(:declaration, application: create(:application, user: create(:user)))
           declaration = create(:declaration, application: create(:application, user: create(:user)))
-          query = Declarations::Query.new(participant_ids: declaration.user.ecf_id)
+          query = described_class.new(participant_ids: declaration.user.ecf_id)
 
           expect(query.declarations).to contain_exactly(declaration)
         end
@@ -104,22 +125,29 @@ RSpec.describe Declarations::Query do
           declaration2 = create(:declaration, application: create(:application, user: create(:user)))
           declaration1 = create(:declaration, application: create(:application, user: create(:user)))
           create(:declaration, application: create(:application, user: create(:user)))
-          query = Declarations::Query.new(participant_ids: [declaration1.user.ecf_id, declaration2.user.ecf_id].join(","))
+          query = described_class.new(participant_ids: [declaration1.user.ecf_id, declaration2.user.ecf_id].join(","))
 
           expect(query.declarations).to contain_exactly(declaration1, declaration2)
         end
 
         it "returns no declarations if no participants are found" do
-          query = Declarations::Query.new(participant_ids: SecureRandom.uuid)
+          query = described_class.new(participant_ids: SecureRandom.uuid)
 
           expect(query.declarations).to be_empty
         end
 
         it "doesn't filter by participant_ids when none supplied" do
-          condition_string = %("user"."ecf_id" =)
+          condition_string = %("ecf_id")
 
-          expect(Declarations::Query.new(participant_ids: SecureRandom.uuid).scope.to_sql).to include(condition_string)
-          expect(Declarations::Query.new.scope.to_sql).not_to include(condition_string)
+          expect(described_class.new(participant_ids: SecureRandom.uuid).scope.to_sql).to include(condition_string)
+          expect(described_class.new.scope.to_sql).not_to include(condition_string)
+        end
+
+        it "does not filter by participant_id if blank" do
+          condition_string = %("ecf_id")
+          query = described_class.new(participant_ids: " ")
+
+          expect(query.scope.to_sql).not_to include(condition_string)
         end
       end
     end
@@ -128,7 +156,7 @@ RSpec.describe Declarations::Query do
   describe "#declaration" do
     let(:lead_provider) { create(:lead_provider, name: "Lead Provider") }
     let(:declaration) { create(:declaration, lead_provider:) }
-    let(:query) { Declarations::Query.new(lead_provider:) }
+    let(:query) { described_class.new(lead_provider:) }
 
     it "returns a declaration by the given id" do
       expect(query.declaration(ecf_id: declaration.ecf_id)).to eq(declaration)

--- a/spec/services/participant_outcomes/query_spec.rb
+++ b/spec/services/participant_outcomes/query_spec.rb
@@ -30,10 +30,17 @@ RSpec.describe ParticipantOutcomes::Query do
         end
 
         it "doesn't filter by lead provider when none supplied" do
-          condition_string = %("lead_provider_id" =)
+          condition_string = %("lead_provider_id")
 
           expect(described_class.new(lead_provider: create(:lead_provider)).scope.to_sql).to include(condition_string)
           expect(described_class.new.scope.to_sql).not_to include(condition_string)
+        end
+
+        it "does not filter by lead provider if an empty string is supplied" do
+          condition_string = %("lead_provider_id")
+          query = described_class.new(lead_provider: " ")
+
+          expect(query.scope.to_sql).not_to include(condition_string)
         end
       end
 
@@ -48,10 +55,17 @@ RSpec.describe ParticipantOutcomes::Query do
         end
 
         it "doesn't filter by created since when none supplied" do
-          condition_string = %("participant_outcomes"."created_at" >=)
+          condition_string = %("created_at")
 
           expect(described_class.new(created_since: 2.days.ago).scope.to_sql).to include(condition_string)
           expect(described_class.new.scope.to_sql).not_to include(condition_string)
+        end
+
+        it "does not filter by created since if an empty string is supplied" do
+          condition_string = %("created_at")
+          query = described_class.new(created_since: " ")
+
+          expect(query.scope.to_sql).not_to include(condition_string)
         end
       end
 
@@ -59,7 +73,7 @@ RSpec.describe ParticipantOutcomes::Query do
         it "filters by participant_ids" do
           create(:participant_outcome, declaration: create(:declaration, user: create(:user)))
           outcome = create(:participant_outcome, declaration: create(:declaration, user: create(:user)))
-          query = ParticipantOutcomes::Query.new(participant_ids: outcome.user.ecf_id)
+          query = described_class.new(participant_ids: outcome.user.ecf_id)
 
           expect(query.participant_outcomes).to contain_exactly(outcome)
         end
@@ -68,22 +82,29 @@ RSpec.describe ParticipantOutcomes::Query do
           outcome2 = create(:participant_outcome, declaration: create(:declaration, user: create(:user)))
           outcome1 = create(:participant_outcome, declaration: create(:declaration, user: create(:user)))
           create(:participant_outcome, declaration: create(:declaration, user: create(:user)))
-          query = ParticipantOutcomes::Query.new(participant_ids: [outcome1.user.ecf_id, outcome2.user.ecf_id].join(","))
+          query = described_class.new(participant_ids: [outcome1.user.ecf_id, outcome2.user.ecf_id].join(","))
 
           expect(query.participant_outcomes).to contain_exactly(outcome1, outcome2)
         end
 
         it "returns no outcomes if no participants are found" do
-          query = ParticipantOutcomes::Query.new(participant_ids: SecureRandom.uuid)
+          query = described_class.new(participant_ids: SecureRandom.uuid)
 
           expect(query.participant_outcomes).to be_empty
         end
 
         it "doesn't filter by participant_ids when none supplied" do
-          condition_string = %("user"."ecf_id" =)
+          condition_string = %("ecf_id")
 
-          expect(ParticipantOutcomes::Query.new(participant_ids: SecureRandom.uuid).scope.to_sql).to include(condition_string)
-          expect(ParticipantOutcomes::Query.new.scope.to_sql).not_to include(condition_string)
+          expect(described_class.new(participant_ids: SecureRandom.uuid).scope.to_sql).to include(condition_string)
+          expect(described_class.new.scope.to_sql).not_to include(condition_string)
+        end
+
+        it "does not filter by participant_ids if an empty string is supplied" do
+          condition_string = %("ecf_id")
+          query = described_class.new(participant_ids: " ")
+
+          expect(query.scope.to_sql).not_to include(condition_string)
         end
       end
     end

--- a/spec/services/participants/query_spec.rb
+++ b/spec/services/participants/query_spec.rb
@@ -47,9 +47,19 @@ RSpec.describe Participants::Query do
           end
         end
 
+        context "when lead provider is blank" do
+          let(:params) { { lead_provider: " " } }
+
+          it "does not filter by lead provider" do
+            condition_string = %("lead_provider_id")
+
+            expect(query.scope.to_sql).not_to include(condition_string)
+          end
+        end
+
         context "when a lead provider is not supplied" do
           it "does not filter by lead provider" do
-            condition_string = %("applications"."lead_provider_id" =)
+            condition_string = %("lead_provider_id")
 
             expect(query.scope.to_sql).not_to include(condition_string)
           end
@@ -67,9 +77,19 @@ RSpec.describe Participants::Query do
           end
         end
 
+        context "when updated since is blank" do
+          let(:params) { { updated_since: " " } }
+
+          it "does not filter by updated since" do
+            condition_string = %("updated_at")
+
+            expect(query.scope.to_sql).not_to include(condition_string)
+          end
+        end
+
         context "when a updated since is not supplied" do
           it "does not filter by updated since" do
-            condition_string = %("applications"."updated_at" >=)
+            condition_string = %("updated_at")
 
             expect(query.scope.to_sql).not_to include(condition_string)
           end
@@ -89,7 +109,17 @@ RSpec.describe Participants::Query do
 
         context "when a training status is not supplied" do
           it "does not filter by training status" do
-            condition_string = %("applications"."training_status" =)
+            condition_string = %("training_status")
+
+            expect(query.scope.to_sql).not_to include(condition_string)
+          end
+        end
+
+        context "when training status is blank" do
+          let(:params) { { training_status: " " } }
+
+          it "does not filter by from training status" do
+            condition_string = %("training_status")
 
             expect(query.scope.to_sql).not_to include(condition_string)
           end
@@ -99,7 +129,7 @@ RSpec.describe Participants::Query do
           let(:params) { { training_status: "any" } }
 
           it "does not filter by training status" do
-            condition_string = %("applications"."training_status" =)
+            condition_string = %("training_status")
 
             expect(query.scope.to_sql).not_to include(condition_string)
           end
@@ -120,7 +150,17 @@ RSpec.describe Participants::Query do
 
         context "when a from participant id is not supplied" do
           it "does not filter by from participant id" do
-            condition_string = %("participant_id_changes"."from_participant_id" =)
+            condition_string = %("from_participant_id")
+
+            expect(query.scope.to_sql).not_to include(condition_string)
+          end
+        end
+
+        context "when a from participant id is blank" do
+          let(:params) { { from_participant_id: " " } }
+
+          it "does not filter by from participant id" do
+            condition_string = %("from_participant_id")
 
             expect(query.scope.to_sql).not_to include(condition_string)
           end

--- a/spec/services/statements/query_spec.rb
+++ b/spec/services/statements/query_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Statements::Query do
 
     it "returns all statements" do
       statement = create(:statement)
-      query = Statements::Query.new
+      query = described_class.new
 
       expect(query.statements).to eq([statement])
     end
@@ -16,7 +16,7 @@ RSpec.describe Statements::Query do
       statement2 = create(:statement, payment_date: 1.day.ago)
       statement3 = create(:statement, payment_date: Time.zone.now)
 
-      query = Statements::Query.new
+      query = described_class.new
 
       expect(query.statements).to eq([statement1, statement2, statement3])
     end
@@ -26,7 +26,7 @@ RSpec.describe Statements::Query do
         it "filters by lead provider" do
           statement = create(:statement, lead_provider:)
           _statement = create(:statement)
-          query = Statements::Query.new(lead_provider:)
+          query = described_class.new(lead_provider:)
 
           expect(query.statements).to eq([statement])
         end
@@ -34,9 +34,23 @@ RSpec.describe Statements::Query do
         it "does not return statements for other Lead Providers" do
           create(:statement, lead_provider: LeadProvider.where.not(id: lead_provider.id).first)
 
-          query = Statements::Query.new(lead_provider:)
+          query = described_class.new(lead_provider:)
 
           expect(query.statements).to eq([])
+        end
+
+        it "does not filter by lead provider if none is supplied" do
+          condition_string = %("lead_provider_id")
+          query = described_class.new
+
+          expect(query.scope.to_sql).not_to include(condition_string)
+        end
+
+        it "does not filter by lead provider if an empty string is supplied" do
+          condition_string = %("lead_provider_id")
+          query = described_class.new(lead_provider: " ")
+
+          expect(query.scope.to_sql).not_to include(condition_string)
         end
       end
 
@@ -51,21 +65,21 @@ RSpec.describe Statements::Query do
             statement2 = FactoryBot.create(:statement, cohort: cohort_2024)
             statement3 = FactoryBot.create(:statement, cohort: cohort_2025)
 
-            expect(Statements::Query.new.statements).to match_array([statement1, statement2, statement3])
+            expect(described_class.new.statements).to match_array([statement1, statement2, statement3])
           end
 
           it "doesn't reference the cohort's start_year in the query" do
             column_name = %("cohort"."start_year")
 
-            expect(Statements::Query.new.scope.to_sql).not_to include(column_name)
-            expect(Statements::Query.new(cohort_start_years: "2021").scope.to_sql).to include(column_name)
+            expect(described_class.new.scope.to_sql).not_to include(column_name)
+            expect(described_class.new(cohort_start_years: "2021").scope.to_sql).to include(column_name)
           end
         end
 
         it "filters by cohort" do
           _statement = create(:statement, cohort: cohort_2023)
           statement = create(:statement, cohort: cohort_2024)
-          query = Statements::Query.new(cohort_start_years: "2024")
+          query = described_class.new(cohort_start_years: "2024")
 
           expect(query.statements).to eq([statement])
         end
@@ -75,17 +89,24 @@ RSpec.describe Statements::Query do
           statement2 = create(:statement, cohort: cohort_2024)
           statement3 = create(:statement, cohort: cohort_2025)
 
-          query1 = Statements::Query.new(cohort_start_years: "2023,2024")
+          query1 = described_class.new(cohort_start_years: "2023,2024")
           expect(query1.statements).to match_array([statement1, statement2])
 
-          query2 = Statements::Query.new(cohort_start_years: %w[2024 2025])
+          query2 = described_class.new(cohort_start_years: %w[2024 2025])
           expect(query2.statements).to match_array([statement2, statement3])
         end
 
         it "returns no statements if no cohorts are found" do
-          query = Statements::Query.new(cohort_start_years: "0000")
+          query = described_class.new(cohort_start_years: "0000")
 
           expect(query.statements).to be_empty
+        end
+
+        it "does not filter by cohort if blank" do
+          condition_string = %("start_year")
+          query = described_class.new(cohort_start_years: " ")
+
+          expect(query.scope.to_sql).not_to include(condition_string)
         end
       end
 
@@ -96,7 +117,7 @@ RSpec.describe Statements::Query do
           create(:statement, lead_provider:, updated_at: 2.days.ago)
           statement2 = create(:statement, lead_provider:, updated_at: Time.zone.now)
 
-          query = Statements::Query.new(lead_provider:, updated_since:)
+          query = described_class.new(lead_provider:, updated_since:)
 
           expect(query.statements).to eq([statement2])
         end
@@ -106,15 +127,22 @@ RSpec.describe Statements::Query do
             statement1 = FactoryBot.create(:statement, updated_at: 1.week.ago)
             statement2 = FactoryBot.create(:statement, updated_at: 2.weeks.ago)
 
-            expect(Statements::Query.new.statements).to match_array([statement1, statement2])
+            expect(described_class.new.statements).to match_array([statement1, statement2])
           end
 
           it "doesn't reference updated_at in the query" do
             column_name = %("updated_at")
 
-            expect(Statements::Query.new.scope.to_sql).not_to include(column_name)
-            expect(Statements::Query.new(updated_since: 1.day.ago).scope.to_sql).to include(column_name)
+            expect(described_class.new.scope.to_sql).not_to include(column_name)
+            expect(described_class.new(updated_since: 1.day.ago).scope.to_sql).to include(column_name)
           end
+        end
+
+        it "does not filter by updated_since if blank" do
+          condition_string = %("updated_at")
+          query = described_class.new(updated_since: " ")
+
+          expect(query.scope.to_sql).not_to include(condition_string)
         end
       end
 
@@ -124,34 +152,41 @@ RSpec.describe Statements::Query do
         let!(:paid_statement) { create(:statement, :paid) }
 
         it "filters by state" do
-          expect(Statements::Query.new(state: "open").statements).to eq([open_statement])
-          expect(Statements::Query.new(state: "payable").statements).to eq([payable_statement])
-          expect(Statements::Query.new(state: "paid").statements).to eq([paid_statement])
+          expect(described_class.new(state: "open").statements).to eq([open_statement])
+          expect(described_class.new(state: "payable").statements).to eq([payable_statement])
+          expect(described_class.new(state: "paid").statements).to eq([paid_statement])
         end
 
         it "filters by multiple states with a comma separated list" do
-          expect(Statements::Query.new(state: "open,paid").statements).to match_array([open_statement, paid_statement])
+          expect(described_class.new(state: "open,paid").statements).to match_array([open_statement, paid_statement])
         end
 
         it "filters by multiple states with an array" do
-          expect(Statements::Query.new(state: %w[open paid]).statements).to match_array([open_statement, paid_statement])
+          expect(described_class.new(state: %w[open paid]).statements).to match_array([open_statement, paid_statement])
         end
 
         xit "raises when invalid states queried" do
-          expect { Statements::Query.new(state: "error").statements }.to raise_error(ArgumentError)
+          expect { described_class.new(state: "error").statements }.to raise_error(ArgumentError)
         end
 
         context "when state param omitted" do
           it "returns all statements" do
-            expect(Statements::Query.new.statements).to match_array([open_statement, payable_statement, paid_statement])
+            expect(described_class.new.statements).to match_array([open_statement, payable_statement, paid_statement])
           end
 
           it "doesn't reference the state in the query" do
             column_name = %("state")
 
-            expect(Statements::Query.new.scope.to_sql).not_to include(column_name)
-            expect(Statements::Query.new(state: "open").scope.to_sql).to include(column_name)
+            expect(described_class.new.scope.to_sql).not_to include(column_name)
+            expect(described_class.new(state: "open").scope.to_sql).to include(column_name)
           end
+        end
+
+        it "does not filter by state if blank" do
+          condition_string = %("state")
+          query = described_class.new(state: " ")
+
+          expect(query.scope.to_sql).not_to include(condition_string)
         end
       end
 
@@ -159,7 +194,7 @@ RSpec.describe Statements::Query do
         it "return only statements with an output fee by default" do
           create(:statement, output_fee: false)
 
-          query = Statements::Query.new
+          query = described_class.new
 
           expect(query.statements).to be_empty
         end
@@ -168,7 +203,7 @@ RSpec.describe Statements::Query do
           it "return only statements with an output fee by default" do
             output_fee = create(:statement, output_fee: false)
 
-            query = Statements::Query.new(output_fee: false)
+            query = described_class.new(output_fee: false)
 
             expect(query.statements).to include(output_fee)
           end
@@ -179,15 +214,22 @@ RSpec.describe Statements::Query do
             statement1 = FactoryBot.create(:statement, output_fee: true)
             statement2 = FactoryBot.create(:statement, output_fee: false)
 
-            expect(Statements::Query.new(output_fee: :ignore).statements).to match_array([statement1, statement2])
+            expect(described_class.new(output_fee: :ignore).statements).to match_array([statement1, statement2])
           end
 
           it "doesn't reference the output_fee in the query" do
             column_name = %("output_fee")
 
-            expect(Statements::Query.new.scope.to_sql).to include(column_name)
-            expect(Statements::Query.new(output_fee: :ignore).scope.to_sql).not_to include(column_name)
+            expect(described_class.new.scope.to_sql).to include(column_name)
+            expect(described_class.new(output_fee: :ignore).scope.to_sql).not_to include(column_name)
           end
+        end
+
+        it "does not filter by output_fee if blank" do
+          condition_string = %("output_fee")
+          query = described_class.new(output_fee: " ")
+
+          expect(query.scope.to_sql).not_to include(condition_string)
         end
       end
     end
@@ -198,14 +240,14 @@ RSpec.describe Statements::Query do
 
     it "returns the statement for a Lead Provider" do
       statement = create(:statement, lead_provider:)
-      query = Statements::Query.new
+      query = described_class.new
 
       expect(query.statement(ecf_id: statement.ecf_id)).to eq(statement)
       expect(query.statement(id: statement.id)).to eq(statement)
     end
 
     it "raises an error if the statement does not exist" do
-      query = Statements::Query.new
+      query = described_class.new
 
       expect { query.statement(ecf_id: "XXX123") }.to raise_error(ActiveRecord::RecordNotFound)
       expect { query.statement(id: "XXX123") }.to raise_error(ActiveRecord::RecordNotFound)
@@ -215,14 +257,14 @@ RSpec.describe Statements::Query do
       other_lead_provider = create(:lead_provider)
       other_statement = create(:statement, lead_provider: other_lead_provider)
 
-      query = Statements::Query.new(lead_provider:)
+      query = described_class.new(lead_provider:)
 
       expect { query.statement(ecf_id: other_statement.ecf_id) }.to raise_error(ActiveRecord::RecordNotFound)
       expect { query.statement(id: other_statement.id) }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it "raises an error if neither an ecf_id or id is supplied" do
-      expect { Statements::Query.new.statement }.to raise_error(ArgumentError, "id or ecf_id needed")
+      expect { described_class.new.statement }.to raise_error(ArgumentError, "id or ecf_id needed")
     end
   end
 end


### PR DESCRIPTION
[Jira-3341](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3341)

### Context

Currently, if we add a blank filter to a query, for example `?filter[cohort_start_years]=` it will return no results. Instead, we want to treat the filter as if it wasn't specified, which is how ECF functions.

### Changes proposed in this pull request

- Treat blank filters as if they are not specified

Add `FilterIgnorable` concern to centralise the logic around filtering. Treat empty values as ignored as well as the `:ignore` symbol. Retain `nil` as a valid/filterable value.
