### PR TITLE
Cache migration dependencies in Redis

### DIFF
--- a/spec/services/migration/migrators/application_spec.rb
+++ b/spec/services/migration/migrators/application_spec.rb
@@ -94,25 +94,25 @@ RSpec.describe Migration::Migrators::Application do
       end
 
       it "records a failure when the schedule cannot be found" do
-        Schedule.find_by!(ecf_id: ecf_resource1.profile.schedule_id).destroy!
+        Rails.cache.delete("schedule_by_ecf_id_#{ecf_resource1.profile.schedule.id}")
         instance.call
         expect(failure_manager).to have_received(:record_failure).with(ecf_resource1, /Couldn't find Schedule/)
       end
 
       it "records a failure when the cohort cannot be found" do
-        Cohort.find_by!(ecf_id: ecf_resource1.cohort_id).update!(ecf_id: SecureRandom.uuid)
+        Rails.cache.delete("cohort_by_ecf_id_#{ecf_resource1.cohort_id}")
         instance.call
         expect(failure_manager).to have_received(:record_failure).with(ecf_resource1, /Couldn't find Cohort/)
       end
 
       it "records a failure when the ITT provider cannot be found" do
-        ecf_resource1.update!(itt_provider: "other-provider")
+        Rails.cache.delete("itt_provider_by_legal_name_and_operating_name_#{ecf_resource1.itt_provider.downcase}")
         instance.call
         expect(failure_manager).to have_received(:record_failure).with(ecf_resource1, /Couldn't find IttProvider/)
       end
 
       it "records a failure when the private childcare provider cannot be found" do
-        ecf_resource1.update!(private_childcare_provider_urn: "999999")
+        Rails.cache.delete("private_childcare_provider_by_urn_#{ecf_resource1.private_childcare_provider_urn}")
         instance.call
         expect(failure_manager).to have_received(:record_failure).with(ecf_resource1, /Couldn't find PrivateChildcareProvider/)
       end

--- a/spec/support/shared_examples/migrator_support.rb
+++ b/spec/support/shared_examples/migrator_support.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.shared_examples "a migrator" do |model, dependencies|
+RSpec.shared_examples "a migrator", :in_memory_rails_cache do |model, dependencies|
   let(:worker) { 0 }
   let(:instance) { described_class.new(worker:) }
   let(:data_migration) { create(:data_migration, model:, worker: 0) }
@@ -19,6 +19,8 @@ RSpec.shared_examples "a migrator" do |model, dependencies|
 
     allow(described_class).to receive(:records_per_worker).and_return(records_per_worker)
     allow(Migration::FailureManager).to receive(:new).with(data_migration:) { failure_manager }
+
+    described_class.warm_cache
   end
 
   describe ".prepare!" do
@@ -148,6 +150,25 @@ RSpec.shared_examples "a migrator" do |model, dependencies|
       it "queues a job for each worker" do
         expect { queue }.to have_enqueued_job(MigratorJob).with(migrator: described_class, worker: 0)
           .and(have_enqueued_job(MigratorJob).with(migrator: described_class, worker: 1))
+      end
+    end
+
+    if dependencies.any?
+      context "when the migration has dependencies" do
+        it "warms the cache for the dependencies" do
+          # We need to clear the cache here as we warm it before all
+          # tests and it will only warm once.
+          Rails.cache.clear
+
+          cache_methods = described_class.warm_cache_methods
+          dependencies_with_cache = dependencies.select { |d| cache_methods.any? { |m| m.include?(d.to_s) } }
+
+          if dependencies_with_cache.any?
+            expect(Rails.cache).to receive(:write_multi).at_least(dependencies_with_cache.count).times
+          end
+
+          queue
+        end
       end
     end
   end


### PR DESCRIPTION
[Jira-3511](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3511)

### Context

Instead of hitting the database to query the IDs used for lookups in each migrator, we want to do this once for each lookup and store the results in Redis to share across workers.

### Changes proposed in this pull request

- Cache migration dependencies in Redis

When a migrator is queued we will now pre-warm the dependency cache in Redis. We cache the lookup hash as individual key/value entries in Redis so we don't have to load the whole lot into memory for each worker.

As we are storing lots of individual keys in Redis, clearing them manually becomes difficult. Instead, I opted to set a 1 hour TTL on the cache keys, which should be long enough for any single run but short enough that the cache is cleared before the next run. That being said, even if the cache is still warm from a previous run it only stores ID mappings which are unlikely to change between runs, so it shouldn't cause us issues.

### Guidance to review

I tried a few ways of caching in Redis; one with a hash stored under a Redis key containing all ID mappings for a model (see [this branch](https://github.com/DFE-Digital/npq-registration/tree/3511-cache-dependencies-in-redis-under-single-key)) and one where each ID mapping was its own Redis key (this branch - having the benefit of not needing to load everything into memory, instead just reading the values it needs for a particular worker).

Despite the slightly longer runtime I think its probably worthwhile merging this down so we have an extra lever to scale the migration up with (by bumping the Redis instance) and it also relieves some load from the DB.

Main:

```
  [["application", "29 minutes and 25.89283599999999 seconds"],
 ["declaration", "4 minutes and 8.569072000000006 seconds"],
 ["statement_item", "2 minutes and 49.38589099999999 seconds"],
 ["user", "2 minutes and 21.038196 seconds"],
 ["contract", "1 minute and 59.136003 seconds"],
 ["application_state", "1 minute and 59.082032 seconds"],
 ["participant_outcome_api_request", "1 minute and 9.245193999999998 seconds"],
 ["participant_outcome", "1 minute and 0.7751540000000006 seconds"],
 ["participant_id_change", "35.009366 seconds"],
 ["school", "19.413319 seconds"],
 ["statement", "15.234018 seconds"],
 ["declaration_superseded_by", "8.076017 seconds"],
 ["private_childcare_provider", "6.151425 seconds"],
 ["itt_provider", "2.152112 seconds"],
 ["schedule", "1.187606 seconds"],
 ["course", "1.0787 seconds"],
 ["cohort", "1.055177 seconds"],
 ["lead_provider", "1.052633 seconds"]]
```

Caching under fewer keys/large values (containing a hash of all ID mappings):

```
 [["application", "31 minutes and 46.84215799999993 seconds"],
 ["declaration", "3 minutes and 59.66898900000001 seconds"],
 ["statement_item", "2 minutes and 55.736211999999995 seconds"],
 ["user", "2 minutes and 44.99132800000001 seconds"],
 ["application_state", "2 minutes and 35.80960999999999 seconds"],
 ["contract", "1 minute and 58.542092 seconds"],
 ["participant_outcome_api_request", "1 minute and 6.304102999999998 seconds"],
 ["participant_outcome", "1 minute and 2.7366779999999977 seconds"],
 ["participant_id_change", "36.760728 seconds"],
 ["school", "17.051869 seconds"],
 ["statement", "15.399948 seconds"],
 ["declaration_superseded_by", "10.921051 seconds"],
 ["private_childcare_provider", "7.270594 seconds"],
 ["itt_provider", "1.973176 seconds"],
 ["schedule", "1.307122 seconds"],
 ["cohort", "1.10821 seconds"],
 ["course", "1.098061 seconds"],
 ["lead_provider", "1.044529 seconds"]]
```

Caching under many keys/small values (one per ID mapping) - this branch: 
 
```
[["application", "28 minutes and 33.51087099999995 seconds"],
 ["declaration", "4 minutes and 46.355233999999996 seconds"],
 ["statement_item", "3 minutes and 27.48512199999999 seconds"],
 ["contract", "3 minutes and 2.8663709999999867 seconds"],
 ["user", "2 minutes and 54.73174599999999 seconds"],
 ["application_state", "2 minutes and 1.395315999999994 seconds"],
 ["participant_outcome", "1 minute and 9.668215000000004 seconds"],
 ["participant_outcome_api_request", "1 minute and 7.577979999999997 seconds"],
 ["participant_id_change", "36.453701 seconds"],
 ["statement", "24.248105 seconds"],
 ["school", "20.73992 seconds"],
 ["private_childcare_provider", "8.841484 seconds"],
 ["declaration_superseded_by", "7.761238 seconds"],
 ["itt_provider", "2.214833 seconds"],
 ["schedule", "1.490856 seconds"],
 ["course", "1.15602 seconds"],
 ["cohort", "1.060205 seconds"],
 ["lead_provider", "1.051977 seconds"]]
```

| Main    | Large cache values | Small cache values (this branch) |
| -------- | ------- | ------- |
| <img width="1004" alt="main" src="https://github.com/user-attachments/assets/dcc8f90f-34bc-452b-9b53-253e4d339bd5">  |  <img width="1004" alt="redis-small-number-of-keys" src="https://github.com/user-attachments/assets/9c483b33-73aa-488a-92f0-b7209e112302">  |  <img width="985" alt="redis-large-number-of-keys" src="https://github.com/user-attachments/assets/668e26f8-8490-44da-817f-61d4826f1f31"> |

