### PR TITLE
Do not run sonar cloud on dependabot prs

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -160,7 +160,7 @@ jobs:
     name: Sonar Scanner
     runs-on: ubuntu-latest
     needs: [ rspec, ruby_linting ]
-    if: github.ref != 'refs/heads/main'
+    if: github.ref != 'refs/heads/main' && github.actor != 'dependabot[bot]'
     environment:
       name: staging
     steps:


### PR DESCRIPTION
### Context

Sonar cloud is failing on dependabot prs
https://github.com/DFE-Digital/npq-registration/actions/runs/10531124012/job/29182659403

### Changes proposed in this pull request

We don't need to run sonar cloud on dependabot. Also this is causing failures in azure login due to not deploying anything in dependabot prs and we are missing azure login setup
### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
