### PR TITLE
Migrate `Schedules` from ECF

### DIFF
--- a/app/models/migration/ecf/finance/milestone.rb
+++ b/app/models/migration/ecf/finance/milestone.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Migration::Ecf::Finance
+  class Milestone < Migration::Ecf::BaseRecord
+    belongs_to :schedule
+  end
+end

--- a/app/models/migration/ecf/finance/schedule.rb
+++ b/app/models/migration/ecf/finance/schedule.rb
@@ -4,6 +4,8 @@ module Migration::Ecf::Finance
 
     belongs_to :cohort
     has_many :participant_profiles
+    has_many :schedule_milestones, class_name: "Migration::Ecf::Finance::ScheduleMilestone"
+    has_many :milestones
 
     default_scope { where("schedules.type ilike ?", "Finance::Schedule::NPQ%") }
   end

--- a/app/models/migration/ecf/finance/schedule/npq.rb
+++ b/app/models/migration/ecf/finance/schedule/npq.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Migration::Ecf::Finance::Schedule::Npq < Migration::Ecf::Finance::Schedule
+end
+
+require_relative "npq_leadership"
+require_relative "npq_specialist"
+require_relative "npq_support"

--- a/app/models/migration/ecf/finance/schedule/npq_ehco.rb
+++ b/app/models/migration/ecf/finance/schedule/npq_ehco.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Migration::Ecf::Finance::Schedule::NpqEhco < Migration::Ecf::Finance::Schedule::Npq
+end

--- a/app/models/migration/ecf/finance/schedule/npq_leadership.rb
+++ b/app/models/migration/ecf/finance/schedule/npq_leadership.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Migration::Ecf::Finance::Schedule::NpqLeadership < Migration::Ecf::Finance::Schedule::Npq
+end

--- a/app/models/migration/ecf/finance/schedule/npq_specialist.rb
+++ b/app/models/migration/ecf/finance/schedule/npq_specialist.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Migration::Ecf::Finance::Schedule::NpqSpecialist < Migration::Ecf::Finance::Schedule::Npq
+end

--- a/app/models/migration/ecf/finance/schedule/npq_support.rb
+++ b/app/models/migration/ecf/finance/schedule/npq_support.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Migration::Ecf::Finance::Schedule::NpqSupport < Migration::Ecf::Finance::Schedule::Npq
+end

--- a/app/models/migration/ecf/finance/schedule_milestone.rb
+++ b/app/models/migration/ecf/finance/schedule_milestone.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Migration::Ecf::Finance
+  class ScheduleMilestone < Migration::Ecf::BaseRecord
+    self.table_name = "schedule_milestones"
+
+    belongs_to :schedule
+    belongs_to :milestone
+  end
+end

--- a/app/services/migration/migrators/course.rb
+++ b/app/services/migration/migrators/course.rb
@@ -1,5 +1,12 @@
 module Migration::Migrators
   class Course < Base
+    COURSE_GROUP_NAMES = %w[
+      leadership
+      specialist
+      support
+      ehco
+    ].freeze
+
     class << self
       def record_count
         ecf_npq_courses.count
@@ -15,13 +22,31 @@ module Migration::Migrators
     end
 
     def call
+      COURSE_GROUP_NAMES.each { |name| ::CourseGroup.find_or_create_by!(name:) }
+
       migrate(self.class.ecf_npq_courses) do |ecf_npq_course|
         course = ::Course.find_or_initialize_by(ecf_id: ecf_npq_course.id)
+        course_group = find_course_group!(course, ecf_npq_course.identifier)
+
         course.update!(
           name: ecf_npq_course.name,
           identifier: ecf_npq_course.identifier,
+          course_group:,
         )
       end
+    end
+
+  private
+
+    def find_course_group!(course, identifier)
+      course_definition = ::Courses::DEFINITIONS.find { |d| d[:identifier] == identifier }
+
+      if course_definition.nil?
+        course.errors.add(:base, "A course group could not be found for the course #{identifier}")
+        raise ActiveRecord::RecordInvalid, course
+      end
+
+      ::CourseGroup.find_by(name: course_definition[:course_group_name])
     end
   end
 end

--- a/app/services/migration/migrators/schedule.rb
+++ b/app/services/migration/migrators/schedule.rb
@@ -1,0 +1,75 @@
+module Migration::Migrators
+  class Schedule < Base
+    class << self
+      def record_count
+        ecf_schedules.count
+      end
+
+      def model
+        :schedule
+      end
+
+      def ecf_schedules
+        Migration::Ecf::Finance::Schedule.includes(:cohort, :milestones)
+      end
+
+      def dependencies
+        %i[cohort course]
+      end
+    end
+
+    def call
+      migrate(self.class.ecf_schedules) do |ecf_schedule|
+        ensure_milestone_dates_are_all_the_same!(ecf_schedule)
+
+        course_group = course_groups_by_identifier(ecf_schedule.type)
+
+        unless course_group
+          ecf_schedule.errors.add(:base, "Course group not found for schedule")
+          raise ActiveRecord::RecordInvalid, ecf_schedule
+        end
+
+        ::Schedule.find_or_initialize_by(
+          cohort_id: cohorts_by_start_year[ecf_schedule.cohort.start_year].id,
+          identifier: ecf_schedule.schedule_identifier,
+          course_group:,
+        ).tap do |schedule|
+          ecf_milestone = ecf_schedule.milestones.first
+          schedule.update!(
+            applies_from: ecf_milestone.start_date,
+            applies_to: ecf_milestone.payment_date,
+            name: ecf_schedule.name,
+            allowed_declaration_types: ecf_schedule.milestones.pluck(:declaration_type),
+          )
+        end
+      end
+    end
+
+  private
+
+    def course_groups_by_identifier(ecf_type)
+      case ecf_type
+      when "Finance::Schedule::NPQLeadership"
+        CourseGroup.find_by!(name: :leadership)
+      when "Finance::Schedule::NPQSpecialist"
+        CourseGroup.find_by!(name: :specialist)
+      when "Finance::Schedule::NPQSupport"
+        CourseGroup.find_by!(name: :support)
+      when "Finance::Schedule::NPQEhco"
+        CourseGroup.find_by!(name: :ehco)
+      end
+    end
+
+    def ensure_milestone_dates_are_all_the_same!(ecf_schedule)
+      dates = ecf_schedule.milestones.map { |m| [m.start_date, m.payment_date] }
+      return if dates.uniq.size == 1
+
+      ecf_schedule.errors.add(:base, "Milestones contain different dates")
+      raise ActiveRecord::RecordInvalid, ecf_schedule
+    end
+
+    def cohorts_by_start_year
+      @cohorts_by_start_year ||= ::Cohort.all.index_by(&:start_year)
+    end
+  end
+end

--- a/spec/factories/migration/ecf/finance/milestones.rb
+++ b/spec/factories/migration/ecf/finance/milestones.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :ecf_migration_milestone, class: "Migration::Ecf::Finance::Milestone" do
+    sequence(:name) { |n| "Milestone #{n}" }
+    start_date { 1.day.ago }
+    payment_date { 1.day.from_now }
+    schedule { create(:ecf_migration_schedule) }
+  end
+end

--- a/spec/factories/migration/ecf/finance/schedules.rb
+++ b/spec/factories/migration/ecf/finance/schedules.rb
@@ -7,4 +7,32 @@ FactoryBot.define do
     sequence(:schedule_identifier) { |n| "schedule-identifier-#{n}" }
     type { "Finance::Schedule::NPQ" }
   end
+
+  factory :ecf_migration_schedule_npq_support, class: "Migration::Ecf::Finance::Schedule::NpqSupport" do
+    sequence(:name) { |n| "NPQ Support Schedule #{n}" }
+    cohort { create(:ecf_migration_cohort) }
+    sequence(:schedule_identifier) { |n| "npq-support-schedule-identifier-#{n}" }
+    type { "Finance::Schedule::NPQSupport" }
+  end
+
+  factory :ecf_migration_schedule_npq_specialist, class: "Migration::Ecf::Finance::Schedule::NpqSpecialist" do
+    sequence(:name) { |n| "NPQ Specialist Schedule #{n}" }
+    cohort { create(:ecf_migration_cohort) }
+    sequence(:schedule_identifier) { |n| "npq-specialist-schedule-identifier-#{n}" }
+    type { "Finance::Schedule::NPQSpecialist" }
+  end
+
+  factory :ecf_migration_schedule_npq_ehco, class: "Migration::Ecf::Finance::Schedule::NpqEhco" do
+    sequence(:name) { |n| "NPQ Echo Schedule #{n}" }
+    cohort { create(:ecf_migration_cohort) }
+    sequence(:schedule_identifier) { |n| "npq-ehco-schedule-identifier-#{n}" }
+    type { "Finance::Schedule::NPQEhco" }
+  end
+
+  factory :ecf_migration_schedule_npq_leadership, class: "Migration::Ecf::Finance::Schedule::NpqLeadership" do
+    sequence(:name) { |n| "NPQ Leadership Schedule #{n}" }
+    cohort { create(:ecf_migration_cohort) }
+    sequence(:schedule_identifier) { |n| "npq-leadership-schedule-identifier-#{n}" }
+    type { "Finance::Schedule::NPQLeadership" }
+  end
 end

--- a/spec/models/migration/ecf/finance/milestone_spec.rb
+++ b/spec/models/migration/ecf/finance/milestone_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+RSpec.describe Migration::Ecf::Finance::Milestone, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:schedule) }
+  end
+end

--- a/spec/models/migration/ecf/finance/schedule_spec.rb
+++ b/spec/models/migration/ecf/finance/schedule_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Migration::Ecf::Finance::Schedule, type: :model do
   describe "associations" do
     it { is_expected.to belong_to(:cohort) }
     it { is_expected.to have_many(:participant_profiles) }
+    it { is_expected.to have_many(:milestones) }
   end
 
   describe "scopes" do

--- a/spec/services/migration/migrators/course_spec.rb
+++ b/spec/services/migration/migrators/course_spec.rb
@@ -1,18 +1,40 @@
 require "rails_helper"
 
 RSpec.describe Migration::Migrators::Course do
+  before { ::Course.destroy_all }
+
   it_behaves_like "a migrator", :course, [] do
     def create_ecf_resource
-      create(:ecf_migration_npq_course)
+      existing_identifiers = Course.all.pluck(:identifier)
+      identifier = Courses::DEFINITIONS.map { |h| h[:identifier] }.excluding(existing_identifiers).sample
+      create(:ecf_migration_npq_course, identifier:)
     end
 
     def create_npq_resource(ecf_resource)
-      create(:course, ecf_id: ecf_resource.id)
+      create(:course, identifier: ecf_resource.identifier, ecf_id: ecf_resource.id, course_group: nil)
     end
 
     def setup_failure_state
-      # ECF course with no identifier
-      create(:ecf_migration_npq_course, identifier: "")
+      # ECF course we don't have a group mapping for.
+      create(:ecf_migration_npq_course, name: "not-recognised")
+    end
+
+    describe "#call" do
+      it "sets the created Course attributes correctly" do
+        instance.call
+        course = Course.find_by(ecf_id: ecf_resource1.id)
+        expect(course).to have_attributes(ecf_resource1.attributes.slice(:identifier, :name))
+        expect(course.course_group.name).to eq(Courses::DEFINITIONS.find { |d| d[:identifier] == ecf_resource1.identifier }[:course_group_name])
+      end
+
+      it "creates the course groups" do
+        Course.destroy_all
+        CourseGroup.destroy_all
+
+        expect { instance.call }.to change(CourseGroup, :count).by(described_class::COURSE_GROUP_NAMES.count)
+
+        expect(CourseGroup.where(name: described_class::COURSE_GROUP_NAMES).count).to eq(described_class::COURSE_GROUP_NAMES.count)
+      end
     end
   end
 end

--- a/spec/services/migration/migrators/schedule_spec.rb
+++ b/spec/services/migration/migrators/schedule_spec.rb
@@ -1,0 +1,85 @@
+require "rails_helper"
+
+RSpec.describe Migration::Migrators::Schedule do
+  it_behaves_like "a migrator", :schedule, %i[cohort course] do
+    let(:ecf_class) { Migration::Ecf::Finance::Schedule }
+
+    def create_ecf_resource
+      create(:ecf_migration_schedule_npq_support).tap do |schedule|
+        create(:ecf_migration_milestone, schedule:)
+      end
+    end
+
+    def create_npq_resource(ecf_resource)
+      cohort = create(:cohort, start_year: ecf_resource.cohort.start_year)
+
+      create(:schedule,
+             cohort:,
+             identifier: ecf_resource.schedule_identifier,
+             course_group: create(:course_group, name: :support))
+    end
+
+    def setup_failure_state
+      # Schedule milestones contain different dates
+      schedule = create(:ecf_migration_schedule_npq_support)
+      create(:ecf_migration_milestone, schedule:, start_date: 1.day.ago)
+      create(:ecf_migration_milestone, schedule:, start_date: 2.days.ago)
+    end
+
+    describe "#call" do
+      it "sets the applies from/to of the schedule" do
+        ecf_milestone = ecf_resource1.milestones.first
+        schedule = Schedule.first
+
+        expect { instance.call }.to change { schedule.reload.applies_from }.to(ecf_milestone.start_date)
+          .and change { schedule.applies_to }.to(ecf_milestone.payment_date)
+      end
+
+      it "sets the allowed declaration types of the schedule" do
+        ecf_milestones = ecf_resource1.milestones
+        schedule = Schedule.first
+
+        expect { instance.call }.to change { schedule.reload.allowed_declaration_types }.to(ecf_milestones.pluck(:declaration_type))
+      end
+
+      context "when the schedule type cannot be mapped to a course group" do
+        it "records a failure" do
+          schedule = create(:ecf_migration_schedule)
+          create(:ecf_migration_milestone, schedule:)
+
+          instance.call
+
+          expect(failure_manager).to have_received(:record_failure).once.with(schedule, /Validation failed: Course group not found for schedule/)
+        end
+      end
+
+      it "creates a new schedule in NPQ when a matching schedule does not exist" do
+        create(:ecf_migration_schedule_npq_support).tap do |schedule|
+          create(:ecf_migration_milestone, schedule:)
+        end
+
+        expect { instance.call }.to change(Schedule, :count).by(1)
+      end
+
+      {
+        ecf_migration_schedule_npq_support: "support",
+        ecf_migration_schedule_npq_specialist: "specialist",
+        ecf_migration_schedule_npq_ehco: "ehco",
+        ecf_migration_schedule_npq_leadership: "leadership",
+      }.each do |scehdule_factory, course_group_name|
+        context "when there are #{scehdule_factory} schedules" do
+          it "creates a new schedule in NPQ with the correct course group" do
+            ecf_schedule = create(scehdule_factory).tap do |schedule| # rubocop:disable RSpec/SaveBang
+              create(:ecf_migration_milestone, schedule:)
+            end
+
+            expect { instance.call }.to change(Schedule, :count).by(1)
+
+            schedule = Schedule.find_by(identifier: ecf_schedule.schedule_identifier)
+            expect(schedule.course_group.name).to eq(course_group_name)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/migrator_support.rb
+++ b/spec/support/shared_examples/migrator_support.rb
@@ -9,6 +9,7 @@ RSpec.shared_examples "a migrator" do |model, dependencies|
   let(:failure_manager) { instance_double(Migration::FailureManager, record_failure: nil) }
   let(:ecf_resource1) { create_ecf_resource }
   let(:ecf_resource2) { create_ecf_resource }
+  let(:ecf_class) { ecf_resource1.class }
   let(:records_per_worker) { 3 }
   let(:model_name) { model.to_s }
 
@@ -181,7 +182,7 @@ RSpec.shared_examples "a migrator" do |model, dependencies|
 
       it "increments the failure/processed counts and logs the failure" do
         expect { call }.to change { data_migration.reload.failure_count }.by(1).and(change(data_migration, :processed_count).by(3))
-        expect(failure_manager).to have_received(:record_failure).with(be_a(ecf_resource1.class), be_a(String))
+        expect(failure_manager).to have_received(:record_failure).with(be_a(ecf_class), be_a(String))
       end
     end
 


### PR DESCRIPTION
### Context

We want to migrate NPQ schedules from ECF into NPQ reg.

### Changes proposed in this pull request

- Add `Schedule` migrator

Add the `Schedule` migrator to bring across all NPQ schedules from ECF. As part of this change we also now create `CourseGroup` during the `Course` migration (we can't do this in its own migrator as it doesn't fir the pattern of bringing across records from ECF).

A `Schedule` must match on cohort, name, identifier and course group (derived from the ECF schedule type). We set the applies from/to based on the milestone dates. All milestone dates for ECF schedules must be the same or a failure is recorded.