### PR TITLE
Only raise on multiple application TRNs if no teacher profile TRN

### DIFF
--- a/spec/services/migration/migrators/user_spec.rb
+++ b/spec/services/migration/migrators/user_spec.rb
@@ -49,11 +49,21 @@ RSpec.describe Migration::Migrators::User do
         )
       end
 
-      it "records a failure when there are multiple, different TRNs for the user's NPQApplications in ECF" do
-        ecf_user = create(:ecf_migration_user, :npq)
+      it "records a failure when there are multiple, different TRNs for the user's NPQApplications in ECF and no teacher profile TRN" do
+        ecf_user = create(:ecf_migration_user, :npq).tap { |u| u.teacher_profile.update!(trn: nil) }
         create(:ecf_migration_npq_application, teacher_reference_number: "123456", teacher_reference_number_verified: true, participant_identity: ecf_user.participant_identities.first)
         instance.call
         expect(failure_manager).to have_received(:record_failure).with(ecf_user, /There are multiple different TRNs from NPQ applications/)
+      end
+
+      it "does not record a failure when there are multiple, different TRNs for the user's NPQApplications in ECF and there is also a teacher profile TRN" do
+        ecf_user = create(:ecf_migration_user, :npq).tap { |u| u.teacher_profile.update!(trn: "1234567") }
+        create(:ecf_migration_npq_application, teacher_reference_number: "123456", teacher_reference_number_verified: true, participant_identity: ecf_user.participant_identities.first)
+        instance.call
+        expect(failure_manager).not_to have_received(:record_failure)
+        user = User.find_by(ecf_id: ecf_user.id)
+        expect(user.trn).to eq(ecf_user.teacher_profile.trn)
+        expect(user).to be_trn_verified
       end
 
       it "does not record a failure if there are multiple, unverified TRNs for the user's NPQApplications in ECF" do
@@ -61,6 +71,20 @@ RSpec.describe Migration::Migrators::User do
         create(:ecf_migration_npq_application, teacher_reference_number: "123456", teacher_reference_number_verified: false, participant_identity: ecf_user.participant_identities.first)
         instance.call
         expect(failure_manager).not_to have_received(:record_failure)
+        user = User.find_by(ecf_id: ecf_user.id)
+        expect(user.trn).to eq(ecf_user.teacher_profile.trn)
+        expect(user).to be_trn_verified
+      end
+
+      it "retains the NPQ user TRN if the ECF user does not have a verified TRN" do
+        ecf_user = create(:ecf_migration_user, :npq).tap do |u|
+          u.npq_applications.update!(teacher_reference_number_verified: false)
+          u.teacher_profile.update!(trn: nil)
+        end
+        existing_user = create(:user, ecf_id: ecf_user.id, email: ecf_user.email, trn: "123123", trn_verified: true)
+        instance.call
+        expect(failure_manager).not_to have_received(:record_failure)
+        expect(existing_user.reload).to have_attributes(trn: "123123", trn_verified: true)
       end
 
       context "when there are multiple users with the same ecf_id" do


### PR DESCRIPTION
[Jira-3594](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3594)

### Context

We only want to raise an error for multiple verified `NPQApplication` TRNs if there is not a `teacher_profile.trn` on the ECF user. We will favour the profile TRN over the `NPQApplication` TRNs and fallback on the NPQ user TRN in case there is not a verified TRN in ECF (and the NPQ user already has one).

### Changes proposed in this pull request

- Only raise on multiple application TRNs if no teacher profile TRN

### Guidance for review

<img width="1025" alt="Screenshot 2024-09-20 at 15 47 40" src="https://github.com/user-attachments/assets/c2b3a425-6967-4bd4-9d55-f42e5359c0f6">
