### PR TITLE
[CPDLP-3434] Fix flakey tests linked to rack attack

### DIFF
--- a/spec/support/helpers/admin_login.rb
+++ b/spec/support/helpers/admin_login.rb
@@ -9,8 +9,6 @@ module Helpers
     end
 
     def sign_in_as(admin_account)
-      Rack::Attack.enabled = false
-
       visit("/admin")
       expect(page).to have_current_path(sign_in_path)
 
@@ -24,8 +22,6 @@ module Helpers
       page.click_button "Sign in"
 
       expect(page).to have_current_path("/admin")
-
-      Rack::Attack.enabled = true
     end
   end
 end

--- a/spec/support/rack_attack.rb
+++ b/spec/support/rack_attack.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+Rack::Attack.enabled = false
+
+RSpec.configure do |config|
+  config.around do |example|
+    if example.metadata[:rack_attack] == true
+      begin
+        Rack::Attack.enabled = true
+        Rack::Attack.reset!
+
+        example.run
+      ensure
+        Rack::Attack.enabled = false
+      end
+    else
+      example.run
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: [CPDLP-3434](https://dfedigital.atlassian.net/browse/CPDLP-3434)

Intermittently we get 429 failures in one of the parallel builds in Rspec in NPQ reg see https://github.com/DFE-Digital/npq-registration/actions/runs/10453888479/job/28945276236. After it’s rebuilt it passes ok

### Changes proposed in this pull request

- Fix this issue to avoid flakiness and delays in the build
- Rack attack was being turned on in a test and depending upon whether it runs before the `spec/requests` specs, we then were getting rack attack blocking requests specs afterwards.
- Add missing `spec/support/rack_attack.rb` to turn rack attack off by default in tests and cause we still wanna optionally turn it on in [spec/support/shared_examples/rate_limiting_support.rb](https://github.com/DFE-Digital/npq-registration/blob/main/spec/support/shared_examples/rate_limiting_support.rb#L3) in order to test specifics like [spec/requests/rate_limiting_spec.rb](https://github.com/DFE-Digital/npq-registration/blob/main/spec/requests/rate_limiting_spec.rb ).

[CPDLP-3434]: https://dfedigital.atlassian.net/browse/CPDLP-3434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ