### PR TITLE
Add warning message to the provider page

### DIFF
--- a/app/views/registration_wizard/choose_your_provider.html.erb
+++ b/app/views/registration_wizard/choose_your_provider.html.erb
@@ -1,3 +1,7 @@
+<% content_for :before_submit do %>
+  <%= govuk_warning_text(text: t('helpers.warnings.registration_wizard.check_provider_is_open')) %>
+<% end %>
+
 <%=
   render(
     'registration_wizard/shared/questions_page',

--- a/app/views/registration_wizard/shared/_questions_page.html.erb
+++ b/app/views/registration_wizard/shared/_questions_page.html.erb
@@ -27,9 +27,7 @@
         %>
       <% end %>
 
-      <% if @wizard.current_step == :choose_your_provider %>
-        <%= govuk_warning_text(text: t('helpers.warnings.registration_wizard.check_provider_is_open')) %>
-      <% end %>
+      <%= yield :before_submit %> 
 
       <%= f.govuk_submit %>
     <% end %>

--- a/app/views/registration_wizard/shared/_questions_page.html.erb
+++ b/app/views/registration_wizard/shared/_questions_page.html.erb
@@ -27,6 +27,10 @@
         %>
       <% end %>
 
+      <% if @wizard.current_step == :choose_your_provider %>
+        <%= govuk_warning_text(text: t('helpers.warnings.registration_wizard.check_provider_is_open')) %>
+      <% end %>
+
       <%= f.govuk_submit %>
     <% end %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -577,7 +577,7 @@ en:
   helpers:
     warnings: 
       registration_wizard:
-        check_provider_is_open: "Before selecting your provider, you must check that they are currently open to accepting NPQ applications.​"
+        check_provider_is_open: "Before selecting your provider, you must check that they are currently open to accepting NPQ applications."
     title:
       registration_wizard:
         get_an_identity: "Get an identity"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -575,6 +575,9 @@ en:
     not_eligible_for_funding: "If your provider does not confirm you've started the course before %{date}, your registration will expire. You can register again later."
 
   helpers:
+    warnings: 
+      registration_wizard:
+        check_provider_is_open: "Before selecting your provider, you must check that they are currently open to accepting NPQ applications.​"
     title:
       registration_wizard:
         get_an_identity: "Get an identity"

--- a/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
@@ -70,7 +70,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
     expect_page_to_have(path: "/registration/choose-your-provider", submit_form: true) do
       expect(page).to have_text("Select your provider")
-      expect(page).to have_text("Before selecting your provider, you must check that they are currently open to accepting NPQ applications.​")
+      expect(page).to have_text("Before selecting your provider​")
       page.choose("Teach First", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
@@ -70,6 +70,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
     expect_page_to_have(path: "/registration/choose-your-provider", submit_form: true) do
       expect(page).to have_text("Select your provider")
+      expect(page).to have_text("Before selecting your provider, you must check that they are currently open to accepting NPQ applications.​")
       page.choose("Teach First", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
@@ -70,7 +70,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
     expect_page_to_have(path: "/registration/choose-your-provider", submit_form: true) do
       expect(page).to have_text("Select your provider")
-      expect(page).to have_text(/Before selecting your provider, you must check that they are currently open to accepting NPQ applications.​​/)
+      expect(page).to have_text("Before selecting your provider, you must check that they are currently open to accepting NPQ applications.")
       page.choose("Teach First", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
@@ -70,7 +70,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
     expect_page_to_have(path: "/registration/choose-your-provider", submit_form: true) do
       expect(page).to have_text("Select your provider")
-      expect(page).to have_text("Before selecting your provider​")
+      expect(page).to have_text(/Before selecting your provider, you must check that they are currently open to accepting NPQ applications.​​/)
       page.choose("Teach First", visible: :all)
     end
 


### PR DESCRIPTION
Add warning text to provider page as specified in the **prototype**:

![Screenshot 2024-09-20 at 15 01 34](https://github.com/user-attachments/assets/cb6937fd-f26f-475c-81ff-a771ba927b80)

How it's rendering **locally on the app**:

![Screenshot 2024-09-20 at 15 02 58](https://github.com/user-attachments/assets/225bcc6f-c152-499d-b16a-11f07783e315)

We discussed improving on the design, e.g. hint text outlining the exact dates, or removing the radios when that provider is no longer open, but [Nabi would like to get something out sooner rather than later](https://ukgovernmentdfe.slack.com/archives/C05A3H3ENRG/p1726664111768049).