### PR TITLE
Change Declaration#declaration_date to DateTime

### DIFF
--- a/db/migrate/20240812095216_change_declaration_date_to_datetime_in_declarations.rb
+++ b/db/migrate/20240812095216_change_declaration_date_to_datetime_in_declarations.rb
@@ -1,0 +1,9 @@
+class ChangeDeclarationDateToDatetimeInDeclarations < ActiveRecord::Migration[7.1]
+  def up
+    change_column :declarations, :declaration_date, :datetime, precision: nil
+  end
+
+  def down
+    change_column :declarations, :declaration_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_25_102353) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_12_095216) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -174,7 +174,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_25_102353) do
     t.bigint "lead_provider_id", null: false
     t.bigint "cohort_id", null: false
     t.enum "declaration_type", enum_type: "declaration_types"
-    t.date "declaration_date"
+    t.datetime "declaration_date", precision: nil
     t.enum "state", default: "submitted", null: false, enum_type: "declaration_states"
     t.enum "state_reason", enum_type: "declaration_state_reasons"
     t.datetime "created_at", null: false

--- a/public/api/docs/v1/swagger.yaml
+++ b/public/api/docs/v1/swagger.yaml
@@ -414,7 +414,7 @@ paths:
                         participant_id: db3a7848-7308-4879-942a-c4a70ced400a
                         declaration_type: started
                         course_identifier: npq-senior-leadership
-                        declaration_date: '2022-04-30'
+                        declaration_date: '2021-05-31T02:22:32Z'
                         state: submitted
                         has_passed:
                         voided: false
@@ -505,7 +505,7 @@ paths:
                         participant_id: db3a7848-7308-4879-942a-c4a70ced400a
                         declaration_type: started
                         course_identifier: npq-senior-leadership
-                        declaration_date: '2022-04-30'
+                        declaration_date: '2021-05-31T02:22:32Z'
                         state: voided
                         has_passed:
                         voided: true
@@ -1401,7 +1401,7 @@ components:
           description: The event declaration date
           type: string
           format: date-time
-          example: '2021-05-31T02:22:32.000Z'
+          example: '2021-05-31T02:22:32Z'
         state:
           description: Indicates the state of this payment declaration
           type: string
@@ -2228,7 +2228,7 @@ components:
               description: The event declaration date
               type: string
               nullable: false
-              example: '2022-04-30'
+              example: '2021-05-31T02:22:32Z'
             state:
               description: Indicates the state of this payment declaration
               type: string
@@ -2335,7 +2335,7 @@ components:
           required: true
           nullable: false
           format: date-time
-          example: '2021-05-31T02:21:32.000Z'
+          example: '2021-05-31T02:21:32Z'
         course_identifier:
           description: The type of course the participant is enrolled in
           type: string
@@ -2363,7 +2363,7 @@ components:
       example:
         participant_id: db3a7848-7308-4879-942a-c4a70ced400a
         declaration_type: started
-        declaration_date: '2021-05-31T02:21:32.000Z'
+        declaration_date: '2021-05-31T02:21:32Z'
         course_identifier: npq-senior-leadership
     ParticipantDeclarationRetainedRequest:
       description: An NPQ participant retained declaration
@@ -2392,7 +2392,7 @@ components:
           required: true
           nullable: false
           format: date-time
-          example: '2021-05-31T02:21:32.000Z'
+          example: '2021-05-31T02:21:32Z'
         course_identifier:
           description: The type of course the participant is enrolled in
           type: string
@@ -2420,7 +2420,7 @@ components:
       example:
         participant_id: db3a7848-7308-4879-942a-c4a70ced400a
         declaration_type: retained-1
-        declaration_date: '2021-05-31T02:21:32.000Z'
+        declaration_date: '2021-05-31T02:21:32Z'
         course_identifier: npq-senior-leadership
     ParticipantDeclarationCompletedRequest:
       description: An NPQ completed participant declaration
@@ -2454,7 +2454,7 @@ components:
           required: true
           nullable: false
           format: date-time
-          example: '2021-05-31T02:21:32.000Z'
+          example: '2021-05-31T02:21:32Z'
         course_identifier:
           description: The type of course the participant is enrolled in
           type: string
@@ -2483,6 +2483,6 @@ components:
       example:
         participant_id: db3a7848-7308-4879-942a-c4a70ced400a
         declaration_type: completed
-        declaration_date: '2021-05-31T02:21:32.000Z'
+        declaration_date: '2021-05-31T02:21:32Z'
         course_identifier: npq-senior-leadership
         has_passed: true

--- a/public/api/docs/v2/swagger.yaml
+++ b/public/api/docs/v2/swagger.yaml
@@ -414,7 +414,7 @@ paths:
                         participant_id: db3a7848-7308-4879-942a-c4a70ced400a
                         declaration_type: started
                         course_identifier: npq-senior-leadership
-                        declaration_date: '2022-04-30'
+                        declaration_date: '2021-05-31T02:22:32Z'
                         state: submitted
                         has_passed:
                         updated_at: '2021-05-31T02:22:32.000Z'
@@ -503,7 +503,7 @@ paths:
                         participant_id: db3a7848-7308-4879-942a-c4a70ced400a
                         declaration_type: started
                         course_identifier: npq-senior-leadership
-                        declaration_date: '2022-04-30'
+                        declaration_date: '2021-05-31T02:22:32Z'
                         state: voided
                         has_passed:
                         updated_at: '2021-05-31T02:22:32.000Z'
@@ -1600,7 +1600,7 @@ components:
           description: The event declaration date
           type: string
           format: date-time
-          example: '2021-05-31T02:22:32.000Z'
+          example: '2021-05-31T02:22:32Z'
         state:
           description: Indicates the state of this payment declaration
           type: string
@@ -2444,7 +2444,7 @@ components:
               description: The event declaration date
               type: string
               nullable: false
-              example: '2022-04-30'
+              example: '2021-05-31T02:22:32Z'
             state:
               description: Indicates the state of this payment declaration
               type: string
@@ -2539,7 +2539,7 @@ components:
           required: true
           nullable: false
           format: date-time
-          example: '2021-05-31T02:21:32.000Z'
+          example: '2021-05-31T02:21:32Z'
         course_identifier:
           description: The type of course the participant is enrolled in
           type: string
@@ -2567,7 +2567,7 @@ components:
       example:
         participant_id: db3a7848-7308-4879-942a-c4a70ced400a
         declaration_type: started
-        declaration_date: '2021-05-31T02:21:32.000Z'
+        declaration_date: '2021-05-31T02:21:32Z'
         course_identifier: npq-senior-leadership
     ParticipantDeclarationRetainedRequest:
       description: An NPQ participant retained declaration
@@ -2596,7 +2596,7 @@ components:
           required: true
           nullable: false
           format: date-time
-          example: '2021-05-31T02:21:32.000Z'
+          example: '2021-05-31T02:21:32Z'
         course_identifier:
           description: The type of course the participant is enrolled in
           type: string
@@ -2624,7 +2624,7 @@ components:
       example:
         participant_id: db3a7848-7308-4879-942a-c4a70ced400a
         declaration_type: retained-1
-        declaration_date: '2021-05-31T02:21:32.000Z'
+        declaration_date: '2021-05-31T02:21:32Z'
         course_identifier: npq-senior-leadership
     ParticipantDeclarationCompletedRequest:
       description: An NPQ completed participant declaration
@@ -2658,7 +2658,7 @@ components:
           required: true
           nullable: false
           format: date-time
-          example: '2021-05-31T02:21:32.000Z'
+          example: '2021-05-31T02:21:32Z'
         course_identifier:
           description: The type of course the participant is enrolled in
           type: string
@@ -2687,6 +2687,6 @@ components:
       example:
         participant_id: db3a7848-7308-4879-942a-c4a70ced400a
         declaration_type: completed
-        declaration_date: '2021-05-31T02:21:32.000Z'
+        declaration_date: '2021-05-31T02:21:32Z'
         course_identifier: npq-senior-leadership
         has_passed: true

--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -445,7 +445,7 @@ paths:
                         participant_id: db3a7848-7308-4879-942a-c4a70ced400a
                         declaration_type: started
                         course_identifier: npq-senior-leadership
-                        declaration_date: '2022-04-30'
+                        declaration_date: '2021-05-31T02:22:32Z'
                         state: voided
                         has_passed:
                         statement_id: cd3a12347-7308-4879-942a-c4a70ced400a
@@ -2305,7 +2305,7 @@ components:
               description: The event declaration date
               type: string
               nullable: false
-              example: '2022-04-30'
+              example: '2021-05-31T02:22:32Z'
             state:
               description: Indicates the state of this payment declaration
               type: string
@@ -2437,7 +2437,7 @@ components:
           required: true
           nullable: false
           format: date-time
-          example: '2021-05-31T02:21:32.000Z'
+          example: '2021-05-31T02:21:32Z'
         course_identifier:
           description: The type of course the participant is enrolled in
           type: string
@@ -2465,7 +2465,7 @@ components:
       example:
         participant_id: db3a7848-7308-4879-942a-c4a70ced400a
         declaration_type: started
-        declaration_date: '2021-05-31T02:21:32.000Z'
+        declaration_date: '2021-05-31T02:21:32Z'
         course_identifier: npq-senior-leadership
     ParticipantDeclarationRetainedRequest:
       description: An NPQ participant retained declaration
@@ -2494,7 +2494,7 @@ components:
           required: true
           nullable: false
           format: date-time
-          example: '2021-05-31T02:21:32.000Z'
+          example: '2021-05-31T02:21:32Z'
         course_identifier:
           description: The type of course the participant is enrolled in
           type: string
@@ -2522,7 +2522,7 @@ components:
       example:
         participant_id: db3a7848-7308-4879-942a-c4a70ced400a
         declaration_type: retained-1
-        declaration_date: '2021-05-31T02:21:32.000Z'
+        declaration_date: '2021-05-31T02:21:32Z'
         course_identifier: npq-senior-leadership
     ParticipantDeclarationCompletedRequest:
       description: An NPQ completed participant declaration
@@ -2556,7 +2556,7 @@ components:
           required: true
           nullable: false
           format: date-time
-          example: '2021-05-31T02:21:32.000Z'
+          example: '2021-05-31T02:21:32Z'
         course_identifier:
           description: The type of course the participant is enrolled in
           type: string
@@ -2585,6 +2585,6 @@ components:
       example:
         participant_id: db3a7848-7308-4879-942a-c4a70ced400a
         declaration_type: completed
-        declaration_date: '2021-05-31T02:21:32.000Z'
+        declaration_date: '2021-05-31T02:21:32Z'
         course_identifier: npq-senior-leadership
         has_passed: true

--- a/spec/swagger_schemas/models/declaration_csv.rb
+++ b/spec/swagger_schemas/models/declaration_csv.rb
@@ -43,7 +43,7 @@ DECLARATION_CSV = {
         description: "The event declaration date",
         type: :string,
         format: :"date-time",
-        example: "2021-05-31T02:22:32.000Z",
+        example: "2021-05-31T02:22:32Z",
       },
       state: {
         description: "Indicates the state of this payment declaration",

--- a/spec/swagger_schemas/models/participant_declaration.rb
+++ b/spec/swagger_schemas/models/participant_declaration.rb
@@ -51,7 +51,7 @@ PARTICIPANT_DECLARATION = {
             description: "The event declaration date",
             type: :string,
             nullable: false,
-            example: "2022-04-30",
+            example: "2021-05-31T02:22:32Z",
           },
           state: {
             description: "Indicates the state of this payment declaration",

--- a/spec/swagger_schemas/requests/participant_declaration_completed_request.rb
+++ b/spec/swagger_schemas/requests/participant_declaration_completed_request.rb
@@ -34,7 +34,7 @@ PARTICIPANT_DECLARATION_COMPLETED_REQUEST = {
       required: true,
       nullable: false,
       format: "date-time",
-      example: "2021-05-31T02:21:32.000Z",
+      example: "2021-05-31T02:21:32Z",
     },
     course_identifier: {
       description: "The type of course the participant is enrolled in",
@@ -55,7 +55,7 @@ PARTICIPANT_DECLARATION_COMPLETED_REQUEST = {
   example: {
     participant_id: "db3a7848-7308-4879-942a-c4a70ced400a",
     declaration_type: "completed",
-    declaration_date: "2021-05-31T02:21:32.000Z",
+    declaration_date: "2021-05-31T02:21:32Z",
     course_identifier: Course::IDENTIFIERS.first,
     has_passed: true,
   },

--- a/spec/swagger_schemas/requests/participant_declaration_retained_request.rb
+++ b/spec/swagger_schemas/requests/participant_declaration_retained_request.rb
@@ -28,7 +28,7 @@ PARTICIPANT_DECLARATION_RETAINED_REQUEST = {
       required: true,
       nullable: false,
       format: "date-time",
-      example: "2021-05-31T02:21:32.000Z",
+      example: "2021-05-31T02:21:32Z",
     },
     course_identifier: {
       description: "The type of course the participant is enrolled in",
@@ -48,7 +48,7 @@ PARTICIPANT_DECLARATION_RETAINED_REQUEST = {
   example: {
     participant_id: "db3a7848-7308-4879-942a-c4a70ced400a",
     declaration_type: "retained-1",
-    declaration_date: "2021-05-31T02:21:32.000Z",
+    declaration_date: "2021-05-31T02:21:32Z",
     course_identifier: Course::IDENTIFIERS.first,
   },
 }.freeze

--- a/spec/swagger_schemas/requests/participant_declaration_started_request.rb
+++ b/spec/swagger_schemas/requests/participant_declaration_started_request.rb
@@ -27,7 +27,7 @@ PARTICIPANT_DECLARATION_STARTED_REQUEST = {
       required: true,
       nullable: false,
       format: "date-time",
-      example: "2021-05-31T02:21:32.000Z",
+      example: "2021-05-31T02:21:32Z",
     },
     course_identifier: {
       description: "The type of course the participant is enrolled in",
@@ -47,7 +47,7 @@ PARTICIPANT_DECLARATION_STARTED_REQUEST = {
   example: {
     participant_id: "db3a7848-7308-4879-942a-c4a70ced400a",
     declaration_type: "started",
-    declaration_date: "2021-05-31T02:21:32.000Z",
+    declaration_date: "2021-05-31T02:21:32Z",
     course_identifier: Course::IDENTIFIERS.first,
   },
 }.freeze


### PR DESCRIPTION
[Jira-3390](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3390)

### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-000

The `Declaration#declaration_date` is a `Date` in NPQ reg and a `DateTime` in ECF. The side-effect of having it as a `Date` in NPQ reg is that the `rfc3889` format uses an explicit timezone offset of `+00:00` instead of the shorthand `Z` that is used for `DateTime`. We're concerned this might break provider integrations, so to keep it consistently using the `Z` shorthand we are changing the field to a `DateTime` in NPQ reg.

### Changes proposed in this pull request

- Change Declaration#declaration_date to DateTime

### Guidance to review

The issue in NPQ reg is the explicit `+00:00` in the formatted date:

```
(byebug) declaration.declaration_date.class
Date
(byebug) declaration.declaration_date.rfc3339
"2024-08-12T00:00:00+00:00"
```

In ECF as we're using a `DateTime` it seems to prefer the `Z` shorthand for UTC:

```
(byebug) participant_declaration.declaration_date.class
ActiveSupport::TimeWithZone
(byebug) participant_declaration.declaration_date.rfc3339
"2023-09-01T00:00:00Z"
```

This change will ensure NPQ reg uses the `Z` shorthand in the formatted declaration date.