### PR TITLE
Added 'How-to guides' anchor link to primary navigation on API guidance pages

### DIFF
--- a/app/components/npq_separation/navigation_structures/guidance_navigation_structure.rb
+++ b/app/components/npq_separation/navigation_structures/guidance_navigation_structure.rb
@@ -22,6 +22,11 @@ module NpqSeparation
             href: api_guidance_page_path(page: "release-notes"),
             prefix: "/api/guidance/release-notes",
           ) => [],
+          Node.new(
+            name: "How-to guides",
+            href: api_guidance_page_path(page: "/", anchor: "how-to-guides"),
+            prefix: "/api/guidance/",
+          ) => [],
         }
       end
     end

--- a/app/views/api/guidance/index.html.erb
+++ b/app/views/api/guidance/index.html.erb
@@ -43,7 +43,7 @@
     <div class="govuk-grid-column-full-from-desktop">
       <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--invisible">
       <div class="govuk-grid-column-two-thirds ">
-        <h2 class="govuk-heading-l">How-to guides</h2>
+        <h2 class="govuk-heading-l" id="how-to-guides">How-to guides</h2>
         <p class="govuk-body">Guidance on how lead providers can integrate with this API so they can view, submit and update data.</p>
         <ul class="govuk-list">
           <li><%= govuk_link_to("How NPQs work", '/api/guidance/how-npqs-work', class: "govuk-!-font-weight-bold") %></li>


### PR DESCRIPTION
### Context

Moved 'How-to guides' link to right of primary navigation

### Changes proposed in this pull request

add new how to section to nav, also add anchor as it's on the same page

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
