### PR TITLE
Add Terraform & dependencies to compose ops image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,8 +31,11 @@ services:
         FROM mcr.microsoft.com/azure-cli:cbl-mariner2.0
         RUN mkdir /app
         WORKDIR /app
-        RUN yum install -y make
+        RUN yum install -y git make tar unzip
         RUN az aks install-cli
+        RUN curl -O https://releases.hashicorp.com/terraform/1.5.4/terraform_1.5.4_linux_amd64.zip && \
+          unzip terraform_1.5.4_linux_amd64.zip && \
+          mv terraform /usr/local/bin/
     command: bash
     scale: 0
     volumes:


### PR DESCRIPTION
### Changes proposed in this pull request

Simple change here to add Terraform & dependencies to the Docker Compose `ops` service, so that you can run make tasks that require Terraform