### PR TITLE
Make TRN nullable in API docs

### DIFF
--- a/public/api/docs/v1/swagger.yaml
+++ b/public/api/docs/v1/swagger.yaml
@@ -1170,6 +1170,7 @@ components:
               description: The Teacher Reference Number (TRN) for this NPQ participant
               type: string
               example: '1234567'
+              nullable: true
             teacher_reference_number_validated:
               description: Indicates whether the Teacher Reference Number (TRN) has
                 been validated
@@ -1463,7 +1464,6 @@ components:
       - full_name
       - email
       - email_validated
-      - teacher_reference_number
       - teacher_reference_number_validated
       - school_urn
       - headteacher_status
@@ -1496,6 +1496,7 @@ components:
           description: The Teacher Reference Number (TRN) for this NPQ participant
           type: string
           example: '1234567'
+          nullable: true
         teacher_reference_number_validated:
           description: Indicates whether the Teacher Reference Number (TRN) has been
             validated
@@ -1780,6 +1781,7 @@ components:
               description: The Teacher Reference Number (TRN) for this NPQ participant
               type: string
               example: '1234567'
+              nullable: true
             updated_at:
               description: The date the application was last updated
               type: string

--- a/public/api/docs/v2/swagger.yaml
+++ b/public/api/docs/v2/swagger.yaml
@@ -1267,6 +1267,7 @@ components:
               description: The Teacher Reference Number (TRN) for this NPQ participant
               type: string
               example: '1234567'
+              nullable: true
             teacher_reference_number_validated:
               description: Indicates whether the Teacher Reference Number (TRN) has
                 been validated
@@ -1651,7 +1652,6 @@ components:
       - full_name
       - email
       - email_validated
-      - teacher_reference_number
       - teacher_reference_number_validated
       - school_urn
       - headteacher_status
@@ -1684,6 +1684,7 @@ components:
           description: The Teacher Reference Number (TRN) for this NPQ participant
           type: string
           example: '1234567'
+          nullable: true
         teacher_reference_number_validated:
           description: Indicates whether the Teacher Reference Number (TRN) has been
             validated
@@ -1900,6 +1901,7 @@ components:
               description: The Teacher Reference Number (TRN) for this NPQ participant
               type: string
               example: '1234567'
+              nullable: true
             updated_at:
               description: The date the application was last updated
               type: string

--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -1322,6 +1322,7 @@ components:
               description: The Teacher Reference Number (TRN) for this NPQ participant
               type: string
               example: '1234567'
+              nullable: true
             teacher_reference_number_validated:
               description: Indicates whether the Teacher Reference Number (TRN) has
                 been validated
@@ -1565,6 +1566,7 @@ components:
               description: The Teacher Reference Number (TRN) for this NPQ participant
               type: string
               example: '1234567'
+              nullable: true
             updated_at:
               description: The date the application was last updated
               type: string

--- a/spec/swagger_schemas/models/application.rb
+++ b/spec/swagger_schemas/models/application.rb
@@ -89,6 +89,7 @@ APPLICATION = {
             description: "The Teacher Reference Number (TRN) for this NPQ participant",
             type: :string,
             example: "1234567",
+            nullable: true,
           },
           teacher_reference_number_validated: {
             description: "Indicates whether the Teacher Reference Number (TRN) has been validated",

--- a/spec/swagger_schemas/models/application_csv.rb
+++ b/spec/swagger_schemas/models/application_csv.rb
@@ -8,7 +8,6 @@ APPLICATION_CSV = {
       full_name
       email
       email_validated
-      teacher_reference_number
       teacher_reference_number_validated
       school_urn
       headteacher_status
@@ -47,6 +46,7 @@ APPLICATION_CSV = {
         description: "The Teacher Reference Number (TRN) for this NPQ participant",
         type: :string,
         example: "1234567",
+        nullable: true,
       },
       teacher_reference_number_validated: {
         description: "Indicates whether the Teacher Reference Number (TRN) has been validated",

--- a/spec/swagger_schemas/models/participant.rb
+++ b/spec/swagger_schemas/models/participant.rb
@@ -78,6 +78,7 @@ PARTICIPANT = {
             description: "The Teacher Reference Number (TRN) for this NPQ participant",
             type: :string,
             example: "1234567",
+            nullable: true,
           },
           updated_at: {
             description: "The date the application was last updated",


### PR DESCRIPTION
### Context

The `teacher_reference_number` returned in Application and Participant responses can be `nil`; we should indicate this in the API docs.

### Changes proposed in this pull request

- Make TRN nullable in API docs

