### PR TITLE
Migrate `ParticipantIdChange` records from ECF

### DIFF
--- a/app/models/migration/ecf/participant_id_change.rb
+++ b/app/models/migration/ecf/participant_id_change.rb
@@ -1,0 +1,7 @@
+module Migration::Ecf
+  class ParticipantIdChange < BaseRecord
+    belongs_to :user
+    belongs_to :from_participant, class_name: "User"
+    belongs_to :to_participant, class_name: "User"
+  end
+end

--- a/app/models/migration/ecf/user.rb
+++ b/app/models/migration/ecf/user.rb
@@ -3,6 +3,7 @@ module Migration::Ecf
     has_many :participant_identities, dependent: :destroy
     has_one :teacher_profile
     has_many :npq_profiles, through: :teacher_profile, dependent: :destroy
+    has_many :participant_id_changes
 
     def npq_applications
       Migration::Ecf::NpqApplication.joins(:participant_identity).where(participant_identity: { user_id: id })

--- a/app/models/participant_id_change.rb
+++ b/app/models/participant_id_change.rb
@@ -4,4 +4,6 @@ class ParticipantIdChange < ApplicationRecord
   belongs_to :user
   belongs_to :from_participant, class_name: "User"
   belongs_to :to_participant, class_name: "User"
+
+  validates :user, :from_participant, :to_participant, presence: true
 end

--- a/app/services/migration/migrators/participant_id_change.rb
+++ b/app/services/migration/migrators/participant_id_change.rb
@@ -1,7 +1,7 @@
 module Migration::Migrators
   class ParticipantIdChange < Base
     class << self
-      def model_count
+      def record_count
         ecf_participant_id_changes.count
       end
 
@@ -29,7 +29,9 @@ module Migration::Migrators
           user_id: user_id_by_ecf_id[ecf_participant_id_change.user_id],
           from_participant_id: user_id_by_ecf_id[ecf_participant_id_change.from_participant_id],
           to_participant_id: user_id_by_ecf_id[ecf_participant_id_change.to_participant_id],
-        )
+        ).tap do |participant_id_change|
+          participant_id_change.update!(created_at: ecf_participant_id_change.created_at)
+        end
       end
     end
   end

--- a/app/services/migration/migrators/participant_id_change.rb
+++ b/app/services/migration/migrators/participant_id_change.rb
@@ -1,0 +1,36 @@
+module Migration::Migrators
+  class ParticipantIdChange < Base
+    class << self
+      def model_count
+        ecf_participant_id_changes.count
+      end
+
+      def model
+        :participant_id_change
+      end
+
+      def dependencies
+        %i[user]
+      end
+
+      def ecf_participant_id_changes
+        Migration::Ecf::ParticipantIdChange
+          .joins(:user)
+          .where(user: { id: User.ecf_users.pluck(:id) })
+      end
+    end
+
+    def call
+      migrate(self.class.ecf_participant_id_changes) do |ecf_participant_id_change|
+        ecf_ids = ecf_participant_id_change.attributes.slice("user_id", "from_participant_id", "to_participant_id").values
+        user_id_by_ecf_id = ::User.where(ecf_id: ecf_ids).select(:id, :ecf_id).index_by(&:ecf_id).transform_values(&:id)
+
+        ::ParticipantIdChange.find_or_create_by!(
+          user_id: user_id_by_ecf_id[ecf_participant_id_change.user_id],
+          from_participant_id: user_id_by_ecf_id[ecf_participant_id_change.from_participant_id],
+          to_participant_id: user_id_by_ecf_id[ecf_participant_id_change.to_participant_id],
+        )
+      end
+    end
+  end
+end

--- a/spec/factories/migration/ecf/participant_id_changes.rb
+++ b/spec/factories/migration/ecf/participant_id_changes.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :ecf_migration_participant_id_change, class: "Migration::Ecf::ParticipantIdChange" do
+    user { create(:ecf_migration_user) }
+    from_participant { create(:ecf_migration_user) }
+    to_participant { create(:ecf_migration_user) }
+  end
+end

--- a/spec/models/migration/ecf/participant_id_change_spec.rb
+++ b/spec/models/migration/ecf/participant_id_change_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe Migration::Ecf::ParticipantIdChange, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:from_participant) }
+    it { is_expected.to belong_to(:to_participant) }
+  end
+end

--- a/spec/models/migration/ecf/user_spec.rb
+++ b/spec/models/migration/ecf/user_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Migration::Ecf::User, type: :model do
     it { is_expected.to have_many(:participant_identities) }
     it { is_expected.to have_one(:teacher_profile) }
     it { is_expected.to have_many(:npq_profiles).through(:teacher_profile) }
+    it { is_expected.to have_many(:participant_id_changes) }
   end
 
   describe "instance methods" do

--- a/spec/models/participant_id_change_spec.rb
+++ b/spec/models/participant_id_change_spec.rb
@@ -3,6 +3,12 @@
 require "rails_helper"
 
 RSpec.describe ParticipantIdChange, type: :model do
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:user) }
+    it { is_expected.to validate_presence_of(:from_participant) }
+    it { is_expected.to validate_presence_of(:to_participant) }
+  end
+
   describe "associations" do
     it { is_expected.to belong_to(:user).class_name("User") }
     it { is_expected.to belong_to(:from_participant).class_name("User") }

--- a/spec/services/migration/migrators/participant_id_change_spec.rb
+++ b/spec/services/migration/migrators/participant_id_change_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Migration::Migrators::ParticipantIdChange do
           user_id: User.find_by(ecf_id: ecf_resource1.user_id).id,
           from_participant_id: User.find_by(ecf_id: ecf_resource1.from_participant_id).id,
           to_participant_id: User.find_by(ecf_id: ecf_resource1.to_participant_id).id,
+          created_at: ecf_resource1.created_at,
         })
       end
     end

--- a/spec/services/migration/migrators/participant_id_change_spec.rb
+++ b/spec/services/migration/migrators/participant_id_change_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe Migration::Migrators::ParticipantIdChange do
+  it_behaves_like "a migrator", :participant_id_change, %i[user] do
+    def create_ecf_resource
+      user = create(:ecf_migration_user, :npq)
+      create(:ecf_migration_participant_id_change, user:)
+    end
+
+    def create_npq_resource(ecf_resource)
+      user = create(:user, ecf_id: ecf_resource.user.id)
+      from_participant = create(:user, ecf_id: ecf_resource.from_participant.id)
+      to_participant = create(:user, ecf_id: ecf_resource.to_participant.id)
+
+      create(:participant_id_change, user:, from_participant:, to_participant:)
+    end
+
+    def setup_failure_state
+      # Corresponding users were not migrated from ECF.
+      user = create(:ecf_migration_user, :npq)
+      create(:ecf_migration_participant_id_change, user:)
+    end
+
+    describe "#call" do
+      it "sets the created ParticipantIdChange attributes correctly" do
+        instance.call
+
+        participant_id_change = ParticipantIdChange.first
+        expect(participant_id_change).to have_attributes({
+          user_id: User.find_by(ecf_id: ecf_resource1.user_id).id,
+          from_participant_id: User.find_by(ecf_id: ecf_resource1.from_participant_id).id,
+          to_participant_id: User.find_by(ecf_id: ecf_resource1.to_participant_id).id,
+        })
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Jira-3437](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3437)

### Context

We want to migrate participant ID changes from ECF to NPQ reg. We have to do this in a separate migrator (to the users migrator) as we need to migrate the users first (the `ParticipantIdChange` model does not store the `ecf_id`, instead using the NPQ reg ids).

### Changes proposed in this pull request

- Add ParticipantIdChange migrator
