### PR TITLE
Add `StatementLineItem` to `Statement` migrator

### DIFF
--- a/app/models/migration/ecf/finance/statement.rb
+++ b/app/models/migration/ecf/finance/statement.rb
@@ -5,6 +5,7 @@ module Migration::Ecf::Finance
     belongs_to :cohort
     belongs_to :cpd_lead_provider
     has_one :npq_lead_provider, through: :cpd_lead_provider
+    has_many :statement_line_items, class_name: "Migration::Ecf::Finance::StatementLineItem"
 
     default_scope { where("statements.type ilike ?", "Finance::Statement::NPQ%") }
   end

--- a/app/models/migration/ecf/finance/statement_line_item.rb
+++ b/app/models/migration/ecf/finance/statement_line_item.rb
@@ -1,0 +1,8 @@
+module Migration::Ecf::Finance
+  class StatementLineItem < Migration::Ecf::BaseRecord
+    self.table_name = "statement_line_items"
+
+    belongs_to :statement
+    belongs_to :participant_declaration, class_name: "Migration::Ecf::ParticipantDeclaration"
+  end
+end

--- a/app/services/migration/migrators/statement.rb
+++ b/app/services/migration/migrators/statement.rb
@@ -11,7 +11,10 @@ module Migration::Migrators
 
       def ecf_statements
         Migration::Ecf::Finance::Statement
-          .includes(:cohort, cpd_lead_provider: :npq_lead_provider)
+          .includes(
+            :cohort,
+            cpd_lead_provider: :npq_lead_provider,
+          )
       end
 
       def dependencies

--- a/app/services/migration/migrators/statement_item.rb
+++ b/app/services/migration/migrators/statement_item.rb
@@ -1,0 +1,35 @@
+module Migration::Migrators
+  class StatementItem < Base
+    class << self
+      def record_count
+        ecf_statement_items.count
+      end
+
+      def model
+        :statement_item
+      end
+
+      def ecf_statement_items
+        Migration::Ecf::Finance::StatementLineItem
+      end
+
+      def dependencies
+        %i[statement declaration]
+      end
+    end
+
+    def call
+      migrate(self.class.ecf_statement_items) do |ecf_statement_item|
+        statement = ::Statement.find_or_initialize_by(ecf_id: ecf_statement_item.statement_id)
+        declaration_id = ::Declaration.select(:id).find_by!(ecf_id: ecf_statement_item.participant_declaration_id).id
+        statement_item = ::StatementItem.find_or_initialize_by(
+          statement:,
+          declaration_id:,
+          state: ecf_statement_item.state,
+        )
+
+        statement_item.update!(ecf_statement_item.attributes.slice(:created_at, :updated_at))
+      end
+    end
+  end
+end

--- a/spec/factories/migration/ecf/finance/statement_line_item.rb
+++ b/spec/factories/migration/ecf/finance/statement_line_item.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :ecf_migration_statement_line_item, class: "Migration::Ecf::Finance::StatementLineItem" do
+    state { :payable }
+    participant_declaration { create(:ecf_migration_participant_declaration) }
+    statement { create(:ecf_migration_statement) }
+  end
+end

--- a/spec/models/migration/ecf/finance/statement_line_item_spec.rb
+++ b/spec/models/migration/ecf/finance/statement_line_item_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+RSpec.describe Migration::Ecf::Finance::StatementLineItem, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:statement) }
+    it { is_expected.to belong_to(:participant_declaration).class_name("Migration::Ecf::ParticipantDeclaration") }
+  end
+end

--- a/spec/models/migration/ecf/finance/statement_spec.rb
+++ b/spec/models/migration/ecf/finance/statement_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Migration::Ecf::Finance::Statement, type: :model do
     it { is_expected.to belong_to(:cohort) }
     it { is_expected.to belong_to(:cpd_lead_provider) }
     it { is_expected.to have_one(:npq_lead_provider).through(:cpd_lead_provider) }
+    it { is_expected.to have_many(:statement_line_items).class_name("Migration::Ecf::Finance::StatementLineItem") }
   end
 
   describe "scopes" do

--- a/spec/services/migration/migrators/statement_item_spec.rb
+++ b/spec/services/migration/migrators/statement_item_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe Migration::Migrators::StatementItem do
+  it_behaves_like "a migrator", :statement_item, %i[statement declaration] do
+    def create_ecf_resource
+      create(:ecf_migration_statement_line_item)
+    end
+
+    def create_npq_resource(ecf_resource)
+      statement = create(:statement, ecf_id: ecf_resource.statement_id)
+      declaration = create(:declaration, ecf_id: ecf_resource.participant_declaration_id)
+      create(:statement_item, declaration:, statement:, state: ecf_resource.state)
+    end
+
+    def setup_failure_state
+      # Declaration does not exist in NPQ reg
+      create(:ecf_migration_statement_line_item)
+    end
+
+    describe "#call" do
+      it "creates the StatementItems and sets attributes correctly" do
+        instance.call
+
+        statement_item = StatementItem.includes(:statement, :declaration).find_by(statement: { ecf_id: ecf_resource1.statement_id })
+        expect(statement_item).to have_attributes(ecf_resource1.attributes.slice(:state, :created_at, :updated_at))
+        expect(statement_item.declaration.ecf_id).to eq(ecf_resource1.participant_declaration_id)
+        expect(statement_item.statement.ecf_id).to eq(ecf_resource1.statement_id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Jira-3440](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3440)

### Context

As part of the `Statement` migrator we also want to bring across `StatementLineItem` records from ECF. We can match these on the `declaration_id` and `state` for each statement.

### Changes proposed in this pull request

- Migrate statement line items from ECF
