### PR TITLE
Add back link to guidance pages

### DIFF
--- a/app/views/layouts/api_guidance.html.erb
+++ b/app/views/layouts/api_guidance.html.erb
@@ -15,7 +15,7 @@
     <div class="govuk-width-container">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-quarter">
-          <div role="region" aria-label="Backwards navigation">
+          <div role="region" aria-label="Backwards navigation", class="govuk-!-margin-bottom-6">
             <%= govuk_back_link(href: url_for(:back)) %>
           </div>
         </div>

--- a/app/views/layouts/api_guidance.html.erb
+++ b/app/views/layouts/api_guidance.html.erb
@@ -5,22 +5,35 @@
 <body class="govuk-template__body js-enabled <%= yield :body_class %>">
   <%= render partial: "layouts/shared/govuk_javascript" %>
 
-<a href="#main-content" class="govuk-skip-link">Skip to main content</a>
+  <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 
-<%= render partial: "layouts/api_guidance/header" %>
-<% primary_navigation = NpqSeparation::PrimaryNavigationComponent.new(request.path, default_to_first_section: false, structure: guidance_navigation_structure) %>
-<%= render(primary_navigation) %>
+  <%= render partial: "layouts/api_guidance/header" %>
+  <% primary_navigation = NpqSeparation::PrimaryNavigationComponent.new(request.path, default_to_first_section: false, structure: guidance_navigation_structure) %>
+  <%= render(primary_navigation) %>
 
-<main id="main-content" class="api-guidance">
-  <%= render partial: "layouts/shared/messages" %>
+  <% if !@page.index_page? %>
+    <div class="govuk-width-container">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-quarter">
+          <div role="region" aria-label="Backwards navigation">
+            <%= govuk_back_link(href: url_for(:back)) %>
+          </div>
+        </div>
+      </div>
+    </div>
+  <% end %>
 
-  <div class="govuk-grid-row">
+  <main id="main-content" class="api-guidance">
+    <%= render partial: "layouts/shared/messages" %>
+
     <% if @page.index_page? %>
-      <div class="govuk-grid-column-full">
-        <%= yield %>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <%= yield %>
+        </div>
       </div>
     <% else %>
-      <div class="govuk-width-container  govuk-!-padding-top-7">
+      <div class="govuk-width-container">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-one-quarter">
             <nav class="x-govuk-sub-navigation" aria-labelledby="sub-navigation-heading">
@@ -49,8 +62,7 @@
         <% end %>
       </div>
     <% end %>
-  </div>
-</main>
+  </main>
 </body>
 <%= render partial: "layouts/shared/footer" %>
 </html>

--- a/spec/features/guidance_spec.rb
+++ b/spec/features/guidance_spec.rb
@@ -1,6 +1,22 @@
 require "rails_helper"
 
 RSpec.feature "Guidance", type: :feature do
+  describe "Back link navigation" do
+    it "renders a working back link on non-index guidance pages" do
+      visit "/api/guidance"
+
+      expect(page).not_to have_link("Back")
+
+      within("nav") { click_on "Get started" }
+
+      expect(page).to have_link("Back", href: %r{/api/guidance})
+
+      click_on "Back"
+
+      expect(page).to have_current_path("/api/guidance", ignore_query: true)
+    end
+  end
+
   describe "GET /api/guidance" do
     it "renders the index page" do
       visit "/api/guidance"


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3Aacb48219-565b-41a9-a019-3a72ebc165b0&selectedIssue=CPDLP-3474

Gotta go back innit

### Changes proposed in this pull request

- Add backlink to guidance pages except for the index page.
- Move grid row div only into index section

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
