### PR TITLE
Reconfigure Docker Compose for development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,11 +22,13 @@ RUN gem install bundler:2.5.15 --no-document
 COPY .ruby-version Gemfile Gemfile.lock ./
 
 ENV NODE_OPTIONS=--openssl-legacy-provider
+
+ARG BUNDLE_WITHOUT="development test"
 # Install gems and remove gem cache
 RUN bundler -v && \
     bundle config set no-cache 'true' && \
     bundle config set no-binstubs 'true' && \
-    bundle config set without 'development test' && \
+    bundle config without ${BUNDLE_WITHOUT} && \
     bundle install --retry=5 --jobs=4 && \
     rm -rf /usr/local/bundle/cache
 
@@ -57,7 +59,8 @@ FROM ruby:3.3.4-alpine3.20 AS production
 WORKDIR /app
 
 # Add the timezone as it's not configured by default in Alpine
-RUN apk add --update --no-cache libpq tzdata && \
+ARG EXTRA_PACKAGES=""
+RUN apk add --update --no-cache libpq tzdata ${EXTRA_PACKAGES} && \
     cp /usr/share/zoneinfo/Europe/London /etc/localtime && \
     echo "Europe/London" > /etc/timezone
 

--- a/Gemfile
+++ b/Gemfile
@@ -89,7 +89,7 @@ group :test do
   gem "rspec-default_http_header"
   gem "shoulda-matchers", "~> 6.4"
   gem "site_prism", "~> 5.0"
-  gem "webdrivers"
+  gem "selenium-webdriver"
   gem "webmock", "~> 3.23"
   gem "with_model", "~> 2.1", ">= 2.1.7"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -87,9 +87,9 @@ group :test do
   gem "axe-core-capybara", "~> 4.6"
   gem "axe-core-rspec", "~> 4.9"
   gem "rspec-default_http_header"
+  gem "selenium-webdriver"
   gem "shoulda-matchers", "~> 6.4"
   gem "site_prism", "~> 5.0"
-  gem "selenium-webdriver"
   gem "webmock", "~> 3.23"
   gem "with_model", "~> 2.1", ">= 2.1.7"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -637,10 +637,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.3.1)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0, < 4.11)
     webmock (3.23.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -664,6 +660,7 @@ PLATFORMS
   ruby
   x86_64-darwin-20
   x86_64-linux
+  x86_64-linux-musl
 
 DEPENDENCIES
   activerecord-session_store
@@ -733,6 +730,7 @@ DEPENDENCIES
   scenic
   scss_lint-govuk
   secure_headers
+  selenium-webdriver
   sentry-delayed_job
   sentry-rails
   sentry-ruby
@@ -745,7 +743,6 @@ DEPENDENCIES
   stimulus-rails
   tzinfo-data
   web-console (>= 3.3.0)
-  webdrivers
   webmock (~> 3.23)
   whenever
   with_model (~> 2.1, >= 2.1.7)

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
-web: env RUBY_DEBUG_OPEN=true bin/rails server
+web: env RUBY_DEBUG_OPEN=true bin/rails server -p 3000 -b 0.0.0.0
 js: yarn build --watch
 css: yarn build:css --watch

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,32 +1,48 @@
-volumes:
-  dbdata:
-
 services:
   db:
     image: postgres:14-alpine
     restart: always
-    # To preserve data between runs of docker-compose, we mount a folder from the host machine.
     volumes:
-      - dbdata:/var/lib/postgresql/data
+      - db-data:/var/lib/postgresql/data
     environment:
-      - POSTGRES_USER=root
-      - POSTGRES_PASSWORD=password
+      - POSTGRES_HOST_AUTH_METHOD=trust
+
+  ops:
+    build:
+      dockerfile_inline: |
+        FROM mcr.microsoft.com/azure-cli:cbl-mariner2.0
+        RUN mkdir /app
+        WORKDIR /app
+        RUN yum install -y make
+        RUN az aks install-cli
+    command: bash
+    scale: 0
+    volumes:
+      - azure-data:/root/.azure
+      - .:/app
 
   web:
     build:
-      context: .
-      dockerfile: ./Dockerfile
       args:
-        GIT_COMMIT_SHA: DOCKER_COMPOSE_GIT_COMMIT_SHA
-    ports:
-      - 8080:8080
+        - BUNDLE_WITHOUT=production review separation
+        - EXTRA_PACKAGES=chromium chromium-chromedriver gcompat yarn
+      context: .
+    command: bin/dev
     depends_on:
       - db
     environment:
-      - DATABASE_URL=postgresql://root:password@db:5432/npq_registration_local
-      - ECF_DATABASE_URL=postgresql://root:password@db:5432/early_careers_framework_local
-      - RAILS_ENV=production
+      - DATABASE_URL=postgresql://postgres@db:5432/
+      - ECF_DATABASE_URL=postgresql://postgres@db:5432/
+      - RAILS_ENV=development
       - RAILS_SERVE_STATIC_FILES=true
       - RAILS_LOG_TO_STDOUT=true
       - SECRET_KEY_BASE=abcd1234
-      - GOVUK_NOTIFY_API_KEY=addnotifykeyhere
+    ports:
+      - 3000:3000
+    shm_size: '512mb' # required for chromium / selenium
+    volumes:
+      - .:/app
+
+volumes:
+  azure-data:
+  db-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,21 @@
+x-app: &app
+  build:
+    args:
+      - BUNDLE_WITHOUT=production review separation
+      - EXTRA_PACKAGES=chromium chromium-chromedriver gcompat yarn
+    context: .
+  depends_on:
+    - db
+  environment:
+    - DATABASE_URL=postgresql://postgres@db:5432/
+    - ECF_DATABASE_URL=postgresql://postgres@db:5432/
+    - RAILS_ENV=development
+    - RAILS_LOG_TO_STDOUT=true
+    - RAILS_SERVE_STATIC_FILES=true
+    - SECRET_KEY_BASE=abcd1234
+  volumes:
+    - .:/app
+
 services:
   db:
     image: postgres:14-alpine
@@ -22,26 +40,15 @@ services:
       - .:/app
 
   web:
-    build:
-      args:
-        - BUNDLE_WITHOUT=production review separation
-        - EXTRA_PACKAGES=chromium chromium-chromedriver gcompat yarn
-      context: .
+    <<: *app
     command: bin/dev
-    depends_on:
-      - db
-    environment:
-      - DATABASE_URL=postgresql://postgres@db:5432/
-      - ECF_DATABASE_URL=postgresql://postgres@db:5432/
-      - RAILS_ENV=development
-      - RAILS_SERVE_STATIC_FILES=true
-      - RAILS_LOG_TO_STDOUT=true
-      - SECRET_KEY_BASE=abcd1234
     ports:
       - 3000:3000
     shm_size: '512mb' # required for chromium / selenium
-    volumes:
-      - .:/app
+
+  worker:
+    <<: *app
+    command: bundle exec rake jobs:work
 
 volumes:
   azure-data:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -5,6 +5,7 @@
 1. [Local development](#local-development)
 2. [Codespaces](#codespaces)
 3. [Docker](#docker)
+4. [Docker Compose](#docker-compose)
 
 ## Local development
 
@@ -46,11 +47,22 @@ rails action_mailbox:ingress:exim        # Relay an inbound email from Exim to A
 ...
 ```
 
-### Run in production mode
-Docker compose provides a default empty database to run rails in production mode.
+## Docker Compose
+
+Starts the stack (database and application) for development. You only need Docker on your machine.
 
 ```
-docker-compose up
+docker-compose up -d
 ```
 
-Open: http://localhost:3000
+Open http://localhost:3000 to browse the app. Edit code as normal (the project directory is mounted as a volume.)
+
+Prefix other commands with `docker compose run web`, e.g.:
+- `docker compose run web bundle exec rails c`
+- `docker compose run web bundle exec rails db:migrate`
+- `docker compose run web bundle exec rake`
+- `docker compose run web bundle add foobar`
+
+If you need to rebuild the image (e.g. `Gemfile.lock` changed), add `--build`: `docker compose up -d --build`
+
+The `ops` service (`docker compose run ops`) starts a bash shell with `make`, `az` and `kubectl` ready to use.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -63,6 +63,8 @@ Prefix other commands with `docker compose run web`, e.g.:
 - `docker compose run web bundle exec rake`
 - `docker compose run web bundle add foobar`
 
+n.b. to run parallel tests, you need to explicitly set RAILS_ENV e.g.: `docker compose run -e RAILS_ENV=test web bundle exec rake parallel:spec`
+
 If you need to rebuild the image (e.g. `Gemfile.lock` changed), add `--build`: `docker compose up -d --build`
 
 The `ops` service (`docker compose run ops`) starts a bash shell with `make`, `az` and `kubectl` ready to use.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -27,6 +27,7 @@ Capybara.register_driver :headless_chrome do |app|
   options_key = Capybara::Selenium::Driver::CAPS_VERSION.satisfied_by?(version) ? :capabilities : :options
   browser_options = ::Selenium::WebDriver::Chrome::Options.new.tap do |opts|
     opts.add_argument("--headless")
+    opts.add_argument("--no-sandbox")
     opts.add_argument("--disable-gpu")
     opts.add_argument("--window-size=1920,1080")
     # Workaround https://bugs.chromium.org/p/chromedriver/issues/detail?id=2650&q=load&sort=-id&colspec=ID%20Status%20Pri%20Owner%20Summary

--- a/spec/services/migration/migrators/schedule_spec.rb
+++ b/spec/services/migration/migrators/schedule_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Migration::Migrators::Schedule do
       }.each do |scehdule_factory, course_group_name|
         context "when there are #{scehdule_factory} schedules" do
           it "creates a new schedule in NPQ with the correct course group" do
-            ecf_schedule = create(scehdule_factory).tap do |schedule| # rubocop:disable RSpec/SaveBang
+            ecf_schedule = create(scehdule_factory).tap do |schedule| # rubocop:disable Rails/SaveBang
               create(:ecf_migration_milestone, schedule:)
             end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,6 @@
 require "knapsack"
 Knapsack::Adapters::RSpecAdapter.bind
 
-require "webdrivers"
-Webdrivers.install_dir = [Webdrivers.install_dir, ENV["TEST_ENV_NUMBER"]].compact.join(File::SEPARATOR)
-
 require "simplecov"
 require "simplecov_json_formatter"
 SimpleCov.start "rails"


### PR DESCRIPTION
### Context

No ticket – based on my first-time setup experience as a new team member. I can keep this as a local patch if there's no appetite to merge!

### Changes proposed in this pull request

Re-configures Docker Compose for development so that on any machine with Docker installed you can type `docker compose up -d` and start working, no other dependencies/setup needed.

- By default, starts Postgres and Rails containers, and mounts the project directory as a volume so that you can work from your local filesystem
- Also provides an `ops` container with Azure and Kubernetes tools available

See changes to docs for more info.

#### Changes outside the scope of Docker Compose: 

To get the Rails container working properly:

1. To make browser-driven tests work, the Rails-default `webdrivers` gem is swapped for `selenium-webdriver` specifically — as far as I can see, Capybara only uses Selenium anyway, and all the tests pass, so hopefully not a biggie.

2. `bin/dev` now binds to 0.0.0.0 rather than 127.0.0.1, to accept requests from outside the container. (It looks the default command in Dockerfile already specifies the same.)

#### Changes for Docker Compose users:

If you already use Compose (excluding VS Code devcontainers) then this PR would affect you. But I'm not sure anyone does?

Apart from developers, I searched the project for "compose" and didn't see anything except a Make task that isn't referenced anywhere else (aside: can/should we delete this?), so it looks like Compose also isn't used for ops either? 

In theory even if you currently use Docker Compose, with this commit checked out it should be a case of running `docker compose up -d` and carrying on, but it'd be great to know of any problems.