### PR TITLE
Exclude ECF statement line items from migration

### DIFF
--- a/app/services/migration/migrators/statement_item.rb
+++ b/app/services/migration/migrators/statement_item.rb
@@ -11,6 +11,8 @@ module Migration::Migrators
 
       def ecf_statement_items
         Migration::Ecf::Finance::StatementLineItem
+          .joins(:participant_declaration)
+          .where(participant_declaration: { type: "ParticipantDeclaration::NPQ" })
       end
 
       def dependencies

--- a/spec/factories/migration/ecf/participant_declarations.rb
+++ b/spec/factories/migration/ecf/participant_declarations.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     declaration_date { 1.day.ago }
     state { Declaration.states.keys.sample }
     declaration_type { Declaration.declaration_types.keys.sample }
+    type { "ParticipantDeclaration::NPQ" }
     course_identifier { "course-identifier" }
     user { create(:ecf_migration_user) }
     cohort { create(:ecf_migration_cohort) }

--- a/spec/services/migration/migrators/statement_item_spec.rb
+++ b/spec/services/migration/migrators/statement_item_spec.rb
@@ -26,6 +26,12 @@ RSpec.describe Migration::Migrators::StatementItem do
         expect(statement_item.declaration.ecf_id).to eq(ecf_resource1.participant_declaration_id)
         expect(statement_item.statement.ecf_id).to eq(ecf_resource1.statement_id)
       end
+
+      it "ignores StatementItem records for ECF declarations" do
+        create(:ecf_migration_statement_line_item, participant_declaration: create(:ecf_migration_participant_declaration, type: "ParticipantDeclaration::ECF"))
+
+        expect { instance.call }.to change { data_migration.reload.processed_count }.by(2).and(not_change { data_migration.failure_count })
+      end
     end
   end
 end


### PR DESCRIPTION
[Jira-3499](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3499)

### Context

We get a number of failures due to migrating ECF statement items (as we don't migrate ECF statements they fail to match up to a statement in NPQ reg).

### Changes proposed in this pull request

- Exclude ECF statement items from `StatementItem` migrator.

### Guidance for review

<img width="1024" alt="Screenshot 2024-09-12 at 14 24 43" src="https://github.com/user-attachments/assets/fa94b4a2-65ed-4f40-b9b7-3379bf8469e5">

