### PR TITLE
Fix Codespaces

### DIFF
--- a/.devcontainer/boot.sh
+++ b/.devcontainer/boot.sh
@@ -4,8 +4,14 @@ echo "Updating RubyGems..."
 gem update --system -N
 
 echo "Installing dependencies..."
+# Bigdecimal fails to compile natively on Ubuntu with
+# Ruby 3.3.4. This is a workaround to fix that.
+# See: https://github.com/ruby/bigdecimal/issues/297
+export CC=/usr/bin/clang && export CXX=/usr/bin/clang++
 bundle install
 yarn install
+yarn build
+yarn build:css
 
 echo "Creating database..."
 bin/rails db:prepare 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
   "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
   "features": {
     "ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
-      "packages": "libpq-dev, libvips, postgresql-client-15"
+      "packages": "libpq-dev, libvips, postgresql-client-15, clang"
     },
     "ghcr.io/devcontainers/features/git:1": {
       "version": "latest"
@@ -48,7 +48,7 @@
   // Use 'postCreateCommand' to run commands after the container is created.
   "postCreateCommand": ".devcontainer/boot.sh",
 
-	"postStartCommand": "bin/rails s"
+  "postStartCommand": "bin/dev"
 
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
   // "remoteUser": "root"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   app:
     build:


### PR DESCRIPTION
### Context

Codespaces has stopped working recently; its failing to boot rails on some occasions and on older PRs the asset pipeline appears to be broken.

### Changes proposed in this pull request

- Fix Codespaces not booting

Codespaces fails to run since we changed the asset pipeline; we need to run `yarn build` and `yarn build:css` to compile the JS/CSS assets. Instead of doing this once on boot I've opted to run Foreman in the Codespace, which gives us the `--watch` behaviour to recompile CSS/JS as and when it changes.

The codespace was also failing to boot due to `bundle install` failing to compile native gems (`bigdecimal`). I went on a bit of a wild goose chase with this error; initially I thought it was because the `docker-compose.yml` recently changed, but Codespaces uses a different one. I then thought it was due to native libraries not being present so tried installing various dependencies (`build-essential`, `ruby-dev`, etc). None of this worked; in the end it turned out to be a recent upgrade to Ruby breaking `bigdecimal` on Ubuntu. The fix is to install `clang`, which requires the `universe` repository.

We were also getting a warning for including the `version` in the `docker-compose.yml` file; its no longer required.

### Guidance to review

You can verify its now working by booting up a a codespace on this branch.