### PR TITLE
Add `ecf_id` to remaning migration tables

### DIFF
--- a/app/services/migration/migrators/application.rb
+++ b/app/services/migration/migrators/application.rb
@@ -56,11 +56,7 @@ module Migration::Migrators
         ensure_relationships_are_consistent!(ecf_npq_application, application)
 
         ecf_schedule = ecf_npq_application.profile&.schedule
-        if ecf_schedule
-          schedule_cohort_id = find_cohort_id!(ecf_id: ecf_schedule.cohort_id)
-          course_group_name = course_groups_by_schedule_type(ecf_schedule.type).name
-          application.schedule_id = find_schedule_id!(cohort_id: schedule_cohort_id, identifier: ecf_schedule.schedule_identifier, course_group_name:)
-        end
+        application.schedule_id = find_schedule_id!(ecf_id: ecf_schedule.id) if ecf_schedule
 
         application.cohort_id = find_cohort_id!(ecf_id: ecf_npq_application.cohort_id)
         application.itt_provider_id = find_itt_provider_id!(legal_name: ecf_npq_application.itt_provider) if ecf_npq_application.itt_provider
@@ -80,21 +76,6 @@ module Migration::Migrators
     end
 
   private
-
-    def find_schedule_id!(cohort_id:, identifier:, course_group_name:)
-      schedule_ids_by_cohort_id_and_identifier_and_course_group.dig(cohort_id, identifier, course_group_name) || raise(ActiveRecord::RecordNotFound, "Couldn't find Schedule")
-    end
-
-    def schedule_ids_by_cohort_id_and_identifier_and_course_group
-      @schedule_ids_by_cohort_id_and_identifier_and_course_group ||= begin
-        schedules = ::Schedule.includes(:course_group).pluck(:id, :cohort_id, :identifier, "course_groups.name")
-        schedules.each_with_object({}) do |(id, cohort_id, identifier, course_group), hash|
-          hash[cohort_id] ||= {}
-          hash[cohort_id][identifier] ||= {}
-          hash[cohort_id][identifier][course_group] = id
-        end
-      end
-    end
 
     def ensure_relationships_are_consistent!(ecf_npq_application, application)
       if application.user_id != find_user_id!(ecf_id: ecf_npq_application.user.id)

--- a/app/services/migration/migrators/application.rb
+++ b/app/services/migration/migrators/application.rb
@@ -43,7 +43,7 @@ module Migration::Migrators
       def ecf_npq_applications
         Migration::Ecf::NpqApplication
           .joins(:participant_identity)
-          .includes(:cohort, :user, profile: :schedule)
+          .includes(:user, profile: :schedule)
       end
     end
 
@@ -57,12 +57,12 @@ module Migration::Migrators
 
         ecf_schedule = ecf_npq_application.profile&.schedule
         if ecf_schedule
-          schedule_cohort_id = find_cohort_id!(start_year: ecf_schedule.cohort.start_year)
+          schedule_cohort_id = find_cohort_id!(ecf_id: ecf_schedule.cohort_id)
           course_group_name = course_groups_by_schedule_type(ecf_schedule.type).name
           application.schedule_id = find_schedule_id!(cohort_id: schedule_cohort_id, identifier: ecf_schedule.schedule_identifier, course_group_name:)
         end
 
-        application.cohort_id = find_cohort_id!(start_year: ecf_npq_application.cohort.start_year)
+        application.cohort_id = find_cohort_id!(ecf_id: ecf_npq_application.cohort_id)
         application.itt_provider_id = find_itt_provider_id!(legal_name: ecf_npq_application.itt_provider) if ecf_npq_application.itt_provider
         application.private_childcare_provider_id = find_private_childcare_provider_id!(provider_urn: ecf_npq_application.private_childcare_provider_urn) if ecf_npq_application.private_childcare_provider_urn
 

--- a/app/services/migration/migrators/base.rb
+++ b/app/services/migration/migrators/base.rb
@@ -126,6 +126,10 @@ module Migration::Migrators
       user_ids_by_ecf_id[ecf_id] || raise(ActiveRecord::RecordNotFound, "Couldn't find User")
     end
 
+    def find_schedule_id!(ecf_id:)
+      schedule_ids_by_ecf_id[ecf_id] || raise(ActiveRecord::RecordNotFound, "Couldn't find Schedule")
+    end
+
     def course_groups_by_schedule_type(ecf_type)
       case ecf_type
       when "Finance::Schedule::NPQLeadership"
@@ -171,6 +175,10 @@ module Migration::Migrators
 
     def cohort_ids_by_ecf_id
       @cohort_ids_by_ecf_id ||= ::Cohort.pluck(:ecf_id, :id).to_h
+    end
+
+    def schedule_ids_by_ecf_id
+      @schedule_ids_by_ecf_id ||= ::Schedule.pluck(:ecf_id, :id).to_h
     end
 
     def school_ids_by_urn

--- a/app/services/migration/migrators/base.rb
+++ b/app/services/migration/migrators/base.rb
@@ -87,8 +87,8 @@ module Migration::Migrators
       lead_provider_ids_by_ecf_id[ecf_id] || raise(ActiveRecord::RecordNotFound, "Couldn't find LeadProvider")
     end
 
-    def find_cohort_id!(start_year:)
-      cohort_ids_by_start_year[start_year] || raise(ActiveRecord::RecordNotFound, "Couldn't find Cohort")
+    def find_cohort_id!(ecf_id:)
+      cohort_ids_by_ecf_id[ecf_id] || raise(ActiveRecord::RecordNotFound, "Couldn't find Cohort")
     end
 
     def find_application_id!(ecf_id:)
@@ -169,8 +169,8 @@ module Migration::Migrators
       @user_ids_by_ecf_id ||= ::User.pluck(:ecf_id, :id).to_h
     end
 
-    def cohort_ids_by_start_year
-      @cohort_ids_by_start_year ||= ::Cohort.pluck(:start_year, :id).to_h
+    def cohort_ids_by_ecf_id
+      @cohort_ids_by_ecf_id ||= ::Cohort.pluck(:ecf_id, :id).to_h
     end
 
     def school_ids_by_urn

--- a/app/services/migration/migrators/cohort.rb
+++ b/app/services/migration/migrators/cohort.rb
@@ -16,8 +16,11 @@ module Migration::Migrators
 
     def call
       migrate(self.class.ecf_cohorts) do |ecf_cohort|
-        cohort = ::Cohort.find_or_initialize_by(start_year: ecf_cohort.start_year)
-        cohort.update!(registration_start_date: ecf_cohort.npq_registration_start_date.presence || ecf_cohort.registration_start_date)
+        cohort = ::Cohort.find_or_initialize_by(ecf_id: ecf_cohort.id)
+        cohort.update!(
+          start_year: ecf_cohort.start_year,
+          registration_start_date: ecf_cohort.npq_registration_start_date.presence || ecf_cohort.registration_start_date,
+        )
       end
     end
   end

--- a/app/services/migration/migrators/contract.rb
+++ b/app/services/migration/migrators/contract.rb
@@ -42,12 +42,9 @@ module Migration::Migrators
           contract_template = ::ContractTemplate.find_or_initialize_by(ecf_id: ecf_contract.id)
           contract_template.update!(ecf_contract.attributes.slice(*SHARED_ATTRIBUTES))
 
-          contract = ::Contract.find_or_initialize_by(
-            statement_id:,
-            course_id:,
-          )
+          contract = ::Contract.find_or_initialize_by(ecf_id: ecf_contract.id)
 
-          contract.update!(contract_template:)
+          contract.update!(contract_template:, statement_id:, course_id:)
         end
       end
     end

--- a/app/services/migration/migrators/contract.rb
+++ b/app/services/migration/migrators/contract.rb
@@ -42,9 +42,12 @@ module Migration::Migrators
           contract_template = ::ContractTemplate.find_or_initialize_by(ecf_id: ecf_contract.id)
           contract_template.update!(ecf_contract.attributes.slice(*SHARED_ATTRIBUTES))
 
-          contract = ::Contract.find_or_initialize_by(ecf_id: ecf_contract.id)
+          contract = ::Contract.find_or_initialize_by(
+            statement_id:,
+            course_id:,
+          )
 
-          contract.update!(contract_template:, statement_id:, course_id:)
+          contract.update!(contract_template:)
         end
       end
     end

--- a/app/services/migration/migrators/course.rb
+++ b/app/services/migration/migrators/course.rb
@@ -46,7 +46,7 @@ module Migration::Migrators
         raise ActiveRecord::RecordInvalid, course
       end
 
-      ::CourseGroup.find_by(name: course_definition[:course_group_name])
+      ::CourseGroup.find_by!(name: course_definition[:course_group_name])
     end
   end
 end

--- a/app/services/migration/migrators/declaration.rb
+++ b/app/services/migration/migrators/declaration.rb
@@ -10,7 +10,7 @@ module Migration::Migrators
       end
 
       def ecf_declarations
-        Migration::Ecf::ParticipantDeclaration.includes(:cohort, :declaration_states, cpd_lead_provider: :npq_lead_provider)
+        Migration::Ecf::ParticipantDeclaration.includes(:declaration_states, cpd_lead_provider: :npq_lead_provider)
       end
 
       def dependencies
@@ -30,7 +30,7 @@ module Migration::Migrators
           declaration_date: ecf_declaration.declaration_date,
           state: ecf_declaration.state,
           state_reason: latest_declaration_state&.state_reason,
-          cohort_id: find_cohort_id!(start_year: ecf_declaration.cohort.start_year),
+          cohort_id: find_cohort_id!(ecf_id: ecf_declaration.cohort_id),
           lead_provider_id: find_lead_provider_id!(ecf_id: ecf_declaration.cpd_lead_provider.npq_lead_provider.id),
           application_id: find_application_id!(course_identifier: ecf_declaration.course_identifier, ecf_user_id: ecf_declaration.user_id),
         )

--- a/app/services/migration/migrators/participant_id_change.rb
+++ b/app/services/migration/migrators/participant_id_change.rb
@@ -26,13 +26,14 @@ module Migration::Migrators
 
     def call
       migrate(self.class.ecf_participant_id_changes) do |ecf_participant_id_change|
-        ::ParticipantIdChange.find_or_create_by!(
+        participant_id_change = ::ParticipantIdChange.find_or_initialize_by(ecf_id: ecf_participant_id_change.id)
+
+        participant_id_change.update!(
           user: find_user!(ecf_id: ecf_participant_id_change.user_id),
           from_participant: find_user!(ecf_id: ecf_participant_id_change.from_participant_id),
           to_participant: find_user!(ecf_id: ecf_participant_id_change.to_participant_id),
-        ).tap do |participant_id_change|
-          participant_id_change.update!(created_at: ecf_participant_id_change.created_at)
-        end
+          created_at: ecf_participant_id_change.created_at,
+        )
       end
     end
 

--- a/app/services/migration/migrators/schedule.rb
+++ b/app/services/migration/migrators/schedule.rb
@@ -10,7 +10,7 @@ module Migration::Migrators
       end
 
       def ecf_schedules
-        Migration::Ecf::Finance::Schedule.includes(:cohort, :milestones)
+        Migration::Ecf::Finance::Schedule.includes(:milestones)
       end
 
       def dependencies
@@ -32,7 +32,7 @@ module Migration::Migrators
         ::Schedule.find_or_initialize_by(ecf_id: ecf_schedule.id).tap do |schedule|
           ecf_milestone = ecf_schedule.milestones.first
           schedule.update!(
-            cohort_id: find_cohort_id!(start_year: ecf_schedule.cohort.start_year),
+            cohort_id: find_cohort_id!(ecf_id: ecf_schedule.cohort_id),
             course_group:,
             identifier: ecf_schedule.schedule_identifier,
             applies_from: ecf_milestone.start_date,

--- a/app/services/migration/migrators/schedule.rb
+++ b/app/services/migration/migrators/schedule.rb
@@ -29,13 +29,12 @@ module Migration::Migrators
           raise ActiveRecord::RecordInvalid, ecf_schedule
         end
 
-        ::Schedule.find_or_initialize_by(
-          cohort_id: find_cohort_id!(start_year: ecf_schedule.cohort.start_year),
-          identifier: ecf_schedule.schedule_identifier,
-          course_group:,
-        ).tap do |schedule|
+        ::Schedule.find_or_initialize_by(ecf_id: ecf_schedule.id).tap do |schedule|
           ecf_milestone = ecf_schedule.milestones.first
           schedule.update!(
+            cohort_id: find_cohort_id!(start_year: ecf_schedule.cohort.start_year),
+            course_group:,
+            identifier: ecf_schedule.schedule_identifier,
             applies_from: ecf_milestone.start_date,
             applies_to: ecf_milestone.payment_date,
             name: ecf_schedule.name,

--- a/app/services/migration/migrators/statement.rb
+++ b/app/services/migration/migrators/statement.rb
@@ -11,10 +11,7 @@ module Migration::Migrators
 
       def ecf_statements
         Migration::Ecf::Finance::Statement
-          .includes(
-            :cohort,
-            cpd_lead_provider: :npq_lead_provider,
-          )
+          .includes(cpd_lead_provider: :npq_lead_provider)
       end
 
       def dependencies
@@ -32,7 +29,7 @@ module Migration::Migrators
           deadline_date: ecf_statement.deadline_date,
           payment_date: ecf_statement.payment_date,
           output_fee: ecf_statement.output_fee,
-          cohort_id: find_cohort_id!(start_year: ecf_statement.cohort.start_year),
+          cohort_id: find_cohort_id!(ecf_id: ecf_statement.cohort_id),
           lead_provider_id: find_lead_provider_id!(ecf_id: ecf_statement.cpd_lead_provider.npq_lead_provider.id),
           marked_as_paid_at: ecf_statement.marked_as_paid_at,
           reconcile_amount: ecf_statement.reconcile_amount,

--- a/app/services/migration/migrators/statement_item.rb
+++ b/app/services/migration/migrators/statement_item.rb
@@ -24,13 +24,11 @@ module Migration::Migrators
       migrate(self.class.ecf_statement_items) do |ecf_statement_item|
         statement_id = find_statement_id!(ecf_id: ecf_statement_item.statement_id)
         declaration_id = find_declaration_id!(ecf_id: ecf_statement_item.participant_declaration_id)
-        statement_item = ::StatementItem.find_or_initialize_by(
-          statement_id:,
-          declaration_id:,
-          state: ecf_statement_item.state,
-        )
+        statement_item = ::StatementItem.find_or_initialize_by(ecf_id: ecf_statement_item.id)
 
-        statement_item.update!(ecf_statement_item.attributes.slice(:created_at, :updated_at))
+        statement_item.update!(
+          ecf_statement_item.attributes.slice(:state, :created_at, :updated_at).merge(statement_id:, declaration_id:),
+        )
       end
     end
   end

--- a/db/migrate/20240916124923_add_ecf_id_to_remaining_tables.rb
+++ b/db/migrate/20240916124923_add_ecf_id_to_remaining_tables.rb
@@ -1,0 +1,15 @@
+class AddEcfIdToRemainingTables < ActiveRecord::Migration[7.1]
+  def change
+    add_column :cohorts, :ecf_id, :uuid, null: true
+    add_column :contracts, :ecf_id, :uuid, null: true
+    add_column :schedules, :ecf_id, :uuid, null: true
+    add_column :statement_items, :ecf_id, :uuid, null: true
+    add_column :participant_id_changes, :ecf_id, :uuid, null: true
+
+    add_index :cohorts, :ecf_id, unique: true
+    add_index :contracts, :ecf_id, unique: true
+    add_index :schedules, :ecf_id, unique: true
+    add_index :statement_items, :ecf_id, unique: true
+    add_index :participant_id_changes, :ecf_id, unique: false
+  end
+end

--- a/db/migrate/20240916124923_add_ecf_id_to_remaining_tables.rb
+++ b/db/migrate/20240916124923_add_ecf_id_to_remaining_tables.rb
@@ -1,13 +1,11 @@
 class AddEcfIdToRemainingTables < ActiveRecord::Migration[7.1]
   def change
     add_column :cohorts, :ecf_id, :uuid, null: true
-    add_column :contracts, :ecf_id, :uuid, null: true
     add_column :schedules, :ecf_id, :uuid, null: true
     add_column :statement_items, :ecf_id, :uuid, null: true
     add_column :participant_id_changes, :ecf_id, :uuid, null: true
 
     add_index :cohorts, :ecf_id, unique: true
-    add_index :contracts, :ecf_id, unique: true
     add_index :schedules, :ecf_id, unique: true
     add_index :statement_items, :ecf_id, unique: true
     add_index :participant_id_changes, :ecf_id, unique: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_12_135346) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_16_124923) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -134,6 +134,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_12_135346) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "funding_cap", default: false, null: false
+    t.uuid "ecf_id"
+    t.index ["ecf_id"], name: "index_cohorts_on_ecf_id", unique: true
     t.index ["start_year"], name: "index_cohorts_on_start_year", unique: true
   end
 
@@ -159,8 +161,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_12_135346) do
     t.bigint "contract_template_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "ecf_id"
     t.index ["contract_template_id"], name: "index_contracts_on_contract_template_id"
     t.index ["course_id"], name: "index_contracts_on_course_id"
+    t.index ["ecf_id"], name: "index_contracts_on_ecf_id", unique: true
     t.index ["statement_id", "course_id"], name: "index_contracts_on_statement_id_and_course_id", unique: true
     t.index ["statement_id"], name: "index_contracts_on_statement_id"
   end
@@ -315,6 +319,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_12_135346) do
     t.bigint "to_participant_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "ecf_id"
+    t.index ["ecf_id"], name: "index_participant_id_changes_on_ecf_id"
     t.index ["from_participant_id"], name: "index_participant_id_changes_on_from_participant_id"
     t.index ["to_participant_id"], name: "index_participant_id_changes_on_to_participant_id"
     t.index ["user_id"], name: "index_participant_id_changes_on_user_id"
@@ -399,8 +405,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_12_135346) do
     t.enum "allowed_declaration_types", default: ["started", "retained-1", "retained-2", "completed"], array: true, enum_type: "declaration_types"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "ecf_id"
     t.index ["cohort_id"], name: "index_schedules_on_cohort_id"
     t.index ["course_group_id"], name: "index_schedules_on_course_group_id"
+    t.index ["ecf_id"], name: "index_schedules_on_ecf_id", unique: true
     t.index ["identifier", "cohort_id"], name: "index_schedules_on_identifier_and_cohort_id", unique: true
   end
 
@@ -460,7 +468,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_12_135346) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "declaration_id"
+    t.uuid "ecf_id"
     t.index ["declaration_id"], name: "index_statement_items_on_declaration_id"
+    t.index ["ecf_id"], name: "index_statement_items_on_ecf_id", unique: true
     t.index ["statement_id"], name: "index_statement_items_on_statement_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -161,10 +161,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_16_124923) do
     t.bigint "contract_template_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "ecf_id"
     t.index ["contract_template_id"], name: "index_contracts_on_contract_template_id"
     t.index ["course_id"], name: "index_contracts_on_course_id"
-    t.index ["ecf_id"], name: "index_contracts_on_ecf_id", unique: true
     t.index ["statement_id", "course_id"], name: "index_contracts_on_statement_id_and_course_id", unique: true
     t.index ["statement_id"], name: "index_contracts_on_statement_id"
   end

--- a/spec/factories/migration/ecf/cohorts.rb
+++ b/spec/factories/migration/ecf/cohorts.rb
@@ -14,5 +14,9 @@ FactoryBot.define do
     trait :with_sequential_start_year do
       sequence(:start_year) { |n| 2021 + (n % 9) }
     end
+
+    trait :with_npq_registration_start_date do
+      npq_registration_start_date { Date.new(start_year.to_i, 7, 6) }
+    end
   end
 end

--- a/spec/features/migration_spec.rb
+++ b/spec/features/migration_spec.rb
@@ -97,8 +97,8 @@ RSpec.feature "Migration", :in_memory_rails_cache, :rack_test_driver, type: :fea
         ecf_cohort1 = create(:ecf_migration_cohort, start_year: 2026)
         ecf_cohort2 = create(:ecf_migration_cohort, start_year: 2029)
 
-        create(:cohort, start_year: ecf_cohort1.start_year)
-        create(:cohort, start_year: ecf_cohort2.start_year)
+        create(:cohort, ecf_id: ecf_cohort1.id, start_year: ecf_cohort1.start_year)
+        create(:cohort, ecf_id: ecf_cohort2.id, start_year: ecf_cohort2.start_year)
 
         create(:ecf_migration_cohort, registration_start_date: nil)
       end
@@ -140,8 +140,8 @@ RSpec.feature "Migration", :in_memory_rails_cache, :rack_test_driver, type: :fea
         lead_provider1 = create(:lead_provider, ecf_id: ecf_statement1.npq_lead_provider.id)
         lead_provider2 = create(:lead_provider, ecf_id: ecf_statement2.npq_lead_provider.id)
 
-        create(:statement, month: 7, year: 2026, lead_provider: lead_provider1)
-        create(:statement, month: 1, year: 2030, lead_provider: lead_provider2)
+        create(:statement, ecf_id: ecf_statement1.id, month: 7, year: 2026, lead_provider: lead_provider1)
+        create(:statement, ecf_id: ecf_statement2.id, month: 1, year: 2030, lead_provider: lead_provider2)
 
         create(:ecf_migration_statement, output_fee: nil)
       end

--- a/spec/features/migration_spec.rb
+++ b/spec/features/migration_spec.rb
@@ -137,11 +137,14 @@ RSpec.feature "Migration", :in_memory_rails_cache, :rack_test_driver, type: :fea
         ecf_statement1 = create(:ecf_migration_statement, name: "July 2026")
         ecf_statement2 = create(:ecf_migration_statement, name: "January 2030")
 
+        cohort1 = create(:cohort, ecf_id: ecf_statement1.cohort_id, start_year: ecf_statement1.cohort.start_year)
+        cohort2 = create(:cohort, ecf_id: ecf_statement2.cohort_id, start_year: ecf_statement2.cohort.start_year)
+
         lead_provider1 = create(:lead_provider, ecf_id: ecf_statement1.npq_lead_provider.id)
         lead_provider2 = create(:lead_provider, ecf_id: ecf_statement2.npq_lead_provider.id)
 
-        create(:statement, ecf_id: ecf_statement1.id, month: 7, year: 2026, lead_provider: lead_provider1)
-        create(:statement, ecf_id: ecf_statement2.id, month: 1, year: 2030, lead_provider: lead_provider2)
+        create(:statement, ecf_id: ecf_statement1.id, month: 7, year: 2026, lead_provider: lead_provider1, cohort: cohort1)
+        create(:statement, ecf_id: ecf_statement2.id, month: 1, year: 2030, lead_provider: lead_provider2, cohort: cohort2)
 
         create(:ecf_migration_statement, output_fee: nil)
       end

--- a/spec/services/migration/migrators/application_spec.rb
+++ b/spec/services/migration/migrators/application_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe Migration::Migrators::Application do
     def create_npq_resource(ecf_resource)
       cohort = create(:cohort, ecf_id: ecf_resource.cohort_id, start_year: ecf_resource.cohort.start_year)
       ecf_schedule = ecf_resource.profile.schedule
-      create(:schedule, :npq_aso_december, cohort:, identifier: ecf_schedule.schedule_identifier)
+      create(:schedule, :npq_aso_december, ecf_id: ecf_schedule.id, cohort:, identifier: ecf_schedule.schedule_identifier)
       create(:private_childcare_provider, provider_urn: ecf_resource.private_childcare_provider_urn)
 
       school = create(:school, urn: ecf_resource.school_urn)
-      course = create(:course, ecf_id: ecf_resource.npq_course_id, identifier: ecf_resource.npq_course.identifier, ecf_id: ecf_resource.npq_course_id)
+      course = create(:course, identifier: ecf_resource.npq_course.identifier, ecf_id: ecf_resource.npq_course_id)
       lead_provider = create(:lead_provider, ecf_id: ecf_resource.npq_lead_provider_id)
       user = create(:user, ecf_id: ecf_resource.user.id)
       create(:application, ecf_id: ecf_resource.id, school:, course:, lead_provider:, user:)
@@ -27,7 +27,7 @@ RSpec.describe Migration::Migrators::Application do
     describe "#call" do
       it "sets the attributes from the ECF NPQApplication on the NPQ application" do
         instance.call
-        application = Application.find_by(ecf_id: ecf_resource1.id)
+        application = Application.find_by!(ecf_id: ecf_resource1.id)
         expect(application.attributes).to include(ecf_resource1.attributes.slice(*described_class::ATTRIBUTES))
         expect(application.training_status).to eq(ecf_resource1.profile.training_status)
         expect(application.ukprn).to eq(ecf_resource1.school_ukprn)
@@ -36,31 +36,29 @@ RSpec.describe Migration::Migrators::Application do
       it "sets the schedule from the ECF NPQApplication on the NPQ application" do
         instance.call
 
-        application = Application.find_by(ecf_id: ecf_resource1.id)
+        application = Application.find_by!(ecf_id: ecf_resource1.id)
         ecf_schedule = ecf_resource1.profile.schedule
-        expect(application.schedule.identifier).to eq(ecf_schedule.schedule_identifier)
-        expect(application.schedule.cohort.start_year).to eq(ecf_schedule.cohort.start_year)
-        expect(application.schedule.course_group.name).to eq("support")
+        expect(application.schedule.ecf_id).to eq(ecf_schedule.id)
       end
 
       it "sets the cohort from the ECF NPQApplication on the NPQ application" do
         instance.call
 
-        application = Application.find_by(ecf_id: ecf_resource1.id)
+        application = Application.find_by!(ecf_id: ecf_resource1.id)
         expect(application.cohort.start_year).to eq(ecf_resource1.cohort.start_year)
       end
 
       it "sets the ITT provider from the ECF NPQApplication on the NPQ application" do
         instance.call
 
-        application = Application.find_by(ecf_id: ecf_resource1.id)
+        application = Application.find_by!(ecf_id: ecf_resource1.id)
         expect(application.itt_provider.legal_name).to eq(ecf_resource1.itt_provider)
       end
 
       it "sets the private childcare provider from the ECF NPQApplication on the NPQ application" do
         instance.call
 
-        application = Application.find_by(ecf_id: ecf_resource1.id)
+        application = Application.find_by!(ecf_id: ecf_resource1.id)
         expect(application.private_childcare_provider.provider_urn).to eq(ecf_resource1.private_childcare_provider_urn)
       end
 
@@ -90,13 +88,13 @@ RSpec.describe Migration::Migrators::Application do
       end
 
       it "records a failure when the user in NPQ reg does not match the user in ECF" do
-        Application.first.update!(user: create(:user))
+        Application.find_by!(ecf_id: ecf_resource1.id).update!(user: create(:user))
         instance.call
         expect(failure_manager).to have_received(:record_failure).with(ecf_resource1, /User in ECF is different/)
       end
 
       it "records a failure when the schedule cannot be found" do
-        ecf_resource1.profile.schedule.update!(schedule_identifier: "other-schedule")
+        Schedule.find_by!(ecf_id: ecf_resource1.profile.schedule_id).destroy!
         instance.call
         expect(failure_manager).to have_received(:record_failure).with(ecf_resource1, /Couldn't find Schedule/)
       end

--- a/spec/services/migration/migrators/application_spec.rb
+++ b/spec/services/migration/migrators/application_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe Migration::Migrators::Application do
     end
 
     def create_npq_resource(ecf_resource)
-      cohort = create(:cohort, start_year: ecf_resource.cohort.start_year)
+      cohort = create(:cohort, ecf_id: ecf_resource.cohort_id, start_year: ecf_resource.cohort.start_year)
       ecf_schedule = ecf_resource.profile.schedule
       create(:schedule, :npq_aso_december, cohort:, identifier: ecf_schedule.schedule_identifier)
       create(:private_childcare_provider, provider_urn: ecf_resource.private_childcare_provider_urn)
 
       school = create(:school, urn: ecf_resource.school_urn)
-      course = create(:course, identifier: ecf_resource.npq_course.identifier, ecf_id: ecf_resource.npq_course_id)
+      course = create(:course, ecf_id: ecf_resource.npq_course_id, identifier: ecf_resource.npq_course.identifier, ecf_id: ecf_resource.npq_course_id)
       lead_provider = create(:lead_provider, ecf_id: ecf_resource.npq_lead_provider_id)
       user = create(:user, ecf_id: ecf_resource.user.id)
       create(:application, ecf_id: ecf_resource.id, school:, course:, lead_provider:, user:)
@@ -102,7 +102,7 @@ RSpec.describe Migration::Migrators::Application do
       end
 
       it "records a failure when the cohort cannot be found" do
-        ecf_resource1.cohort.update!(start_year: "1999")
+        Cohort.find_by!(ecf_id: ecf_resource1.cohort_id).update!(ecf_id: SecureRandom.uuid)
         instance.call
         expect(failure_manager).to have_received(:record_failure).with(ecf_resource1, /Couldn't find Cohort/)
       end

--- a/spec/services/migration/migrators/cohort_spec.rb
+++ b/spec/services/migration/migrators/cohort_spec.rb
@@ -7,12 +7,29 @@ RSpec.describe Migration::Migrators::Cohort do
     end
 
     def create_npq_resource(ecf_resource)
-      create(:cohort, start_year: ecf_resource.start_year)
+      create(:cohort, ecf_id: ecf_resource.id)
     end
 
     def setup_failure_state
       # ECF cohort with no registration start date
       create(:ecf_migration_cohort, :with_sequential_start_year, registration_start_date: nil)
+    end
+
+    describe "#call" do
+      it "sets the created Cohort attributes correctly" do
+        instance.call
+        cohort = Cohort.find_by!(ecf_id: ecf_resource1.id)
+        expect(cohort.attributes).to include(ecf_resource1.attributes.slice("start_year", "registration_start_date"))
+      end
+
+      context "when the npq_registration_start_date is set on the ECF cohort" do
+        it "favours this over the registration_start_date" do
+          ecf_cohort = create(:ecf_migration_cohort, :with_sequential_start_year, :with_npq_registration_start_date)
+          instance.call
+          cohort = Cohort.find_by!(ecf_id: ecf_cohort.id)
+          expect(cohort.registration_start_date).to eq(ecf_cohort.npq_registration_start_date)
+        end
+      end
     end
   end
 end

--- a/spec/services/migration/migrators/cohort_spec.rb
+++ b/spec/services/migration/migrators/cohort_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Migration::Migrators::Cohort do
     end
 
     def create_npq_resource(ecf_resource)
-      create(:cohort, ecf_id: ecf_resource.id)
+      create(:cohort, ecf_id: ecf_resource.id, start_year: ecf_resource.start_year)
     end
 
     def setup_failure_state

--- a/spec/services/migration/migrators/contract_spec.rb
+++ b/spec/services/migration/migrators/contract_spec.rb
@@ -28,23 +28,21 @@ RSpec.describe Migration::Migrators::Contract do
     def create_npq_resource(ecf_resource)
       lead_provider = create(:lead_provider, ecf_id: ecf_resource.npq_lead_provider.id)
       cohort = create(:cohort, start_year: ecf_resource.cohort.start_year)
-      course = create(:course, identifier: ecf_resource.course_identifier)
+      create(:course, identifier: ecf_resource.course_identifier)
       ecf_statement = Migration::Ecf::Finance::Statement.where(cpd_lead_provider: ecf_resource.npq_lead_provider.cpd_lead_provider).first!
-      statement = create(
+      create(
         :statement,
         ecf_id: ecf_statement.id,
         lead_provider:,
         cohort:,
       )
-      contract_template = create(
+      create(
         :contract_template,
         ecf_id: ecf_resource.id,
       )
       create(
         :contract,
-        statement:,
-        course:,
-        contract_template:,
+        ecf_id: ecf_resource.id,
       )
     end
 

--- a/spec/services/migration/migrators/contract_spec.rb
+++ b/spec/services/migration/migrators/contract_spec.rb
@@ -28,21 +28,23 @@ RSpec.describe Migration::Migrators::Contract do
     def create_npq_resource(ecf_resource)
       lead_provider = create(:lead_provider, ecf_id: ecf_resource.npq_lead_provider.id)
       cohort = create(:cohort, start_year: ecf_resource.cohort.start_year)
-      create(:course, identifier: ecf_resource.course_identifier)
+      course = create(:course, identifier: ecf_resource.course_identifier)
       ecf_statement = Migration::Ecf::Finance::Statement.where(cpd_lead_provider: ecf_resource.npq_lead_provider.cpd_lead_provider).first!
-      create(
+      statement = create(
         :statement,
         ecf_id: ecf_statement.id,
         lead_provider:,
         cohort:,
       )
-      create(
+      contract_template = create(
         :contract_template,
         ecf_id: ecf_resource.id,
       )
       create(
         :contract,
-        ecf_id: ecf_resource.id,
+        statement:,
+        course:,
+        contract_template:,
       )
     end
 

--- a/spec/services/migration/migrators/declaration_spec.rb
+++ b/spec/services/migration/migrators/declaration_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Migration::Migrators::Declaration do
 
     def create_npq_resource(ecf_resource)
       lead_provider = create(:lead_provider, ecf_id: ecf_resource.cpd_lead_provider.npq_lead_provider.id)
-      cohort = create(:cohort, start_year: ecf_resource.cohort.start_year)
+      cohort = create(:cohort, ecf_id: ecf_resource.cohort_id, start_year: ecf_resource.cohort.start_year)
       course = create(:course, identifier: ecf_resource.course_identifier.upcase)
       user = create(:user, ecf_id: ecf_resource.user.id)
       application = create(:application, :accepted, course:, user:)

--- a/spec/services/migration/migrators/participant_id_change_spec.rb
+++ b/spec/services/migration/migrators/participant_id_change_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe Migration::Migrators::ParticipantIdChange do
     end
 
     def create_npq_resource(ecf_resource)
-      user = create(:user, ecf_id: ecf_resource.user.id)
-      from_participant = create(:user, ecf_id: ecf_resource.from_participant.id)
-      to_participant = create(:user, ecf_id: ecf_resource.to_participant.id)
+      create(:user, ecf_id: ecf_resource.user.id)
+      create(:user, ecf_id: ecf_resource.from_participant.id)
+      create(:user, ecf_id: ecf_resource.to_participant.id)
 
-      create(:participant_id_change, user:, from_participant:, to_participant:)
+      create(:participant_id_change, ecf_id: ecf_resource.id)
     end
 
     def setup_failure_state
@@ -25,7 +25,7 @@ RSpec.describe Migration::Migrators::ParticipantIdChange do
       it "sets the created ParticipantIdChange attributes correctly" do
         instance.call
 
-        participant_id_change = ParticipantIdChange.first
+        participant_id_change = ParticipantIdChange.find_by!(ecf_id: ecf_resource1.id)
         expect(participant_id_change).to have_attributes({
           user_id: User.find_by(ecf_id: ecf_resource1.user_id).id,
           from_participant_id: User.find_by(ecf_id: ecf_resource1.from_participant_id).id,

--- a/spec/services/migration/migrators/schedule_spec.rb
+++ b/spec/services/migration/migrators/schedule_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Migration::Migrators::Schedule do
     end
 
     def create_npq_resource(ecf_resource)
-      create(:cohort, start_year: ecf_resource.cohort.start_year)
+      create(:cohort, ecf_id: ecf_resource.cohort_id, start_year: ecf_resource.cohort.start_year)
       create(:course_group, name: :support)
 
       create(:schedule, ecf_id: ecf_resource.id)

--- a/spec/services/migration/migrators/schedule_spec.rb
+++ b/spec/services/migration/migrators/schedule_spec.rb
@@ -11,12 +11,10 @@ RSpec.describe Migration::Migrators::Schedule do
     end
 
     def create_npq_resource(ecf_resource)
-      cohort = create(:cohort, start_year: ecf_resource.cohort.start_year)
+      create(:cohort, start_year: ecf_resource.cohort.start_year)
+      create(:course_group, name: :support)
 
-      create(:schedule,
-             cohort:,
-             identifier: ecf_resource.schedule_identifier,
-             course_group: create(:course_group, name: :support))
+      create(:schedule, ecf_id: ecf_resource.id)
     end
 
     def setup_failure_state
@@ -29,7 +27,7 @@ RSpec.describe Migration::Migrators::Schedule do
     describe "#call" do
       it "sets the applies from/to of the schedule" do
         ecf_milestone = ecf_resource1.milestones.first
-        schedule = Schedule.first
+        schedule = Schedule.find_by!(ecf_id: ecf_resource1.id)
 
         expect { instance.call }.to change { schedule.reload.applies_from }.to(ecf_milestone.start_date)
           .and change { schedule.applies_to }.to(ecf_milestone.payment_date)
@@ -37,7 +35,7 @@ RSpec.describe Migration::Migrators::Schedule do
 
       it "sets the allowed declaration types of the schedule" do
         ecf_milestones = ecf_resource1.milestones
-        schedule = Schedule.first
+        schedule = Schedule.find_by!(ecf_id: ecf_resource1.id)
 
         expect { instance.call }.to change { schedule.reload.allowed_declaration_types }.to(ecf_milestones.pluck(:declaration_type))
       end
@@ -75,7 +73,7 @@ RSpec.describe Migration::Migrators::Schedule do
 
             expect { instance.call }.to change(Schedule, :count).by(1)
 
-            schedule = Schedule.find_by(identifier: ecf_schedule.schedule_identifier)
+            schedule = Schedule.find_by(ecf_id: ecf_schedule.id)
             expect(schedule.course_group.name).to eq(course_group_name)
           end
         end

--- a/spec/services/migration/migrators/statement_item_spec.rb
+++ b/spec/services/migration/migrators/statement_item_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe Migration::Migrators::StatementItem do
     end
 
     def create_npq_resource(ecf_resource)
-      statement = create(:statement, ecf_id: ecf_resource.statement_id)
-      declaration = create(:declaration, ecf_id: ecf_resource.participant_declaration_id)
-      create(:statement_item, declaration:, statement:, state: ecf_resource.state)
+      create(:statement, ecf_id: ecf_resource.statement_id)
+      create(:declaration, ecf_id: ecf_resource.participant_declaration_id)
+      create(:statement_item, ecf_id: ecf_resource.id)
     end
 
     def setup_failure_state
@@ -21,7 +21,7 @@ RSpec.describe Migration::Migrators::StatementItem do
       it "creates the StatementItems and sets attributes correctly" do
         instance.call
 
-        statement_item = StatementItem.includes(:statement, :declaration).find_by(statement: { ecf_id: ecf_resource1.statement_id })
+        statement_item = StatementItem.includes(:statement, :declaration).find_by(ecf_id: ecf_resource1.id)
         expect(statement_item).to have_attributes(ecf_resource1.attributes.slice(:state, :created_at, :updated_at))
         expect(statement_item.declaration.ecf_id).to eq(ecf_resource1.participant_declaration_id)
         expect(statement_item.statement.ecf_id).to eq(ecf_resource1.statement_id)

--- a/spec/services/migration/migrators/statement_spec.rb
+++ b/spec/services/migration/migrators/statement_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Migration::Migrators::Statement do
 
     def create_npq_resource(ecf_resource)
       lead_provider = create(:lead_provider, ecf_id: ecf_resource.npq_lead_provider.id)
-      cohort = create(:cohort, start_year: ecf_resource.cohort.start_year)
+      cohort = create(:cohort, ecf_id: ecf_resource.cohort_id, start_year: ecf_resource.cohort.start_year)
       create(:statement, lead_provider:, cohort:)
     end
 

--- a/spec/services/valid_test_data_generators/separation_shared_data_spec.rb
+++ b/spec/services/valid_test_data_generators/separation_shared_data_spec.rb
@@ -112,6 +112,8 @@ RSpec.describe ValidTestDataGenerators::SeparationSharedData, :with_default_sche
       end
 
       it "voids some declarations" do
+        allow(Faker::Boolean).to receive(:boolean).and_return(false)
+
         expect {
           subject.populate
         }.to(change(Declaration.voided_state, :count).and(change(ParticipantOutcome.voided_state, :count)))


### PR DESCRIPTION
[Jira-3569](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-3569)

### Context

We want to add the `ecf_id` to all the tables (apart from schools) where we're bringing across data from ECF. This will enable us to simplify the migration logic and speed up some of the lookups.

### Changes proposed in this pull request

- Add ecf_id to remaining migration tables

Add the `ecf_id` to the remaining migration tables, apart from `schools` as these already exist in NPQ reg and are only verified/not actually migrated as part of the migration process.

The `ecf_id` fields are nullable since we don't expose them to lead providers and will not need to generate them going forward.

-  Use ecf_id in all migrators

We now have `ecf_id` on cohorts, contracts, participant_id_changes, schedules and statement_items, so we want to match on this attribute going forward as part of the  migration process.

- Optimise cohort lookups with ecf_id

Use `ecf_id` for cohort lookups to avoid including the cohort in the underlying queries.

- Clean up application migrator to use schedule ecf_id

As we now have `ecf_id` on schedule we can perform a simpler lookup.

### Guidance for review

| Main | This branch |
| -- | -- |
| <img width="1025" alt="Screenshot 2024-09-17 at 13 20 10" src="https://github.com/user-attachments/assets/d1d81b00-753b-4925-bb23-b24750732c39"> |  <img width="1025" alt="Screenshot 2024-09-17 at 10 57 45" src="https://github.com/user-attachments/assets/974a2f79-fe91-40da-8098-0f8546623aae"> |
