### PR TITLE
[CPDLP-3442] Add new table and model for outcomes api request

### DIFF
--- a/app/models/participant_outcome.rb
+++ b/app/models/participant_outcome.rb
@@ -1,5 +1,6 @@
 class ParticipantOutcome < ApplicationRecord
   belongs_to :declaration
+  has_many :participant_outcome_api_requests
 
   validates :ecf_id, uniqueness: true
   validates :state, presence: true

--- a/app/models/participant_outcome_api_request.rb
+++ b/app/models/participant_outcome_api_request.rb
@@ -1,10 +1,5 @@
 class ParticipantOutcomeAPIRequest < ApplicationRecord
   belongs_to :participant_outcome
 
-  validates :ecf_id,
-            presence: { message: "Enter an ECF ID" },
-            uniqueness: {
-              case_sensitive: false,
-              message: "ECF ID must be unique",
-            }
+  validates :ecf_id, presence: true, uniqueness: { case_sensitive: false }
 end

--- a/app/models/participant_outcome_api_request.rb
+++ b/app/models/participant_outcome_api_request.rb
@@ -1,0 +1,10 @@
+class ParticipantOutcomeAPIRequest < ApplicationRecord
+  belongs_to :participant_outcome
+
+  validates :ecf_id,
+            presence: { message: "Enter an ECF ID" },
+            uniqueness: {
+              case_sensitive: false,
+              message: "ECF ID must be unique",
+            }
+end

--- a/db/migrate/20240820153944_create_participant_outcome_api_requests.rb
+++ b/db/migrate/20240820153944_create_participant_outcome_api_requests.rb
@@ -1,0 +1,18 @@
+class CreateParticipantOutcomeAPIRequests < ActiveRecord::Migration[7.1]
+  def change
+    create_table :participant_outcome_api_requests do |t|
+      t.uuid :ecf_id, default: "gen_random_uuid()", null: false, index: { unique: true }
+
+      t.references :participant_outcome, null: false, foreign_key: true, index: { name: "index_participant_outcome_api_requests_on_participant_outcome" }
+
+      t.string :request_path
+      t.integer :status_code
+      t.jsonb :request_headers
+      t.jsonb :request_body
+      t.jsonb :response_body
+      t.jsonb :response_headers
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_14_120004) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_20_153944) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -288,6 +288,21 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_14_120004) do
     t.index ["user_id"], name: "index_participant_id_changes_on_user_id"
   end
 
+  create_table "participant_outcome_api_requests", force: :cascade do |t|
+    t.uuid "ecf_id", default: -> { "gen_random_uuid()" }, null: false
+    t.bigint "participant_outcome_id", null: false
+    t.string "request_path"
+    t.integer "status_code"
+    t.jsonb "request_headers"
+    t.jsonb "request_body"
+    t.jsonb "response_body"
+    t.jsonb "response_headers"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["ecf_id"], name: "index_participant_outcome_api_requests_on_ecf_id", unique: true
+    t.index ["participant_outcome_id"], name: "index_participant_outcome_api_requests_on_participant_outcome"
+  end
+
   create_table "participant_outcomes", force: :cascade do |t|
     t.enum "state", null: false, enum_type: "outcome_states"
     t.date "completion_date", null: false
@@ -493,6 +508,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_14_120004) do
   add_foreign_key "participant_id_changes", "users"
   add_foreign_key "participant_id_changes", "users", column: "from_participant_id"
   add_foreign_key "participant_id_changes", "users", column: "to_participant_id"
+  add_foreign_key "participant_outcome_api_requests", "participant_outcomes"
   add_foreign_key "participant_outcomes", "declarations"
   add_foreign_key "schedules", "cohorts"
   add_foreign_key "schedules", "course_groups"

--- a/spec/factories/participant_outcome_api_requests.rb
+++ b/spec/factories/participant_outcome_api_requests.rb
@@ -1,0 +1,43 @@
+FactoryBot.define do
+  factory :participant_outcome_api_request do
+    participant_outcome
+    ecf_id { SecureRandom.uuid }
+
+    trait :with_trn_success do
+      request_path { "https://example.com/v2/npq-qualifications?trn=1234567" }
+      status_code { 204 }
+      request_headers do
+        {
+          "host" => "example.com",
+          "accept" => "*/*",
+          "user-agent" => "Ruby",
+          "content-type" => "application/json",
+          "content-length" => "59",
+          "accept-encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+        }
+      end
+      request_body { { "completionDate" => "2023-02-21", "qualificationType" => "NPQLT" } }
+      response_body { nil }
+      response_headers do
+        {
+          "date" => "Thu, 11 May 2023 12:44:39 GMT",
+          "connection" => "keep-alive",
+          "request-context" => "appId=cid-v1:b3114e2d-c1ab-4870-90b8-88ccc4bdc491",
+          "x-frame-options" => "deny",
+          "x-xss-protection" => "0",
+          "x-vcap-request-id" => "6aaeb6a1-1697-4e12-694e-a9c3d4c63250",
+          "x-rate-limit-limit" => "60s",
+          "x-rate-limit-reset" => "2023-05-11T12:45:00.0000000Z",
+          "x-content-type-options" => "nosniff",
+          "x-rate-limit-remaining" => "225",
+          "strict-transport-security" => "max-age=31536000; includeSubDomains; preload",
+        }
+      end
+    end
+
+    trait :with_trn_not_found do
+      status_code { 404 }
+      response_body { { errorCode: 10_001 } }
+    end
+  end
+end

--- a/spec/models/participant_outcome_api_request_spec.rb
+++ b/spec/models/participant_outcome_api_request_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ParticipantOutcomeAPIRequest, type: :model do
   end
 
   describe "validations" do
-    it { is_expected.to validate_presence_of(:ecf_id).with_message("Enter an ECF ID") }
-    it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique") }
+    it { is_expected.to validate_presence_of(:ecf_id) }
+    it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive }
   end
 end

--- a/spec/models/participant_outcome_api_request_spec.rb
+++ b/spec/models/participant_outcome_api_request_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe ParticipantOutcomeAPIRequest, type: :model do
+  subject(:participant_outcome_api_request) { create(:participant_outcome_api_request) }
+
+  describe "associations" do
+    it { is_expected.to belong_to(:participant_outcome) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:ecf_id).with_message("Enter an ECF ID") }
+    it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique") }
+  end
+end

--- a/spec/models/participant_outcome_spec.rb
+++ b/spec/models/participant_outcome_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe ParticipantOutcome, type: :model do
 
   describe "associations" do
     it { is_expected.to belong_to(:declaration) }
+    it { is_expected.to have_many(:participant_outcome_api_requests) }
   end
 
   describe "#has_passed?" do


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-3442

Following [CPDLP-3396](https://dfedigital.atlassian.net/browse/CPDLP-3396) we came up with a plan to implement sending outcomes to TRA in NPQ reg app.

### Changes proposed in this pull request

- Add new table and model for participant outcomes api request;
- Check indexes/FK we need to also create (per ECF app);

[CPDLP-3396]: https://dfedigital.atlassian.net/browse/CPDLP-3396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ