### PR TITLE
Add `ApplicationState` migrator

### DIFF
--- a/app/models/migration/ecf/participant_profile_state.rb
+++ b/app/models/migration/ecf/participant_profile_state.rb
@@ -1,0 +1,6 @@
+module Migration::Ecf
+  class ParticipantProfileState < BaseRecord
+    belongs_to :participant_profile
+    belongs_to :cpd_lead_provider, optional: true
+  end
+end

--- a/app/services/migration/migrators/application_state.rb
+++ b/app/services/migration/migrators/application_state.rb
@@ -1,0 +1,38 @@
+module Migration::Migrators
+  class ApplicationState < Base
+    class << self
+      def record_count
+        ecf_participant_profile_states.count
+      end
+
+      def model
+        :application_state
+      end
+
+      def dependencies
+        %i[application lead_provider]
+      end
+
+      def ecf_participant_profile_states
+        Migration::Ecf::ParticipantProfileState
+          .joins(participant_profile: :teacher_profile)
+          .includes(:cpd_lead_provider)
+          .where(teacher_profile: { user_id: User.ecf_users.pluck(:id) })
+      end
+    end
+
+    def call
+      migrate(self.class.ecf_participant_profile_states) do |ecf_participant_profile_state|
+        application_state = ::ApplicationState.find_or_initialize_by(ecf_id: ecf_participant_profile_state.id)
+
+        ecf_lead_provider_id = ecf_participant_profile_state.cpd_lead_provider&.npq_lead_provider&.id
+        application_state.lead_provider = ::LeadProvider.find_by!(ecf_id: ecf_lead_provider_id) if ecf_lead_provider_id
+
+        ecf_application_id = ecf_participant_profile_state.participant_profile_id
+        application_state.application_id = ::Application.select(:id).find_by!(ecf_id: ecf_application_id).id
+
+        application_state.update!(ecf_participant_profile_state.attributes.slice(%w[state reason created_at updated_at]))
+      end
+    end
+  end
+end

--- a/db/migrate/20240904072033_add_ecf_id_to_application_states.rb
+++ b/db/migrate/20240904072033_add_ecf_id_to_application_states.rb
@@ -1,0 +1,6 @@
+class AddEcfIdToApplicationStates < ActiveRecord::Migration[7.1]
+  def change
+    add_column :application_states, :ecf_id, :uuid, null: true
+    add_index :application_states, :ecf_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_22_131123) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_04_072033) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -58,7 +58,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_22_131123) do
     t.text "reason"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "ecf_id"
     t.index ["application_id"], name: "index_application_states_on_application_id"
+    t.index ["ecf_id"], name: "index_application_states_on_ecf_id", unique: true
     t.index ["lead_provider_id"], name: "index_application_states_on_lead_provider_id"
   end
 

--- a/spec/factories/migration/ecf/participant_profile_states.rb
+++ b/spec/factories/migration/ecf/participant_profile_states.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :ecf_migration_participant_profile_state, class: "Migration::Ecf::ParticipantProfileState" do
+    state { :active }
+    reason { "reason" }
+    participant_profile { create(:ecf_migration_npq_participant_profile) }
+    cpd_lead_provider { create(:ecf_migration_npq_lead_provider).cpd_lead_provider }
+  end
+end

--- a/spec/models/migration/ecf/participant_profile_state_spec.rb
+++ b/spec/models/migration/ecf/participant_profile_state_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+RSpec.describe Migration::Ecf::ParticipantProfileState, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:participant_profile) }
+    it { is_expected.to belong_to(:cpd_lead_provider).optional }
+  end
+end

--- a/spec/services/migration/migrators/application_state_spec.rb
+++ b/spec/services/migration/migrators/application_state_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe Migration::Migrators::ApplicationState do
+  it_behaves_like "a migrator", :application_state, %i[application lead_provider] do
+    def create_ecf_resource
+      create(:ecf_migration_participant_profile_state)
+    end
+
+    def create_npq_resource(ecf_resource)
+      create(:lead_provider, ecf_id: ecf_resource.cpd_lead_provider.npq_lead_provider.id)
+      application = create(:application, :accepted, ecf_id: ecf_resource.participant_profile_id)
+      create(:application_state, application:, ecf_id: ecf_resource.id)
+    end
+
+    def setup_failure_state
+      # Application does not exist in NPQ reg
+      participant_profile_state = create(:ecf_migration_participant_profile_state)
+      create(:lead_provider, ecf_id: participant_profile_state.cpd_lead_provider.npq_lead_provider.id)
+    end
+
+    describe "#call" do
+      it "sets the migrated ApplicationState attributes from ECF" do
+        instance.call
+
+        application_state = ApplicationState.joins(:application).find_by(application: { ecf_id: ecf_resource1.participant_profile_id })
+        expect(application_state).to have_attributes(ecf_resource1.attributes.slice(%w[state reason created_at updated_at]))
+        expect(application_state.lead_provider.ecf_id).to eq(ecf_resource1.cpd_lead_provider.npq_lead_provider.id)
+      end
+
+      it "records a failure when the lead provider can't be matched in NPQ reg" do
+        participant_profile_state = create(:ecf_migration_participant_profile_state)
+        create(:application, :accepted, ecf_id: participant_profile_state.participant_profile_id)
+
+        instance.call
+
+        expect(failure_manager).to have_received(:record_failure).once.with(participant_profile_state, /Couldn't find LeadProvider/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Jira-3489](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3489)

### Context

We want to bring across the `ParticipantProfileState` records from ECF to NPQ reg, as `ApplicationState` records. The `participant_profile_id` will match up to the `ecf_id` on the `Application` in NPQ reg.

### Changes proposed in this pull request

- Add `ApplicationState` migrator
