### PR TITLE
Optimise records_per_worker

### DIFF
--- a/app/services/migration/migrators/application.rb
+++ b/app/services/migration/migrators/application.rb
@@ -45,6 +45,10 @@ module Migration::Migrators
           .joins(:participant_identity)
           .includes(:user, profile: :schedule)
       end
+
+      def records_per_worker
+        (super / 2.0).ceil
+      end
     end
 
     def call

--- a/app/services/migration/migrators/application_state.rb
+++ b/app/services/migration/migrators/application_state.rb
@@ -19,6 +19,10 @@ module Migration::Migrators
           .includes(:cpd_lead_provider)
           .where(teacher_profile: { user_id: User.ecf_users.pluck(:id) })
       end
+
+      def records_per_worker
+        (super / 2.0).ceil
+      end
     end
 
     def call

--- a/app/services/migration/migrators/base.rb
+++ b/app/services/migration/migrators/base.rb
@@ -3,6 +3,8 @@ module Migration::Migrators
     include ActiveModel::Model
     include ActiveModel::Attributes
 
+    INFRA_WORKER_COUNT = 30
+
     attribute :worker
 
     class << self
@@ -48,7 +50,8 @@ module Migration::Migrators
       end
 
       def records_per_worker
-        5_000
+        # By default ensure all workers are exercised.
+        [1, (record_count / INFRA_WORKER_COUNT.to_f).ceil].max
       end
     end
 

--- a/app/services/migration/migrators/declaration.rb
+++ b/app/services/migration/migrators/declaration.rb
@@ -16,6 +16,10 @@ module Migration::Migrators
       def dependencies
         %i[cohort application lead_provider course user]
       end
+
+      def records_per_worker
+        (super / 2.0).ceil
+      end
     end
 
     def call

--- a/app/services/migration/migrators/participant_id_change.rb
+++ b/app/services/migration/migrators/participant_id_change.rb
@@ -18,10 +18,6 @@ module Migration::Migrators
           .joins(:user)
           .where(user: { id: User.ecf_users.pluck(:id) })
       end
-
-      def records_per_worker
-        1_000
-      end
     end
 
     def call

--- a/app/services/migration/migrators/statement_item.rb
+++ b/app/services/migration/migrators/statement_item.rb
@@ -18,6 +18,10 @@ module Migration::Migrators
       def dependencies
         %i[statement declaration]
       end
+
+      def records_per_worker
+        (super / 2.0).ceil
+      end
     end
 
     def call

--- a/app/services/migration/migrators/user.rb
+++ b/app/services/migration/migrators/user.rb
@@ -24,6 +24,10 @@ module Migration::Migrators
           .includes(:teacher_profile, :npq_profiles)
           .from("(#{users_with_npq_profiles.to_sql} UNION #{users_with_npq_applications.to_sql}) AS users")
       end
+
+      def records_per_worker
+        (super / 2.0).ceil
+      end
     end
 
     def call

--- a/spec/features/migration_spec.rb
+++ b/spec/features/migration_spec.rb
@@ -68,7 +68,7 @@ RSpec.feature "Migration", :in_memory_rails_cache, :rack_test_driver, type: :fea
 
         click_button "Run migration"
 
-        within ".data-migration-lead_provider" do
+        within first(".data-migration-lead_provider") do
           expect(page).to have_css(".govuk-task-list__name-and-hint", text: "Lead provider")
           expect(page).to have_css(".govuk-task-list__status", text: "Pending")
         end
@@ -108,7 +108,7 @@ RSpec.feature "Migration", :in_memory_rails_cache, :rack_test_driver, type: :fea
 
         click_button "Run migration"
 
-        within ".data-migration-cohort" do
+        within first(".data-migration-cohort") do
           expect(page).to have_css(".govuk-task-list__name-and-hint", text: "Cohort")
           expect(page).to have_css(".govuk-task-list__status", text: "Pending")
         end
@@ -154,7 +154,7 @@ RSpec.feature "Migration", :in_memory_rails_cache, :rack_test_driver, type: :fea
 
         click_button "Run migration"
 
-        within ".data-migration-statement" do
+        within first(".data-migration-statement") do
           expect(page).to have_css(".govuk-task-list__name-and-hint", text: "Statement")
           expect(page).to have_css(".govuk-task-list__status", text: "Pending")
         end
@@ -197,7 +197,7 @@ RSpec.feature "Migration", :in_memory_rails_cache, :rack_test_driver, type: :fea
 
         click_button "Run migration"
 
-        within ".data-migration-user" do
+        within first(".data-migration-user") do
           expect(page).to have_css(".govuk-task-list__name-and-hint", text: "User")
           expect(page).to have_css(".govuk-task-list__status", text: "Pending")
         end

--- a/spec/services/migration/migrators/application_spec.rb
+++ b/spec/services/migration/migrators/application_spec.rb
@@ -2,6 +2,8 @@ require "rails_helper"
 
 RSpec.describe Migration::Migrators::Application do
   it_behaves_like "a migrator", :application, %i[private_childcare_provider itt_provider cohort lead_provider schedule course user school] do
+    let(:records_per_worker_divider) { 2 }
+
     def create_ecf_resource
       create(:ecf_migration_npq_application, :accepted)
     end

--- a/spec/services/migration/migrators/application_state_spec.rb
+++ b/spec/services/migration/migrators/application_state_spec.rb
@@ -2,6 +2,8 @@ require "rails_helper"
 
 RSpec.describe Migration::Migrators::ApplicationState do
   it_behaves_like "a migrator", :application_state, %i[application lead_provider] do
+    let(:records_per_worker_divider) { 2 }
+
     def create_ecf_resource
       create(:ecf_migration_participant_profile_state)
     end

--- a/spec/services/migration/migrators/declaration_spec.rb
+++ b/spec/services/migration/migrators/declaration_spec.rb
@@ -2,6 +2,8 @@ require "rails_helper"
 
 RSpec.describe Migration::Migrators::Declaration do
   it_behaves_like "a migrator", :declaration, %i[cohort application lead_provider course user] do
+    let(:records_per_worker_divider) { 2 }
+
     def create_ecf_resource
       create(:ecf_migration_participant_declaration, :ineligible)
     end

--- a/spec/services/migration/migrators/statement_item_spec.rb
+++ b/spec/services/migration/migrators/statement_item_spec.rb
@@ -2,6 +2,8 @@ require "rails_helper"
 
 RSpec.describe Migration::Migrators::StatementItem do
   it_behaves_like "a migrator", :statement_item, %i[statement declaration] do
+    let(:records_per_worker_divider) { 2 }
+
     def create_ecf_resource
       create(:ecf_migration_statement_line_item)
     end

--- a/spec/services/migration/migrators/user_spec.rb
+++ b/spec/services/migration/migrators/user_spec.rb
@@ -2,6 +2,8 @@ require "rails_helper"
 
 RSpec.describe Migration::Migrators::User do
   it_behaves_like "a migrator", :user, [] do
+    let(:records_per_worker_divider) { 2 }
+
     def create_ecf_resource
       travel_to 10.days.ago do
         create(:ecf_migration_user, :npq)

--- a/terraform/application/config/migration.tfvars.json
+++ b/terraform/application/config/migration.tfvars.json
@@ -8,7 +8,7 @@
     "redis_cache_sku_name": "Basic",
     "enable_logit": true,
     "webapp_replicas": 3,
-    "worker_replicas": 20,
+    "worker_replicas": 30,
     "webapp_memory_max": "4Gi",
     "worker_memory_max": "2Gi",
     "postgres_flexible_server_sku": "GP_Standard_D2ds_v5"


### PR DESCRIPTION
[Jira-3511](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3511)

### Context

We want to utilise all available workers where possible by ensuring the records_per_worker split evenly across a multiple of the number of workers.

### Changes proposed in this pull request

- Optimise records_per_worker

Also increases to 30 workers for better throughput.

### Guidance to review

Main:

```
  [["application", "29 minutes and 25.89283599999999 seconds"],
 ["declaration", "4 minutes and 8.569072000000006 seconds"],
 ["statement_item", "2 minutes and 49.38589099999999 seconds"],
 ["user", "2 minutes and 21.038196 seconds"],
 ["contract", "1 minute and 59.136003 seconds"],
 ["application_state", "1 minute and 59.082032 seconds"],
 ["participant_outcome_api_request", "1 minute and 9.245193999999998 seconds"],
 ["participant_outcome", "1 minute and 0.7751540000000006 seconds"],
 ["participant_id_change", "35.009366 seconds"],
 ["school", "19.413319 seconds"],
 ["statement", "15.234018 seconds"],
 ["declaration_superseded_by", "8.076017 seconds"],
 ["private_childcare_provider", "6.151425 seconds"],
 ["itt_provider", "2.152112 seconds"],
 ["schedule", "1.187606 seconds"],
 ["course", "1.0787 seconds"],
 ["cohort", "1.055177 seconds"],
 ["lead_provider", "1.052633 seconds"]]
```

This branch: 
 
```
 [["application", "28 minutes and 36.58124500000008 seconds"],
 ["declaration", "3 minutes and 20.99262300000001 seconds"],
 ["user", "3 minutes and 1.441744 seconds"],
 ["statement_item", "2 minutes and 47.366584999999986 seconds"],
 ["application_state", "2 minutes and 17.27501000000001 seconds"],
 ["participant_id_change", "56.015721 seconds"],
 ["participant_outcome", "34.129365 seconds"],
 ["participant_outcome_api_request", "32.001896 seconds"],
 ["school", "13.180682 seconds"],
 ["contract", "12.058219 seconds"],
 ["private_childcare_provider", "5.90575 seconds"],
 ["declaration_superseded_by", "5.891588 seconds"],
 ["statement", "4.422493 seconds"],
 ["itt_provider", "4.343207 seconds"],
 ["schedule", "2.320284 seconds"],
 ["course", "1.262134 seconds"],
 ["lead_provider", "1.214325 seconds"],
 ["cohort", "1.206152 seconds"]]
```

| Main    | This Branch |
| -------- | ------- |
| <img width="1004" alt="main" src="https://github.com/user-attachments/assets/dcc8f90f-34bc-452b-9b53-253e4d339bd5">  | <img width="1007" alt="split-workers-better" src="https://github.com/user-attachments/assets/dec1534f-fb83-4abd-b253-5c3c2bcfb1cd">   |




