### PR TITLE
[CPDNPQ-2004] TRN import with missing leading zeros

### DIFF
--- a/app/services/importers/manual_validation.rb
+++ b/app/services/importers/manual_validation.rb
@@ -16,9 +16,10 @@ class Importers::ManualValidation
       Rails.logger.debug "no application found for #{row['application_ecf_id']}" if application.nil?
       next if application.nil?
 
-      Rails.logger.debug "updating trn for application: #{row['application_ecf_id']} with trn: #{row['validated_trn']}"
+      trn = add_leading_zero(row["validated_trn"])
+      Rails.logger.debug "updating trn for application: #{row['application_ecf_id']} with trn: #{trn}"
 
-      application.user.update!(trn: row["validated_trn"], trn_verified: true)
+      application.user.update!(trn:, trn_verified: true)
     end
   end
 
@@ -32,5 +33,9 @@ private
 
   def rows
     @rows ||= CSV.read(path_to_csv, headers: true)
+  end
+
+  def add_leading_zero(trn)
+    trn.rjust(7, "0")
   end
 end

--- a/spec/lib/services/importers/manual_validation_spec.rb
+++ b/spec/lib/services/importers/manual_validation_spec.rb
@@ -4,6 +4,7 @@ require "tempfile"
 RSpec.describe Importers::ManualValidation do
   let(:school) { create(:school) }
   let(:user) { create(:user) }
+  let(:trn) { "7654321" }
   let(:application) { create(:application, user:, school:) }
   let(:file) { Tempfile.new("test.csv") }
 
@@ -27,7 +28,7 @@ RSpec.describe Importers::ManualValidation do
         file.write("\n")
         file.write("123,7654321")
         file.write("\n")
-        file.write("#{application.ecf_id},7654321")
+        file.write("#{application.ecf_id},#{trn}")
         file.rewind
       end
 
@@ -41,6 +42,16 @@ RSpec.describe Importers::ManualValidation do
         expect {
           subject.call
         }.to change { user.reload.trn_verified }.to(true)
+      end
+
+      context "when application trn is less than 7 digits" do
+        let(:trn) { "123456" }
+
+        it "adds leading zero" do
+          expect {
+            subject.call
+          }.to change { user.reload.trn }.to("0123456")
+        end
       end
     end
 


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/CPDNPQ-2004

Excel strips leading zeros from TRNs. This PR adds them back if they are missing.

TRNs must be 7 digits. If the importer receives a validated TRN that is less then it will assume excel has stripped them. This PR therefore add 0's until the TRN is 7 digits.