### PR TITLE
[CPDLP-3344] MVP NPQ Prep - Add training status error

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -8,6 +8,7 @@ module API
     rescue_from ActionController::UnpermittedParameters, with: :unpermitted_parameter_response
     rescue_from ActionController::BadRequest, with: :bad_request_response
     rescue_from ArgumentError, with: :bad_request_response
+    rescue_from API::Errors::FilterValidationError, with: :filter_validation_error_response
 
   private
 
@@ -22,6 +23,10 @@ module API
     def bad_request_response(exception)
       Sentry.capture_exception(exception)
       render json: { errors: API::Errors::Response.new(error: I18n.t(:bad_request), params: exception.message).call }, status: :bad_request
+    end
+
+    def filter_validation_error_response(exception)
+      render json: { errors: API::Errors::Response.new(error: I18n.t(:unpermitted_parameters), params: exception.message).call }, status: :unprocessable_entity
     end
   end
 end

--- a/app/services/api/errors/filter_validation_error.rb
+++ b/app/services/api/errors/filter_validation_error.rb
@@ -1,0 +1,5 @@
+module API
+  module Errors
+    class FilterValidationError < StandardError; end
+  end
+end

--- a/app/services/participants/query.rb
+++ b/app/services/participants/query.rb
@@ -42,7 +42,10 @@ module Participants
 
     def where_training_status_is(training_status)
       return if ignore?(filter: training_status)
-      return unless Application.training_statuses[training_status]
+
+      unless Application.training_statuses[training_status]
+        raise API::Errors::FilterValidationError, I18n.t(:invalid_training_status, valid_training_status: Application.training_statuses.keys)
+      end
 
       scope.merge!(Application.where(training_status:))
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,7 @@ en:
   bad_request: "Bad request"
   not_found: "Not found"
   invalid_date_filter: "The filter '#/%{parameterized_attribute}' must be a valid ISO 8601 date"
+  invalid_training_status: "The filter '#/training_status' must be %{valid_training_status}"
   invalid_page_parameters: "The '#/page[page]' and '#/page[per_page]' parameter values must be a valid positive number"
   invalid_data_structure: correct json data structure required. See API docs for reference
   cannot_create_completed_declaration: "Could not create completed declaration. Contact the DfE for support."

--- a/spec/services/participants/query_spec.rb
+++ b/spec/services/participants/query_spec.rb
@@ -126,12 +126,10 @@ RSpec.describe Participants::Query do
         end
 
         context "when an invalid training status is supplied" do
-          let(:params) { { training_status: "any" } }
+          let(:params) { { training_status: "not_valid_status" } }
 
-          it "does not filter by training status" do
-            condition_string = %("training_status")
-
-            expect(query.scope.to_sql).not_to include(condition_string)
+          it "raises an error" do
+            expect { query.scope.to_sql }.to raise_error(API::Errors::FilterValidationError).with_message(%(The filter '#/training_status' must be ["active", "deferred", "withdrawn"]))
           end
         end
       end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-3344

### Changes proposed in this pull request

* We can now raise `API::Errors::FilterValidationError` from query service classes.
* Base controller rescues `API::Errors::FilterValidationError` with a 422 response.
* Added filter validation on `Participants::Query` for `training_status`