### PR TITLE
Fix mismatch between schedule and declaration_date in factories

### DIFF
--- a/spec/factories/schedules.rb
+++ b/spec/factories/schedules.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     sequence(:name) { |n| "Schedule #{n}" }
     sequence(:identifier) { |n| "schedule-#{n}" }
 
-    applies_from { Date.new(cohort.start_year, 10, 1) }
+    applies_from { Date.new(cohort.start_year, 9, 1) }
     applies_to { Date.new(cohort.start_year, 11, 1) }
 
     allowed_declaration_types { %w[started retained-1 retained-2 completed] }


### PR DESCRIPTION
On 1st September the current cohort rolls over to the following year (according to the cohort factory), however the schedule only allows delcarations after 1st October. To fix this I've updated the `applies_from` to match the cohort rollover date. We may run into a similar issue with the `applies_to` in November.
