### PR TITLE
[CPDLP-3292] Stream API requests events to BQ

### DIFF
--- a/app/jobs/stream_api_requests_to_big_query_job.rb
+++ b/app/jobs/stream_api_requests_to_big_query_job.rb
@@ -1,0 +1,72 @@
+require "google/cloud/bigquery"
+
+class StreamApiRequestsToBigQueryJob < ApplicationJob
+  include ActionController::HttpAuthentication::Token
+
+  queue_as :low_priority
+
+  def perform(request_data, response_data, status_code, created_at)
+    return if table.nil?
+
+    request_data = request_data.with_indifferent_access
+    response_data = response_data.with_indifferent_access
+    request_headers = request_data.fetch(:headers, {})
+    token = auth_token(request_headers.delete("HTTP_AUTHORIZATION"))
+    lead_provider = token.is_a?(APIToken) ? token.lead_provider : nil
+
+    response_headers = response_data[:headers]
+    response_body = response_data[:body]
+
+    rows = [
+      {
+        request_path: request_data[:path],
+        status_code:,
+        request_headers:,
+        request_method: request_data[:method],
+        request_body: request_body(request_data),
+        response_body: response_hash(response_body, status_code),
+        response_headers:,
+        lead_provider: lead_provider&.name,
+        created_at:,
+      }.stringify_keys,
+    ]
+
+    table.insert(rows, ignore_unknown: true)
+  end
+
+private
+
+  def table
+    bigquery = Google::Cloud::Bigquery.new
+    dataset = bigquery.dataset "npq_registration", skip_lookup: true
+    dataset.table "api_requests_#{Rails.env.downcase}"
+  end
+
+  AuthorizationStruct = Struct.new(:authorization)
+
+  def auth_token(auth_header)
+    return if auth_header.blank?
+
+    token, _options = token_and_options(AuthorizationStruct.new(auth_header))
+    APIToken.find_by_unhashed_token(token)
+  end
+
+  def response_hash(response_body, status)
+    return {} unless status > 299
+    return {} unless response_body
+
+    JSON.parse(response_body)
+  rescue JSON::ParserError
+    { body: "#{status} did not respond with JSON" }
+  end
+
+  def request_body(request_data)
+    if request_data[:body].present?
+      JSON.parse(request_data[:body])
+    else
+      request_data[:params]
+    end
+  rescue JSON::ParserError
+    { error: "request data did not contain valid JSON" }
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,11 +8,7 @@ require "active_record/railtie"
 require "active_storage/engine"
 require "action_controller/railtie"
 require "action_mailer/railtie"
-# require "action_mailbox/engine"
-# require "action_text/engine"
 require "action_view/railtie"
-# require "action_cable/engine"
-# require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -38,5 +34,9 @@ module NpqRegistration
     # Used to handle HTTP_X_WITH_SERVER_DATE header for server side datetime overwrite
     require "middleware/time_traveler"
     config.middleware.use Middleware::TimeTraveler
+
+    # Used to stream API requests to BigQuery
+    require "middleware/api_request_middleware"
+    config.middleware.use Middleware::ApiRequestMiddleware
   end
 end

--- a/config/initializers/google_big_query.rb
+++ b/config/initializers/google_big_query.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "google/cloud/bigquery"
+require "base64"
+
+Google::Cloud::Bigquery.configure do |config|
+  config.project_id = "ecf-bq"
+
+  if ENV["GOOGLE_BQ_SERVICE_ACCOUNT_BASE64"]
+    config.credentials = JSON.parse(Base64.decode64(ENV["GOOGLE_BQ_SERVICE_ACCOUNT_BASE64"]))
+  end
+end

--- a/lib/middleware/api_request_middleware.rb
+++ b/lib/middleware/api_request_middleware.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "./app/jobs/application_job"
+require "./app/jobs/stream_api_requests_to_big_query_job"
+
+module Middleware
+  class ApiRequestMiddleware
+    REQUEST_HEADER_KEYS = %w[
+      HTTP_VERSION
+      HTTP_HOST
+      HTTP_USER_AGENT
+      HTTP_ACCEPT
+      HTTP_ACCEPT_ENCODING
+      HTTP_AUTHORIZATION
+      HTTP_CONNECTION
+      HTTP_CACHE_CONTROL
+      QUERY_STRING
+    ].freeze
+
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      dup._call(env)
+    end
+
+    def _call(env)
+      @request = Rack::Request.new(env)
+      status, @headers, @response = @app.call(env)
+
+      begin
+        if trace_request?
+          StreamApiRequestsToBigQueryJob.perform_later(request_data.stringify_keys, response_data.stringify_keys, status, Time.zone.now.to_s)
+        end
+      rescue StandardError => e
+        Rails.logger.warn e.message
+        Sentry.capture_exception(e)
+      end
+
+      [status, @headers, @response]
+    end
+
+  private
+
+    def response_data
+      body = @response.respond_to?(:body) ? @response.body : @response.join
+      body = body.join if body.is_a?(Array)
+
+      {
+        headers: @headers,
+        body:,
+      }
+    end
+
+    def request_data
+      {
+        path: @request.path,
+        params: @request.params,
+        body: @request.body.read.dup.force_encoding("utf-8"),
+        headers: request_headers,
+        method: @request.request_method,
+      }
+    end
+
+    def request_headers
+      @request.env.slice(*REQUEST_HEADER_KEYS)
+    end
+
+    def trace_request?
+      Rails.env.in?(%w[migration review separation staging production]) && vendor_api_path?
+    end
+
+    def vendor_api_path?
+      @request.path =~ /^\/api\/v\d+\/.*$/
+    end
+  end
+end

--- a/spec/jobs/stream_api_requests_to_big_query_job_spec.rb
+++ b/spec/jobs/stream_api_requests_to_big_query_job_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StreamApiRequestsToBigQueryJob, type: :job do
+  subject(:job) { described_class.perform_now(request_data, response_data, status_code, created_at) }
+
+  let(:bigquery) { instance_double("bigquery") }
+  let(:dataset)  { instance_double("dataset") }
+  let(:table)    { instance_double("table", insert: nil) }
+  let(:status_code) { 200 }
+  let(:created_at) { Time.zone.now.to_s }
+  let(:lead_provider) { LeadProvider.find_by(name: "Ambition Institute") }
+
+  let(:request_data) do
+    {
+      "path" => "/api/v3/participants/npq",
+      "params" => {},
+      "body" => { "foo" => "bar" }.to_json,
+      "headers" => {
+        "HTTP_VERSION" => "HTTP/1.1",
+        "HTTP_HOST" => "localhost:3000",
+        "HTTP_USER_AGENT" => "PostmanRuntime/7.39.0",
+        "HTTP_ACCEPT" => "*/*",
+        "HTTP_ACCEPT_ENCODING" => "gzip, deflate, br",
+        "HTTP_AUTHORIZATION" => "Bearer ambition-token",
+        "HTTP_CONNECTION" => "keep-alive",
+        "QUERY_STRING" => "",
+      },
+      "method" => "GET",
+    }
+  end
+  let(:response_data) do
+    {
+      "headers" => { "Content-Type" => "application/json" },
+      "body" => {
+        "data" => [{
+          "id" => "123456",
+          "type" => "npq-participant",
+          "attributes" => {
+            "full_name": "Test Example",
+            "teacher_reference_number": "123",
+          },
+        }],
+      }.to_json,
+    }
+  end
+
+  before do
+    APIToken.create_with_known_token!("ambition-token", lead_provider:)
+
+    allow(Google::Cloud::Bigquery).to receive(:new).and_return(bigquery)
+    allow(bigquery).to receive(:dataset).and_return(dataset)
+  end
+
+  describe "#perform" do
+    context "when the BigQuery table exists" do
+      before do
+        allow(dataset).to receive(:table).and_return(table)
+      end
+
+      it "enqueues a job" do
+        expect {
+          described_class.perform_later
+        }.to have_enqueued_job
+      end
+
+      context "when API Request response is success" do
+        it "sends correct data to BigQuery with no `response_body`" do
+          job
+
+          expect(table).to have_received(:insert).with([{
+            request_path: request_data["path"],
+            status_code:,
+            request_headers: request_data["headers"].except("HTTP_AUTHORIZATION"),
+            request_method: request_data["method"],
+            request_body: { "foo" => "bar" },
+            response_body: {},
+            response_headers: response_data["headers"],
+            lead_provider: lead_provider.name,
+            created_at:,
+          }.stringify_keys], ignore_unknown: true)
+        end
+      end
+
+      context "when API Request response is not success" do
+        let(:status_code) { 422 }
+        let(:response_data) do
+          {
+            "headers" => { "Content-Type" => "application/json" },
+            "body" => {
+              "errors" => [{
+                "title" => "application",
+                "detail" => "This NPQ application has already been accepted",
+              }],
+            }.to_json,
+          }
+        end
+
+        it "sends correct data to BigQuery with `response_body`" do
+          job
+
+          expect(table).to have_received(:insert).with([{
+            request_path: request_data["path"],
+            status_code:,
+            request_headers: request_data["headers"].except("HTTP_AUTHORIZATION"),
+            request_method: request_data["method"],
+            request_body: { "foo" => "bar" },
+            response_body: {
+              "errors" => [{
+                "title" => "application",
+                "detail" => "This NPQ application has already been accepted",
+              }],
+            },
+            response_headers: response_data["headers"],
+            lead_provider: lead_provider.name,
+            created_at:,
+          }.stringify_keys], ignore_unknown: true)
+        end
+      end
+    end
+
+    context "when the BigQuery table does not exist" do
+      before do
+        allow(dataset).to receive(:table).and_return(nil)
+      end
+
+      it "doesn't attempt to stream" do
+        job
+
+        expect(table).not_to have_received(:insert)
+      end
+    end
+  end
+end

--- a/spec/lib/middleware/api_request_middleware_spec.rb
+++ b/spec/lib/middleware/api_request_middleware_spec.rb
@@ -1,0 +1,86 @@
+require "rails_helper"
+require "middleware/api_request_middleware"
+
+RSpec.describe Middleware::ApiRequestMiddleware, type: :request do
+  let(:status) { 200 }
+  let(:request) { Rack::MockRequest.new(subject) }
+  let(:headers) { { "HEADER" => "Yeah!" } }
+  let(:mock_response) { ["Hellowwworlds!"] }
+
+  let(:mock_app) do
+    lambda do |env|
+      @env = env
+      [status, headers, mock_response]
+    end
+  end
+
+  subject { described_class.new(mock_app) }
+
+  before do
+    allow(Rails).to receive(:env) { environment.inquiry }
+    allow(StreamApiRequestsToBigQueryJob).to receive(:perform_later)
+  end
+
+  context "when running in other environments other than the allowed ones" do
+    let(:environment) { "test" }
+
+    it "does not fire StreamApiRequestsToBigQueryJob" do
+      request.get "/"
+
+      expect(StreamApiRequestsToBigQueryJob).not_to have_received(:perform_later)
+    end
+  end
+
+  context "when running in allowed environments" do
+    let(:environment) { "separation" }
+
+    describe "#call on a non-API path" do
+      it "does not fire StreamApiRequestsToBigQueryJob" do
+        request.get "/"
+
+        expect(StreamApiRequestsToBigQueryJob).not_to have_received(:perform_later)
+      end
+    end
+
+    describe "#call on an API path" do
+      it "fires an StreamApiRequestsToBigQueryJob" do
+        request.get "/api/v1/participants/ecf", params: { foo: "bar" }
+
+        expect(StreamApiRequestsToBigQueryJob).to have_received(:perform_later).with(
+          hash_including("path" => "/api/v1/participants/ecf", "params" => { "foo" => "bar" }, "method" => "GET"), anything, 200, anything
+        )
+      end
+    end
+
+    describe "#call on a different version API path" do
+      it "fires an StreamApiRequestsToBigQueryJob" do
+        request.get "/api/v3/participants/ecf", params: { foo: "bar" }
+
+        expect(StreamApiRequestsToBigQueryJob).to have_received(:perform_later).with(
+          hash_including("path" => "/api/v3/participants/ecf", "params" => { "foo" => "bar" }, "method" => "GET"), anything, 200, anything
+        )
+      end
+    end
+
+    describe "#call on an API path with POST data" do
+      it "fires an StreamApiRequestsToBigQueryJob including post data" do
+        request.post "/api/v1/participant-declarations", as: :json, params: { foo: "bar" }.to_json
+
+        expect(StreamApiRequestsToBigQueryJob).to have_received(:perform_later).with(
+          hash_including("path" => "/api/v1/participant-declarations", "body" => '{"foo":"bar"}', "method" => "POST"), anything, 200, anything
+        )
+      end
+    end
+
+    describe "#call on an API path when an exception happens in the job" do
+      it "logs the exception and returns" do
+        allow(Rails.logger).to receive(:warn)
+        allow(StreamApiRequestsToBigQueryJob).to receive(:perform_later).and_raise(StandardError)
+
+        request.get "/api/v1/participants/ecf"
+
+        expect(Rails.logger).to have_received(:warn)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: [CPDLP-3292](https://dfedigital.atlassian.net/browse/CPDLP-3292)

We'd like to stream to BQ the request and response for error messages so that they are viewable in BQ for the team to build dashboards to access this data.

### Changes proposed in this pull request

Stream API requests events to BQ.

[CPDLP-3292]: https://dfedigital.atlassian.net/browse/CPDLP-3292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ