### PR TITLE
Fix Codespaces not booting

### DIFF
--- a/.devcontainer/boot.sh
+++ b/.devcontainer/boot.sh
@@ -6,6 +6,8 @@ gem update --system -N
 echo "Installing dependencies..."
 bundle install
 yarn install
+yarn build
+yarn build:css
 
 echo "Creating database..."
 bin/rails db:prepare 


### PR DESCRIPTION
Codespaces fails to run since we changed the asset pipeline; we need to run `yarn build` and `yarn build:css` to compile the JS/CSS assets.
