### PR TITLE
[CPDNPQ-2073] Standardise hyphenation of "state-funded"

### DIFF
--- a/app/views/registration_wizard/ineligible_for_funding/_not_eligible_for_scholarship_funding.html.erb
+++ b/app/views/registration_wizard/ineligible_for_funding/_not_eligible_for_scholarship_funding.html.erb
@@ -1,7 +1,7 @@
 <h1 class="govuk-heading-xl">Funding</h1>
 
 <p class="govuk-body">
-  You’re not eligible for scholarship funding for <%= localise_sentence_embedded_course_name(course) %> as you do not work in one of the eligible settings, such as state funded schools.
+  You’re not eligible for scholarship funding for <%= localise_sentence_embedded_course_name(course) %> as you do not work in one of the eligible settings, such as state-funded schools.
 </p>
 
 <p class="govuk-body">

--- a/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
       expect(page).to have_text("Funding")
-      expect(page).to have_text("such as state funded schools")
+      expect(page).to have_text("such as state-funded schools")
       expect(page).to have_text("This means that you would need to pay for the course another way")
 
       page.click_link("Continue")

--- a/spec/features/journeys/happy_paths/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
@@ -112,7 +112,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
       expect(page).to have_text("Funding")
-      expect(page).to have_text("such as state funded schools")
+      expect(page).to have_text("such as state-funded schools")
       expect(page).to have_text("You’re not eligible for scholarship funding")
 
       page.click_link("Continue")

--- a/spec/features/journeys/happy_paths/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
@@ -72,7 +72,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
       expect(page).to have_text("Funding")
-      expect(page).to have_text("such as state funded schools")
+      expect(page).to have_text("such as state-funded schools")
       expect(page).to have_text("This means that you would need to pay for the course another way")
 
       page.click_link("Continue")

--- a/spec/features/journeys/happy_paths/changing_from_outside_of_catchment_area_to_inside_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_from_outside_of_catchment_area_to_inside_spec.rb
@@ -109,7 +109,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
       expect(page).to have_text("Funding")
-      expect(page).to have_text("such as state funded schools")
+      expect(page).to have_text("such as state-funded schools")
       expect(page).to have_text("You’re not eligible for scholarship funding")
 
       page.click_link("Continue")

--- a/spec/features/journeys/happy_paths/via_using_old_name_and_not_headship_spec.rb
+++ b/spec/features/journeys/happy_paths/via_using_old_name_and_not_headship_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
       expect(page).to have_text("Funding")
-      expect(page).to have_text("such as state funded schools")
+      expect(page).to have_text("such as state-funded schools")
       expect(page).to have_text("This means that you would need to pay for the course another way")
 
       page.click_link("Continue")

--- a/spec/features/journeys/happy_paths/via_using_same_name_spec.rb
+++ b/spec/features/journeys/happy_paths/via_using_same_name_spec.rb
@@ -64,7 +64,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, type: :feature do
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
       expect(page).to have_text("Funding")
       expect(page).to have_text("not eligible for scholarship funding")
-      expect(page).to have_text("such as state funded schools")
+      expect(page).to have_text("such as state-funded schools")
       expect(page).to have_text("This means that you would need to pay for the course another way")
 
       page.click_link("Continue")

--- a/spec/features/journeys/happy_paths/when_get_an_identity_returns_no_trn_spec.rb
+++ b/spec/features/journeys/happy_paths/when_get_an_identity_returns_no_trn_spec.rb
@@ -87,7 +87,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
       expect(page).to have_text("Funding")
-      expect(page).to have_text("such as state funded schools")
+      expect(page).to have_text("such as state-funded schools")
       expect(page).to have_text("This means that you would need to pay for the course another way")
 
       page.click_link("Continue")

--- a/spec/features/journeys/happy_paths/when_working_in_other_spec.rb
+++ b/spec/features/journeys/happy_paths/when_working_in_other_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
       expect(page).to have_text("Funding")
-      expect(page).to have_text("such as state funded schools")
+      expect(page).to have_text("such as state-funded schools")
       expect(page).to have_text("You’re not eligible for scholarship funding")
 
       page.click_link("Continue")

--- a/spec/features/journeys/happy_paths/while_working_at_public_nursery_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_at_public_nursery_spec.rb
@@ -77,7 +77,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
       expect(page).to have_text("Funding")
       expect(page).to have_text("You’re not eligible for scholarship funding")
-      expect(page).to have_text("such as state funded schools")
+      expect(page).to have_text("such as state-funded schools")
       expect(page).to have_text("This means that you would need to pay for the course another way")
 
       page.click_link("Continue")


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2073

### Changes proposed in this pull request

Throughout the NPQ application, all text which currently says “state funded” should say “state-funded”