### PR TITLE
[CPDLP-3257] Add in DB `kind_of_nursery` enum in application

### DIFF
--- a/db/migrate/20240814093003_create_kind_of_nurseries_enum.rb
+++ b/db/migrate/20240814093003_create_kind_of_nurseries_enum.rb
@@ -1,0 +1,5 @@
+class CreateKindOfNurseriesEnum < ActiveRecord::Migration[7.1]
+  def change
+    create_enum :kind_of_nurseries, %w[local_authority_maintained_nursery preschool_class_as_part_of_school private_nursery another_early_years_setting childminder]
+  end
+end

--- a/db/migrate/20240814095351_change_applications_kind_of_nursery_to_enum.rb
+++ b/db/migrate/20240814095351_change_applications_kind_of_nursery_to_enum.rb
@@ -1,0 +1,16 @@
+class ChangeApplicationsKindOfNurseryToEnum < ActiveRecord::Migration[7.1]
+  def up
+    execute <<-SQL
+      ALTER TABLE applications
+      ALTER COLUMN kind_of_nursery TYPE kind_of_nurseries
+      USING kind_of_nursery::kind_of_nurseries
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      ALTER TABLE applications
+      ALTER COLUMN kind_of_nursery TYPE text
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_12_095216) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_14_095351) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -25,6 +25,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_12_095216) do
   create_enum "declaration_types", ["started", "retained-1", "retained-2", "completed"]
   create_enum "funding_choices", ["school", "trust", "self", "another", "employer"]
   create_enum "headteacher_statuses", ["no", "yes_when_course_starts", "yes_in_first_two_years", "yes_over_two_years", "yes_in_first_five_years", "yes_over_five_years"]
+  create_enum "kind_of_nurseries", ["local_authority_maintained_nursery", "preschool_class_as_part_of_school", "private_nursery", "another_early_years_setting", "childminder"]
   create_enum "lead_provider_approval_statuses", ["pending", "accepted", "rejected"]
   create_enum "outcome_states", ["passed", "failed", "voided"]
   create_enum "schedule_declaration_types", ["started", "retained-1", "retained-2", "completed"]
@@ -82,7 +83,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_12_095216) do
     t.text "DEPRECATED_private_childcare_provider_urn"
     t.boolean "works_in_nursery"
     t.boolean "works_in_childcare"
-    t.text "kind_of_nursery"
+    t.enum "kind_of_nursery", enum_type: "kind_of_nurseries"
     t.integer "DEPRECATED_cohort"
     t.boolean "targeted_delivery_funding_eligibility", default: false
     t.string "funding_eligiblity_status_code"

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Application do
         private_nursery: "private_nursery",
         another_early_years_setting: "another_early_years_setting",
         childminder: "childminder",
-      ).backed_by_column_of_type(:text).with_suffix
+      ).backed_by_column_of_type(:enum).with_suffix
     }
 
     it {


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-3257

We currently set an enum for `kind_of_nursery` in the application model but don’t have it in the db

### Changes proposed in this pull request

Set `kind_of_nursery` as an enum in the db.