### PR TITLE
[CPDLP-3508] Add Participant Outcome API migrator

### DIFF
--- a/app/models/migration/ecf/participant_outcome_api_request.rb
+++ b/app/models/migration/ecf/participant_outcome_api_request.rb
@@ -1,0 +1,5 @@
+module Migration::Ecf
+  class ParticipantOutcomeAPIRequest < BaseRecord
+    belongs_to :participant_outcome, class_name: "ParticipantOutcome::Npq"
+  end
+end

--- a/app/services/migration/migrators/participant_outcome_api_request.rb
+++ b/app/services/migration/migrators/participant_outcome_api_request.rb
@@ -1,0 +1,30 @@
+module Migration::Migrators
+  class ParticipantOutcomeAPIRequest < Base
+    class << self
+      def record_count
+        ecf_outcome_api_requests.count
+      end
+
+      def model
+        :participant_outcome_api_request
+      end
+
+      def ecf_outcome_api_requests
+        Migration::Ecf::ParticipantOutcomeAPIRequest
+      end
+
+      def dependencies
+        %i[participant_outcome]
+      end
+    end
+
+    def call
+      migrate(self.class.ecf_outcome_api_requests) do |ecf_outcome_api_request|
+        outcome_api_request = ::ParticipantOutcomeAPIRequest.find_or_initialize_by(ecf_id: ecf_outcome_api_request.id)
+        participant_outcome_id = ::ParticipantOutcome.select(:id).find_by!(ecf_id: ecf_outcome_api_request.participant_outcome_id).id
+
+        outcome_api_request.update!(ecf_outcome_api_request.attributes.except("id", "participant_outcome_id").merge({ participant_outcome_id: }))
+      end
+    end
+  end
+end

--- a/spec/factories/migration/ecf/participant_outcome_api_requests.rb
+++ b/spec/factories/migration/ecf/participant_outcome_api_requests.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :ecf_migration_participant_outcome_api_request, class: "Migration::Ecf::ParticipantOutcomeAPIRequest" do
+    association :participant_outcome, factory: :ecf_migration_participant_outcome
+
+    trait :with_trn_success do
+      request_path { "https://example.com/v2/npq-qualifications?trn=1234567" }
+      status_code { 204 }
+      request_headers do
+        {
+          "host" => "example.com",
+          "accept" => "*/*",
+          "user-agent" => "Ruby",
+          "content-type" => "application/json",
+          "content-length" => "59",
+          "accept-encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+        }
+      end
+      request_body { { "completionDate" => "2023-02-21", "qualificationType" => "NPQLT" } }
+      response_body { nil }
+      response_headers do
+        {
+          "date" => "Thu, 11 May 2023 12:44:39 GMT",
+          "connection" => "keep-alive",
+          "request-context" => "appId=cid-v1:b3114e2d-c1ab-4870-90b8-88ccc4bdc491",
+          "x-frame-options" => "deny",
+          "x-xss-protection" => "0",
+          "x-vcap-request-id" => "6aaeb6a1-1697-4e12-694e-a9c3d4c63250",
+          "x-rate-limit-limit" => "60s",
+          "x-rate-limit-reset" => "2023-05-11T12:45:00.0000000Z",
+          "x-content-type-options" => "nosniff",
+          "x-rate-limit-remaining" => "225",
+          "strict-transport-security" => "max-age=31536000; includeSubDomains; preload",
+        }
+      end
+    end
+  end
+end

--- a/spec/services/migration/migrators/participant_outcome_api_request_spec.rb
+++ b/spec/services/migration/migrators/participant_outcome_api_request_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe Migration::Migrators::ParticipantOutcomeAPIRequest do
+  it_behaves_like "a migrator", :participant_outcome_api_request, %i[participant_outcome] do
+    def create_ecf_resource
+      create(:ecf_migration_participant_outcome_api_request, :with_trn_success)
+    end
+
+    def create_npq_resource(ecf_resource)
+      participant_outcome = create(:participant_outcome, ecf_id: ecf_resource.participant_outcome_id)
+      create(:participant_outcome_api_request, :with_trn_success, participant_outcome:, ecf_id: ecf_resource.id)
+    end
+
+    def setup_failure_state
+      # Participant Outcome Api Request in ECF where the Participant Outcome hasn't been migrated to NPQ reg.
+      create(:ecf_migration_participant_outcome_api_request)
+    end
+
+    describe "#call" do
+      it "sets the created ParticipantOutcomeAPIRequest attributes correctly" do
+        instance.call
+
+        outcome_api_request = ParticipantOutcomeAPIRequest.find_by(ecf_id: ecf_resource1.id)
+        expect(outcome_api_request).to have_attributes(ecf_resource1.attributes.except("id", "participant_outcome_id"))
+        expect(outcome_api_request.participant_outcome.ecf_id).to eq(ecf_resource1.participant_outcome_id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: [CPDLP-3508](https://dfedigital.atlassian.net/browse/CPDLP-3508)

We need to pull in participant outcome api request data to NPQ.

### Changes proposed in this pull request

Add Participant Outcome API migrator.

[CPDLP-3508]: https://dfedigital.atlassian.net/browse/CPDLP-3508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ