### PR TITLE
Optimise application lookup

### DIFF
--- a/app/services/migration/migrators/application.rb
+++ b/app/services/migration/migrators/application.rb
@@ -50,8 +50,12 @@ module Migration::Migrators
     def call
       run_once { report_applications_not_in_ecf_as_failures }
 
+      applications_by_ecf_id = ::Application.where(ecf_id: self.class.ecf_npq_applications.pluck(:id)).index_by(&:ecf_id)
+
       migrate(self.class.ecf_npq_applications) do |ecf_npq_application|
-        application = ::Application.find_by!(ecf_id: ecf_npq_application.id)
+        application = applications_by_ecf_id[ecf_npq_application.id]
+
+        raise ActiveRecord::RecordNotFound, "Couldn't find Application" unless application
 
         ensure_relationships_are_consistent!(ecf_npq_application, application)
 


### PR DESCRIPTION
[Jira-3511](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3511)

Preload the matching applications in NPQ reg instead of finding on each iteration.

### Guidance to review

Main:

```
  [["application", "29 minutes and 25.89283599999999 seconds"],
 ["declaration", "4 minutes and 8.569072000000006 seconds"],
 ["statement_item", "2 minutes and 49.38589099999999 seconds"],
 ["user", "2 minutes and 21.038196 seconds"],
 ["contract", "1 minute and 59.136003 seconds"],
 ["application_state", "1 minute and 59.082032 seconds"],
 ["participant_outcome_api_request", "1 minute and 9.245193999999998 seconds"],
 ["participant_outcome", "1 minute and 0.7751540000000006 seconds"],
 ["participant_id_change", "35.009366 seconds"],
 ["school", "19.413319 seconds"],
 ["statement", "15.234018 seconds"],
 ["declaration_superseded_by", "8.076017 seconds"],
 ["private_childcare_provider", "6.151425 seconds"],
 ["itt_provider", "2.152112 seconds"],
 ["schedule", "1.187606 seconds"],
 ["course", "1.0787 seconds"],
 ["cohort", "1.055177 seconds"],
 ["lead_provider", "1.052633 seconds"]]
```

This branch: 
 
```
[["application", "4 minutes and 43.65048899999999 seconds"],
 ["declaration", "3 minutes and 55.093413999999996 seconds"],
 ["statement_item", "2 minutes and 49.504136999999986 seconds"],
 ["user", "2 minutes and 41.597207 seconds"],
 ["contract", "2 minutes and 15.031901000000005 seconds"],
 ["application_state", "2 minutes and 3.9946800000000025 seconds"],
 ["participant_outcome_api_request", "1 minute and 2.3513480000000015 seconds"],
 ["participant_outcome", "57.576789 seconds"],
 ["participant_id_change", "33.931136 seconds"],
 ["school", "17.512235 seconds"],
 ["statement", "16.995607 seconds"],
 ["private_childcare_provider", "7.70383 seconds"],
 ["declaration_superseded_by", "7.249116 seconds"],
 ["itt_provider", "2.280035 seconds"],
 ["schedule", "1.333261 seconds"],
 ["course", "1.115042 seconds"],
 ["cohort", "1.114218 seconds"],
 ["lead_provider", "1.052123 seconds"]]
```

| Main    | This Branch |
| -------- | ------- |
| <img width="1004" alt="main" src="https://github.com/user-attachments/assets/dcc8f90f-34bc-452b-9b53-253e4d339bd5">  |  <img width="989" alt="optimise-application-lookup" src="https://github.com/user-attachments/assets/20c94807-a9b3-4bc5-9711-ba3a4525b2e6">  |