### PR TITLE
Fix declaration_date mismatch with schedule

### DIFF
--- a/spec/factories/cohorts.rb
+++ b/spec/factories/cohorts.rb
@@ -8,11 +8,11 @@ FactoryBot.define do
     end
 
     trait :current do
-      start_year { Date.current.month < 9 ? Date.current.year.pred : Date.current.year }
+      start_year { Date.current.month < 10 ? Date.current.year.pred : Date.current.year }
     end
 
     trait :next do
-      start_year { Date.current.month < 9 ? Date.current.year : Date.current.year.succ }
+      start_year { Date.current.month < 10 ? Date.current.year : Date.current.year.succ }
     end
 
     trait :with_funding_cap do


### PR DESCRIPTION
On 1st September we rolled over to the next cohort (as the current) and this caused the `declaration_date` to be invalid. Pushing the rollover date to next month to unblock the pipeline while we fix properly.
