### PR TITLE
Ensure the user registrations page isn't public

### DIFF
--- a/app/controllers/accounts/user_registrations_controller.rb
+++ b/app/controllers/accounts/user_registrations_controller.rb
@@ -1,5 +1,5 @@
-class Accounts::UserRegistrationsController < ApplicationController
+class Accounts::UserRegistrationsController < AccountsController
   def show
-    @application = Application.find(params[:id])
+    @application = current_user.applications.find(params[:id])
   end
 end

--- a/spec/features/account_spec.rb
+++ b/spec/features/account_spec.rb
@@ -3,9 +3,21 @@ require "rails_helper"
 RSpec.feature "Account", type: :feature do
   include_context "Stub Get An Identity Omniauth Responses"
 
-  scenario "when not logged in, it redirects to sign in" do
-    visit "/account"
-    expect(page).to be_accessible
-    expect(page).to have_current_path("/sign-in")
+  describe "accounts page" do
+    scenario "when not logged in, it redirects to sign in" do
+      visit "/account"
+      expect(page).to be_accessible
+      expect(page).to have_current_path("/sign-in")
+    end
+  end
+
+  describe "accounts user registration page" do
+    let!(:application) { FactoryBot.create(:application) }
+
+    scenario "when not logged in, it redirects to sign in" do
+      visit(accounts_user_registration_path(application.id))
+
+      expect(page).to have_current_path("/sign-in")
+    end
   end
 end


### PR DESCRIPTION
The user registrations page doesn't really show any personal data but should be behind a login regardless. No data can be changed from it without signing in.
