### PR TITLE
Migrate ECF applications to NPQ reg

### DIFF
--- a/app/services/migration/migrators/base.rb
+++ b/app/services/migration/migrators/base.rb
@@ -103,14 +103,50 @@ module Migration::Migrators
       statement_ids_by_ecf_id[ecf_id] || raise(ActiveRecord::RecordNotFound, "Couldn't find Statement")
     end
 
-    def find_course_id!(identifier:)
-      course_ids_by_identifier[identifier] || raise(ActiveRecord::RecordNotFound, "Couldn't find Course")
+    def find_course_id!(identifier: nil, ecf_id: nil)
+      raise ActiveRecord::RecordNotFound, "Couldn't find Course" unless identifier || ecf_id
+
+      return course_ids_by_identifier[identifier] || raise(ActiveRecord::RecordNotFound, "Couldn't find Course") if identifier
+      course_ids_by_ecf_id[ecf_id] || raise(ActiveRecord::RecordNotFound, "Couldn't find Course") if ecf_id
+    end
+
+    def find_school_id!(urn:)
+      school_ids_by_urn[urn] || raise(ActiveRecord::RecordNotFound, "Couldn't find School")
+    end
+
+    def find_itt_provider_id!(legal_name:)
+      itt_provider_ids_by_legal_name[legal_name] || raise(ActiveRecord::RecordNotFound, "Couldn't find IttProvider")
+    end
+
+    def find_private_childcare_provider_id!(provider_urn:)
+      private_childcare_provider_ids_by_provider_urn[provider_urn] || raise(ActiveRecord::RecordNotFound, "Couldn't find PrivateChildcareProvider")
+    end
+
+    def find_user_id!(ecf_id:)
+      user_ids_by_ecf_id[ecf_id] || raise(ActiveRecord::RecordNotFound, "Couldn't find User")
+    end
+
+    def course_groups_by_schedule_type(ecf_type)
+      case ecf_type
+      when "Finance::Schedule::NPQLeadership"
+        CourseGroup.find_by!(name: :leadership)
+      when "Finance::Schedule::NPQSpecialist"
+        CourseGroup.find_by!(name: :specialist)
+      when "Finance::Schedule::NPQSupport"
+        CourseGroup.find_by!(name: :support)
+      when "Finance::Schedule::NPQEhco"
+        CourseGroup.find_by!(name: :ehco)
+      end
     end
 
   private
 
     def course_ids_by_identifier
       @course_ids_by_identifier ||= ::Course.pluck(:identifier, :id).to_h
+    end
+
+    def course_ids_by_ecf_id
+      @course_ids_by_ecf_id ||= ::Course.pluck(:ecf_id, :id).to_h
     end
 
     def statement_ids_by_ecf_id
@@ -129,8 +165,24 @@ module Migration::Migrators
       @lead_provider_ids_by_ecf_id ||= ::LeadProvider.pluck(:ecf_id, :id).to_h
     end
 
+    def user_ids_by_ecf_id
+      @user_ids_by_ecf_id ||= ::User.pluck(:ecf_id, :id).to_h
+    end
+
     def cohort_ids_by_start_year
       @cohort_ids_by_start_year ||= ::Cohort.pluck(:start_year, :id).to_h
+    end
+
+    def school_ids_by_urn
+      @school_ids_by_urn ||= ::School.pluck(:urn, :id).to_h
+    end
+
+    def itt_provider_ids_by_legal_name
+      @itt_provider_ids_by_legal_name ||= ::IttProvider.pluck(:legal_name, :id).to_h
+    end
+
+    def private_childcare_provider_ids_by_provider_urn
+      @private_childcare_provider_ids_by_provider_urn ||= ::PrivateChildcareProvider.pluck(:provider_urn, :id).to_h
     end
 
     def offset

--- a/app/services/migration/migrators/schedule.rb
+++ b/app/services/migration/migrators/schedule.rb
@@ -22,7 +22,7 @@ module Migration::Migrators
       migrate(self.class.ecf_schedules) do |ecf_schedule|
         ensure_milestone_dates_are_all_the_same!(ecf_schedule)
 
-        course_group = course_groups_by_identifier(ecf_schedule.type)
+        course_group = course_groups_by_schedule_type(ecf_schedule.type)
 
         unless course_group
           ecf_schedule.errors.add(:base, "Course group not found for schedule")
@@ -46,19 +46,6 @@ module Migration::Migrators
     end
 
   private
-
-    def course_groups_by_identifier(ecf_type)
-      case ecf_type
-      when "Finance::Schedule::NPQLeadership"
-        CourseGroup.find_by!(name: :leadership)
-      when "Finance::Schedule::NPQSpecialist"
-        CourseGroup.find_by!(name: :specialist)
-      when "Finance::Schedule::NPQSupport"
-        CourseGroup.find_by!(name: :support)
-      when "Finance::Schedule::NPQEhco"
-        CourseGroup.find_by!(name: :ehco)
-      end
-    end
 
     def ensure_milestone_dates_are_all_the_same!(ecf_schedule)
       dates = ecf_schedule.milestones.map { |m| [m.start_date, m.payment_date] }

--- a/spec/factories/migration/ecf/npq_applications.rb
+++ b/spec/factories/migration/ecf/npq_applications.rb
@@ -21,6 +21,7 @@ FactoryBot.define do
     teacher_catchment_country { nil }
     itt_provider { "University of Southampton" }
     lead_mentor { true }
+    private_childcare_provider_urn { rand(100_000..999_999).to_s }
 
     trait :accepted do
       lead_provider_approval_status { "accepted" }
@@ -31,7 +32,7 @@ FactoryBot.define do
           teacher_profile: npq_application.user.teacher_profile,
           user: npq_application.user,
           type: "ParticipantProfile::NPQ",
-          schedule: create(:ecf_migration_schedule, cohort: npq_application.cohort, schedule_identifier: npq_application.npq_course.identifier),
+          schedule: create(:ecf_migration_schedule_npq_support, cohort: npq_application.cohort, schedule_identifier: npq_application.npq_course.identifier),
           participant_identity_id: npq_application.participant_identity_id,
         )
       end

--- a/spec/services/migration/migrators/application_spec.rb
+++ b/spec/services/migration/migrators/application_spec.rb
@@ -1,13 +1,22 @@
 require "rails_helper"
 
 RSpec.describe Migration::Migrators::Application do
-  it_behaves_like "a migrator", :application, [] do
+  it_behaves_like "a migrator", :application, %i[cohort lead_provider schedule course user school] do
     def create_ecf_resource
-      create(:ecf_migration_npq_application)
+      create(:ecf_migration_npq_application, :accepted)
     end
 
     def create_npq_resource(ecf_resource)
-      create(:application, ecf_id: ecf_resource.id, **ecf_resource.slice(described_class::ATTRIBUTES_TO_COMPARE))
+      cohort = create(:cohort, start_year: ecf_resource.cohort.start_year)
+      ecf_schedule = ecf_resource.profile.schedule
+      create(:schedule, :npq_aso_december, cohort:, identifier: ecf_schedule.schedule_identifier)
+      create(:private_childcare_provider, provider_urn: ecf_resource.private_childcare_provider_urn)
+
+      school = create(:school, urn: ecf_resource.school_urn)
+      course = create(:course, identifier: ecf_resource.npq_course.identifier, ecf_id: ecf_resource.npq_course_id)
+      lead_provider = create(:lead_provider, ecf_id: ecf_resource.npq_lead_provider_id)
+      user = create(:user, ecf_id: ecf_resource.user.id)
+      create(:application, ecf_id: ecf_resource.id, school:, course:, lead_provider:, user:)
     end
 
     def setup_failure_state
@@ -16,10 +25,110 @@ RSpec.describe Migration::Migrators::Application do
     end
 
     describe "#call" do
-      it "records a failure when the attribute values do not match" do
-        ecf_resource1.update!(teacher_catchment: "any")
+      it "sets the attributes from the ECF NPQApplication on the NPQ application" do
         instance.call
-        expect(failure_manager).to have_received(:record_failure).with(ecf_resource1, /Validation failed/)
+        application = Application.find_by(ecf_id: ecf_resource1.id)
+        expect(application.attributes).to include(ecf_resource1.attributes.slice(*described_class::ATTRIBUTES))
+        expect(application.training_status).to eq(ecf_resource1.profile.training_status)
+        expect(application.ukprn).to eq(ecf_resource1.school_ukprn)
+      end
+
+      it "sets the schedule from the ECF NPQApplication on the NPQ application" do
+        instance.call
+
+        application = Application.find_by(ecf_id: ecf_resource1.id)
+        ecf_schedule = ecf_resource1.profile.schedule
+        expect(application.schedule.identifier).to eq(ecf_schedule.schedule_identifier)
+        expect(application.schedule.cohort.start_year).to eq(ecf_schedule.cohort.start_year)
+        expect(application.schedule.course_group.name).to eq("support")
+      end
+
+      it "sets the cohort from the ECF NPQApplication on the NPQ application" do
+        instance.call
+
+        application = Application.find_by(ecf_id: ecf_resource1.id)
+        expect(application.cohort.start_year).to eq(ecf_resource1.cohort.start_year)
+      end
+
+      it "sets the ITT provider from the ECF NPQApplication on the NPQ application" do
+        instance.call
+
+        application = Application.find_by(ecf_id: ecf_resource1.id)
+        expect(application.itt_provider.legal_name).to eq(ecf_resource1.itt_provider)
+      end
+
+      it "sets the private childcare provider from the ECF NPQApplication on the NPQ application" do
+        instance.call
+
+        application = Application.find_by(ecf_id: ecf_resource1.id)
+        expect(application.private_childcare_provider.provider_urn).to eq(ecf_resource1.private_childcare_provider_urn)
+      end
+
+      it "records a failure when the school in NPQ reg does not match the school in ECF" do
+        Application.first.update!(school: create(:school, urn: "111333"))
+        instance.call
+        expect(failure_manager).to have_received(:record_failure).with(ecf_resource1, /School in ECF is different/)
+      end
+
+      it "records a failure when the school exists on the application in NPQ reg but not ECF" do
+        ecf_resource1.update!(school_urn: nil)
+        instance.call
+        expect(failure_manager).to have_received(:record_failure).with(ecf_resource1, /School in ECF is different/)
+      end
+
+      it "does not record a failure when the school is nil for both ECF and NPQ reg" do
+        ecf_resource1.update!(school_urn: nil)
+        Application.find_by(ecf_id: ecf_resource1.id).update!(school: nil)
+        instance.call
+        expect(failure_manager).not_to have_received(:record_failure)
+      end
+
+      it "records a failure when the user in NPQ reg does not match the user in ECF" do
+        Application.first.update!(user: create(:user))
+        instance.call
+        expect(failure_manager).to have_received(:record_failure).with(ecf_resource1, /User in ECF is different/)
+      end
+
+      it "records a failure when the course in NPQ reg does not match the course in ECF" do
+        Application.first.update!(course: create(:course))
+        instance.call
+        expect(failure_manager).to have_received(:record_failure).with(ecf_resource1, /Course in ECF is different/)
+      end
+
+      it "records a failure when the lead provider in NPQ reg does not match the lead provider in ECF" do
+        Application.first.update!(lead_provider: create(:lead_provider))
+        instance.call
+        expect(failure_manager).to have_received(:record_failure).with(ecf_resource1, /LeadProvider in ECF is different/)
+      end
+
+      it "records a failure when the schedule cannot be found" do
+        ecf_resource1.profile.schedule.update!(schedule_identifier: "other-schedule")
+        instance.call
+        expect(failure_manager).to have_received(:record_failure).with(ecf_resource1, /Couldn't find Schedule/)
+      end
+
+      it "records a failure when the cohort cannot be found" do
+        ecf_resource1.cohort.update!(start_year: "1999")
+        instance.call
+        expect(failure_manager).to have_received(:record_failure).with(ecf_resource1, /Couldn't find Cohort/)
+      end
+
+      it "records a failure when the ITT provider cannot be found" do
+        ecf_resource1.update!(itt_provider: "other-provider")
+        instance.call
+        expect(failure_manager).to have_received(:record_failure).with(ecf_resource1, /Couldn't find IttProvider/)
+      end
+
+      it "records a failure when the private childcare provider cannot be found" do
+        ecf_resource1.update!(private_childcare_provider_urn: "999999")
+        instance.call
+        expect(failure_manager).to have_received(:record_failure).with(ecf_resource1, /Couldn't find PrivateChildcareProvider/)
+      end
+
+      it "treats the schedule and training_status as optional (as profile can be nil)" do
+        ecf_resource1.profile.destroy!
+        instance.call
+        expect(failure_manager).not_to have_received(:record_failure)
       end
 
       it "records a failure if applications exist in NPQ reg but not in ECF, but only on the first run" do


### PR DESCRIPTION
[Jira-3497](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3497)

### Context

We want to bring across the data associated with NPQ applications in ECF to NPQ reg. Previously we were performing an integrity check on the attributes, but after investigation we determined all attributes should be updated from ECF to NPQ reg for applications.

The school, course, lead provider and user should not be different and we have added an integrity check to ensure this.

### Changes proposed in this pull request

- Migrate ECF applications to NPQ reg
 
### Guidance to review

The attributes that are identical in each:

```
created_at
updated_at
headteacher_status
eligible_for_funding
funding_choice
works_in_school
employer_name
employment_role
targeted_support_funding_eligibility
teacher_catchment_iso_country_code
works_in_nursery
works_in_childcare
kind_of_nursery
targeted_delivery_funding_eligibility
funding_eligiblity_status_code
employment_type
lead_mentor
primary_establishment
number_of_pupils
tsf_primary_eligibility
tsf_primary_plus_eligibility
lead_provider_approval_status
teacher_catchment
teacher_catchment_country
notes
funded_place
```

The attributes that needed to be remapped:

| ECF    | NPQ |
| -------- | ------- |
| itt_provider  | itt_provider - legal_name   |
| private_childcare_provider_urn | private_childcare_provider - provider_urn    |
| cohort - start_year | cohort - start_year    |
| school_ukprn | ukprn - provider_urn    |
| profile - training_status | private_childcare_provider - provider_urn    |
| profile - schedule_id | schedule_id    |

The relationships that we check are consistent without overwritting:

| ECF    | NPQ |
| -------- | ------- |
| school_urn  | school - urn   |
| npq_course_id | course - ecf_id    |
| npq_lead_provider - id | lead_provider - ecf_id    |
| profile - user_id | user - ecf_id    |

The vast majority of failures are around applications where we can't find the school in NPQ reg, oddly, since there are no school failures I'm not sure why the applications fail:

<img width="1032" alt="Screenshot 2024-09-11 at 15 17 41" src="https://github.com/user-attachments/assets/22172d44-0a85-4467-bc13-07375da2259f">
