### PR TITLE
Rename WebhookMessage processed method

### DIFF
--- a/app/models/get_an_identity/webhook_message.rb
+++ b/app/models/get_an_identity/webhook_message.rb
@@ -29,7 +29,7 @@ class GetAnIdentity::WebhookMessage < ApplicationRecord
     failed_status? || unhandled_message_type_status?
   end
 
-  def processed!
+  def make_processed!
     update!(status: :processed, processed_at: Time.zone.now)
   end
 end

--- a/app/services/get_an_identity_service/webhooks/user_updated_processor.rb
+++ b/app/services/get_an_identity_service/webhooks/user_updated_processor.rb
@@ -24,7 +24,7 @@ module GetAnIdentityService
 
         if user.update(update_params)
           sync_user_changes_to_ecf
-          webhook_message.processed_status!
+          webhook_message.make_processed!
         else
           record_error(user.errors.full_messages.join(", "))
         end

--- a/spec/models/get_an_identity/webhook_message_spec.rb
+++ b/spec/models/get_an_identity/webhook_message_spec.rb
@@ -12,4 +12,18 @@ RSpec.describe GetAnIdentity::WebhookMessage, type: :model do
       ).backed_by_column_of_type(:string).with_suffix
     }
   end
+
+  describe "instance methods" do
+    describe "#make_processed!" do
+      it "sets status to processed and processed_at" do
+        expect(subject).not_to be_processed_status
+        expect(subject.processed_at).to be_nil
+
+        subject.make_processed!
+
+        expect(subject).to be_processed_status
+        expect(subject.processed_at).to be_within(1.second).of(Time.zone.now)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-3252

There's a regression created after https://github.com/DFE-Digital/npq-registration/pull/1593/files#diff-af07b0740b12a08358fb8e2d95eaddb480d815b03088b29ffbc6a308abb3e67dL27

### Changes proposed in this pull request

Name the method properly so it fixes the regression.
