### PR TITLE
Scale up the separation environment

### DIFF
--- a/terraform/application/config/separation.tfvars.json
+++ b/terraform/application/config/separation.tfvars.json
@@ -2,5 +2,10 @@
   "cluster": "production",
   "namespace": "cpd-production",
   "environment": "separation",
-  "enable_logit": true
+  "enable_logit": true,
+  "webapp_replicas": 4,
+  "worker_replicas": 2,
+  "webapp_memory_max": "4Gi",
+  "worker_memory_max": "2Gi",
+  "postgres_flexible_server_sku": "GP_Standard_D2ds_v4"
 }


### PR DESCRIPTION
> ⚠️ As the DB is not high availability there will be downtime when this rolls out, so we may want to merge it at a quiet time (infra team say GitHub is fine to deploy it).

[Jira-3447](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-3447)

### Context

We noticed that the separation env was quite slow; we want to scale it up to be similar to production as providers are actively using this environment now.

### Changes proposed in this pull request

- Scale up the separation environment

### Guidance to review

I've manually checked this with `terraform-plan` and it looks good:

```
DOCKER_IMAGE=ghcr.io/dfe-digital/npq-registration:824c2224f04129ed50d2d7302c7be480a036ed79 make ci separation terraform-plan
```
