### PR TITLE
Workaround for declaration validation failures in specs

### DIFF
--- a/db/seeds/base/add_schedules.rb
+++ b/db/seeds/base/add_schedules.rb
@@ -13,6 +13,6 @@ Cohort.find_each do |cohort|
     npq_specialist_autumn
     npq_specialist_spring
   ].each do |schedule_identifier|
-    FactoryBot.create(:schedule, schedule_identifier, cohort:)
+    FactoryBot.create(:schedule, schedule_identifier, cohort:, change_applies_dates: false)
   end
 end

--- a/spec/factories/cohorts.rb
+++ b/spec/factories/cohorts.rb
@@ -8,11 +8,11 @@ FactoryBot.define do
     end
 
     trait :current do
-      start_year { Date.current.month < 10 ? Date.current.year.pred : Date.current.year }
+      start_year { Date.current.month < 9 ? Date.current.year.pred : Date.current.year }
     end
 
     trait :next do
-      start_year { Date.current.month < 10 ? Date.current.year : Date.current.year.succ }
+      start_year { Date.current.month < 9 ? Date.current.year : Date.current.year.succ }
     end
 
     trait :with_funding_cap do

--- a/spec/support/with_default_schedules.rb
+++ b/spec/support/with_default_schedules.rb
@@ -20,7 +20,7 @@ RSpec.shared_context "with default schedules", shared_context: :metadata do
         npq_specialist_spring
         npq_specialist_autumn
       ].each do |schedule_identifier|
-        FactoryBot.create(:schedule, schedule_identifier, cohort:)
+        FactoryBot.create(:schedule, schedule_identifier, cohort:, change_applies_dates: false)
       end
     end
   end


### PR DESCRIPTION
### Context

Declaration model validations rely on:
- `declaration_date` being in the future
- `declaration_date` being on/after the `applies_from` date in the schedule attached to the accepted application

Our factory set up data for schedules/cohorts is close to production data, where the schedule `applies_from` date can start from October for a new cohort. 

For the previous cohort since October was in the past all tests were passing. However after September the 1st we moved into a new cohort due to our cohort factory set up. That rendered the new schedules and `applies_from` dates in the future. This meant most of our test suite failed where declarations were being created.

After multiple iterations found in: https://github.com/DFE-Digital/npq-registration/pull/1684 to https://github.com/DFE-Digital/npq-registration/pull/1681 to utilise time travel in the factories and in the tests for declarations, we ended up with complicated test setup and most importantly a declaration factory that was invalid.

Thanks to @ethax-ross 💡 we landed on the following solution which seemed simple enough to resolve all failures and can be disabled easily.

### Changes proposed in this pull request
- Revert fix to push cohort rollover to the next month back to September
- Add a callback to the schedule factory which sets the `applies_from` to 1 week ago. This ensures that the declaration date in the factory (set to the current date) is always valid regardless of where we are in the cohort. When a new cohort rolls along we will always be safe. Also add a transient value to disable this, which is required in the seed data and shared context default schedule set up

