### PR TITLE
Clear migration failures prior to running

### DIFF
--- a/app/models/migration/data_migration.rb
+++ b/app/models/migration/data_migration.rb
@@ -16,13 +16,13 @@ module Migration
     def percentage_migrated_successfully
       return 0 unless processed_count&.positive?
 
-      ((processed_count - failure_count) / processed_count.to_f * 100).round
+      ((processed_count - failure_count) / processed_count.to_f * 100).floor
     end
 
     def percentage_migrated
       return 0 unless total_count&.positive?
 
-      (processed_count / total_count.to_f * 100).round
+      (processed_count / total_count.to_f * 100).floor
     end
 
     def duration_in_seconds

--- a/app/services/migration/migrators/base.rb
+++ b/app/services/migration/migrators/base.rb
@@ -20,7 +20,10 @@ module Migration::Migrators
 
       def prepare!
         model = name.gsub(/^.*::/, "").underscore.to_sym
-        number_of_workers.times { |worker| Migration::DataMigration.create!(model:, worker:) }
+        number_of_workers.times do |worker|
+          data_migration = Migration::DataMigration.create!(model:, worker:)
+          Migration::FailureManager.purge_failures!(data_migration)
+        end
       end
 
       def runnable?

--- a/spec/features/migration_spec.rb
+++ b/spec/features/migration_spec.rb
@@ -84,7 +84,7 @@ RSpec.feature "Migration", :in_memory_rails_cache, :rack_test_driver, type: :fea
         within ".data-migration-lead_provider" do
           expect(page).to have_css(".total-count", text: 3)
           expect(page).to have_css(".failure-count", text: 1)
-          expect(page).to have_css(".percentage-successfully-migrated", text: "67%")
+          expect(page).to have_css(".percentage-successfully-migrated", text: "66%")
 
           data_migration = Migration::DataMigration.find_by(model: :lead_provider)
           expect(page).to have_link("Failures report", href: download_report_npq_separation_migration_migrations_path(data_migration.model))
@@ -124,7 +124,7 @@ RSpec.feature "Migration", :in_memory_rails_cache, :rack_test_driver, type: :fea
         within ".data-migration-cohort" do
           expect(page).to have_css(".total-count", text: 3)
           expect(page).to have_css(".failure-count", text: 1)
-          expect(page).to have_css(".percentage-successfully-migrated", text: "67%")
+          expect(page).to have_css(".percentage-successfully-migrated", text: "66%")
 
           data_migration = Migration::DataMigration.find_by(model: :cohort)
           expect(page).to have_link("Failures report", href: download_report_npq_separation_migration_migrations_path(data_migration.model))
@@ -167,7 +167,7 @@ RSpec.feature "Migration", :in_memory_rails_cache, :rack_test_driver, type: :fea
         within ".data-migration-statement" do
           expect(page).to have_css(".total-count", text: 3)
           expect(page).to have_css(".failure-count", text: 1)
-          expect(page).to have_css(".percentage-successfully-migrated", text: "67%")
+          expect(page).to have_css(".percentage-successfully-migrated", text: "66%")
 
           data_migration = Migration::DataMigration.find_by(model: :statement)
           expect(page).to have_link("Failures report", href: download_report_npq_separation_migration_migrations_path(data_migration.model))
@@ -208,7 +208,7 @@ RSpec.feature "Migration", :in_memory_rails_cache, :rack_test_driver, type: :fea
         within ".data-migration-user" do
           expect(page).to have_css(".total-count", text: 3)
           expect(page).to have_css(".failure-count", text: 1)
-          expect(page).to have_css(".percentage-successfully-migrated", text: "67%")
+          expect(page).to have_css(".percentage-successfully-migrated", text: "66%")
         end
       end
     end

--- a/spec/helpers/migration_helper_spec.rb
+++ b/spec/helpers/migration_helper_spec.rb
@@ -173,8 +173,7 @@ RSpec.describe MigrationHelper, type: :helper do
       context "when the percentage would round up to 100" do
         let(:data_migrations) do
           [
-            create(:data_migration, :in_progress, processed_count: 100, failure_count: 1),
-            create(:data_migration, :in_progress, processed_count: 100, failure_count: 0),
+            create(:data_migration, :in_progress, processed_count: 100_000, failure_count: 1),
           ]
         end
 

--- a/spec/models/migration/data_migration_spec.rb
+++ b/spec/models/migration/data_migration_spec.rb
@@ -62,6 +62,12 @@ RSpec.describe Migration::DataMigration, :in_memory_rails_cache, type: :model do
 
         it { is_expected.to be(73) }
       end
+
+      context "when the percentage would round up to 100%" do
+        before { instance.assign_attributes(processed_count: 10_000, failure_count: 1) }
+
+        it { is_expected.to be(99) }
+      end
     end
   end
 
@@ -74,6 +80,12 @@ RSpec.describe Migration::DataMigration, :in_memory_rails_cache, type: :model do
       before { instance.assign_attributes(total_count: 96, processed_count: 27) }
 
       it { is_expected.to be(28) }
+    end
+
+    context "when the percentage would round up to 100%" do
+      before { instance.assign_attributes(total_count: 10_000, processed_count: 9_999) }
+
+      it { is_expected.to be(99) }
     end
   end
 

--- a/spec/services/migration/failure_manager_spec.rb
+++ b/spec/services/migration/failure_manager_spec.rb
@@ -31,6 +31,25 @@ RSpec.describe Migration::FailureManager, :in_memory_rails_cache do
     end
   end
 
+  describe ".migration_failure_key" do
+    subject { described_class.migration_failure_key(data_migration) }
+
+    let(:data_migration) { create(:data_migration, model: :statement) }
+
+    it { is_expected.to eq("migration_failure_#{data_migration.model}_#{data_migration.id}") }
+  end
+
+  describe ".purge_failures!" do
+    let(:item) { create(:ecf_migration_statement) }
+    let(:data_migration) { create(:data_migration, model: :statement, failure_count: 1) }
+
+    before { instance.record_failure(item, "failure message") }
+
+    subject(:purge_failures) { described_class.purge_failures!(data_migration) }
+
+    it { expect { purge_failures }.to change(instance, :all_failures).from(be_present).to be_nil }
+  end
+
   describe "#record_failure" do
     subject { instance.record_failure(item, failure_message) }
 


### PR DESCRIPTION
[Jira-3485](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3485)

### Context

We are finding that failures are duplicated in the reports, so the same ID for an object that has failed will appear multiple times.

### Changes proposed in this pull request

- Clear migration failures prior to running

As we store failures in Redis, when we clear the NPQ reg database and re-run a migration after a failed migration the failure manager will add the failures to those from the last run (as the `DataMigration` models/ids get reset so are the same as the previous run).

To avoid this, we can purge the failures from Redis for a `DataMigration` as part of the migration preparation.

- Fix rounding issues with data migrations

We are rounding down in the `MigrationHelper`, however we were still rounding up in the `DataMigration` model; this ensures both round down correctly and improves the tests.

### Guidance to review

The `FailureManager` is becoming a not so great mix of instance/class methods; it could do with a tidy up but its probably not worth the effort given this code is going to be relatively short-lived.