### PR TITLE
Update MigrationsController to inherit from SuperAdminController

### DIFF
--- a/app/controllers/npq_separation/migration/migrations_controller.rb
+++ b/app/controllers/npq_separation/migration/migrations_controller.rb
@@ -1,6 +1,4 @@
-class NpqSeparation::Migration::MigrationsController < ApplicationController
-  before_action :require_super_admin
-
+class NpqSeparation::Migration::MigrationsController < SuperAdminController
   def index
     @data_migrations = Migration::DataMigration.all
     @in_progress_migration = @data_migrations.present? && !@data_migrations.all?(&:complete?)
@@ -19,14 +17,5 @@ class NpqSeparation::Migration::MigrationsController < ApplicationController
     failures = Migration::FailureManager.new(data_migration:).all_failures
 
     send_data(failures, filename: "migration_failures_#{data_migration.model}_#{data_migration.id}.yaml", type: "text/yaml", disposition: "attachment")
-  end
-
-private
-
-  def require_super_admin
-    unless current_admin&.super_admin?
-      flash[:negative] = { title: "Unauthorized", text: "Sign in with your admininstrator account" }
-      redirect_to sign_in_path
-    end
   end
 end


### PR DESCRIPTION
[Jira-3441](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3441)

### Context

This removes the need to manually check for super_admin users in a `before_action`.

### Changes proposed in this pull request

- Update MigrationsController to inherit from SuperAdminController