### PR TITLE
Create IttProvider and PrivateChildcareProvider on migration

### DIFF
--- a/app/services/migration/migrators/application.rb
+++ b/app/services/migration/migrators/application.rb
@@ -37,7 +37,7 @@ module Migration::Migrators
       end
 
       def dependencies
-        %i[cohort lead_provider schedule course user school]
+        %i[private_childcare_provider itt_provider cohort lead_provider schedule course user school]
       end
 
       def ecf_npq_applications
@@ -59,7 +59,7 @@ module Migration::Migrators
         application.schedule_id = find_schedule_id!(ecf_id: ecf_schedule.id) if ecf_schedule
 
         application.cohort_id = find_cohort_id!(ecf_id: ecf_npq_application.cohort_id)
-        application.itt_provider_id = find_itt_provider_id!(legal_name: ecf_npq_application.itt_provider) if ecf_npq_application.itt_provider
+        application.itt_provider_id = find_itt_provider_id!(itt_provider: ecf_npq_application.itt_provider) if ecf_npq_application.itt_provider
         application.private_childcare_provider_id = find_private_childcare_provider_id!(provider_urn: ecf_npq_application.private_childcare_provider_urn) if ecf_npq_application.private_childcare_provider_urn
 
         if ecf_npq_application.school_urn.present?

--- a/app/services/migration/migrators/itt_provider.rb
+++ b/app/services/migration/migrators/itt_provider.rb
@@ -1,0 +1,27 @@
+module Migration::Migrators
+  class IttProvider < Base
+    class << self
+      def record_count
+        ecf_applications.count
+      end
+
+      def model
+        :itt_provider
+      end
+
+      def ecf_applications
+        Migration::Ecf::NpqApplication.where.not(itt_provider: nil)
+      end
+    end
+
+    def call
+      migrate(self.class.ecf_applications) do |application|
+        itt_provider = application.itt_provider
+
+        next if ::IttProvider.including_disabled.where("legal_name ILIKE ? OR operating_name ILIKE ?", itt_provider, itt_provider).exists?
+
+        ::IttProvider.create!(operating_name: itt_provider, legal_name: itt_provider, disabled_at: Time.zone.now)
+      end
+    end
+  end
+end

--- a/app/services/migration/migrators/private_childcare_provider.rb
+++ b/app/services/migration/migrators/private_childcare_provider.rb
@@ -1,0 +1,27 @@
+module Migration::Migrators
+  class PrivateChildcareProvider < Base
+    class << self
+      def record_count
+        ecf_applications.count
+      end
+
+      def model
+        :private_childcare_provider
+      end
+
+      def ecf_applications
+        Migration::Ecf::NpqApplication.where.not(private_childcare_provider_urn: nil)
+      end
+    end
+
+    def call
+      migrate(self.class.ecf_applications) do |application|
+        provider_urn = application.private_childcare_provider_urn
+
+        next if ::PrivateChildcareProvider.including_disabled.where(provider_urn:).exists?
+
+        ::PrivateChildcareProvider.create!(provider_urn:, disabled_at: Time.zone.now)
+      end
+    end
+  end
+end

--- a/spec/serializers/api/application_serializer_spec.rb
+++ b/spec/serializers/api/application_serializer_spec.rb
@@ -120,6 +120,15 @@ RSpec.describe API::ApplicationSerializer, type: :serializer do
 
         it { expect(attributes["itt_provider"]).to be_nil }
       end
+
+      context "when the `itt_provider` is disabled" do
+        let(:itt_provider) { build(:itt_provider, :disabled) }
+
+        it "serializes the `itt_provider`" do
+          itt_provider.legal_name = "provider"
+          expect(attributes["itt_provider"]).to eq(itt_provider.legal_name)
+        end
+      end
     end
 
     describe "school serialization" do
@@ -158,6 +167,15 @@ RSpec.describe API::ApplicationSerializer, type: :serializer do
         let(:private_childcare_provider) { nil }
 
         it { expect(attributes["private_childcare_provider_urn"]).to be_nil }
+      end
+
+      context "when the `private_childcare_provider` is disabled" do
+        let(:private_childcare_provider) { build(:private_childcare_provider, :disabled) }
+
+        it "serializes the `private_childcare_provider_urn`" do
+          private_childcare_provider.provider_urn = "2345678"
+          expect(attributes["private_childcare_provider_urn"]).to eq(private_childcare_provider.provider_urn)
+        end
       end
     end
 

--- a/spec/services/migration/migrators/application_spec.rb
+++ b/spec/services/migration/migrators/application_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Migration::Migrators::Application do
-  it_behaves_like "a migrator", :application, %i[cohort lead_provider schedule course user school] do
+  it_behaves_like "a migrator", :application, %i[private_childcare_provider itt_provider cohort lead_provider schedule course user school] do
     def create_ecf_resource
       create(:ecf_migration_npq_application, :accepted)
     end

--- a/spec/services/migration/migrators/itt_provider_spec.rb
+++ b/spec/services/migration/migrators/itt_provider_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe Migration::Migrators::IttProvider do
+  it_behaves_like "a migrator", :itt_provider, [] do
+    def create_ecf_resource
+      create(:ecf_migration_npq_application)
+    end
+
+    def create_npq_resource(ecf_resource)
+      create(:itt_provider, legal_name: ecf_resource.itt_provider.upcase)
+    end
+
+    def setup_failure_state
+      # Empty legal_name
+      create(:ecf_migration_npq_application, itt_provider: " ")
+    end
+
+    describe "#call" do
+      it "does not change existing provider or create any more if already present" do
+        provider = IttProvider.find_by(legal_name: ecf_resource1.itt_provider)
+
+        expect { instance.call }.not_to(change(IttProvider, :count))
+        expect(provider.reload.disabled_at).to be_nil
+      end
+
+      it "does not create any more providers if already present and disabled" do
+        IttProvider.find_by(legal_name: ecf_resource1.itt_provider, disabled_at: 1.day.ago)
+
+        expect { instance.call }.not_to(change(IttProvider, :count))
+      end
+
+      it "creates a disabled provider if it doesn't exist in NPQ reg" do
+        ecf_provider = create(:ecf_migration_npq_application, itt_provider: "other-provider")
+        instance.call
+        created_provider = IttProvider.including_disabled.find_by!(legal_name: ecf_provider.itt_provider, operating_name: ecf_provider.itt_provider)
+        expect(created_provider.disabled_at).to be_within(5.seconds).of(Time.zone.now)
+      end
+
+      it "fallsback to operating_name if legal_name is not a match" do
+        ecf_provider = create(:ecf_migration_npq_application)
+        npq_provider = create(:itt_provider, legal_name: "not-a-match", operating_name: ecf_provider.itt_provider)
+
+        expect { instance.call }.not_to(change(IttProvider, :count))
+        expect(npq_provider.reload.disabled_at).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/migration/migrators/private_childcare_provider_spec.rb
+++ b/spec/services/migration/migrators/private_childcare_provider_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe Migration::Migrators::PrivateChildcareProvider do
+  it_behaves_like "a migrator", :private_childcare_provider, [] do
+    def create_ecf_resource
+      create(:ecf_migration_npq_application)
+    end
+
+    def create_npq_resource(ecf_resource)
+      create(:private_childcare_provider, provider_urn: ecf_resource.private_childcare_provider_urn)
+    end
+
+    def setup_failure_state
+      # Empty urn
+      create(:ecf_migration_npq_application, private_childcare_provider_urn: " ")
+    end
+
+    describe "#call" do
+      it "does not change existing provider or create any more if already present" do
+        provider = PrivateChildcareProvider.find_by(provider_urn: ecf_resource1.private_childcare_provider_urn)
+
+        expect { instance.call }.not_to(change(PrivateChildcareProvider, :count))
+        expect(provider.reload.disabled_at).to be_nil
+      end
+
+      it "does not create any more providers if already present and disabled" do
+        PrivateChildcareProvider.find_by(provider_urn: ecf_resource1.private_childcare_provider_urn, disabled_at: 1.day.ago)
+
+        expect { instance.call }.not_to(change(PrivateChildcareProvider, :count))
+      end
+
+      it "creates a disabled provider if it doesn't exist in NPQ reg" do
+        ecf_provider = create(:ecf_migration_npq_application, private_childcare_provider_urn: "0123456")
+        instance.call
+        created_provider = PrivateChildcareProvider.including_disabled.find_by!(provider_urn: ecf_provider.private_childcare_provider_urn)
+        expect(created_provider.disabled_at).to be_within(5.seconds).of(Time.zone.now)
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Jira-3574](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-3574)

### Context

We want to bring across any IttProvider or PrivateChildcareProvider records that exist in ECF (as part of an NPQApplication) but are not present in NPQ reg. When we bring them across we want to flag them as disabled so that they don't appear in other areas of the NPQ reg application.

### Changes proposed in this pull request

- Migrate IttProvider and PrivateChildcareProvider

Providers are matched case insensitively. We can also fallback on the `operating_name` of the `IttProvider` if set.

### Guidance for review

| Main | This branch |
| -- | -- |
| <img width="1025" alt="Screenshot 2024-09-17 at 13 20 10" src="https://github.com/user-attachments/assets/d1d81b00-753b-4925-bb23-b24750732c39"> |  <img width="1005" alt="Screenshot 2024-09-17 at 14 56 22" src="https://github.com/user-attachments/assets/90e149ac-b34f-446f-b10d-49b59f703970"> |



