### PR TITLE
Add state machine to `Declaration` model

### DIFF
--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -46,6 +46,36 @@ class Declaration < ApplicationRecord
     clawed_back: "clawed_back",
   }, _suffix: true
 
+  state_machine :state, initial: :submitted do
+    event :mark_eligible do
+      transition [:submitted] => :eligible
+    end
+
+    event :mark_payable do
+      transition [:eligible] => :payable
+    end
+
+    event :mark_paid do
+      transition [:payable] => :paid
+    end
+
+    event :mark_ineligible do
+      transition %i[submitted eligible payable paid] => :ineligible
+    end
+
+    event :mark_awaiting_clawback do
+      transition %i[paid] => :awaiting_clawback
+    end
+
+    event :mark_clawed_back do
+      transition %i[awaiting_clawback] => :clawed_back
+    end
+
+    event :mark_voided do
+      transition %i[submitted eligible payable ineligible] => :voided
+    end
+  end
+
   enum declaration_type: {
     started: "started",
     "retained-1": "retained-1",

--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -3,7 +3,6 @@ class Declaration < ApplicationRecord
   CHANGEABLE_STATES = %w[eligible submitted].freeze
   UPLIFT_PAID_STATES = %w[paid awaiting_clawback clawed_back].freeze
   COURSE_IDENTIFIERS_INELIGIBLE_FOR_UPLIFT = %w[npq-additional-support-offer npq-early-headship-coaching-offer].freeze
-  ELIGIBLE_FOR_PAYMENT_STATES = %w[payable eligible].freeze
   VOIDABLE_STATES = %w[submitted eligible payable ineligible].freeze
 
   belongs_to :application
@@ -107,11 +106,7 @@ class Declaration < ApplicationRecord
   end
 
   def eligible_for_payment?
-    state.in?(ELIGIBLE_FOR_PAYMENT_STATES)
-  end
-
-  def voidable?
-    state.in?(VOIDABLE_STATES)
+    can_mark_paid? || can_mark_payable?
   end
 
   def ineligible_for_funding_reason

--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -59,7 +59,7 @@ class Declaration < ApplicationRecord
     end
 
     event :mark_ineligible do
-      transition %i[submitted eligible payable paid] => :ineligible
+      transition %i[submitted] => :ineligible
     end
 
     event :mark_awaiting_clawback do

--- a/app/services/declarations/create.rb
+++ b/app/services/declarations/create.rb
@@ -115,9 +115,9 @@ module Declarations
     def set_eligibility!
       if declaration.duplicate_declarations.any?
         declaration.update!(superseded_by: original_declaration)
-        declaration.ineligible_state!
+        declaration.mark_ineligible!
       elsif application.fundable?
-        declaration.eligible_state!
+        declaration.mark_eligible!
       end
     end
 

--- a/app/services/declarations/void.rb
+++ b/app/services/declarations/void.rb
@@ -32,12 +32,12 @@ module Declarations
   private
 
     def clawback_declaration
-      declaration.awaiting_clawback_state!
+      declaration.mark_awaiting_clawback!
       statement_attacher.attach
     end
 
     def void_declaration
-      declaration.voided_state!
+      declaration.mark_voided!
       declaration.statement_items.with_state(:eligible, :payable).first&.mark_voided!
     end
 

--- a/docs/state_machines.md
+++ b/docs/state_machines.md
@@ -36,3 +36,35 @@ stateDiagram-v2
     awaiting_clawback --> clawed_back: mark_clawed_back
     eligible --> ineligible: mark_ineligible
 ```
+
+## Declaration
+
+```mermaid
+---
+title: State
+---
+stateDiagram-v2
+    submitted
+    eligible
+    payable
+    paid
+    voided
+    ineligible
+    awaiting_clawback
+    clawed_back
+
+    [*] --> submitted
+    submitted --> eligible: mark_eligible
+    eligible --> payable: mark_payable
+    payable --> paid: mark_paid
+    submitted --> ineligible: mark_ineligible
+    eligible --> ineligible: mark_ineligible
+    payable --> ineligible: mark_ineligible
+    paid --> ineligible: mark_ineligible
+    paid --> awaiting_clawback: mark_awaiting_clawback
+    awaiting_clawback --> clawed_back: mark_clawed_back
+    submitted --> voided: mark_voided
+    eligible --> voided: mark_voided
+    payable --> voided: mark_voided
+    ineligible --> voided: mark_voided
+```

--- a/docs/state_machines.md
+++ b/docs/state_machines.md
@@ -58,9 +58,6 @@ stateDiagram-v2
     eligible --> payable: mark_payable
     payable --> paid: mark_paid
     submitted --> ineligible: mark_ineligible
-    eligible --> ineligible: mark_ineligible
-    payable --> ineligible: mark_ineligible
-    paid --> ineligible: mark_ineligible
     paid --> awaiting_clawback: mark_awaiting_clawback
     awaiting_clawback --> clawed_back: mark_clawed_back
     submitted --> voided: mark_voided

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -303,39 +303,23 @@ RSpec.describe Declaration, type: :model do
   describe "#eligible_for_payment?" do
     subject { build(:declaration, state:) }
 
-    described_class::ELIGIBLE_FOR_PAYMENT_STATES.each do |eligible_state|
-      context "when the state is #{eligible_state}" do
-        let(:state) { eligible_state }
+    context "when the state is payable" do
+      let(:state) { :payable }
 
-        it { is_expected.to be_eligible_for_payment }
-      end
+      it { is_expected.to be_eligible_for_payment }
     end
 
-    described_class.states.keys.excluding(described_class::ELIGIBLE_FOR_PAYMENT_STATES).each do |ineligible_state|
-      context "when the state is #{ineligible_state}" do
-        let(:state) { ineligible_state }
+    context "when the state is eligible" do
+      let(:state) { :eligible }
+
+      it { is_expected.to be_eligible_for_payment }
+    end
+
+    described_class.states.keys.excluding("payable", "eligible").each do |eligible_state|
+      context "when the state is #{eligible_state}" do
+        let(:state) { eligible_state }
 
         it { is_expected.not_to be_eligible_for_payment }
-      end
-    end
-  end
-
-  describe "#voidable?" do
-    subject { build(:declaration, state:) }
-
-    described_class::VOIDABLE_STATES.each do |eligible_state|
-      context "when the state is #{eligible_state}" do
-        let(:state) { eligible_state }
-
-        it { is_expected.to be_voidable }
-      end
-    end
-
-    described_class.states.keys.excluding(described_class::VOIDABLE_STATES).each do |ineligible_state|
-      context "when the state is #{ineligible_state}" do
-        let(:state) { ineligible_state }
-
-        it { is_expected.not_to be_voidable }
       end
     end
   end

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -134,24 +134,6 @@ RSpec.describe Declaration, type: :model do
         it { expect { declaration.mark_ineligible }.to change(declaration, :state).from("submitted").to("ineligible") }
       end
 
-      context "when eligible" do
-        let(:state) { :eligible }
-
-        it { expect { declaration.mark_ineligible }.to change(declaration, :state).from("eligible").to("ineligible") }
-      end
-
-      context "when payable" do
-        let(:state) { :payable }
-
-        it { expect { declaration.mark_ineligible }.to change(declaration, :state).from("payable").to("ineligible") }
-      end
-
-      context "when paid" do
-        let(:state) { :paid }
-
-        it { expect { declaration.mark_ineligible }.to change(declaration, :state).from("paid").to("ineligible") }
-      end
-
       context "when not submitted/eligible/payable/paid" do
         let(:state) { :voided }
 


### PR DESCRIPTION
### Context

We want to add a state machine to the `Declaration` model to be consistent with `Statement` and `StatementItem`.

### Changes proposed in this pull request

- Add state machine to `Declaration` model

Add state machine, defining transitions.

- Use state machine where possible

We can clean up/remove some of our methods to use the convenience methods provided by the state machine library.

### Guidance to review

I opted not to add a state machine to the `ParticipantOutcome#state` as we don't appear to transition between states with outcomes, instead creating a new outcome of a different state.

I'm not sure how much value this is actually adding; I think we need to go more 'all in' on the state machine and look to consolidate some of the constants/state logic spread throughout the various service classes.