### PR TITLE
Fix error inconsistencies with ECF

### DIFF
--- a/app/controllers/api/v1/participants/outcomes_controller.rb
+++ b/app/controllers/api/v1/participants/outcomes_controller.rb
@@ -30,7 +30,7 @@ module API
             .permit(:course_identifier, :state, :completion_date)
             .merge(
               lead_provider: current_lead_provider,
-              participant:,
+              participant_id: participant.id,
             )
         rescue ActionController::ParameterMissing
           raise ActionController::BadRequest, I18n.t(:invalid_data_structure)

--- a/app/controllers/api/v1/participants/outcomes_controller.rb
+++ b/app/controllers/api/v1/participants/outcomes_controller.rb
@@ -30,7 +30,7 @@ module API
             .permit(:course_identifier, :state, :completion_date)
             .merge(
               lead_provider: current_lead_provider,
-              participant_id: participant.id,
+              participant_id: participant.ecf_id,
             )
         rescue ActionController::ParameterMissing
           raise ActionController::BadRequest, I18n.t(:invalid_data_structure)

--- a/app/controllers/api/v1/participants_controller.rb
+++ b/app/controllers/api/v1/participants_controller.rb
@@ -74,7 +74,7 @@ module API
           .require(:attributes)
           .permit(:course_identifier, :reason, :schedule_identifier, :cohort)
           .merge(
-            participant:,
+            participant_id: participant.id,
             lead_provider: current_lead_provider,
           )
       rescue ActionController::ParameterMissing

--- a/app/controllers/api/v1/participants_controller.rb
+++ b/app/controllers/api/v1/participants_controller.rb
@@ -74,7 +74,7 @@ module API
           .require(:attributes)
           .permit(:course_identifier, :reason, :schedule_identifier, :cohort)
           .merge(
-            participant_id: participant.id,
+            participant_id: participant.ecf_id,
             lead_provider: current_lead_provider,
           )
       rescue ActionController::ParameterMissing

--- a/app/controllers/api/v2/participants/outcomes_controller.rb
+++ b/app/controllers/api/v2/participants/outcomes_controller.rb
@@ -30,7 +30,7 @@ module API
             .permit(:course_identifier, :state, :completion_date)
             .merge(
               lead_provider: current_lead_provider,
-              participant:,
+              participant_id: participant.id,
             )
         rescue ActionController::ParameterMissing
           raise ActionController::BadRequest, I18n.t(:invalid_data_structure)

--- a/app/controllers/api/v2/participants/outcomes_controller.rb
+++ b/app/controllers/api/v2/participants/outcomes_controller.rb
@@ -30,7 +30,7 @@ module API
             .permit(:course_identifier, :state, :completion_date)
             .merge(
               lead_provider: current_lead_provider,
-              participant_id: participant.id,
+              participant_id: participant.ecf_id,
             )
         rescue ActionController::ParameterMissing
           raise ActionController::BadRequest, I18n.t(:invalid_data_structure)

--- a/app/controllers/api/v2/participants_controller.rb
+++ b/app/controllers/api/v2/participants_controller.rb
@@ -74,7 +74,7 @@ module API
           .require(:attributes)
           .permit(:course_identifier, :reason, :schedule_identifier, :cohort)
           .merge(
-            participant:,
+            participant_id: participant.id,
             lead_provider: current_lead_provider,
           )
       rescue ActionController::ParameterMissing

--- a/app/controllers/api/v2/participants_controller.rb
+++ b/app/controllers/api/v2/participants_controller.rb
@@ -74,7 +74,7 @@ module API
           .require(:attributes)
           .permit(:course_identifier, :reason, :schedule_identifier, :cohort)
           .merge(
-            participant_id: participant.id,
+            participant_id: participant.ecf_id,
             lead_provider: current_lead_provider,
           )
       rescue ActionController::ParameterMissing

--- a/app/controllers/api/v3/participants/outcomes_controller.rb
+++ b/app/controllers/api/v3/participants/outcomes_controller.rb
@@ -30,7 +30,7 @@ module API
             .permit(:course_identifier, :state, :completion_date)
             .merge(
               lead_provider: current_lead_provider,
-              participant:,
+              participant_id: participant.id,
             )
         rescue ActionController::ParameterMissing
           raise ActionController::BadRequest, I18n.t(:invalid_data_structure)

--- a/app/controllers/api/v3/participants/outcomes_controller.rb
+++ b/app/controllers/api/v3/participants/outcomes_controller.rb
@@ -30,7 +30,7 @@ module API
             .permit(:course_identifier, :state, :completion_date)
             .merge(
               lead_provider: current_lead_provider,
-              participant_id: participant.id,
+              participant_id: participant.ecf_id,
             )
         rescue ActionController::ParameterMissing
           raise ActionController::BadRequest, I18n.t(:invalid_data_structure)

--- a/app/controllers/api/v3/participants_controller.rb
+++ b/app/controllers/api/v3/participants_controller.rb
@@ -82,7 +82,7 @@ module API
           .require(:attributes)
           .permit(:course_identifier, :reason, :schedule_identifier, :cohort)
           .merge(
-            participant_id: participant.id,
+            participant_id: participant.ecf_id,
             lead_provider: current_lead_provider,
           )
       rescue ActionController::ParameterMissing

--- a/app/controllers/api/v3/participants_controller.rb
+++ b/app/controllers/api/v3/participants_controller.rb
@@ -82,7 +82,7 @@ module API
           .require(:attributes)
           .permit(:course_identifier, :reason, :schedule_identifier, :cohort)
           .merge(
-            participant:,
+            participant_id: participant.id,
             lead_provider: current_lead_provider,
           )
       rescue ActionController::ParameterMissing

--- a/app/services/declarations/create.rb
+++ b/app/services/declarations/create.rb
@@ -174,7 +174,7 @@ module Declarations
 
       service = ParticipantOutcomes::Create.new(
         lead_provider:,
-        participant_id: participant.id,
+        participant_id: participant.ecf_id,
         course_identifier:,
         state: has_passed.to_s == "true" ? "passed" : "failed",
         completion_date: declaration_date.rfc3339,

--- a/app/services/declarations/create.rb
+++ b/app/services/declarations/create.rb
@@ -174,7 +174,7 @@ module Declarations
 
       service = ParticipantOutcomes::Create.new(
         lead_provider:,
-        participant:,
+        participant_id: participant.id,
         course_identifier:,
         state: has_passed.to_s == "true" ? "passed" : "failed",
         completion_date: declaration_date.rfc3339,

--- a/app/services/participant_outcomes/create.rb
+++ b/app/services/participant_outcomes/create.rb
@@ -43,7 +43,7 @@ module ParticipantOutcomes
     end
 
     def participant
-      @participant ||= Participants::Query.new(lead_provider:).participant(id: participant_id)
+      @participant ||= Participants::Query.new(lead_provider:).participant(ecf_id: participant_id)
     rescue ActiveRecord::RecordNotFound, ArgumentError
       nil
     end

--- a/app/services/participant_outcomes/create.rb
+++ b/app/services/participant_outcomes/create.rb
@@ -13,19 +13,20 @@ module ParticipantOutcomes
     attr_reader :created_outcome
 
     attribute :lead_provider
-    attribute :participant
+    attribute :participant_id
     attribute :course_identifier
     attribute :state
     attribute :completion_date
 
     validates :lead_provider, presence: true
-    validates :participant, presence: true
+    validates :participant_id, presence: true
     validates :course_identifier, inclusion: { in: PERMITTED_COURSES }, presence: true
     validates :state, inclusion: { in: STATES }, presence: true
     validates :completion_date, presence: true, format: { with: COMPLETION_DATE_FORMAT }
     validate :participant_has_no_completed_declarations
     validate :completion_date_is_a_valid_date
     validate :completion_date_not_in_the_future
+    validate :participant_exists
 
     def create_outcome
       return false unless valid?
@@ -39,6 +40,12 @@ module ParticipantOutcomes
       end
 
       true
+    end
+
+    def participant
+      @participant ||= Participants::Query.new(lead_provider:).participant(id: participant_id)
+    rescue ActiveRecord::RecordNotFound, ArgumentError
+      nil
     end
 
   private
@@ -75,6 +82,10 @@ module ParticipantOutcomes
       return if errors.key?(:completion_date)
 
       errors.add(:completion_date, :future_date) if completion_date&.to_date&.future?
+    end
+
+    def participant_exists
+      errors.add(:participant_id, :invalid_participant) if participant.blank?
     end
 
     def completion_date_is_a_valid_date

--- a/app/services/participants/action.rb
+++ b/app/services/participants/action.rb
@@ -6,13 +6,20 @@ module Participants
     include ActiveModel::Attributes
 
     attribute :lead_provider
-    attribute :participant
+    attribute :participant_id
     attribute :course_identifier
 
     validates :lead_provider, presence: true
-    validates :participant, presence: true
+    validates :participant_id, presence: true
     validates :course_identifier, inclusion: { in: Course::IDENTIFIERS }, allow_blank: false
     validate :application_exists
+    validate :participant_exists
+
+    def participant
+      @participant ||= Query.new(lead_provider:).participant(id: participant_id)
+    rescue ActiveRecord::RecordNotFound, ArgumentError
+      nil
+    end
 
   private
 
@@ -29,7 +36,11 @@ module Participants
     end
 
     def application_exists
-      errors.add(:participant, :blank) if application.blank?
+      errors.add(:participant_id, :invalid_participant) if application.blank?
+    end
+
+    def participant_exists
+      errors.add(:participant_id, :invalid_participant) if participant.blank?
     end
   end
 end

--- a/app/services/participants/action.rb
+++ b/app/services/participants/action.rb
@@ -16,7 +16,7 @@ module Participants
     validate :participant_exists
 
     def participant
-      @participant ||= Query.new(lead_provider:).participant(id: participant_id)
+      @participant ||= Query.new(lead_provider:).participant(ecf_id: participant_id)
     rescue ActiveRecord::RecordNotFound, ArgumentError
       nil
     end

--- a/app/services/participants/change_schedule.rb
+++ b/app/services/participants/change_schedule.rb
@@ -67,7 +67,7 @@ module Participants
 
     def validate_not_withdrawn
       if application&.withdrawn?
-        errors.add(:participant, :already_withdrawn)
+        errors.add(:participant_id, :already_withdrawn)
       end
     end
 

--- a/app/services/participants/change_schedule.rb
+++ b/app/services/participants/change_schedule.rb
@@ -62,7 +62,7 @@ module Participants
     def validate_new_schedule_found
       return if schedule_identifier.present? && new_schedule
 
-      errors.add(:schedule_identifier, :invalid_schedule)
+      errors.add(:schedule_identifier, :blank)
     end
 
     def validate_not_withdrawn

--- a/app/services/participants/defer.rb
+++ b/app/services/participants/defer.rb
@@ -32,15 +32,15 @@ module Participants
   private
 
     def not_withdrawn
-      errors.add(:participant, :already_withdrawn) if application&.withdrawn?
+      errors.add(:participant_id, :already_withdrawn) if application&.withdrawn?
     end
 
     def not_already_deferred
-      errors.add(:participant, :already_deferred) if application&.deferred?
+      errors.add(:participant_id, :already_deferred) if application&.deferred?
     end
 
     def has_declarations
-      errors.add(:participant, :no_declarations) if application&.declarations&.none?
+      errors.add(:participant_id, :no_declarations) if application&.declarations&.none?
     end
   end
 end

--- a/app/services/participants/resume.rb
+++ b/app/services/participants/resume.rb
@@ -19,7 +19,7 @@ module Participants
   private
 
     def not_already_active
-      errors.add(:participant, :already_active) if application&.active?
+      errors.add(:participant_id, :already_active) if application&.active?
     end
   end
 end

--- a/app/services/participants/withdraw.rb
+++ b/app/services/participants/withdraw.rb
@@ -43,11 +43,11 @@ module Participants
   private
 
     def not_withdrawn
-      errors.add(:participant, :already_withdrawn) if application&.withdrawn?
+      errors.add(:participant_id, :already_withdrawn) if application&.withdrawn?
     end
 
     def has_started_declarations
-      errors.add(:participant, :no_started_declarations) unless application&.declarations&.any?(&:started_declaration_type?)
+      errors.add(:participant_id, :no_started_declarations) unless application&.declarations&.any?(&:started_declaration_type?)
     end
   end
 end

--- a/app/services/valid_test_data_generators/applications_populater.rb
+++ b/app/services/valid_test_data_generators/applications_populater.rb
@@ -130,14 +130,14 @@ module ValidTestDataGenerators
 
     def defer_application(application)
       Participants::Defer.new(lead_provider:,
-                              participant_id: application.user.id,
+                              participant_id: application.user.ecf_id,
                               course_identifier: application.course.identifier,
                               reason: Participants::Defer::DEFERRAL_REASONS.sample).defer
     end
 
     def withdrawn_application(application)
       Participants::Withdraw.new(lead_provider:,
-                                 participant_id: application.user.id,
+                                 participant_id: application.user.ecf_id,
                                  course_identifier: application.course.identifier,
                                  reason: Participants::Withdraw::WITHDRAWAL_REASONS.sample).withdraw
     end

--- a/app/services/valid_test_data_generators/applications_populater.rb
+++ b/app/services/valid_test_data_generators/applications_populater.rb
@@ -130,14 +130,14 @@ module ValidTestDataGenerators
 
     def defer_application(application)
       Participants::Defer.new(lead_provider:,
-                              participant: application.user,
+                              participant_id: application.user.id,
                               course_identifier: application.course.identifier,
                               reason: Participants::Defer::DEFERRAL_REASONS.sample).defer
     end
 
     def withdrawn_application(application)
       Participants::Withdraw.new(lead_provider:,
-                                 participant: application.user,
+                                 participant_id: application.user.id,
                                  course_identifier: application.course.identifier,
                                  reason: Participants::Withdraw::WITHDRAWAL_REASONS.sample).withdraw
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,11 @@ en:
 
   participant_id: &participant_id
     blank: "The property '#/participant_id' must be present"
+    already_active: The participant is already active
+    already_deferred: The participant is already deferred
+    already_withdrawn: The participant is already withdrawn
+    no_declarations: You cannot defer an NPQ participant that has no declarations
+    no_started_declarations: An NPQ participant who has not got a started declaration cannot be withdrawn. Please contact support for assistance
     declaration_must_be_before_withdrawal_date: "This participant withdrew from this course on %{withdrawal_date}. Enter a '#/declaration_date' that's on or before the withdrawal date."
     invalid_participant: "Your update cannot be made as the '#/participant_id' is not recognised. Check participant details and try again."
 
@@ -70,14 +75,6 @@ en:
 
   lead_provider: &lead_provider
     blank: Your update cannot be made as the '#/%{parameterized_attribute}' is not recognised. Check lead provider details and try again.
-
-  participant: &participant
-    blank: Your update cannot be made as the '#/%{parameterized_attribute}' is not recognised. Check participant details and try again.
-    already_active: The participant is already active
-    already_deferred: The participant is already deferred
-    already_withdrawn: The participant is already withdrawn
-    no_declarations: You cannot defer an NPQ participant that has no declarations
-    no_started_declarations: An NPQ participant who has not got a started declaration cannot be withdrawn. Please contact support for assistance
 
   participant_course_identifier: &participant_course_identifier
     blank: Enter a '#/%{parameterized_attribute}' value for this participant.
@@ -283,16 +280,16 @@ en:
           attributes:
             course_identifier:
               <<: *participant_course_identifier
-            participant:
-              <<: *participant
+            participant_id:
+              <<: *participant_id
             lead_provider:
               <<: *lead_provider
         participants/defer:
           attributes:
             course_identifier:
               <<: *participant_course_identifier
-            participant:
-              <<: *participant
+            participant_id:
+              <<: *participant_id
             lead_provider:
               <<: *lead_provider
             reason:
@@ -301,8 +298,8 @@ en:
           attributes:
             course_identifier:
               <<: *participant_course_identifier
-            participant:
-              <<: *participant
+            participant_id:
+              <<: *participant_id
             lead_provider:
               <<: *lead_provider
             reason:
@@ -311,8 +308,8 @@ en:
           attributes:
             course_identifier:
               <<: *participant_course_identifier
-            participant:
-              <<: *participant
+            participant_id:
+              <<: *participant_id
             schedule_identifier:
               <<: *schedule_identifier
             cohort:
@@ -361,8 +358,8 @@ en:
               <<: *participant_course_identifier
             state:
               <<: *state
-            participant:
-              <<: *participant
+            participant_id:
+              <<: *participant_id
             lead_provider:
               <<: *lead_provider
         applications/accept:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -91,7 +91,6 @@ en:
   schedule_identifier: &schedule_identifier
     blank: "The property '#/%{parameterized_attribute}' must be present"
     invalidates_declaration: Changing schedule would invalidate existing declarations. Please void them first.
-    invalid_schedule: "The property '#/%{parameterized_attribute}' must be present and correspond to a valid schedule"
     already_on_the_profile: Selected schedule is already on the profile
     invalid_for_course: Selected schedule is not valid for the course
 

--- a/spec/requests/api/v1/participants/outcomes_spec.rb
+++ b/spec/requests/api/v1/participants/outcomes_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Participants outcome endpoints", type: :request do
     end
     let(:service) { ParticipantOutcomes::Create }
     let(:action) { :create_outcome }
-    let(:service_args) { { lead_provider: current_lead_provider, participant_id: user.id }.merge!(attributes) }
+    let(:service_args) { { lead_provider: current_lead_provider, participant_id: user.ecf_id }.merge!(attributes) }
     let(:service_methods) { { participant: user } }
     let(:resource) { build(:participant_outcome) }
     let(:resource_id) { resource.ecf_id }

--- a/spec/requests/api/v1/participants/outcomes_spec.rb
+++ b/spec/requests/api/v1/participants/outcomes_spec.rb
@@ -45,7 +45,8 @@ RSpec.describe "Participants outcome endpoints", type: :request do
     end
     let(:service) { ParticipantOutcomes::Create }
     let(:action) { :create_outcome }
-    let(:service_args) { { lead_provider: current_lead_provider, participant: user }.merge!(attributes) }
+    let(:service_args) { { lead_provider: current_lead_provider, participant_id: user.id }.merge!(attributes) }
+    let(:service_methods) { { participant: user } }
     let(:resource) { build(:participant_outcome) }
     let(:resource_id) { resource.ecf_id }
     let(:resource_name) { :created_outcome }

--- a/spec/requests/api/v1/participants_spec.rb
+++ b/spec/requests/api/v1/participants_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe "Participant endpoints", type: :request do
     let(:service) { Participants::Resume }
     let(:action) { :resume }
     let(:attributes) { { course_identifier: "course", lead_provider: current_lead_provider } }
-    let(:service_args) { { participant: resource }.merge!(attributes) }
+    let(:service_args) { { participant_id: resource.id }.merge!(attributes) }
+    let(:service_methods) { { participant: resource } }
 
     def path(id = nil)
       resume_api_v1_participant_path(ecf_id: id)
@@ -54,7 +55,8 @@ RSpec.describe "Participant endpoints", type: :request do
     let(:service) { Participants::Defer }
     let(:action) { :defer }
     let(:attributes) { { course_identifier: "course", reason: "reason", lead_provider: current_lead_provider } }
-    let(:service_args) { { participant: resource }.merge!(attributes) }
+    let(:service_args) { { participant_id: resource.id }.merge!(attributes) }
+    let(:service_methods) { { participant: resource } }
 
     def path(id = nil)
       defer_api_v1_participant_path(ecf_id: id)
@@ -70,7 +72,8 @@ RSpec.describe "Participant endpoints", type: :request do
     let(:service) { Participants::Withdraw }
     let(:action) { :withdraw }
     let(:attributes) { { course_identifier: "course", reason: "reason", lead_provider: current_lead_provider } }
-    let(:service_args) { { participant: resource }.merge!(attributes) }
+    let(:service_args) { { participant_id: resource.id }.merge!(attributes) }
+    let(:service_methods) { { participant: resource } }
 
     def path(id = nil)
       withdraw_api_v1_participant_path(ecf_id: id)
@@ -88,7 +91,8 @@ RSpec.describe "Participant endpoints", type: :request do
     let(:service) { Participants::ChangeSchedule }
     let(:action) { :change_schedule }
     let(:attributes) { { schedule_identifier:, course_identifier:, lead_provider: current_lead_provider } }
-    let(:service_args) { { participant: resource }.merge!(attributes) }
+    let(:service_args) { { participant_id: resource.id }.merge!(attributes) }
+    let(:service_methods) { { participant: resource } }
 
     def path(id = nil)
       change_schedule_api_v1_participant_path(id)

--- a/spec/requests/api/v1/participants_spec.rb
+++ b/spec/requests/api/v1/participants_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "Participant endpoints", type: :request do
     let(:service) { Participants::Resume }
     let(:action) { :resume }
     let(:attributes) { { course_identifier: "course", lead_provider: current_lead_provider } }
-    let(:service_args) { { participant_id: resource.id }.merge!(attributes) }
+    let(:service_args) { { participant_id: resource_id }.merge!(attributes) }
     let(:service_methods) { { participant: resource } }
 
     def path(id = nil)
@@ -55,7 +55,7 @@ RSpec.describe "Participant endpoints", type: :request do
     let(:service) { Participants::Defer }
     let(:action) { :defer }
     let(:attributes) { { course_identifier: "course", reason: "reason", lead_provider: current_lead_provider } }
-    let(:service_args) { { participant_id: resource.id }.merge!(attributes) }
+    let(:service_args) { { participant_id: resource_id }.merge!(attributes) }
     let(:service_methods) { { participant: resource } }
 
     def path(id = nil)
@@ -72,7 +72,7 @@ RSpec.describe "Participant endpoints", type: :request do
     let(:service) { Participants::Withdraw }
     let(:action) { :withdraw }
     let(:attributes) { { course_identifier: "course", reason: "reason", lead_provider: current_lead_provider } }
-    let(:service_args) { { participant_id: resource.id }.merge!(attributes) }
+    let(:service_args) { { participant_id: resource_id }.merge!(attributes) }
     let(:service_methods) { { participant: resource } }
 
     def path(id = nil)
@@ -91,7 +91,7 @@ RSpec.describe "Participant endpoints", type: :request do
     let(:service) { Participants::ChangeSchedule }
     let(:action) { :change_schedule }
     let(:attributes) { { schedule_identifier:, course_identifier:, lead_provider: current_lead_provider } }
-    let(:service_args) { { participant_id: resource.id }.merge!(attributes) }
+    let(:service_args) { { participant_id: resource_id }.merge!(attributes) }
     let(:service_methods) { { participant: resource } }
 
     def path(id = nil)

--- a/spec/requests/api/v2/participants/outcomes_spec.rb
+++ b/spec/requests/api/v2/participants/outcomes_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Participants outcome endpoints", type: :request do
     end
     let(:service) { ParticipantOutcomes::Create }
     let(:action) { :create_outcome }
-    let(:service_args) { { lead_provider: current_lead_provider, participant_id: user.id }.merge!(attributes) }
+    let(:service_args) { { lead_provider: current_lead_provider, participant_id: user.ecf_id }.merge!(attributes) }
     let(:service_methods) { { participant: user } }
     let(:resource) { build(:participant_outcome) }
     let(:resource_id) { resource.ecf_id }

--- a/spec/requests/api/v2/participants/outcomes_spec.rb
+++ b/spec/requests/api/v2/participants/outcomes_spec.rb
@@ -45,7 +45,8 @@ RSpec.describe "Participants outcome endpoints", type: :request do
     end
     let(:service) { ParticipantOutcomes::Create }
     let(:action) { :create_outcome }
-    let(:service_args) { { lead_provider: current_lead_provider, participant: user }.merge!(attributes) }
+    let(:service_args) { { lead_provider: current_lead_provider, participant_id: user.id }.merge!(attributes) }
+    let(:service_methods) { { participant: user } }
     let(:resource) { build(:participant_outcome) }
     let(:resource_id) { resource.ecf_id }
     let(:resource_name) { :created_outcome }

--- a/spec/requests/api/v2/participants_spec.rb
+++ b/spec/requests/api/v2/participants_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe "Participant endpoints", type: :request do
     let(:service) { Participants::Resume }
     let(:action) { :resume }
     let(:attributes) { { course_identifier: "course", lead_provider: current_lead_provider } }
-    let(:service_args) { { participant: resource }.merge!(attributes) }
+    let(:service_args) { { participant_id: resource.id }.merge!(attributes) }
+    let(:service_methods) { { participant: resource } }
 
     def path(id = nil)
       resume_api_v2_participant_path(ecf_id: id)
@@ -54,7 +55,8 @@ RSpec.describe "Participant endpoints", type: :request do
     let(:service) { Participants::Defer }
     let(:action) { :defer }
     let(:attributes) { { course_identifier: "course", reason: "reason", lead_provider: current_lead_provider } }
-    let(:service_args) { { participant: resource }.merge!(attributes) }
+    let(:service_args) { { participant_id: resource.id }.merge!(attributes) }
+    let(:service_methods) { { participant: resource } }
 
     def path(id = nil)
       defer_api_v2_participant_path(ecf_id: id)
@@ -70,7 +72,8 @@ RSpec.describe "Participant endpoints", type: :request do
     let(:service) { Participants::Withdraw }
     let(:action) { :withdraw }
     let(:attributes) { { course_identifier: "course", reason: "reason", lead_provider: current_lead_provider } }
-    let(:service_args) { { participant: resource }.merge!(attributes) }
+    let(:service_args) { { participant_id: resource.id }.merge!(attributes) }
+    let(:service_methods) { { participant: resource } }
 
     def path(id = nil)
       withdraw_api_v2_participant_path(ecf_id: id)
@@ -88,7 +91,8 @@ RSpec.describe "Participant endpoints", type: :request do
     let(:service) { Participants::ChangeSchedule }
     let(:action) { :change_schedule }
     let(:attributes) { { schedule_identifier:, course_identifier:, lead_provider: current_lead_provider } }
-    let(:service_args) { { participant: resource }.merge!(attributes) }
+    let(:service_args) { { participant_id: resource.id }.merge!(attributes) }
+    let(:service_methods) { { participant: resource } }
 
     def path(id = nil)
       change_schedule_api_v2_participant_path(id)

--- a/spec/requests/api/v2/participants_spec.rb
+++ b/spec/requests/api/v2/participants_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "Participant endpoints", type: :request do
     let(:service) { Participants::Resume }
     let(:action) { :resume }
     let(:attributes) { { course_identifier: "course", lead_provider: current_lead_provider } }
-    let(:service_args) { { participant_id: resource.id }.merge!(attributes) }
+    let(:service_args) { { participant_id: resource_id }.merge!(attributes) }
     let(:service_methods) { { participant: resource } }
 
     def path(id = nil)
@@ -55,7 +55,7 @@ RSpec.describe "Participant endpoints", type: :request do
     let(:service) { Participants::Defer }
     let(:action) { :defer }
     let(:attributes) { { course_identifier: "course", reason: "reason", lead_provider: current_lead_provider } }
-    let(:service_args) { { participant_id: resource.id }.merge!(attributes) }
+    let(:service_args) { { participant_id: resource_id }.merge!(attributes) }
     let(:service_methods) { { participant: resource } }
 
     def path(id = nil)
@@ -72,7 +72,7 @@ RSpec.describe "Participant endpoints", type: :request do
     let(:service) { Participants::Withdraw }
     let(:action) { :withdraw }
     let(:attributes) { { course_identifier: "course", reason: "reason", lead_provider: current_lead_provider } }
-    let(:service_args) { { participant_id: resource.id }.merge!(attributes) }
+    let(:service_args) { { participant_id: resource_id }.merge!(attributes) }
     let(:service_methods) { { participant: resource } }
 
     def path(id = nil)
@@ -91,7 +91,7 @@ RSpec.describe "Participant endpoints", type: :request do
     let(:service) { Participants::ChangeSchedule }
     let(:action) { :change_schedule }
     let(:attributes) { { schedule_identifier:, course_identifier:, lead_provider: current_lead_provider } }
-    let(:service_args) { { participant_id: resource.id }.merge!(attributes) }
+    let(:service_args) { { participant_id: resource_id }.merge!(attributes) }
     let(:service_methods) { { participant: resource } }
 
     def path(id = nil)

--- a/spec/requests/api/v3/participants/outcomes_spec.rb
+++ b/spec/requests/api/v3/participants/outcomes_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Participants outcome endpoints", type: :request do
     end
     let(:service) { ParticipantOutcomes::Create }
     let(:action) { :create_outcome }
-    let(:service_args) { { lead_provider: current_lead_provider, participant_id: user.id }.merge!(attributes) }
+    let(:service_args) { { lead_provider: current_lead_provider, participant_id: user.ecf_id }.merge!(attributes) }
     let(:service_methods) { { participant: user } }
     let(:resource) { build(:participant_outcome) }
     let(:resource_id) { resource.ecf_id }

--- a/spec/requests/api/v3/participants/outcomes_spec.rb
+++ b/spec/requests/api/v3/participants/outcomes_spec.rb
@@ -45,7 +45,8 @@ RSpec.describe "Participants outcome endpoints", type: :request do
     end
     let(:service) { ParticipantOutcomes::Create }
     let(:action) { :create_outcome }
-    let(:service_args) { { lead_provider: current_lead_provider, participant: user }.merge!(attributes) }
+    let(:service_args) { { lead_provider: current_lead_provider, participant_id: user.id }.merge!(attributes) }
+    let(:service_methods) { { participant: user } }
     let(:resource) { build(:participant_outcome) }
     let(:resource_id) { resource.ecf_id }
     let(:resource_name) { :created_outcome }

--- a/spec/requests/api/v3/participants_spec.rb
+++ b/spec/requests/api/v3/participants_spec.rb
@@ -40,7 +40,8 @@ RSpec.describe "Participant endpoints", type: :request do
     let(:service) { Participants::Resume }
     let(:action) { :resume }
     let(:attributes) { { course_identifier: "course", lead_provider: current_lead_provider } }
-    let(:service_args) { { participant: resource }.merge!(attributes) }
+    let(:service_args) { { participant_id: resource.id }.merge!(attributes) }
+    let(:service_methods) { { participant: resource } }
 
     def path(id = nil)
       resume_api_v3_participant_path(ecf_id: id)
@@ -56,7 +57,8 @@ RSpec.describe "Participant endpoints", type: :request do
     let(:service) { Participants::Defer }
     let(:action) { :defer }
     let(:attributes) { { course_identifier: "course", reason: "reason", lead_provider: current_lead_provider } }
-    let(:service_args) { { participant: resource }.merge!(attributes) }
+    let(:service_args) { { participant_id: resource.id }.merge!(attributes) }
+    let(:service_methods) { { participant: resource } }
 
     def path(id = nil)
       defer_api_v3_participant_path(ecf_id: id)
@@ -72,7 +74,8 @@ RSpec.describe "Participant endpoints", type: :request do
     let(:service) { Participants::Withdraw }
     let(:action) { :withdraw }
     let(:attributes) { { course_identifier: "course", reason: "reason", lead_provider: current_lead_provider } }
-    let(:service_args) { { participant: resource }.merge!(attributes) }
+    let(:service_args) { { participant_id: resource.id }.merge!(attributes) }
+    let(:service_methods) { { participant: resource } }
 
     def path(id = nil)
       withdraw_api_v3_participant_path(ecf_id: id)
@@ -90,7 +93,8 @@ RSpec.describe "Participant endpoints", type: :request do
     let(:service) { Participants::ChangeSchedule }
     let(:action) { :change_schedule }
     let(:attributes) { { schedule_identifier:, course_identifier:, lead_provider: current_lead_provider } }
-    let(:service_args) { { participant: resource }.merge!(attributes) }
+    let(:service_args) { { participant_id: resource.id }.merge!(attributes) }
+    let(:service_methods) { { participant: resource } }
 
     def path(id = nil)
       change_schedule_api_v3_participant_path(id)

--- a/spec/requests/api/v3/participants_spec.rb
+++ b/spec/requests/api/v3/participants_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Participant endpoints", type: :request do
     let(:service) { Participants::Resume }
     let(:action) { :resume }
     let(:attributes) { { course_identifier: "course", lead_provider: current_lead_provider } }
-    let(:service_args) { { participant_id: resource.id }.merge!(attributes) }
+    let(:service_args) { { participant_id: resource_id }.merge!(attributes) }
     let(:service_methods) { { participant: resource } }
 
     def path(id = nil)
@@ -57,7 +57,7 @@ RSpec.describe "Participant endpoints", type: :request do
     let(:service) { Participants::Defer }
     let(:action) { :defer }
     let(:attributes) { { course_identifier: "course", reason: "reason", lead_provider: current_lead_provider } }
-    let(:service_args) { { participant_id: resource.id }.merge!(attributes) }
+    let(:service_args) { { participant_id: resource_id }.merge!(attributes) }
     let(:service_methods) { { participant: resource } }
 
     def path(id = nil)
@@ -74,7 +74,7 @@ RSpec.describe "Participant endpoints", type: :request do
     let(:service) { Participants::Withdraw }
     let(:action) { :withdraw }
     let(:attributes) { { course_identifier: "course", reason: "reason", lead_provider: current_lead_provider } }
-    let(:service_args) { { participant_id: resource.id }.merge!(attributes) }
+    let(:service_args) { { participant_id: resource_id }.merge!(attributes) }
     let(:service_methods) { { participant: resource } }
 
     def path(id = nil)
@@ -93,7 +93,7 @@ RSpec.describe "Participant endpoints", type: :request do
     let(:service) { Participants::ChangeSchedule }
     let(:action) { :change_schedule }
     let(:attributes) { { schedule_identifier:, course_identifier:, lead_provider: current_lead_provider } }
-    let(:service_args) { { participant_id: resource.id }.merge!(attributes) }
+    let(:service_args) { { participant_id: resource_id }.merge!(attributes) }
     let(:service_methods) { { participant: resource } }
 
     def path(id = nil)

--- a/spec/services/participant_outcomes/create_spec.rb
+++ b/spec/services/participant_outcomes/create_spec.rb
@@ -2,19 +2,19 @@ require "rails_helper"
 
 RSpec.describe ParticipantOutcomes::Create, type: :model do
   let(:date_format) { "%Y-%m-%d" }
-  let(:participant) { completed_declaration.user }
+  let(:participant_id) { completed_declaration.user.id }
   let(:lead_provider) { completed_declaration.lead_provider }
   let(:completion_date) { 1.week.ago.strftime(date_format) }
   let(:course_identifier) { described_class::PERMITTED_COURSES.sample }
   let(:course) { Course.find_by(identifier: course_identifier) }
   let(:state) { described_class::STATES.sample }
   let(:completed_declaration) { create(:declaration, :completed, :payable, course:) }
-  let(:instance) { described_class.new(lead_provider:, participant:, completion_date:, state:, course_identifier:) }
+  let(:instance) { described_class.new(lead_provider:, participant_id:, completion_date:, state:, course_identifier:) }
 
   describe "validations" do
     it { expect(instance).to be_valid }
     it { is_expected.to validate_presence_of(:lead_provider).with_message("Your update cannot be made as the '#/lead_provider' is not recognised. Check lead provider details and try again.") }
-    it { is_expected.to validate_presence_of(:participant).with_message("Your update cannot be made as the '#/participant' is not recognised. Check participant details and try again.") }
+    it { is_expected.to validate_presence_of(:participant_id).with_message("Your update cannot be made as the '#/participant_id' is not recognised. Check participant details and try again.") }
     it { is_expected.to validate_presence_of(:completion_date).with_message("The '#/completion_date' is missing from your request. Please include a completion_date value and try again.") }
     it { is_expected.to validate_presence_of(:course_identifier).with_message("Enter a '#/course_identifier' value for this participant.") }
     it { is_expected.to validate_presence_of(:state).with_message("The '#/state' is missing from your request. Please include a 'passed' or 'failed' value and try again.") }

--- a/spec/services/participant_outcomes/create_spec.rb
+++ b/spec/services/participant_outcomes/create_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe ParticipantOutcomes::Create, type: :model do
   let(:date_format) { "%Y-%m-%d" }
-  let(:participant_id) { completed_declaration.user.id }
+  let(:participant_id) { completed_declaration.user.ecf_id }
   let(:lead_provider) { completed_declaration.lead_provider }
   let(:completion_date) { 1.week.ago.strftime(date_format) }
   let(:course_identifier) { described_class::PERMITTED_COURSES.sample }

--- a/spec/services/participants/change_schedule_spec.rb
+++ b/spec/services/participants/change_schedule_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Participants::ChangeSchedule, type: :model do
   let!(:application) { create(:application, :accepted, cohort:, lead_provider:, course:, schedule:) }
 
   let(:participant) { application.user }
-  let(:participant_id) { participant.id }
+  let(:participant_id) { participant.ecf_id }
 
   let(:new_cohort) { create(:cohort, :next) }
   let(:new_schedule) { create(:schedule, :npq_leadership_autumn, cohort: new_cohort) }

--- a/spec/services/participants/change_schedule_spec.rb
+++ b/spec/services/participants/change_schedule_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Participants::ChangeSchedule, type: :model do
       context "when the schedule is invalid" do
         let(:new_schedule_identifier) { "invalid" }
 
-        it { is_expected.to have_error(:schedule_identifier, :invalid_schedule, "The property '#/schedule_identifier' must be present and correspond to a valid schedule") }
+        it { is_expected.to have_error(:schedule_identifier, :blank, "The property '#/schedule_identifier' must be present") }
       end
 
       context "when the schedule identifier change of the same type again" do

--- a/spec/services/participants/change_schedule_spec.rb
+++ b/spec/services/participants/change_schedule_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Participants::ChangeSchedule, type: :model do
   let!(:application) { create(:application, :accepted, cohort:, lead_provider:, course:, schedule:) }
 
   let(:participant) { application.user }
-  let(:participant_id) { participant.ecf_id }
+  let(:participant_id) { participant.id }
 
   let(:new_cohort) { create(:cohort, :next) }
   let(:new_schedule) { create(:schedule, :npq_leadership_autumn, cohort: new_cohort) }
@@ -20,7 +20,7 @@ RSpec.describe Participants::ChangeSchedule, type: :model do
   let(:params) do
     {
       lead_provider:,
-      participant:,
+      participant_id:,
       course_identifier:,
 
       schedule_identifier: new_schedule_identifier,
@@ -36,7 +36,7 @@ RSpec.describe Participants::ChangeSchedule, type: :model do
         let(:params) do
           {
             lead_provider:,
-            participant:,
+            participant_id:,
             course_identifier:,
 
             schedule_identifier: new_schedule_identifier,
@@ -74,14 +74,14 @@ RSpec.describe Participants::ChangeSchedule, type: :model do
         application
       end
 
-      it { is_expected.to have_error(:participant, :already_withdrawn, "The participant is already withdrawn") }
+      it { is_expected.to have_error(:participant_id, :already_withdrawn, "The participant is already withdrawn") }
     end
 
     context "when the cohort is changing" do
       let(:params) do
         {
           lead_provider:,
-          participant:,
+          participant_id:,
           course_identifier:,
 
           schedule_identifier: new_schedule_identifier,
@@ -335,7 +335,7 @@ RSpec.describe Participants::ChangeSchedule, type: :model do
       let(:params) do
         {
           lead_provider:,
-          participant:,
+          participant_id:,
           course_identifier:,
 
           schedule_identifier: new_schedule_identifier,

--- a/spec/services/participants/defer_spec.rb
+++ b/spec/services/participants/defer_spec.rb
@@ -5,12 +5,12 @@ require "rails_helper"
 RSpec.describe Participants::Defer, type: :model do
   it_behaves_like "a participant action" do
     let(:reason) { described_class::DEFERRAL_REASONS.sample }
-    let(:instance) { described_class.new(lead_provider:, participant:, course_identifier:, reason:) }
+    let(:instance) { described_class.new(lead_provider:, participant_id:, course_identifier:, reason:) }
   end
 
   it_behaves_like "a participant state transition", :defer, %w[active], "deferred" do
     let(:reason) { described_class::DEFERRAL_REASONS.sample }
-    let(:instance) { described_class.new(lead_provider:, participant:, course_identifier:, reason:) }
+    let(:instance) { described_class.new(lead_provider:, participant_id:, course_identifier:, reason:) }
 
     describe "validations" do
       it { is_expected.to validate_inclusion_of(:reason).in_array(described_class::DEFERRAL_REASONS).with_message("The property '#/reason' must be a valid reason") }
@@ -18,19 +18,19 @@ RSpec.describe Participants::Defer, type: :model do
       context "when the application is already deferred" do
         let(:application) { create(:application, :with_declaration, :deferred) }
 
-        it { expect(instance).to have_error(:participant, :already_deferred, "The participant is already deferred") }
+        it { expect(instance).to have_error(:participant_id, :already_deferred, "The participant is already deferred") }
       end
 
       context "when the application is withdrawn" do
         let(:application) { create(:application, :with_declaration, :withdrawn) }
 
-        it { expect(instance).to have_error(:participant, :already_withdrawn, "The participant is already withdrawn") }
+        it { expect(instance).to have_error(:participant_id, :already_withdrawn, "The participant is already withdrawn") }
       end
 
       context "when the application has no declarations" do
         let(:application) { create(:application, :accepted) }
 
-        it { expect(instance).to have_error(:participant, :no_declarations, "You cannot defer an NPQ participant that has no declarations") }
+        it { expect(instance).to have_error(:participant_id, :no_declarations, "You cannot defer an NPQ participant that has no declarations") }
       end
     end
   end

--- a/spec/services/participants/resume_spec.rb
+++ b/spec/services/participants/resume_spec.rb
@@ -4,18 +4,18 @@ require "rails_helper"
 
 RSpec.describe Participants::Resume, type: :model do
   it_behaves_like "a participant action" do
-    let(:instance) { described_class.new(lead_provider:, participant:, course_identifier:) }
+    let(:instance) { described_class.new(lead_provider:, participant_id:, course_identifier:) }
     let(:application) { create(:application, :accepted, :with_declaration, training_status: %w[withdrawn deferred].sample) }
   end
 
   it_behaves_like "a participant state transition", :resume, %w[withdrawn deferred], "active" do
-    let(:instance) { described_class.new(lead_provider:, participant:, course_identifier:) }
+    let(:instance) { described_class.new(lead_provider:, participant_id:, course_identifier:) }
 
     describe "validations" do
       context "when the application is already active" do
         let(:application) { create(:application, :accepted) }
 
-        it { expect(instance).to have_error(:participant, :already_active, "The participant is already active") }
+        it { expect(instance).to have_error(:participant_id, :already_active, "The participant is already active") }
       end
     end
   end

--- a/spec/services/participants/withdraw_spec.rb
+++ b/spec/services/participants/withdraw_spec.rb
@@ -5,12 +5,12 @@ require "rails_helper"
 RSpec.describe Participants::Withdraw, type: :model do
   it_behaves_like "a participant action" do
     let(:reason) { described_class::WITHDRAWAL_REASONS.sample }
-    let(:instance) { described_class.new(lead_provider:, participant:, course_identifier:, reason:) }
+    let(:instance) { described_class.new(lead_provider:, participant_id:, course_identifier:, reason:) }
   end
 
   it_behaves_like "a participant state transition", :withdraw, %w[active], "withdrawn" do
     let(:reason) { described_class::WITHDRAWAL_REASONS.sample }
-    let(:instance) { described_class.new(lead_provider:, participant:, course_identifier:, reason:) }
+    let(:instance) { described_class.new(lead_provider:, participant_id:, course_identifier:, reason:) }
 
     describe "validations" do
       it { is_expected.to validate_inclusion_of(:reason).in_array(described_class::WITHDRAWAL_REASONS).with_message("The property '#/reason' must be a valid reason") }
@@ -18,13 +18,13 @@ RSpec.describe Participants::Withdraw, type: :model do
       context "when the application is already withdrawn" do
         let(:application) { create(:application, :accepted, :withdrawn) }
 
-        it { expect(instance).to have_error(:participant, :already_withdrawn, "The participant is already withdrawn") }
+        it { expect(instance).to have_error(:participant_id, :already_withdrawn, "The participant is already withdrawn") }
       end
 
       context "when the application has no declarations" do
         let(:application) { create(:application, :accepted) }
 
-        it { expect(instance).to have_error(:participant, :no_started_declarations, "An NPQ participant who has not got a started declaration cannot be withdrawn. Please contact support for assistance") }
+        it { expect(instance).to have_error(:participant_id, :no_started_declarations, "An NPQ participant who has not got a started declaration cannot be withdrawn. Please contact support for assistance") }
       end
 
       context "when the application has no started declarations" do
@@ -32,7 +32,7 @@ RSpec.describe Participants::Withdraw, type: :model do
 
         before { create(:declaration, application:, declaration_type: "retained-1") }
 
-        it { expect(instance).to have_error(:participant, :no_started_declarations, "An NPQ participant who has not got a started declaration cannot be withdrawn. Please contact support for assistance") }
+        it { expect(instance).to have_error(:participant_id, :no_started_declarations, "An NPQ participant who has not got a started declaration cannot be withdrawn. Please contact support for assistance") }
       end
     end
   end

--- a/spec/support/shared_examples/api_create_endpoint_support.rb
+++ b/spec/support/shared_examples/api_create_endpoint_support.rb
@@ -3,7 +3,7 @@
 RSpec.shared_examples "an API create endpoint" do
   let(:params) { defined?(attributes) ? { data: { attributes: } } : nil }
   let(:stub_service) do
-    service_double = instance_double(service, "#{action}": true, **service_args)
+    service_double = instance_double(service, "#{action}": true, **service_args.merge(defined?(service_methods) ? service_methods : {}))
     allow(service).to receive(:new) { |args|
       expect(args.to_hash.symbolize_keys).to eq(service_args)
     }.and_return(service_double)

--- a/spec/support/shared_examples/api_update_endpoint_support.rb
+++ b/spec/support/shared_examples/api_update_endpoint_support.rb
@@ -3,7 +3,7 @@
 RSpec.shared_examples "an API update endpoint" do
   let(:params) { defined?(attributes) ? { data: { attributes: } } : nil }
   let(:stub_service) do
-    service_double = instance_double(service, "#{action}": true, **service_args)
+    service_double = instance_double(service, "#{action}": true, **service_args.merge(defined?(service_methods) ? service_methods : {}))
     allow(service).to receive(:new) { |args|
       expect(args.to_hash.symbolize_keys).to eq(service_args)
     }.and_return(service_double)

--- a/spec/support/shared_examples/participant_action_support.rb
+++ b/spec/support/shared_examples/participant_action_support.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.shared_examples "a participant action" do
   let(:lead_provider) { application.lead_provider }
-  let(:participant_id) { application.user.id }
+  let(:participant_id) { application.user.ecf_id }
   let(:application) { create(:application, :accepted, :with_declaration) }
   let(:course_identifier) { application.course.identifier }
 
@@ -37,7 +37,7 @@ end
 
 RSpec.shared_examples "a participant state transition" do |action, from_states, to_state|
   let(:lead_provider) { application.lead_provider }
-  let(:participant_id) { application.user.id }
+  let(:participant_id) { application.user.ecf_id }
   let(:application) { create(:application, :accepted, :with_declaration, training_status: from_states.sample) }
   let(:course_identifier) { application.course.identifier }
 

--- a/spec/support/shared_examples/participant_action_support.rb
+++ b/spec/support/shared_examples/participant_action_support.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.shared_examples "a participant action" do
   let(:lead_provider) { application.lead_provider }
-  let(:participant) { application.user }
+  let(:participant_id) { application.user.id }
   let(:application) { create(:application, :accepted, :with_declaration) }
   let(:course_identifier) { application.course.identifier }
 
@@ -12,32 +12,32 @@ RSpec.shared_examples "a participant action" do
 
   describe "validations" do
     it { is_expected.to validate_presence_of(:lead_provider).with_message("Your update cannot be made as the '#/lead_provider' is not recognised. Check lead provider details and try again.") }
-    it { is_expected.to validate_presence_of(:participant).with_message("Your update cannot be made as the '#/participant' is not recognised. Check participant details and try again.") }
+    it { is_expected.to validate_presence_of(:participant_id).with_message("The property '#/participant_id' must be present") }
     it { is_expected.to validate_inclusion_of(:course_identifier).in_array(Course::IDENTIFIERS).with_message("The entered '#/course_identifier' is not recognised for the given participant. Check details and try again.") }
 
     context "when a matching application does not exist (different course identifier)" do
       let(:course_identifier) { Course::IDENTIFIERS.excluding(application.course.identifier).sample }
 
-      it { is_expected.to have_error(:participant, :blank, "Your update cannot be made as the '#/participant' is not recognised. Check participant details and try again.") }
+      it { is_expected.to have_error(:participant_id, :invalid_participant, "Your update cannot be made as the '#/participant_id' is not recognised. Check participant details and try again.") }
     end
 
     context "when a matching application does not exist (different lead provider)" do
       let(:lead_provider) { create(:lead_provider, name: "Different to #{application.lead_provider.name}") }
 
-      it { is_expected.to have_error(:participant, :blank, "Your update cannot be made as the '#/participant' is not recognised. Check participant details and try again.") }
+      it { is_expected.to have_error(:participant_id, :invalid_participant, "Your update cannot be made as the '#/participant_id' is not recognised. Check participant details and try again.") }
     end
 
     context "when there is a matching application, but it is not accepted" do
       let(:application) { create(:application) }
 
-      it { is_expected.to have_error(:participant, :blank, "Your update cannot be made as the '#/participant' is not recognised. Check participant details and try again.") }
+      it { is_expected.to have_error(:participant_id, :invalid_participant, "Your update cannot be made as the '#/participant_id' is not recognised. Check participant details and try again.") }
     end
   end
 end
 
 RSpec.shared_examples "a participant state transition" do |action, from_states, to_state|
   let(:lead_provider) { application.lead_provider }
-  let(:participant) { application.user }
+  let(:participant_id) { application.user.id }
   let(:application) { create(:application, :accepted, :with_declaration, training_status: from_states.sample) }
   let(:course_identifier) { application.course.identifier }
 


### PR DESCRIPTION
[Jira-3347](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3347)

### Context

There are discrepencies between the ECF error messages and those in NPQ reg - namely:

- NPQ reg has multiple invalid schedule error messages whereas ECF only has one.
- NPQ reg returns `participant_id` errors on the `participant` attribute instead of `participant_id`.

### Changes proposed in this pull request

- Remove invalid_schedule error

We only want one `invalid_schedule` error for `ChangeSchedule`, which is the same one we use for `blank`.

-  Change participant errors to participant_id

On various services we accept a `participant` instead of `participant_id`; this results in the error messages being on the `participant` attribute instead of the `participant_id` attribute supplied to the controller (as we retrieve the participant in the controller).

### Guidance to review

We could override the parameter name in the model error messages, but a more intuitive way feels like updating the service to accept the `participant_id` instead of `participant` and then it will all just work as expected. This does, however, result in quite a few changes.
