### PR TITLE
[CPDLP-3488] Update NPQ participant serialiser to show validated trn

### DIFF
--- a/app/serializers/api/participant_serializer.rb
+++ b/app/serializers/api/participant_serializer.rb
@@ -25,7 +25,9 @@ module API
           end
         end
 
-        field(:trn, name: :teacher_reference_number)
+        field(:teacher_reference_number) do |object, _options|
+          object.trn if object.trn_verified
+        end
         field(:updated_at) do |object, _options|
           updated_at(object)
         end
@@ -34,7 +36,9 @@ module API
       view :v2 do
         field(:email)
         field(:full_name)
-        field(:trn, name: :teacher_reference_number)
+        field(:teacher_reference_number) do |object, _options|
+          object.trn if object.trn_verified
+        end
         field(:updated_at) do |object, _options|
           updated_at(object)
         end
@@ -58,7 +62,9 @@ module API
 
       view :v3 do
         field(:full_name)
-        field(:trn, name: :teacher_reference_number)
+        field(:teacher_reference_number) do |object, _options|
+          object.trn if object.trn_verified
+        end
         field(:updated_at) do |object, _options|
           updated_at(object)
         end

--- a/spec/requests/api/docs/v1/participants_spec.rb
+++ b/spec/requests/api/docs/v1/participants_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "NPQ Participants endpoint", openapi_spec: "v1/swagger.yaml", typ
   let(:course) { create(:course, :early_headship_coaching_offer) }
   let(:cohort) { create(:cohort, :current) }
   let(:schedule) { create(:schedule, :npq_ehco_december, cohort:) }
+  let(:user) { create(:user, :with_verified_trn) }
   let(:application) do
     create(:application,
            :accepted,
@@ -17,6 +18,7 @@ RSpec.describe "NPQ Participants endpoint", openapi_spec: "v1/swagger.yaml", typ
            course:,
            cohort:,
            schedule:,
+           user:,
            funded_place: true)
   end
   let!(:participant) { application.user }

--- a/spec/requests/api/docs/v2/participants_spec.rb
+++ b/spec/requests/api/docs/v2/participants_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "NPQ Participants endpoint", openapi_spec: "v2/swagger.yaml", typ
   let(:course) { create(:course, :early_headship_coaching_offer) }
   let(:cohort) { create(:cohort, :current) }
   let(:schedule) { create(:schedule, :npq_ehco_december, cohort:) }
+  let(:user) { create(:user, :with_verified_trn) }
   let(:application) do
     create(:application,
            :accepted,
@@ -17,6 +18,7 @@ RSpec.describe "NPQ Participants endpoint", openapi_spec: "v2/swagger.yaml", typ
            course:,
            cohort:,
            schedule:,
+           user:,
            funded_place: true)
   end
   let!(:participant) { application.user }

--- a/spec/requests/api/docs/v3/participants_spec.rb
+++ b/spec/requests/api/docs/v3/participants_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "NPQ Participants endpoint", openapi_spec: "v3/swagger.yaml", typ
   let(:course) { create(:course, :early_headship_coaching_offer) }
   let(:cohort) { create(:cohort, :current) }
   let(:schedule) { create(:schedule, :npq_ehco_december, cohort:) }
+  let(:user) { create(:user, :with_verified_trn) }
   let(:application) do
     create(:application,
            :accepted,
@@ -17,6 +18,7 @@ RSpec.describe "NPQ Participants endpoint", openapi_spec: "v3/swagger.yaml", typ
            course:,
            cohort:,
            schedule:,
+           user:,
            funded_place: true)
   end
   let!(:participant) { application.user }

--- a/spec/serializers/api/participant_serializer_spec.rb
+++ b/spec/serializers/api/participant_serializer_spec.rb
@@ -55,8 +55,20 @@ RSpec.describe API::ParticipantSerializer, type: :serializer do
         ])
       end
 
-      it "serializes the `teacher_reference_number`" do
-        expect(attributes["teacher_reference_number"]).to eq(participant.trn)
+      context "when serializing `teacher_reference_number`" do
+        context "when trn is verified" do
+          before { participant.update!(trn_verified: true) }
+
+          it "serializes the `teacher_reference_number`" do
+            expect(attributes["teacher_reference_number"]).to eq(participant.trn)
+          end
+        end
+
+        context "when trn is not verified" do
+          it "serializes nil" do
+            expect(attributes["teacher_reference_number"]).to be_nil
+          end
+        end
       end
 
       context "when serializing `updated_at`" do
@@ -106,8 +118,20 @@ RSpec.describe API::ParticipantSerializer, type: :serializer do
         expect(attributes["full_name"]).to eq(participant.full_name)
       end
 
-      it "serializes the `teacher_reference_number`" do
-        expect(attributes["teacher_reference_number"]).to eq(participant.trn)
+      context "when serializing `teacher_reference_number`" do
+        context "when trn is verified" do
+          before { participant.update!(trn_verified: true) }
+
+          it "serializes the `teacher_reference_number`" do
+            expect(attributes["teacher_reference_number"]).to eq(participant.trn)
+          end
+        end
+
+        context "when trn is not verified" do
+          it "serializes nil" do
+            expect(attributes["teacher_reference_number"]).to be_nil
+          end
+        end
       end
 
       context "when serializing `updated_at`" do
@@ -178,8 +202,20 @@ RSpec.describe API::ParticipantSerializer, type: :serializer do
         expect(attributes["full_name"]).to eq(participant.full_name)
       end
 
-      it "serializes the `teacher_reference_number`" do
-        expect(attributes["teacher_reference_number"]).to eq(participant.trn)
+      context "when serializing `teacher_reference_number`" do
+        context "when trn is verified" do
+          before { participant.update!(trn_verified: true) }
+
+          it "serializes the `teacher_reference_number`" do
+            expect(attributes["teacher_reference_number"]).to eq(participant.trn)
+          end
+        end
+
+        context "when trn is not verified" do
+          it "serializes nil" do
+            expect(attributes["teacher_reference_number"]).to be_nil
+          end
+        end
       end
 
       context "when serializing `updated_at`" do

--- a/spec/services/valid_test_data_generators/separation_shared_data_spec.rb
+++ b/spec/services/valid_test_data_generators/separation_shared_data_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe ValidTestDataGenerators::SeparationSharedData, :with_default_sche
 
   before do
     allow(Rails).to receive(:env) { environment.inquiry }
+    # Stub Faker and Courses here so we have all scenarios created regardless
     allow(Faker::Boolean).to receive(:boolean).and_return(false)
+    allow(Course).to receive(:all).and_return([Course.find_by(identifier: "npq-headship"), Course.find_by(identifier: "npq-leading-literacy")])
   end
 
   subject { described_class.new(lead_provider:, cohort:) }


### PR DESCRIPTION
### Context

Ticket: [CPDLP-3488](https://dfedigital.atlassian.net/browse/CPDLP-3488)

In ECF we surface the TRN in the NPQ participant serialiser from the teacher profile. The teacher profile is only updated if the TRN is validated.

### Changes proposed in this pull request

In NPQ update the trn to only read from the teacher_reference_number if it is validated on the application.

[CPDLP-3488]: https://dfedigital.atlassian.net/browse/CPDLP-3488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ