### PR TITLE
[CPDLP-3363] MVP NPQ Prep - Touch model improvements on endpoints

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -218,6 +218,6 @@ private
   def touch_user_if_changed
     return unless saved_change_to_lead_provider_approval_status?
 
-    user.touch
+    user.touch(time: updated_at)
   end
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -13,7 +13,7 @@ class Application < ApplicationRecord
 
   has_paper_trail only: %i[lead_provider_approval_status participant_outcome_state]
 
-  belongs_to :user, touch: true
+  belongs_to :user
   belongs_to :course
   belongs_to :lead_provider
   belongs_to :school, optional: true
@@ -35,6 +35,8 @@ class Application < ApplicationRecord
   scope :with_targeted_delivery_funding_eligibility, -> { where(targeted_delivery_funding_eligibility: true) }
 
   validate :schedule_cohort_matches
+
+  after_commit :touch_user_if_changed
 
   enum kind_of_nursery: {
     local_authority_maintained_nursery: "local_authority_maintained_nursery",
@@ -211,5 +213,11 @@ private
     unless schedule.course_group.courses.include?(course)
       errors.add(:schedule, :invalid_for_course)
     end
+  end
+
+  def touch_user_if_changed
+    return unless saved_change_to_lead_provider_approval_status?
+
+    user.touch
   end
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -13,7 +13,7 @@ class Application < ApplicationRecord
 
   has_paper_trail only: %i[lead_provider_approval_status participant_outcome_state]
 
-  belongs_to :user
+  belongs_to :user, touch: true
   belongs_to :course
   belongs_to :lead_provider
   belongs_to :school, optional: true

--- a/app/serializers/api/declaration_serializer.rb
+++ b/app/serializers/api/declaration_serializer.rb
@@ -35,7 +35,13 @@ module API
         field(:created_at)
       end
 
-      field(:updated_at)
+      field(:updated_at) do |declaration|
+        (
+          declaration.participant_outcomes.map(&:updated_at) +
+          declaration.statement_items.map(&:updated_at) +
+          [ declaration.updated_at ]
+        ).compact.max
+      end
     end
 
     %i[v1 v2 v3].each do |version|

--- a/app/serializers/api/declaration_serializer.rb
+++ b/app/serializers/api/declaration_serializer.rb
@@ -39,7 +39,7 @@ module API
         (
           declaration.participant_outcomes.map(&:updated_at) +
           declaration.statement_items.map(&:updated_at) +
-          [ declaration.updated_at ]
+          [declaration.updated_at]
         ).compact.max
       end
     end

--- a/app/serializers/api/participant_serializer.rb
+++ b/app/serializers/api/participant_serializer.rb
@@ -26,14 +26,18 @@ module API
         end
 
         field(:trn, name: :teacher_reference_number)
-        field(:updated_at)
+        field(:updated_at) do |object, options|
+          updated_at(object)
+        end
       end
 
       view :v2 do
         field(:email)
         field(:full_name)
         field(:trn, name: :teacher_reference_number)
-        field(:updated_at)
+        field(:updated_at) do |object, options|
+          updated_at(object)
+        end
 
         field(:npq_enrolments) do |object, options|
           applications(object, options).map do |application|
@@ -55,7 +59,9 @@ module API
       view :v3 do
         field(:full_name)
         field(:trn, name: :teacher_reference_number)
-        field(:updated_at)
+        field(:updated_at) do |object, options|
+          updated_at(object)
+        end
 
         field(:npq_enrolments) do |object, options|
           applications(object, options).map do |application|
@@ -127,6 +133,14 @@ module API
               }
             end
           end
+        end
+
+        def updated_at(user)
+          (
+            (user.participant_id_changes || []).map(&:updated_at) +
+            (user.applications || []).map(&:updated_at) +
+            [ user.updated_at ]
+          ).compact.max
         end
       end
     end

--- a/app/serializers/api/participant_serializer.rb
+++ b/app/serializers/api/participant_serializer.rb
@@ -26,7 +26,7 @@ module API
         end
 
         field(:trn, name: :teacher_reference_number)
-        field(:updated_at) do |object, options|
+        field(:updated_at) do |object, _options|
           updated_at(object)
         end
       end
@@ -35,7 +35,7 @@ module API
         field(:email)
         field(:full_name)
         field(:trn, name: :teacher_reference_number)
-        field(:updated_at) do |object, options|
+        field(:updated_at) do |object, _options|
           updated_at(object)
         end
 
@@ -59,7 +59,7 @@ module API
       view :v3 do
         field(:full_name)
         field(:trn, name: :teacher_reference_number)
-        field(:updated_at) do |object, options|
+        field(:updated_at) do |object, _options|
           updated_at(object)
         end
 
@@ -139,7 +139,7 @@ module API
           (
             (user.participant_id_changes || []).map(&:updated_at) +
             (user.applications || []).map(&:updated_at) +
-            [ user.updated_at ]
+            [user.updated_at]
           ).compact.max
         end
       end

--- a/app/services/applications/query.rb
+++ b/app/services/applications/query.rb
@@ -69,7 +69,10 @@ module Applications
     def where_updated_since(updated_since)
       return if ignore?(filter: updated_since)
 
-      scope.merge!(Application.where(updated_at: updated_since..))
+      query1 = Application.where(updated_at: updated_since..)
+      query2 = Application.where(user: { updated_at: updated_since.. })
+      query = query1.or(query2)
+      scope.merge!(query)
     end
 
     def where_participant_ids_in(participant_ids)

--- a/app/services/applications/query.rb
+++ b/app/services/applications/query.rb
@@ -69,10 +69,9 @@ module Applications
     def where_updated_since(updated_since)
       return if ignore?(filter: updated_since)
 
-      query1 = Application.where(updated_at: updated_since..)
-      query2 = Application.where(user: { updated_at: updated_since.. })
-      query = query1.or(query2)
-      scope.merge!(query)
+      applications_updated_since = Application.where(updated_at: updated_since..)
+      users_updated_since = Application.where(user: { updated_at: updated_since.. })
+      scope.merge!(applications_updated_since.or(users_updated_since))
     end
 
     def where_participant_ids_in(participant_ids)

--- a/app/services/declarations/query.rb
+++ b/app/services/declarations/query.rb
@@ -37,13 +37,10 @@ module Declarations
     def where_updated_since(updated_since)
       return if ignore?(filter: updated_since)
 
-      query1 = Declaration.where(updated_at: updated_since..)
-      query2 = Declaration.where(participant_outcomes: { updated_at: updated_since.. })
-      query3 = Declaration.where(statement_items: { updated_at: updated_since.. })
-
-      query = query1.or(query2).or(query3)
-
-      scope.merge!(query)
+      declarations_updated_since = Declaration.where(updated_at: updated_since..)
+      participant_outcomes_updated_since = Declaration.where(participant_outcomes: { updated_at: updated_since.. })
+      statement_items_updated_since = Declaration.where(statement_items: { updated_at: updated_since.. })
+      scope.merge!(declarations_updated_since.or(participant_outcomes_updated_since).or(statement_items_updated_since))
     end
 
     def where_participant_ids_in(participant_ids)

--- a/app/services/declarations/query.rb
+++ b/app/services/declarations/query.rb
@@ -37,7 +37,13 @@ module Declarations
     def where_updated_since(updated_since)
       return if ignore?(filter: updated_since)
 
-      scope.merge!(Declaration.where(updated_at: updated_since..))
+      query1 = Declaration.where(updated_at: updated_since..)
+      query2 = Declaration.where(participant_outcomes: { updated_at: updated_since.. })
+      query3 = Declaration.where(statement_items: { updated_at: updated_since.. })
+
+      query = query1.or(query2).or(query3)
+
+      scope.merge!(query)
     end
 
     def where_participant_ids_in(participant_ids)

--- a/app/services/participants/query.rb
+++ b/app/services/participants/query.rb
@@ -67,7 +67,7 @@ module Participants
       User
         .joins(:applications).merge(Application.accepted)
         .includes(
-          :participant_id_changes,
+          participant_id_changes: %i[from_participant to_participant],
           applications: %i[
             course
             school

--- a/app/services/participants/query.rb
+++ b/app/services/participants/query.rb
@@ -37,7 +37,13 @@ module Participants
     def where_updated_since(updated_since)
       return if ignore?(filter: updated_since)
 
-      scope.merge!(User.where(updated_at: updated_since..))
+      query1 = User.where(updated_at: updated_since..)
+      query2 = User.where(applications: { updated_at: updated_since.. })
+      query3 = User.where(participant_id_changes: { updated_at: updated_since.. })
+
+      query = query1.or(query2).or(query3)
+
+      scope.merge!(query)
     end
 
     def where_training_status_is(training_status)

--- a/app/services/participants/query.rb
+++ b/app/services/participants/query.rb
@@ -37,13 +37,10 @@ module Participants
     def where_updated_since(updated_since)
       return if ignore?(filter: updated_since)
 
-      query1 = User.where(updated_at: updated_since..)
-      query2 = User.where(applications: { updated_at: updated_since.. })
-      query3 = User.where(participant_id_changes: { updated_at: updated_since.. })
-
-      query = query1.or(query2).or(query3)
-
-      scope.merge!(query)
+      users_updated_since = User.where(updated_at: updated_since..)
+      applications_updated_since = User.where(applications: { updated_at: updated_since.. })
+      participant_id_changes_updated_since = User.where(participant_id_changes: { updated_at: updated_since.. })
+      scope.merge!(users_updated_since.or(applications_updated_since).or(participant_id_changes_updated_since))
     end
 
     def where_training_status_is(training_status)

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -414,7 +414,7 @@ RSpec.describe Application do
     context "when application is created" do
       it "touch updates field user.updated_at" do
         freeze_time do
-          expect(user.updated_at.rfc3339).to eq(old_datetime.rfc3339)
+          expect(user.updated_at).to be_within(1.second).of(old_datetime)
 
           create(:application, user:)
           expect(user.updated_at).to eq(Time.zone.now)
@@ -434,8 +434,8 @@ RSpec.describe Application do
 
       it "touch updates field user.updated_at" do
         freeze_time do
-          expect(user.updated_at.rfc3339).to eq(old_datetime.rfc3339)
-          expect(application.updated_at.rfc3339).to eq(old_datetime.rfc3339)
+          expect(user.updated_at).to be_within(1.second).of(old_datetime)
+          expect(application.updated_at).to be_within(1.second).of(old_datetime)
 
           application.rejected!
 

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -407,14 +407,14 @@ RSpec.describe Application do
     end
   end
 
-  describe "touch user when application updated" do
+  describe "touch user when application changed" do
     let!(:old_datetime) { 6.months.ago }
     let(:user) { create(:user, updated_at: old_datetime) }
 
     context "when application is created" do
       it "touch updates field user.updated_at" do
         freeze_time do
-          expect(user.updated_at).to eq(old_datetime)
+          expect(user.updated_at.rfc3339).to eq(old_datetime.rfc3339)
 
           create(:application, user:)
           expect(user.updated_at).to eq(Time.zone.now)

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -406,4 +406,43 @@ RSpec.describe Application do
       it { is_expected.not_to be_fundable }
     end
   end
+
+  describe "touch user when application updated" do
+    let!(:old_datetime) { 6.months.ago }
+    let(:user) { create(:user, updated_at: old_datetime) }
+
+    context "when application is created" do
+      it "touch updates field user.updated_at" do
+        freeze_time do
+          expect(user.updated_at).to eq(old_datetime)
+
+          create(:application, user:)
+          expect(user.updated_at).to eq(Time.zone.now)
+        end
+      end
+    end
+
+    context "when application is updated" do
+      let(:application) { create(:application, :pending, user:) }
+
+      before do
+        travel_to(old_datetime) do
+          user
+          application
+        end
+      end
+
+      it "touch updates field user.updated_at" do
+        freeze_time do
+          expect(user.updated_at.rfc3339).to eq(old_datetime.rfc3339)
+          expect(application.updated_at.rfc3339).to eq(old_datetime.rfc3339)
+
+          application.rejected!
+
+          expect(user.updated_at).to eq(Time.zone.now)
+          expect(application.updated_at).to eq(Time.zone.now)
+        end
+      end
+    end
+  end
 end

--- a/spec/serializers/api/declaration_serializer_spec.rb
+++ b/spec/serializers/api/declaration_serializer_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe API::DeclarationSerializer, type: :serializer do
           expect(attributes["updated_at"]).to eq(declaration.updated_at.rfc3339)
         end
 
-        context "when participant_outcome is the latest" do
+        context "when declaration.updated_at is not the latest" do
           let(:old_datetime) { Time.utc(2023, 5, 5, 5, 0, 0) }
           let(:latest_datetime) { Time.utc(2024, 8, 8, 8, 0, 0) }
 
@@ -54,31 +54,28 @@ RSpec.describe API::DeclarationSerializer, type: :serializer do
               create(:participant_outcome, declaration:)
               create(:statement_item, declaration:)
             end
-            declaration.participant_outcomes.first.update!(updated_at: latest_datetime)
           end
 
-          it "returns participant_outcome's `updated_at`" do
-            declaration.reload
-            expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
-          end
-        end
-
-        context "when statement_item is the latest" do
-          let(:old_datetime) { Time.utc(2023, 5, 5, 5, 0, 0) }
-          let(:latest_datetime) { Time.utc(2024, 8, 8, 8, 0, 0) }
-
-          before do
-            travel_to(old_datetime) do
-              declaration
-              create(:participant_outcome, declaration:)
-              create(:statement_item, declaration:)
+          context "when participant_outcome is the latest" do
+            before do
+              declaration.participant_outcomes.first.update!(updated_at: latest_datetime)
+              declaration.reload
             end
-            declaration.statement_items.first.update!(updated_at: latest_datetime)
+
+            it "returns participant_outcome's `updated_at`" do
+              expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
+            end
           end
 
-          it "returns statement_item's `updated_at`" do
-            declaration.reload
-            expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
+          context "when statement_item is the latest" do
+            before do
+              declaration.statement_items.first.update!(updated_at: latest_datetime)
+              declaration.reload
+            end
+
+            it "returns statement_item's `updated_at`" do
+              expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
+            end
           end
         end
 

--- a/spec/serializers/api/declaration_serializer_spec.rb
+++ b/spec/serializers/api/declaration_serializer_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe API::DeclarationSerializer, type: :serializer do
 
           it "returns participant_outcome's `updated_at`" do
             declaration.reload
-            expect(attributes["updated_at"]).to eq("2024-08-08T08:00:00Z")
+            expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
           end
         end
 
@@ -78,7 +78,7 @@ RSpec.describe API::DeclarationSerializer, type: :serializer do
 
           it "returns statement_item's `updated_at`" do
             declaration.reload
-            expect(attributes["updated_at"]).to eq("2024-08-08T08:00:00Z")
+            expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
           end
         end
 

--- a/spec/serializers/api/declaration_serializer_spec.rb
+++ b/spec/serializers/api/declaration_serializer_spec.rb
@@ -44,6 +44,44 @@ RSpec.describe API::DeclarationSerializer, type: :serializer do
           expect(attributes["updated_at"]).to eq(declaration.updated_at.rfc3339)
         end
 
+        context "when participant_outcome is the latest" do
+          let(:old_datetime) { Time.utc(2023, 5, 5, 5, 0, 0) }
+          let(:latest_datetime) { Time.utc(2024, 8, 8, 8, 0, 0) }
+
+          before do
+            travel_to(old_datetime) do
+              declaration
+              create(:participant_outcome, declaration:)
+              create(:statement_item, declaration:)
+            end
+            declaration.participant_outcomes.first.update!(updated_at: latest_datetime)
+          end
+
+          it "returns participant_outcome's `updated_at`" do
+            declaration.reload
+            expect(attributes["updated_at"]).to eq("2024-08-08T08:00:00Z")
+          end
+        end
+
+        context "when statement_item is the latest" do
+          let(:old_datetime) { Time.utc(2023, 5, 5, 5, 0, 0) }
+          let(:latest_datetime) { Time.utc(2024, 8, 8, 8, 0, 0) }
+
+          before do
+            travel_to(old_datetime) do
+              declaration
+              create(:participant_outcome, declaration:)
+              create(:statement_item, declaration:)
+            end
+            declaration.statement_items.first.update!(updated_at: latest_datetime)
+          end
+
+          it "returns statement_item's `updated_at`" do
+            declaration.reload
+            expect(attributes["updated_at"]).to eq("2024-08-08T08:00:00Z")
+          end
+        end
+
         it "serializes the `state`" do
           expect(attributes["state"]).to eq(declaration.state)
         end

--- a/spec/serializers/api/declaration_serializer_spec.rb
+++ b/spec/serializers/api/declaration_serializer_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe API::DeclarationSerializer, type: :serializer do
           context "when participant_outcome is the latest" do
             before do
               declaration.participant_outcomes.first.update!(updated_at: latest_datetime)
-              declaration.reload
             end
 
             it "returns participant_outcome's `updated_at`" do
@@ -70,7 +69,6 @@ RSpec.describe API::DeclarationSerializer, type: :serializer do
           context "when statement_item is the latest" do
             before do
               declaration.statement_items.first.update!(updated_at: latest_datetime)
-              declaration.reload
             end
 
             it "returns statement_item's `updated_at`" do

--- a/spec/serializers/api/participant_serializer_spec.rb
+++ b/spec/serializers/api/participant_serializer_spec.rb
@@ -62,6 +62,34 @@ RSpec.describe API::ParticipantSerializer, type: :serializer do
       it "serializes the `updated_at`" do
         expect(attributes["updated_at"]).to eq(participant.updated_at.rfc3339)
       end
+
+      context "when application is the latest" do
+        let(:old_datetime) { Time.utc(2023, 5, 5, 5, 0, 0) }
+        let(:latest_datetime) { Time.utc(2024, 8, 8, 8, 0, 0) }
+
+        it "returns application's `updated_at`" do
+          application.update!(updated_at: latest_datetime)
+          participant_id_change.update!(updated_at: old_datetime)
+          participant.update!(updated_at: old_datetime)
+
+          participant.reload
+          expect(attributes["updated_at"]).to eq("2024-08-08T08:00:00Z")
+        end
+      end
+
+      context "when participant_id_change is the latest" do
+        let(:old_datetime) { Time.utc(2023, 5, 5, 5, 0, 0) }
+        let(:latest_datetime) { Time.utc(2024, 8, 8, 8, 0, 0) }
+
+        it "returns participant_id_change's `updated_at`" do
+          application.update!(updated_at: old_datetime)
+          participant_id_change.update!(updated_at: latest_datetime)
+          participant.update!(updated_at: old_datetime)
+
+          participant.reload
+          expect(attributes["updated_at"]).to eq("2024-08-08T08:00:00Z")
+        end
+      end
     end
 
     context "when serializing the `v2` view" do
@@ -81,6 +109,34 @@ RSpec.describe API::ParticipantSerializer, type: :serializer do
 
       it "serializes the `updated_at`" do
         expect(attributes["updated_at"]).to eq(participant.updated_at.rfc3339)
+      end
+
+      context "when application is the latest" do
+        let(:old_datetime) { Time.utc(2023, 5, 5, 5, 0, 0) }
+        let(:latest_datetime) { Time.utc(2024, 8, 8, 8, 0, 0) }
+
+        it "returns application's `updated_at`" do
+          application.update!(updated_at: latest_datetime)
+          participant_id_change.update!(updated_at: old_datetime)
+          participant.update!(updated_at: old_datetime)
+
+          participant.reload
+          expect(attributes["updated_at"]).to eq("2024-08-08T08:00:00Z")
+        end
+      end
+
+      context "when participant_id_change is the latest" do
+        let(:old_datetime) { Time.utc(2023, 5, 5, 5, 0, 0) }
+        let(:latest_datetime) { Time.utc(2024, 8, 8, 8, 0, 0) }
+
+        it "returns participant_id_change's `updated_at`" do
+          application.update!(updated_at: old_datetime)
+          participant_id_change.update!(updated_at: latest_datetime)
+          participant.update!(updated_at: old_datetime)
+
+          participant.reload
+          expect(attributes["updated_at"]).to eq("2024-08-08T08:00:00Z")
+        end
       end
 
       it "serializes the `npq_enrolments`" do
@@ -113,6 +169,34 @@ RSpec.describe API::ParticipantSerializer, type: :serializer do
 
       it "serializes the `updated_at`" do
         expect(attributes["updated_at"]).to eq(participant.updated_at.rfc3339)
+      end
+
+      context "when application is the latest" do
+        let(:old_datetime) { Time.utc(2023, 5, 5, 5, 0, 0) }
+        let(:latest_datetime) { Time.utc(2024, 8, 8, 8, 0, 0) }
+
+        it "returns application's `updated_at`" do
+          application.update!(updated_at: latest_datetime)
+          participant_id_change.update!(updated_at: old_datetime)
+          participant.update!(updated_at: old_datetime)
+
+          participant.reload
+          expect(attributes["updated_at"]).to eq("2024-08-08T08:00:00Z")
+        end
+      end
+
+      context "when participant_id_change is the latest" do
+        let(:old_datetime) { Time.utc(2023, 5, 5, 5, 0, 0) }
+        let(:latest_datetime) { Time.utc(2024, 8, 8, 8, 0, 0) }
+
+        it "returns participant_id_change's `updated_at`" do
+          application.update!(updated_at: old_datetime)
+          participant_id_change.update!(updated_at: latest_datetime)
+          participant.update!(updated_at: old_datetime)
+
+          participant.reload
+          expect(attributes["updated_at"]).to eq("2024-08-08T08:00:00Z")
+        end
       end
 
       it "serializes the `npq_enrolments`" do

--- a/spec/serializers/api/participant_serializer_spec.rb
+++ b/spec/serializers/api/participant_serializer_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe API::ParticipantSerializer, type: :serializer do
           participant.update!(updated_at: old_datetime)
 
           participant.reload
-          expect(attributes["updated_at"]).to eq("2024-08-08T08:00:00Z")
+          expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
         end
       end
 
@@ -134,7 +134,7 @@ RSpec.describe API::ParticipantSerializer, type: :serializer do
           participant.update!(updated_at: old_datetime)
 
           participant.reload
-          expect(attributes["updated_at"]).to eq("2024-08-08T08:00:00Z")
+          expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
         end
       end
 
@@ -180,7 +180,7 @@ RSpec.describe API::ParticipantSerializer, type: :serializer do
           participant.update!(updated_at: old_datetime)
 
           participant.reload
-          expect(attributes["updated_at"]).to eq("2024-08-08T08:00:00Z")
+          expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
         end
       end
 
@@ -194,7 +194,7 @@ RSpec.describe API::ParticipantSerializer, type: :serializer do
           participant.update!(updated_at: old_datetime)
 
           participant.reload
-          expect(attributes["updated_at"]).to eq("2024-08-08T08:00:00Z")
+          expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
         end
       end
 

--- a/spec/serializers/api/participant_serializer_spec.rb
+++ b/spec/serializers/api/participant_serializer_spec.rb
@@ -63,31 +63,30 @@ RSpec.describe API::ParticipantSerializer, type: :serializer do
         expect(attributes["updated_at"]).to eq(participant.updated_at.rfc3339)
       end
 
-      context "when application is the latest" do
+      context "when participant.updated_at is not the latest" do
         let(:old_datetime) { Time.utc(2023, 5, 5, 5, 0, 0) }
         let(:latest_datetime) { Time.utc(2024, 8, 8, 8, 0, 0) }
 
-        it "returns application's `updated_at`" do
-          application.update!(updated_at: latest_datetime)
-          participant_id_change.update!(updated_at: old_datetime)
-          participant.update!(updated_at: old_datetime)
+        context "when application is the latest" do
+          it "returns application's `updated_at`" do
+            application.update!(updated_at: latest_datetime)
+            participant_id_change.update!(updated_at: old_datetime)
+            participant.update!(updated_at: old_datetime)
 
-          participant.reload
-          expect(attributes["updated_at"]).to eq("2024-08-08T08:00:00Z")
+            participant.reload
+            expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
+          end
         end
-      end
 
-      context "when participant_id_change is the latest" do
-        let(:old_datetime) { Time.utc(2023, 5, 5, 5, 0, 0) }
-        let(:latest_datetime) { Time.utc(2024, 8, 8, 8, 0, 0) }
+        context "when participant_id_change is the latest" do
+          it "returns participant_id_change's `updated_at`" do
+            application.update!(updated_at: old_datetime)
+            participant_id_change.update!(updated_at: latest_datetime)
+            participant.update!(updated_at: old_datetime)
 
-        it "returns participant_id_change's `updated_at`" do
-          application.update!(updated_at: old_datetime)
-          participant_id_change.update!(updated_at: latest_datetime)
-          participant.update!(updated_at: old_datetime)
-
-          participant.reload
-          expect(attributes["updated_at"]).to eq("2024-08-08T08:00:00Z")
+            participant.reload
+            expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
+          end
         end
       end
     end

--- a/spec/serializers/api/participant_serializer_spec.rb
+++ b/spec/serializers/api/participant_serializer_spec.rb
@@ -59,13 +59,19 @@ RSpec.describe API::ParticipantSerializer, type: :serializer do
         expect(attributes["teacher_reference_number"]).to eq(participant.trn)
       end
 
-      it "serializes the `updated_at`" do
-        expect(attributes["updated_at"]).to eq(participant.updated_at.rfc3339)
-      end
-
-      context "when participant.updated_at is not the latest" do
+      context "when serializing `updated_at`" do
         let(:old_datetime) { Time.utc(2023, 5, 5, 5, 0, 0) }
         let(:latest_datetime) { Time.utc(2024, 8, 8, 8, 0, 0) }
+
+        context "when participant is the latest" do
+          it "serializes the `updated_at`" do
+            application.update!(updated_at: old_datetime)
+            participant_id_change.update!(updated_at: old_datetime)
+            participant.update!(updated_at: latest_datetime)
+
+            expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
+          end
+        end
 
         context "when application is the latest" do
           it "returns application's `updated_at`" do
@@ -73,7 +79,6 @@ RSpec.describe API::ParticipantSerializer, type: :serializer do
             participant_id_change.update!(updated_at: old_datetime)
             participant.update!(updated_at: old_datetime)
 
-            participant.reload
             expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
           end
         end
@@ -84,7 +89,6 @@ RSpec.describe API::ParticipantSerializer, type: :serializer do
             participant_id_change.update!(updated_at: latest_datetime)
             participant.update!(updated_at: old_datetime)
 
-            participant.reload
             expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
           end
         end
@@ -106,35 +110,38 @@ RSpec.describe API::ParticipantSerializer, type: :serializer do
         expect(attributes["teacher_reference_number"]).to eq(participant.trn)
       end
 
-      it "serializes the `updated_at`" do
-        expect(attributes["updated_at"]).to eq(participant.updated_at.rfc3339)
-      end
-
-      context "when application is the latest" do
+      context "when serializing `updated_at`" do
         let(:old_datetime) { Time.utc(2023, 5, 5, 5, 0, 0) }
         let(:latest_datetime) { Time.utc(2024, 8, 8, 8, 0, 0) }
 
-        it "returns application's `updated_at`" do
-          application.update!(updated_at: latest_datetime)
-          participant_id_change.update!(updated_at: old_datetime)
-          participant.update!(updated_at: old_datetime)
+        context "when participant is the latest" do
+          it "serializes the `updated_at`" do
+            application.update!(updated_at: old_datetime)
+            participant_id_change.update!(updated_at: old_datetime)
+            participant.update!(updated_at: latest_datetime)
 
-          participant.reload
-          expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
+            expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
+          end
         end
-      end
 
-      context "when participant_id_change is the latest" do
-        let(:old_datetime) { Time.utc(2023, 5, 5, 5, 0, 0) }
-        let(:latest_datetime) { Time.utc(2024, 8, 8, 8, 0, 0) }
+        context "when application is the latest" do
+          it "returns application's `updated_at`" do
+            application.update!(updated_at: latest_datetime)
+            participant_id_change.update!(updated_at: old_datetime)
+            participant.update!(updated_at: old_datetime)
 
-        it "returns participant_id_change's `updated_at`" do
-          application.update!(updated_at: old_datetime)
-          participant_id_change.update!(updated_at: latest_datetime)
-          participant.update!(updated_at: old_datetime)
+            expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
+          end
+        end
 
-          participant.reload
-          expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
+        context "when participant_id_change is the latest" do
+          it "returns participant_id_change's `updated_at`" do
+            application.update!(updated_at: old_datetime)
+            participant_id_change.update!(updated_at: latest_datetime)
+            participant.update!(updated_at: old_datetime)
+
+            expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
+          end
         end
       end
 
@@ -166,35 +173,38 @@ RSpec.describe API::ParticipantSerializer, type: :serializer do
         expect(attributes["teacher_reference_number"]).to eq(participant.trn)
       end
 
-      it "serializes the `updated_at`" do
-        expect(attributes["updated_at"]).to eq(participant.updated_at.rfc3339)
-      end
-
-      context "when application is the latest" do
+      context "when serializing `updated_at`" do
         let(:old_datetime) { Time.utc(2023, 5, 5, 5, 0, 0) }
         let(:latest_datetime) { Time.utc(2024, 8, 8, 8, 0, 0) }
 
-        it "returns application's `updated_at`" do
-          application.update!(updated_at: latest_datetime)
-          participant_id_change.update!(updated_at: old_datetime)
-          participant.update!(updated_at: old_datetime)
+        context "when participant is the latest" do
+          it "serializes the `updated_at`" do
+            application.update!(updated_at: old_datetime)
+            participant_id_change.update!(updated_at: old_datetime)
+            participant.update!(updated_at: latest_datetime)
 
-          participant.reload
-          expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
+            expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
+          end
         end
-      end
 
-      context "when participant_id_change is the latest" do
-        let(:old_datetime) { Time.utc(2023, 5, 5, 5, 0, 0) }
-        let(:latest_datetime) { Time.utc(2024, 8, 8, 8, 0, 0) }
+        context "when application is the latest" do
+          it "returns application's `updated_at`" do
+            application.update!(updated_at: latest_datetime)
+            participant_id_change.update!(updated_at: old_datetime)
+            participant.update!(updated_at: old_datetime)
 
-        it "returns participant_id_change's `updated_at`" do
-          application.update!(updated_at: old_datetime)
-          participant_id_change.update!(updated_at: latest_datetime)
-          participant.update!(updated_at: old_datetime)
+            expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
+          end
+        end
 
-          participant.reload
-          expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
+        context "when participant_id_change is the latest" do
+          it "returns participant_id_change's `updated_at`" do
+            application.update!(updated_at: old_datetime)
+            participant_id_change.update!(updated_at: latest_datetime)
+            participant.update!(updated_at: old_datetime)
+
+            expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
+          end
         end
       end
 

--- a/spec/services/applications/query_spec.rb
+++ b/spec/services/applications/query_spec.rb
@@ -55,10 +55,10 @@ RSpec.describe Applications::Query do
 
       describe "updated since" do
         it "filters by updated since" do
-          travel_to(2.days.ago) do
-            create(:application, lead_provider:, updated_at: Time.zone.now)
-          end
+          travel_to(2.days.ago) { create(:application, lead_provider:) }
+
           application = create(:application, lead_provider:, updated_at: Time.zone.now)
+          application.user.update!(updated_at: 2.days.ago)
 
           query = described_class.new(lead_provider:, updated_since: 1.day.ago)
 

--- a/spec/services/applications/query_spec.rb
+++ b/spec/services/applications/query_spec.rb
@@ -93,9 +93,9 @@ RSpec.describe Applications::Query do
             query = described_class.new(lead_provider:, updated_since: 7.days.ago)
             expect(query.applications).to contain_exactly(application2)
 
-            application1.user.update!(updated_at: 1.days.ago)
+            application1.user.update!(updated_at: 1.day.ago)
 
-            query = described_class.new(lead_provider:, updated_since: 2.day.ago)
+            query = described_class.new(lead_provider:, updated_since: 2.days.ago)
             expect(query.applications).to contain_exactly(application1)
           end
         end

--- a/spec/services/declarations/query_spec.rb
+++ b/spec/services/declarations/query_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Declarations::Query do
 
         context "when participant_outcome was updated recently" do
           let!(:declaration1) do
-            travel_to(1.days.ago) do
+            travel_to(1.day.ago) do
               dec = create(:declaration)
               create(:participant_outcome, declaration: dec)
               create(:statement_item, declaration: dec)
@@ -95,7 +95,7 @@ RSpec.describe Declarations::Query do
           end
 
           it "filters by participant_outcome.updated_at" do
-            query = described_class.new(updated_since: 3.day.ago)
+            query = described_class.new(updated_since: 3.days.ago)
 
             expect(query.declarations).to contain_exactly(declaration2, declaration1)
 
@@ -106,7 +106,7 @@ RSpec.describe Declarations::Query do
 
         context "when statement_item was updated recently" do
           let!(:declaration1) do
-            travel_to(1.days.ago) do
+            travel_to(1.day.ago) do
               dec = create(:declaration)
               create(:participant_outcome, declaration: dec)
               create(:statement_item, declaration: dec)
@@ -131,7 +131,7 @@ RSpec.describe Declarations::Query do
           end
 
           it "filters by statement_item.updated_at" do
-            query = described_class.new(updated_since: 3.day.ago)
+            query = described_class.new(updated_since: 3.days.ago)
 
             expect(query.declarations).to contain_exactly(declaration2, declaration1)
 

--- a/spec/services/declarations/query_spec.rb
+++ b/spec/services/declarations/query_spec.rb
@@ -67,6 +67,78 @@ RSpec.describe Declarations::Query do
 
           expect(query.scope.to_sql).not_to include(condition_string)
         end
+
+        context "when participant_outcome was updated recently" do
+          let!(:declaration1) do
+            travel_to(1.days.ago) do
+              dec = create(:declaration)
+              create(:participant_outcome, declaration: dec)
+              create(:statement_item, declaration: dec)
+              dec
+            end
+          end
+          let!(:declaration2) do
+            travel_to(2.days.ago) do
+              dec = create(:declaration)
+              create(:participant_outcome, declaration: dec)
+              create(:statement_item, declaration: dec)
+              dec
+            end
+          end
+          let!(:declaration3) do
+            travel_to(5.days.ago) do
+              dec = create(:declaration)
+              create(:participant_outcome, declaration: dec)
+              create(:statement_item, declaration: dec)
+              dec
+            end
+          end
+
+          it "filters by participant_outcome.updated_at" do
+            query = described_class.new(updated_since: 3.day.ago)
+
+            expect(query.declarations).to contain_exactly(declaration2, declaration1)
+
+            declaration3.participant_outcomes.first.update!(updated_at: Time.zone.now)
+            expect(query.declarations).to contain_exactly(declaration2, declaration1, declaration3)
+          end
+        end
+
+        context "when statement_item was updated recently" do
+          let!(:declaration1) do
+            travel_to(1.days.ago) do
+              dec = create(:declaration)
+              create(:participant_outcome, declaration: dec)
+              create(:statement_item, declaration: dec)
+              dec
+            end
+          end
+          let!(:declaration2) do
+            travel_to(2.days.ago) do
+              dec = create(:declaration)
+              create(:participant_outcome, declaration: dec)
+              create(:statement_item, declaration: dec)
+              dec
+            end
+          end
+          let!(:declaration3) do
+            travel_to(5.days.ago) do
+              dec = create(:declaration)
+              create(:participant_outcome, declaration: dec)
+              create(:statement_item, declaration: dec)
+              dec
+            end
+          end
+
+          it "filters by statement_item.updated_at" do
+            query = described_class.new(updated_since: 3.day.ago)
+
+            expect(query.declarations).to contain_exactly(declaration2, declaration1)
+
+            declaration3.statement_items.first.update!(updated_at: Time.zone.now)
+            expect(query.declarations).to contain_exactly(declaration2, declaration1, declaration3)
+          end
+        end
       end
 
       context "when filtering by cohort" do

--- a/spec/services/participants/query_spec.rb
+++ b/spec/services/participants/query_spec.rb
@@ -98,11 +98,11 @@ RSpec.describe Participants::Query do
         end
 
         context "when application was updated recently" do
-          let!(:participant1) { travel_to(1.days.ago) { create(:user, :with_application, lead_provider:) } }
+          let!(:participant1) { travel_to(1.day.ago) { create(:user, :with_application, lead_provider:) } }
           let!(:participant2) { travel_to(2.days.ago) { create(:user, :with_application, lead_provider:) } }
           let!(:participant3) { travel_to(5.days.ago) { create(:user, :with_application, lead_provider:) } }
 
-          let(:params) { { updated_since: 3.day.ago } }
+          let(:params) { { updated_since: 3.days.ago } }
 
           it "filters by applications.updated_at" do
             expect(query.participants).to contain_exactly(participant2, participant1)
@@ -113,11 +113,11 @@ RSpec.describe Participants::Query do
         end
 
         context "when participant_id_change was updated recently" do
-          let!(:participant1) { travel_to(1.days.ago) { create(:user, :with_application, lead_provider:) } }
+          let!(:participant1) { travel_to(1.day.ago) { create(:user, :with_application, lead_provider:) } }
           let!(:participant2) { travel_to(2.days.ago) { create(:user, :with_application, lead_provider:) } }
           let!(:participant3) { travel_to(5.days.ago) { create(:user, :with_application, lead_provider:) } }
 
-          let(:params) { { updated_since: 3.day.ago } }
+          let(:params) { { updated_since: 3.days.ago } }
 
           it "filters by participant_id_change.updated_at" do
             expect(query.participants).to contain_exactly(participant2, participant1)

--- a/spec/services/participants/query_spec.rb
+++ b/spec/services/participants/query_spec.rb
@@ -108,6 +108,7 @@ RSpec.describe Participants::Query do
             expect(query.participants).to contain_exactly(participant2, participant1)
 
             participant3.applications.first.update!(updated_at: Time.zone.now)
+            participant3.update!(updated_at: 5.days.ago) # to account for touch model changes
             expect(query.participants).to contain_exactly(participant2, participant1, participant3)
           end
         end

--- a/spec/services/participants/query_spec.rb
+++ b/spec/services/participants/query_spec.rb
@@ -71,7 +71,9 @@ RSpec.describe Participants::Query do
           let(:params) { { updated_since: 1.day.ago } }
 
           it "filters by updated since" do
-            create(:user, :with_application, lead_provider:, updated_at: 2.days.ago)
+            travel_to(2.days.ago) do
+              create(:user, :with_application, lead_provider:)
+            end
 
             expect(query.participants).to contain_exactly(participant1, participant2)
           end
@@ -92,6 +94,36 @@ RSpec.describe Participants::Query do
             condition_string = %("updated_at")
 
             expect(query.scope.to_sql).not_to include(condition_string)
+          end
+        end
+
+        context "when application was updated recently" do
+          let!(:participant1) { travel_to(1.days.ago) { create(:user, :with_application, lead_provider:) } }
+          let!(:participant2) { travel_to(2.days.ago) { create(:user, :with_application, lead_provider:) } }
+          let!(:participant3) { travel_to(5.days.ago) { create(:user, :with_application, lead_provider:) } }
+
+          let(:params) { { updated_since: 3.day.ago } }
+
+          it "filters by applications.updated_at" do
+            expect(query.participants).to contain_exactly(participant2, participant1)
+
+            participant3.applications.first.update!(updated_at: Time.zone.now)
+            expect(query.participants).to contain_exactly(participant2, participant1, participant3)
+          end
+        end
+
+        context "when participant_id_change was updated recently" do
+          let!(:participant1) { travel_to(1.days.ago) { create(:user, :with_application, lead_provider:) } }
+          let!(:participant2) { travel_to(2.days.ago) { create(:user, :with_application, lead_provider:) } }
+          let!(:participant3) { travel_to(5.days.ago) { create(:user, :with_application, lead_provider:) } }
+
+          let(:params) { { updated_since: 3.day.ago } }
+
+          it "filters by participant_id_change.updated_at" do
+            expect(query.participants).to contain_exactly(participant2, participant1)
+
+            create(:participant_id_change, user: participant3)
+            expect(query.participants).to contain_exactly(participant2, participant1, participant3)
           end
         end
       end

--- a/spec/support/shared_examples/api_index_csv_endpoint_support.rb
+++ b/spec/support/shared_examples/api_index_csv_endpoint_support.rb
@@ -89,8 +89,12 @@ end
 RSpec.shared_examples "an API index Csv endpoint with filter by updated_since" do
   context "when fitlering by updated_since" do
     it "returns resources updated since the specified date" do
-      create_resource(lead_provider: current_lead_provider, updated_at: 2.hours.ago)
-      create_resource(lead_provider: current_lead_provider, updated_at: 1.minute.ago)
+      travel_to(2.hours.ago) do
+        create_resource(lead_provider: current_lead_provider)
+      end
+      travel_to(1.minute.ago) do
+        create_resource(lead_provider: current_lead_provider)
+      end
 
       api_get(path, params: { filter: { updated_since: 1.hour.ago.iso8601 } })
 

--- a/spec/support/shared_examples/api_index_endpoint_support.rb
+++ b/spec/support/shared_examples/api_index_endpoint_support.rb
@@ -142,8 +142,12 @@ end
 RSpec.shared_examples "an API index endpoint with filter by updated_since" do
   context "when fitlering by updated_since" do
     it "returns resources updated since the specified date" do
-      create_resource(lead_provider: current_lead_provider, updated_at: 2.hours.ago)
-      create_resource(lead_provider: current_lead_provider, updated_at: 1.minute.ago)
+      travel_to(2.hours.ago) do
+        create_resource(lead_provider: current_lead_provider)
+      end
+      travel_to(1.minute.ago) do
+        create_resource(lead_provider: current_lead_provider)
+      end
 
       api_get(path, params: { filter: { updated_since: 1.hour.ago.iso8601 } })
 


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-3363

### Changes proposed in this pull request

* `Application` will touch `User` when updated
* `DeclarationSerializer` `updated_at` includes `participant_outcomes` and `statement_items`
* `ParticipantSerializer` `updated_at` includes `participant_id_changes` and `applications`
* Query services have been updated to include all the related tables `updated_at`
