### PR TITLE
Remove hard-coded coverage paths from sonar-project.properties

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -220,5 +220,5 @@ jobs:
             ${{github.workspace}}/${{env.unit-tests-artifact-name}}_3/test-report-3.xml,\
             ${{github.workspace}}/${{env.unit-tests-artifact-name}}_4/test-report-4.xml,\
             ${{github.workspace}}/${{env.unit-tests-artifact-name}}_5/test-report-5.xml
-           -Dsonar.ruby.coverage.reportPaths=${{github.workspace}}/code_coverage/coverage.json
+           -Dsonar.ruby.coverage.reportPaths=${{github.workspace}}/coverage/coverage.json
            -Dsonar.ruby.rubocop.reportPaths=${{github.workspace}}/${{env.rubocop-artifact-name}}/rubocop-result.json

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,5 +4,3 @@ sonar.exclusions=
 sonar.sources=app,lib
 sonar.tests=./spec
 sonar.ruby.coverage.framework=RSpec
-sonar.ruby.rubocop.reportPath=rubocop-result.json
-sonar.ruby.coverage.reportPaths=code_coverage/.resultset.json


### PR DESCRIPTION
These change on each run and are specified in the action when we call the sonar-scanner CLI. The path to the combined coverage report was also wrong as I didn't realise simplecov puts it in the default `coverage` directory instead of the directory where the `collate` is ran.
