### PR TITLE
[CPDLP-3572] Data cleanup - Favour ECF in application migrator

### DIFF
--- a/app/services/migration/migrators/application.rb
+++ b/app/services/migration/migrators/application.rb
@@ -66,6 +66,12 @@ module Migration::Migrators
         application.itt_provider_id = find_itt_provider_id!(legal_name: ecf_npq_application.itt_provider) if ecf_npq_application.itt_provider
         application.private_childcare_provider_id = find_private_childcare_provider_id!(provider_urn: ecf_npq_application.private_childcare_provider_urn) if ecf_npq_application.private_childcare_provider_urn
 
+        if ecf_npq_application.school_urn.present?
+          application.school_id = find_school_id!(urn: ecf_npq_application.school_urn)
+        end
+        application.lead_provider_id = find_lead_provider_id!(ecf_id: ecf_npq_application.npq_lead_provider_id)
+        application.course_id = find_course_id!(ecf_id: ecf_npq_application.npq_course_id)
+
         application.training_status = ecf_npq_application.profile&.training_status if ecf_npq_application.profile
         application.ukprn = ecf_npq_application.school_ukprn
 
@@ -91,18 +97,6 @@ module Migration::Migrators
     end
 
     def ensure_relationships_are_consistent!(ecf_npq_application, application)
-      if application.school_id && !ecf_npq_application.school_urn || ecf_npq_application.school_urn && application.school_id != find_school_id!(urn: ecf_npq_application.school_urn)
-        raise_error(ecf_npq_application, message: "School in ECF is different")
-      end
-
-      if application.course_id != find_course_id!(ecf_id: ecf_npq_application.npq_course_id)
-        raise_error(ecf_npq_application, message: "Course in ECF is different")
-      end
-
-      if application.lead_provider_id != find_lead_provider_id!(ecf_id: ecf_npq_application.npq_lead_provider_id)
-        raise_error(ecf_npq_application, message: "LeadProvider in ECF is different")
-      end
-
       if application.user_id != find_user_id!(ecf_id: ecf_npq_application.user.id)
         raise_error(ecf_npq_application, message: "User in ECF is different")
       end

--- a/spec/services/migration/migrators/application_spec.rb
+++ b/spec/services/migration/migrators/application_spec.rb
@@ -64,41 +64,34 @@ RSpec.describe Migration::Migrators::Application do
         expect(application.private_childcare_provider.provider_urn).to eq(ecf_resource1.private_childcare_provider_urn)
       end
 
-      it "records a failure when the school in NPQ reg does not match the school in ECF" do
+      it "overrides school from ECF NPQApplication on the NPQ application" do
         Application.first.update!(school: create(:school, urn: "111333"))
         instance.call
-        expect(failure_manager).to have_received(:record_failure).with(ecf_resource1, /School in ECF is different/)
+
+        application = Application.find_by(ecf_id: ecf_resource1.id)
+        expect(application.school.urn).to eq(ecf_resource1.school_urn)
       end
 
-      it "records a failure when the school exists on the application in NPQ reg but not ECF" do
-        ecf_resource1.update!(school_urn: nil)
+      it "overrides lead_provider from ECF NPQApplication on the NPQ application" do
+        Application.first.update!(lead_provider: create(:lead_provider, name: "Test Provider"))
         instance.call
-        expect(failure_manager).to have_received(:record_failure).with(ecf_resource1, /School in ECF is different/)
+
+        application = Application.find_by(ecf_id: ecf_resource1.id)
+        expect(application.lead_provider.ecf_id).to eq(ecf_resource1.npq_lead_provider.id)
       end
 
-      it "does not record a failure when the school is nil for both ECF and NPQ reg" do
-        ecf_resource1.update!(school_urn: nil)
-        Application.find_by(ecf_id: ecf_resource1.id).update!(school: nil)
+      it "overrides course from ECF NPQApplication on the NPQ application" do
+        Application.first.update!(course: create(:course, name: "Test Course"))
         instance.call
-        expect(failure_manager).not_to have_received(:record_failure)
+
+        application = Application.find_by(ecf_id: ecf_resource1.id)
+        expect(application.course.ecf_id).to eq(ecf_resource1.npq_course.id)
       end
 
       it "records a failure when the user in NPQ reg does not match the user in ECF" do
         Application.first.update!(user: create(:user))
         instance.call
         expect(failure_manager).to have_received(:record_failure).with(ecf_resource1, /User in ECF is different/)
-      end
-
-      it "records a failure when the course in NPQ reg does not match the course in ECF" do
-        Application.first.update!(course: create(:course))
-        instance.call
-        expect(failure_manager).to have_received(:record_failure).with(ecf_resource1, /Course in ECF is different/)
-      end
-
-      it "records a failure when the lead provider in NPQ reg does not match the lead provider in ECF" do
-        Application.first.update!(lead_provider: create(:lead_provider))
-        instance.call
-        expect(failure_manager).to have_received(:record_failure).with(ecf_resource1, /LeadProvider in ECF is different/)
       end
 
       it "records a failure when the schedule cannot be found" do

--- a/spec/services/migration/migrators/application_spec.rb
+++ b/spec/services/migration/migrators/application_spec.rb
@@ -65,27 +65,28 @@ RSpec.describe Migration::Migrators::Application do
       end
 
       it "overrides school from ECF NPQApplication on the NPQ application" do
-        Application.first.update!(school: create(:school, urn: "111333"))
+        application = Application.find_by!(ecf_id: ecf_resource1.id)
+        application.update!(school: create(:school, urn: "111333"))
         instance.call
 
-        application = Application.find_by(ecf_id: ecf_resource1.id)
-        expect(application.school.urn).to eq(ecf_resource1.school_urn)
+        expect(application.reload.school.urn).to eq(ecf_resource1.school_urn)
       end
 
       it "overrides lead_provider from ECF NPQApplication on the NPQ application" do
-        Application.first.update!(lead_provider: create(:lead_provider, name: "Test Provider"))
+        application = Application.find_by!(ecf_id: ecf_resource1.id)
+        application.update!(lead_provider: create(:lead_provider, name: "Test Provider"))
         instance.call
 
-        application = Application.find_by(ecf_id: ecf_resource1.id)
-        expect(application.lead_provider.ecf_id).to eq(ecf_resource1.npq_lead_provider.id)
+        expect(application.reload.lead_provider.ecf_id).to eq(ecf_resource1.npq_lead_provider.id)
       end
 
       it "overrides course from ECF NPQApplication on the NPQ application" do
-        Application.first.update!(course: create(:course, name: "Test Course"))
+        application = Application.find_by!(ecf_id: ecf_resource1.id)
+        application.update!(course: create(:course, name: "Test Course"))
+
         instance.call
 
-        application = Application.find_by(ecf_id: ecf_resource1.id)
-        expect(application.course.ecf_id).to eq(ecf_resource1.npq_course.id)
+        expect(application.reload.course.ecf_id).to eq(ecf_resource1.npq_course.id)
       end
 
       it "records a failure when the user in NPQ reg does not match the user in ECF" do


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-3572

### Changes proposed in this pull request

* Updated `Migration::Migrators::Application` to save school, lead_provider and course from ECF NPQ Application