### PR TITLE
[CPDLP-3575] Update user from/to participant id changes table

### DIFF
--- a/app/models/participant_id_change.rb
+++ b/app/models/participant_id_change.rb
@@ -2,8 +2,8 @@
 
 class ParticipantIdChange < ApplicationRecord
   belongs_to :user
-  belongs_to :from_participant, class_name: "User"
-  belongs_to :to_participant, class_name: "User"
+  belongs_to :from_participant, class_name: "User", primary_key: "ecf_id"
+  belongs_to :to_participant, class_name: "User", primary_key: "ecf_id"
 
   validates :user, :from_participant, :to_participant, presence: true
 end

--- a/app/models/participant_id_change.rb
+++ b/app/models/participant_id_change.rb
@@ -2,8 +2,6 @@
 
 class ParticipantIdChange < ApplicationRecord
   belongs_to :user
-  belongs_to :from_participant, class_name: "User", primary_key: "ecf_id"
-  belongs_to :to_participant, class_name: "User", primary_key: "ecf_id"
 
-  validates :user, :from_participant, :to_participant, presence: true
+  validates :user, :from_participant_id, :to_participant_id, presence: true
 end

--- a/app/serializers/api/participant_serializer.rb
+++ b/app/serializers/api/participant_serializer.rb
@@ -92,8 +92,8 @@ module API
         field(:participant_id_changes) do |object, _options|
           (object.participant_id_changes || []).map do |participant_id_change|
             {
-              from_participant_id: participant_id_change.from_participant.ecf_id,
-              to_participant_id: participant_id_change.to_participant.ecf_id,
+              from_participant_id: participant_id_change.from_participant_id,
+              to_participant_id: participant_id_change.to_participant_id,
               changed_at: participant_id_change.created_at.rfc3339,
             }
           end

--- a/app/services/migration/migrators/participant_id_change.rb
+++ b/app/services/migration/migrators/participant_id_change.rb
@@ -45,7 +45,7 @@ module Migration::Migrators
 
     def users_by_ecf_id
       @users_by_ecf_id ||= begin
-        ecf_ids = self.class.ecf_participant_id_changes.pluck(:user_id, :from_participant_id, :to_participant_id).flatten.uniq
+        ecf_ids = self.class.ecf_participant_id_changes.pluck(:user_id).flatten.uniq
         ::User.where(ecf_id: ecf_ids).select(:id, :ecf_id).index_by(&:ecf_id)
       end
     end

--- a/app/services/migration/migrators/participant_id_change.rb
+++ b/app/services/migration/migrators/participant_id_change.rb
@@ -30,8 +30,8 @@ module Migration::Migrators
 
         participant_id_change.update!(
           user: find_user!(ecf_id: ecf_participant_id_change.user_id),
-          from_participant: find_user!(ecf_id: ecf_participant_id_change.from_participant_id),
-          to_participant: find_user!(ecf_id: ecf_participant_id_change.to_participant_id),
+          from_participant_id: ecf_participant_id_change.from_participant_id,
+          to_participant_id: ecf_participant_id_change.to_participant_id,
           created_at: ecf_participant_id_change.created_at,
         )
       end

--- a/app/services/participants/query.rb
+++ b/app/services/participants/query.rb
@@ -56,7 +56,7 @@ module Participants
     def where_from_participant_id_is(from_participant_id)
       return if ignore?(filter: from_participant_id)
 
-      scope.merge!(scope.joins(:participant_id_changes).merge(ParticipantIdChange.where(from_participant: User.where(ecf_id: from_participant_id))))
+      scope.merge!(scope.joins(:participant_id_changes).merge(ParticipantIdChange.where(from_participant_id:)))
     end
 
     def order_by
@@ -67,7 +67,7 @@ module Participants
       User
         .joins(:applications).merge(Application.accepted)
         .includes(
-          participant_id_changes: %i[from_participant to_participant],
+          :participant_id_changes,
           applications: %i[
             course
             school

--- a/app/services/valid_test_data_generators/applications_populater.rb
+++ b/app/services/valid_test_data_generators/applications_populater.rb
@@ -91,7 +91,7 @@ module ValidTestDataGenerators
       return if Faker::Boolean.boolean(true_ratio: 0.3)
 
       user = application.user
-      FactoryBot.create(:participant_id_change, to_participant: user, user:)
+      FactoryBot.create(:participant_id_change, to_participant_id: user.ecf_id, user:)
     end
 
     def create_user

--- a/db/migrate/20240917142926_remove_foreign_keys_from_participant_id_changes.rb
+++ b/db/migrate/20240917142926_remove_foreign_keys_from_participant_id_changes.rb
@@ -1,0 +1,8 @@
+class RemoveForeignKeysFromParticipantIdChanges < ActiveRecord::Migration[7.1]
+  def up
+    remove_foreign_key :participant_id_changes, column: :from_participant_id
+    remove_foreign_key :participant_id_changes, column: :to_participant_id
+  end
+
+  def down; end
+end

--- a/db/migrate/20240918145749_change_from_and_to_participant_ids_to_uuid_in_participant_id_changes.rb
+++ b/db/migrate/20240918145749_change_from_and_to_participant_ids_to_uuid_in_participant_id_changes.rb
@@ -1,8 +1,55 @@
 class ChangeFromAndToParticipantIdsToUuidInParticipantIdChanges < ActiveRecord::Migration[7.1]
   def up
-    change_column :participant_id_changes, :from_participant_id, :uuid
-    change_column :participant_id_changes, :to_participant_id, :uuid
+    add_column :participant_id_changes, :from_participant_uuid, :uuid
+    add_column :participant_id_changes, :to_participant_uuid, :uuid
+
+    execute <<-SQL
+      UPDATE participant_id_changes SET from_participant_uuid = users.ecf_id
+      FROM users WHERE participant_id_changes.from_participant_id = users.id;
+    SQL
+
+    execute <<-SQL
+      UPDATE participant_id_changes SET to_participant_uuid = users.ecf_id
+      FROM users WHERE participant_id_changes.to_participant_id = users.id;
+    SQL
+
+    remove_column :participant_id_changes, :from_participant_id
+    remove_column :participant_id_changes, :to_participant_id
+
+    rename_column :participant_id_changes, :from_participant_uuid, :from_participant_id
+    rename_column :participant_id_changes, :to_participant_uuid, :to_participant_id
+
+    change_column_null :participant_id_changes, :from_participant_id, false
+    change_column_null :participant_id_changes, :to_participant_id, false
+
+    add_index :participant_id_changes, :from_participant_id
+    add_index :participant_id_changes, :to_participant_id
   end
 
-  def down; end
+  def down
+    add_column :participant_id_changes, :from_participant_bigid, :bigint
+    add_column :participant_id_changes, :to_participant_bigid, :bigint
+
+    execute <<-SQL
+      UPDATE participant_id_changes SET from_participant_bigid = users.id
+      FROM users WHERE participant_id_changes.from_participant_id = users.ecf_id;
+    SQL
+
+    execute <<-SQL
+      UPDATE participant_id_changes SET to_participant_bigid = users.id
+      FROM users WHERE participant_id_changes.to_participant_id = users.ecf_id;
+    SQL
+
+    remove_column :participant_id_changes, :from_participant_id
+    remove_column :participant_id_changes, :to_participant_id
+
+    rename_column :participant_id_changes, :from_participant_bigid, :from_participant_id
+    rename_column :participant_id_changes, :to_participant_bigid, :to_participant_id
+
+    change_column_null :participant_id_changes, :from_participant_id, false
+    change_column_null :participant_id_changes, :to_participant_id, false
+
+    add_index :participant_id_changes, :from_participant_id
+    add_index :participant_id_changes, :to_participant_id
+  end
 end

--- a/db/migrate/20240918145749_change_from_and_to_participant_ids_to_uuid_in_participant_id_changes.rb
+++ b/db/migrate/20240918145749_change_from_and_to_participant_ids_to_uuid_in_participant_id_changes.rb
@@ -1,0 +1,8 @@
+class ChangeFromAndToParticipantIdsToUuidInParticipantIdChanges < ActiveRecord::Migration[7.1]
+  def up
+    change_column :participant_id_changes, :from_participant_id, :uuid
+    change_column :participant_id_changes, :to_participant_id, :uuid
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -314,11 +314,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_18_145749) do
 
   create_table "participant_id_changes", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.uuid "from_participant_id", null: false
-    t.uuid "to_participant_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "ecf_id"
+    t.uuid "from_participant_id", null: false
+    t.uuid "to_participant_id", null: false
     t.index ["ecf_id"], name: "index_participant_id_changes_on_ecf_id"
     t.index ["from_participant_id"], name: "index_participant_id_changes_on_from_participant_id"
     t.index ["to_participant_id"], name: "index_participant_id_changes_on_to_participant_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_16_194001) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_18_145749) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -314,8 +314,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_16_194001) do
 
   create_table "participant_id_changes", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.bigint "from_participant_id", null: false
-    t.bigint "to_participant_id", null: false
+    t.uuid "from_participant_id", null: false
+    t.uuid "to_participant_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "ecf_id"
@@ -551,8 +551,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_16_194001) do
   add_foreign_key "declarations", "declarations", column: "superseded_by_id"
   add_foreign_key "declarations", "lead_providers"
   add_foreign_key "participant_id_changes", "users"
-  add_foreign_key "participant_id_changes", "users", column: "from_participant_id"
-  add_foreign_key "participant_id_changes", "users", column: "to_participant_id"
   add_foreign_key "participant_outcome_api_requests", "participant_outcomes"
   add_foreign_key "participant_outcomes", "declarations"
   add_foreign_key "schedules", "cohorts"

--- a/spec/factories/applications.rb
+++ b/spec/factories/applications.rb
@@ -111,7 +111,7 @@ FactoryBot.define do
       after(:create) do |application|
         user = application.user
 
-        create(:participant_id_change, to_participant: user, user:)
+        create(:participant_id_change, to_participant_id: user.ecf_id, user:)
       end
     end
 

--- a/spec/factories/participant_id_changes.rb
+++ b/spec/factories/participant_id_changes.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :participant_id_change do
     user
-    association :from_participant, factory: :user
-    association :to_participant, factory: :user
+    from_participant_id { SecureRandom.uuid }
+    to_participant_id { user.ecf_id }
   end
 end

--- a/spec/models/participant_id_change_spec.rb
+++ b/spec/models/participant_id_change_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ParticipantIdChange, type: :model do
 
   describe "associations" do
     it { is_expected.to belong_to(:user).class_name("User") }
-    it { is_expected.to belong_to(:from_participant).class_name("User") }
-    it { is_expected.to belong_to(:to_participant).class_name("User") }
+    it { is_expected.to belong_to(:from_participant).class_name("User").with_primary_key("ecf_id") }
+    it { is_expected.to belong_to(:to_participant).class_name("User").with_primary_key("ecf_id") }
   end
 end

--- a/spec/models/participant_id_change_spec.rb
+++ b/spec/models/participant_id_change_spec.rb
@@ -5,13 +5,11 @@ require "rails_helper"
 RSpec.describe ParticipantIdChange, type: :model do
   describe "validations" do
     it { is_expected.to validate_presence_of(:user) }
-    it { is_expected.to validate_presence_of(:from_participant) }
-    it { is_expected.to validate_presence_of(:to_participant) }
+    it { is_expected.to validate_presence_of(:from_participant_id) }
+    it { is_expected.to validate_presence_of(:to_participant_id) }
   end
 
   describe "associations" do
     it { is_expected.to belong_to(:user).class_name("User") }
-    it { is_expected.to belong_to(:from_participant).class_name("User").with_primary_key("ecf_id") }
-    it { is_expected.to belong_to(:to_participant).class_name("User").with_primary_key("ecf_id") }
   end
 end

--- a/spec/serializers/api/participant_serializer_spec.rb
+++ b/spec/serializers/api/participant_serializer_spec.rb
@@ -330,8 +330,8 @@ RSpec.describe API::ParticipantSerializer, type: :serializer do
       it "serializes the `participant_id_changes`" do
         expect(attributes["participant_id_changes"]).to eq([
           {
-            from_participant_id: participant.participant_id_changes.last.from_participant.ecf_id,
-            to_participant_id: participant.participant_id_changes.last.to_participant.ecf_id,
+            from_participant_id: participant.participant_id_changes.last.from_participant_id,
+            to_participant_id: participant.participant_id_changes.last.to_participant_id,
             changed_at: participant.participant_id_changes.last.created_at.rfc3339,
           }.stringify_keys,
         ])

--- a/spec/services/migration/migrators/participant_id_change_spec.rb
+++ b/spec/services/migration/migrators/participant_id_change_spec.rb
@@ -33,6 +33,16 @@ RSpec.describe Migration::Migrators::ParticipantIdChange do
           created_at: ecf_resource1.created_at,
         })
       end
+
+      context "when a matching `participant_id_change` and the to/from participants do not exist in NPQ reg" do
+        def create_npq_resource(ecf_resource)
+          create(:user, ecf_id: ecf_resource.user.id)
+        end
+
+        it "creates a new participant_id_change record in NPQ reg" do
+          expect { instance.call }.to change(ParticipantIdChange, :count).by(2)
+        end
+      end
     end
   end
 end

--- a/spec/services/migration/migrators/participant_id_change_spec.rb
+++ b/spec/services/migration/migrators/participant_id_change_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe Migration::Migrators::ParticipantIdChange do
         participant_id_change = ParticipantIdChange.find_by!(ecf_id: ecf_resource1.id)
         expect(participant_id_change).to have_attributes({
           user_id: User.find_by(ecf_id: ecf_resource1.user_id).id,
-          from_participant_id: User.find_by(ecf_id: ecf_resource1.from_participant_id).id,
-          to_participant_id: User.find_by(ecf_id: ecf_resource1.to_participant_id).id,
+          from_participant_id: ecf_resource1.from_participant_id,
+          to_participant_id: ecf_resource1.to_participant_id,
           created_at: ecf_resource1.created_at,
         })
       end

--- a/spec/services/participants/query_spec.rb
+++ b/spec/services/participants/query_spec.rb
@@ -168,8 +168,8 @@ RSpec.describe Participants::Query do
       end
 
       describe "from participant id" do
-        let(:participant_id_change) { create(:participant_id_change, user: participant1, to_participant: participant1) }
-        let(:from_participant_id) { participant_id_change.from_participant.ecf_id }
+        let(:participant_id_change) { create(:participant_id_change, user: participant1, to_participant_id: participant1.ecf_id) }
+        let(:from_participant_id) { participant_id_change.from_participant_id }
 
         context "when a from participant id is supplied" do
           let(:params) { { from_participant_id: } }

--- a/spec/support/shared_examples/api_index_endpoint_support.rb
+++ b/spec/support/shared_examples/api_index_endpoint_support.rb
@@ -265,8 +265,8 @@ end
 RSpec.shared_examples "an API index endpoint with filter by from_participant_id" do
   context "when fitlering by from_participant_id" do
     let!(:resource) { create_resource(lead_provider: current_lead_provider) }
-    let(:participant_id_change) { create(:participant_id_change, user: resource, to_participant: resource) }
-    let(:from_participant_id) { participant_id_change.from_participant.ecf_id }
+    let(:participant_id_change) { create(:participant_id_change, user: resource, to_participant_id: resource.ecf_id) }
+    let(:from_participant_id) { participant_id_change.from_participant_id }
 
     it "returns resources with the given `from_participant_id`" do
       create_resource(lead_provider: current_lead_provider)


### PR DESCRIPTION
### Context

Ticket: [CPDLP-3575](https://dfedigital.atlassian.net/browse/CPDLP-3575)

After reviewing errors in migrators, we found out there're some missing users in NPQ as they are orphans. We’ve agreed to change the table to UUIDs and only populate those values without bringing across the users.

### Changes proposed in this pull request

Update user from/to in NPQ for Participant id changes table.


[CPDLP-3575]: https://dfedigital.atlassian.net/browse/CPDLP-3575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ