### PR TITLE
Fix sonar cloud in CI

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -47,6 +47,7 @@ jobs:
         with:
           name: ${{ env.rubocop-artifact-name }}
           path: ${{ github.workspace }}/out/rubocop-result.json
+          include-hidden-files: true
 
   scss_linting:
     name: "Lint SCSS"
@@ -148,6 +149,7 @@ jobs:
         with:
           name: ${{ env.code-coverage-artifact-name }}_${{ matrix.ci_node_index }}
           path: ./coverage
+          include-hidden-files: true
 
       - name:  Keep Unit Tests Results
         if: always()
@@ -155,6 +157,7 @@ jobs:
         with:
           name: ${{ env.unit-tests-artifact-name }}_${{ matrix.ci_node_index }}
           path: ./test-report/*
+          include-hidden-files: true
 
   sonar-scanner:
     name: Sonar Scanner


### PR DESCRIPTION
As of v4.4 of `actions/upload-artifact@v4` it no longer uploads hidden files; this means the `.resultset.json` coverage report is omitted. Add `include-hidden-files: true` to ensure hidden files are picked up.

https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#hidden-files