### PR TITLE
[CPDLP-3444] Add BatchSendLatestOutcomesJob and SendToQualifiedTeachersApiJob

### DIFF
--- a/app/jobs/crons/batch_send_latest_outcomes_job.rb
+++ b/app/jobs/crons/batch_send_latest_outcomes_job.rb
@@ -1,0 +1,28 @@
+class Crons::BatchSendLatestOutcomesJob < CronJob
+  include Sentry::Cron::MonitorCheckIns
+
+  DEFAULT_BATCH_SIZE = 200
+
+  # run every 10 minutes
+  self.cron_expression = "*/10 * * * *"
+
+  sentry_monitor_check_ins slug: "batch-send-latest-outcomes"
+
+  def perform(batch_size = DEFAULT_BATCH_SIZE)
+    outcomes.first(batch_size).each { |outcome| SendToQualifiedTeachersAPIJob.perform_later(participant_outcome_id: outcome.id) }
+  end
+
+  def queue_name
+    "participant_outcomes"
+  end
+
+  def max_attempts
+    1
+  end
+
+private
+
+  def outcomes
+    @outcomes ||= ParticipantOutcome.to_send_to_qualified_teachers_api
+  end
+end

--- a/app/jobs/send_to_qualified_teachers_api_job.rb
+++ b/app/jobs/send_to_qualified_teachers_api_job.rb
@@ -1,0 +1,10 @@
+require "qualified_teachers"
+
+class SendToQualifiedTeachersAPIJob < ApplicationJob
+  queue_as :participant_outcomes
+  retry_on TooManyRequests, attempts: 3
+
+  def perform(participant_outcome_id:)
+    QualifiedTeachersAPISender.new(participant_outcome_id:).send_record
+  end
+end

--- a/app/services/qualified_teachers_api_sender.rb
+++ b/app/services/qualified_teachers_api_sender.rb
@@ -3,7 +3,6 @@ require "qualified_teachers"
 class QualifiedTeachersAPISender
   include ActiveModel::Model
   include ActiveModel::Attributes
-  include CourseHelper
 
   SUCCESS_CODES = %w[204].freeze
 

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,5 +1,6 @@
 Delayed::Worker.queue_attributes = {
   high_priority: { priority: -10 },
   default: { priority: 0 },
+  participant_outcomes: { priority: 5 },
   low_priority: { priority: 10 },
 }

--- a/spec/factories/participant_outcomes.rb
+++ b/spec/factories/participant_outcomes.rb
@@ -22,5 +22,23 @@ FactoryBot.define do
     trait :voided do
       state { "voided" }
     end
+
+    trait :sent_to_qualified_teachers_api do
+      sent_to_qualified_teachers_api_at { Time.zone.now - 1.hour }
+    end
+
+    trait :not_sent_to_qualified_teachers_api do
+      sent_to_qualified_teachers_api_at { nil }
+    end
+
+    trait :successfully_sent_to_qualified_teachers_api do
+      sent_to_qualified_teachers_api
+      qualified_teachers_api_request_successful { true }
+    end
+
+    trait :unsuccessfully_sent_to_qualified_teachers_api do
+      sent_to_qualified_teachers_api
+      qualified_teachers_api_request_successful { false }
+    end
   end
 end

--- a/spec/jobs/crons/batch_send_latest_outcomes_job_spec.rb
+++ b/spec/jobs/crons/batch_send_latest_outcomes_job_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe Crons::BatchSendLatestOutcomesJob, type: :job do
+  let(:outcome_1) { instance_double(ParticipantOutcome, id: 1) }
+  let(:outcome_2) { instance_double(ParticipantOutcome, id: 2) }
+  let(:outcomes) { [outcome_1, outcome_2] }
+
+  before do
+    ActiveJob::Base.queue_adapter.enqueued_jobs.clear
+    allow(ParticipantOutcome).to receive(:to_send_to_qualified_teachers_api).and_return(outcomes)
+  end
+
+  describe "#perform" do
+    context "when there are no more than batch_size records" do
+      let(:batch_size) { 2 }
+
+      it "enqueues the send job for each record" do
+        described_class.perform_now(batch_size)
+
+        expect(SendToQualifiedTeachersAPIJob).to(have_been_enqueued.exactly(:once).with(participant_outcome_id: 1).on_queue("participant_outcomes"))
+        expect(SendToQualifiedTeachersAPIJob).to(have_been_enqueued.exactly(:once).with(participant_outcome_id: 2).on_queue("participant_outcomes"))
+      end
+    end
+
+    context "when there are more than batch_size records" do
+      let(:batch_size) { 1 }
+
+      it "only enqueues the send job for the first records up to the batch_size" do
+        described_class.perform_now(batch_size)
+
+        expect(SendToQualifiedTeachersAPIJob).to have_been_enqueued.exactly(:once).with(participant_outcome_id: 1).on_queue("participant_outcomes")
+        expect(SendToQualifiedTeachersAPIJob).not_to have_been_enqueued.with(participant_outcome_id: 2)
+      end
+    end
+  end
+
+  describe "#perform_later" do
+    it "enqueues the job exactly once" do
+      expect { described_class.perform_later }.to have_enqueued_job(described_class).exactly(:once).on_queue("participant_outcomes")
+    end
+  end
+end

--- a/spec/jobs/send_to_qualified_teachers_api_job_spec.rb
+++ b/spec/jobs/send_to_qualified_teachers_api_job_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe SendToQualifiedTeachersAPIJob, type: :job do
+  describe "#perform" do
+    let(:participant_outcome) { create(:participant_outcome) }
+    let(:api_sender) { double }
+    let!(:participant_outcome_id) { participant_outcome.id }
+
+    subject(:job) { described_class.perform_now(participant_outcome_id:) }
+
+    before do
+      allow(QualifiedTeachersAPISender).to receive(:new).with(participant_outcome_id:).and_return(api_sender)
+      allow(api_sender).to receive(:send_record).and_return(participant_outcome)
+    end
+
+    it "calls the correct service class" do
+      job
+
+      expect(api_sender).to have_received(:send_record)
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: [CPDLP-3444](https://dfedigital.atlassian.net/browse/CPDLP-3444)

We want to implement sending outcomes to TRA in NPQ reg app.

### Changes proposed in this pull request

- Add BatchSendLatestOutcomesJob (per ECF)
- Add SendToQualifiedTeachersApiJob (per ECF)
- Include logic to retry jobs when TooManyRequests is raised (per ECF)
- Add to_send_to_qualified_teachers_api and related scopes

[CPDLP-3444]: https://dfedigital.atlassian.net/browse/CPDLP-3444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ