### PR TITLE
Fix bugs in Contract migrator

### DIFF
--- a/app/services/migration/migrators/application_state.rb
+++ b/app/services/migration/migrators/application_state.rb
@@ -31,7 +31,7 @@ module Migration::Migrators
         ecf_application_id = ecf_participant_profile_state.participant_profile_id
         application_state.application_id = find_application_id!(ecf_id: ecf_application_id)
 
-        application_state.update!(ecf_participant_profile_state.attributes.slice(%w[state reason created_at updated_at]))
+        application_state.update!(ecf_participant_profile_state.attributes.slice("state", "reason", "created_at", "updated_at"))
       end
     end
   end

--- a/app/services/migration/migrators/base.rb
+++ b/app/services/migration/migrators/base.rb
@@ -104,7 +104,7 @@ module Migration::Migrators
     end
 
     def find_course_id!(identifier:)
-      courses_by_identifier[identifier] || raise(ActiveRecord::RecordNotFound, "Couldn't find Course")
+      course_ids_by_identifier[identifier] || raise(ActiveRecord::RecordNotFound, "Couldn't find Course")
     end
 
   private

--- a/app/services/migration/migrators/base.rb
+++ b/app/services/migration/migrators/base.rb
@@ -103,7 +103,15 @@ module Migration::Migrators
       statement_ids_by_ecf_id[ecf_id] || raise(ActiveRecord::RecordNotFound, "Couldn't find Statement")
     end
 
+    def find_course_id!(identifier:)
+      courses_by_identifier[identifier] || raise(ActiveRecord::RecordNotFound, "Couldn't find Course")
+    end
+
   private
+
+    def course_ids_by_identifier
+      @course_ids_by_identifier ||= ::Course.pluck(:identifier, :id).to_h
+    end
 
     def statement_ids_by_ecf_id
       @statement_ids_by_ecf_id ||= ::Statement.pluck(:ecf_id, :id).to_h

--- a/app/services/migration/migrators/contract.rb
+++ b/app/services/migration/migrators/contract.rb
@@ -34,17 +34,17 @@ module Migration::Migrators
 
     def call
       migrate(self.class.ecf_contracts) do |ecf_contract|
-        course = courses_by_identifier[ecf_contract.course_identifier]
+        course_id = find_course_id!(identifier: ecf_contract.course_identifier)
 
         ecf_statements(ecf_contract).find_each do |ecf_statement|
-          statement = ::Statement.find_by!(ecf_id: ecf_statement.id)
+          statement_id = find_statement_id!(ecf_id: ecf_statement.id)
 
           contract_template = ::ContractTemplate.find_or_initialize_by(ecf_id: ecf_contract.id)
           contract_template.update!(ecf_contract.attributes.slice(SHARED_ATTRIBUTES))
 
           contract = ::Contract.find_or_initialize_by(
-            statement:,
-            course:,
+            statement_id:,
+            course_id:,
           )
           contract.update!(contract_template:)
         end

--- a/app/services/migration/migrators/contract.rb
+++ b/app/services/migration/migrators/contract.rb
@@ -28,7 +28,7 @@ module Migration::Migrators
       end
 
       def dependencies
-        %i[cohort lead_provider course statement]
+        %i[course statement]
       end
     end
 
@@ -40,12 +40,13 @@ module Migration::Migrators
           statement_id = find_statement_id!(ecf_id: ecf_statement.id)
 
           contract_template = ::ContractTemplate.find_or_initialize_by(ecf_id: ecf_contract.id)
-          contract_template.update!(ecf_contract.attributes.slice(SHARED_ATTRIBUTES))
+          contract_template.update!(ecf_contract.attributes.slice(*SHARED_ATTRIBUTES))
 
           contract = ::Contract.find_or_initialize_by(
             statement_id:,
             course_id:,
           )
+
           contract.update!(contract_template:)
         end
       end
@@ -57,12 +58,6 @@ module Migration::Migrators
         cohort: ecf_contract.cohort,
         contract_version: ecf_contract.version,
       )
-    end
-
-  private
-
-    def courses_by_identifier
-      @courses_by_identifier ||= ::Course.all.index_by(&:identifier)
     end
   end
 end

--- a/spec/services/migration/migrators/application_state_spec.rb
+++ b/spec/services/migration/migrators/application_state_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Migration::Migrators::ApplicationState do
         instance.call
 
         application_state = ApplicationState.joins(:application).find_by(application: { ecf_id: ecf_resource1.participant_profile_id })
-        expect(application_state).to have_attributes(ecf_resource1.attributes.slice(%w[state reason created_at updated_at]))
+        expect(application_state).to have_attributes(ecf_resource1.attributes.slice("state", "reason", "created_at", "updated_at"))
         expect(application_state.lead_provider.ecf_id).to eq(ecf_resource1.cpd_lead_provider.npq_lead_provider.id)
       end
 

--- a/spec/services/migration/migrators/contract_spec.rb
+++ b/spec/services/migration/migrators/contract_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Migration::Migrators::Contract do
-  it_behaves_like "a migrator", :contract, %i[cohort lead_provider course statement] do
+  it_behaves_like "a migrator", :contract, %i[course statement] do
     def create_ecf_resource
       cohort = create(:ecf_migration_cohort)
       npq_lead_provider = create(:ecf_migration_npq_lead_provider)
@@ -91,18 +91,7 @@ RSpec.describe Migration::Migrators::Contract do
         contract_template = contract.contract_template
         expect(contract_template.ecf_id).to eq(ecf_resource1.id)
 
-        attrs = ecf_resource1.attributes.slice(
-          :service_fee_percentage,
-          :output_payment_percentage,
-          :per_participant,
-          :number_of_payment_periods,
-          :recruitment_target,
-          :service_fee_installments,
-          :targeted_delivery_funding_per_participant,
-          :monthly_service_fee,
-          :created_at,
-          :updated_at,
-        )
+        attrs = ecf_resource1.attributes.slice(*described_class::SHARED_ATTRIBUTES)
         expect(contract_template).to have_attributes(attrs)
 
         expect(Contract.where(contract_template:).count).to eq(1)


### PR DESCRIPTION
[Jira-3563](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3563)

### Context

The `Contract` migrator has a number of failures caused by a bug in the migration code; we are not correctly copying attributes from the ECF model to the NPQ reg model.

### Changes proposed in this pull request

- Optimise lookups in Contract migrator

To be consistent with other migrators and to hopefully speed things up we preload the lookups (course/statement).

- Fix attribute slicing in migrators

In the `Contract` and `ApplicationState` migrators we slice attributes using an array; this results in an empty hash and the tests were passing as we made the same slicing error. We need to use the splat operator here to correctly slice the attributes. In the `Contract` migrator we were also using symbols in the tests instead of strings, which is why the test was also incorrectly passing (slicing by an attribute that doesn't exist omits it).

### Guidance for review

<img width="1060" alt="Screenshot 2024-09-12 at 11 13 22" src="https://github.com/user-attachments/assets/5bd0e371-761d-495a-adca-ca748c08900c">

