### PR TITLE
[CPDLP-3391] Only surface accepted applications in enrolments

### DIFF
--- a/app/serializers/api/participant_serializer.rb
+++ b/app/serializers/api/participant_serializer.rb
@@ -92,7 +92,7 @@ module API
         def applications(object, options)
           return Application.none unless options[:lead_provider]
 
-          object.applications.select { |application| application.lead_provider_id == options[:lead_provider].id }
+          object.applications.accepted.select { |application| application.lead_provider_id == options[:lead_provider].id }
         end
 
         def withdrawal(application:, lead_provider:)

--- a/spec/serializers/api/participant_serializer_spec.rb
+++ b/spec/serializers/api/participant_serializer_spec.rb
@@ -98,6 +98,15 @@ RSpec.describe API::ParticipantSerializer, type: :serializer do
           }.stringify_keys,
         ])
       end
+
+      context "when there're multiple application with different lead provider approval states" do
+        before { create(:application, lead_provider:, user: participant) }
+
+        it "serializes only accepted `npq_enrolments`" do
+          expect(attributes["npq_enrolments"].size).to eq(1)
+          expect(attributes["npq_enrolments"][0]["npq_application_id"]).to eq(application.ecf_id)
+        end
+      end
     end
 
     context "when serializing the `v3` view" do
@@ -197,6 +206,15 @@ RSpec.describe API::ParticipantSerializer, type: :serializer do
             changed_at: participant.participant_id_changes.last.created_at.rfc3339,
           }.stringify_keys,
         ])
+      end
+
+      context "when there're multiple application with different lead provider approval states" do
+        before { create(:application, lead_provider:, user: participant) }
+
+        it "serializes only accepted `npq_enrolments`" do
+          expect(attributes["npq_enrolments"].size).to eq(1)
+          expect(attributes["npq_enrolments"][0]["npq_application_id"]).to eq(application.ecf_id)
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

Ticket: [CPDLP-3391](https://dfedigital.atlassian.net/browse/CPDLP-3391)

On the participant serialiser in npq enrolments we should only surface accepted applications rather than all applications

### Changes proposed in this pull request

Amend the participant serialiser to show a list of only accepted applications for that provider.


[CPDLP-3391]: https://dfedigital.atlassian.net/browse/CPDLP-3391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ