### PR TITLE
Limit response to single errors on certain actions

### DIFF
--- a/app/services/declarations/create.rb
+++ b/app/services/declarations/create.rb
@@ -15,7 +15,7 @@ module Declarations
     validates :lead_provider, presence: true
     validates :participant_id, presence: true
     validates :participant, participant_presence: true, participant_not_withdrawn: true
-    validates :course_identifier, inclusion: { in: Course::IDENTIFIERS }, allow_blank: false, course_for_participant: true
+    validates :course_identifier, course_for_participant: true
     validates :declaration_date, declaration_date: true
     validates :declaration_date, presence: true
     validates :declaration_type, presence: true

--- a/app/services/declarations/void.rb
+++ b/app/services/declarations/void.rb
@@ -59,6 +59,8 @@ module Declarations
     end
 
     def declaration_is_paid
+      return if errors[:declaration].any?
+
       errors.add(:declaration, :must_be_paid) unless declaration&.paid_state?
     end
 

--- a/spec/services/declarations/create_spec.rb
+++ b/spec/services/declarations/create_spec.rb
@@ -42,9 +42,24 @@ RSpec.describe Declarations::Create, type: :model do
     end
 
     context "when the course is invalid" do
-      let(:course_identifier) { "any-course-identifier" }
+      let(:course_identifier) { "invalid" }
 
-      it { is_expected.to have_error(:course_identifier, :inclusion, "The entered '#/course_identifier' is not recognised for the given participant. Check details and try again.") }
+      it { is_expected.to have_error(:course_identifier, :invalid, "The entered '#/course_identifier' is not recognised for the given participant. Check details and try again.") }
+
+      context "when there are other errors" do
+        let(:participant_id) { "not-found" }
+
+        it "omits the course_identifier error" do
+          expect(subject).to have_error(:participant_id)
+          expect(subject).not_to have_error(:course_identifier)
+        end
+      end
+    end
+
+    context "when the course is nil" do
+      let(:course_identifier) { nil }
+
+      it { expect(subject).to have_error(:course_identifier, :invalid, "The entered '#/course_identifier' is not recognised for the given participant. Check details and try again.") }
     end
 
     context "when declaration date is invalid" do

--- a/spec/services/declarations/void_spec.rb
+++ b/spec/services/declarations/void_spec.rb
@@ -50,6 +50,13 @@ RSpec.describe Declarations::Void, type: :model do
           before { declaration.update!(state:) }
 
           it { expect(instance).to have_error(:declaration, :must_be_paid, "The declaration must be paid before it can be clawed back.") }
+
+          context "when there are other declaration errors" do
+            before { create(:statement_item, declaration:, state: StatementItem::REFUNDABLE_STATES.sample) }
+
+            it { expect(instance).to have_error(:declaration) }
+            it { expect(instance).not_to have_error(:declaration, :must_be_paid) }
+          end
         end
       end
     end

--- a/spec/support/matchers/error_matcher.rb
+++ b/spec/support/matchers/error_matcher.rb
@@ -1,7 +1,10 @@
 RSpec::Matchers.define :have_error do |attribute, type, message, context|
   match do |actual|
     actual.invalid?(context) && actual.errors.any? do |error|
-      error.attribute == attribute && error.type == type && error.message == message
+      error_type_match = type.nil? || error.type == type
+      error_message_match = message.nil? || error.message == message
+
+      error.attribute == attribute && error_type_match && error_message_match
     end
   end
 end


### PR DESCRIPTION
[Jira-3348](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3348)

### Context

In a number of scenarios we return multiple error messages whereas in ECF we would only return a single error at a time.

We want to update NPQ reg to be more consistent with ECF; only returning single errors on occasion.

### Changes proposed in this pull request

- Only return one declaration error at a time when voiding

Currently we can return multiple declaration errors when voiding a declaration.

Only return a single declaration error at a time.

- Limit multiple errors on participant actions

Currently, if there is an error on the `participant_id` attribute and the `course_identifier` attribute we would return both errors. Instead, we only want to return the `participant_id` error if there are multiple to match the ECF behaviour.

Minor update to error matcher so we can also check if an error exists (or doesn't exist) for a given attribute.

## Guidance to review

We are removing the `inclusion` validation from the participant actions as the error message is the same as the `invalid` course error which is performed in the custom `CourseForParticipant` validator. The validator also already has the logic in to  omit the error if other errors exist. The validator also ensures the application -> course matches, so we can remove that check from the `Action` class `#application` method.