### PR TITLE
Run migration on a nightly schedule

### DIFF
--- a/.github/actions/refresh-migration-database/action.yml
+++ b/.github/actions/refresh-migration-database/action.yml
@@ -1,6 +1,11 @@
 name: Refresh migration DB
 description: Backup production DB and restore to migration DB
 
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *" # Run at midnight.
+
 inputs:
   environment:
     description: The name of the environment

--- a/.github/workflows/report-migration-results.yml
+++ b/.github/workflows/report-migration-results.yml
@@ -1,0 +1,59 @@
+name: "Report migration results"
+
+on:
+  schedule:
+    - cron: "0 8 * * *" # Run at 8am, daily
+
+jobs:
+  report_results:
+    name: "Report migration results"
+    env:
+      GOVUK_NOTIFY_API_KEY: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        name: Checkout Code
+
+      - name: Login
+        uses: azure/login@v1
+        with:
+          creds: ${{ inputs.azure-credentials }}
+
+      - name: Check for data migration failures
+        shell: bash
+        run: |
+          ANY_FAILURES=$(make ci migration aks-runner code="puts Migration::DataMigration.failed.any?")
+          echo "Failed data migrations? $FAILURES"
+
+          if [[ "$ANY_FAILURES" == "true" ]]; then
+            exit 1
+          fi
+
+      - name: Notify Slack channel of success
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_USERNAME: CI Deployment
+          SLACK_TITLE: Data migration success!
+          SLACK_MESSAGE: No failures were detected in the nightly data migration
+          SLACK_WEBHOOK: ${{ steps.key-vault-secrets.outputs.SLACK-WEBHOOK }}
+          SLACK_COLOR: success
+          SLACK_FOOTER: Sent from report-migration-results workflow
+
+      - name: Retrieve failure details
+        if: failure()
+        shell;: bash
+        run: |
+          FAILURES=$(make ci migration aks-runner code="puts Migration::DataMigration.failed.map { |m| \"#{m.name} - #{m.percentage_migrated_successfully}%\" }.join(\"\n\")")
+          echo "Failed data migrations:\n $FAILURES"
+
+      - name: Notify Slack channel of failures
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_USERNAME: CI Deployment
+          SLACK_TITLE: Data migration failure!
+          SLACK_MESSAGE: "$FAILURES"
+          SLACK_WEBHOOK: ${{ steps.key-vault-secrets.outputs.SLACK-WEBHOOK }}
+          SLACK_COLOR: failure
+          SLACK_FOOTER: Sent from report-migration-results workflow

--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,10 @@ aks-console: get-cluster-credentials
 	$(if $(PULL_REQUEST_NUMBER), $(eval export APP_ID=review-$(PULL_REQUEST_NUMBER)) , $(eval export APP_ID=$(CONFIG_LONG)))
 	kubectl -n ${NAMESPACE} exec -ti --tty deployment/npq-registration-${APP_ID}-web -- /bin/sh -c "cd /app && bundle exec rails c"
 
+aks-runner: get-cluster-credentials
+	$(if $(PULL_REQUEST_NUMBER), $(eval export APP_ID=review-$(PULL_REQUEST_NUMBER)) , $(eval export APP_ID=$(CONFIG_LONG)))
+	kubectl -n ${NAMESPACE} exec -ti --tty deployment/npq-registration-${APP_ID}-web -- /bin/sh -c "cd /app && bundle exec rails runner \"$(code)\""
+
 aks-ssh: get-cluster-credentials
 	$(if $(PULL_REQUEST_NUMBER), $(eval export APP_ID=review-$(PULL_REQUEST_NUMBER)) , $(eval export APP_ID=$(CONFIG_LONG)))
 	kubectl -n ${NAMESPACE} exec -ti --tty deployment/npq-registration-${APP_ID}-web -- /bin/sh

--- a/app/jobs/crons/migration_job.rb
+++ b/app/jobs/crons/migration_job.rb
@@ -1,0 +1,17 @@
+class Crons::MigrationJob < CronJob
+  queue_as :high_priority
+
+  include Sentry::Cron::MonitorCheckIns
+
+  # run at 12:30 AM every day
+  self.cron_expression = "30 0 * * *"
+
+  sentry_monitor_check_ins slug: "migration"
+
+  def perform
+    return unless Rails.application.config.npq_separation[:migration_enabled]
+
+    migrator = Migration::Coordinator.new
+    migrator.migrate!
+  end
+end

--- a/app/models/migration/data_migration.rb
+++ b/app/models/migration/data_migration.rb
@@ -12,6 +12,7 @@ module Migration
     scope :complete, -> { where.not(completed_at: nil) }
     scope :incomplete, -> { where(completed_at: nil) }
     scope :queued, -> { where.not(queued_at: nil) }
+    scope :failed, -> { where.not(failure_count: 0) }
 
     def percentage_migrated_successfully
       return 0 unless processed_count&.positive?

--- a/config/environments/review.rb
+++ b/config/environments/review.rb
@@ -7,7 +7,7 @@ Rails.application.configure do
   config.npq_separation = {
     admin_portal_enabled: true,
     api_enabled: true,
-    migration_enabled: true,
+    migration_enabled: false,
     ecf_api_disabled: false,
   }
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -8,7 +8,7 @@ Rails.application.configure do
   config.npq_separation = {
     admin_portal_enabled: true,
     api_enabled: true,
-    migration_enabled: true,
+    migration_enabled: false,
     ecf_api_disabled: false,
   }
 end

--- a/spec/jobs/crons/migration_job_spec.rb
+++ b/spec/jobs/crons/migration_job_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe Crons::MigrationJob do
+  let(:instance) { described_class.new }
+
+  before { allow(Rails.application.config).to receive(:npq_separation) { { migration_enabled: } } }
+
+  it { expect(described_class.cron_expression).to eq("30 0 * * *") }
+
+  describe "#perform" do
+    subject(:perform_migration) { instance.perform }
+
+    let(:migration_enabled) { true }
+    let(:coordinator_double) { instance_double(Migration::Coordinator, migrate!: nil) }
+
+    before { allow(Migration::Coordinator).to receive(:new).and_return(coordinator_double) }
+
+    it "triggers a migration" do
+      perform_migration
+      expect(coordinator_double).to have_received(:migrate!).once
+    end
+
+    context "when the migration is disabled" do
+      let(:migration_enabled) { false }
+
+      it "does not trigger a migration" do
+        perform_migration
+        expect(coordinator_double).not_to have_received(:migrate!)
+      end
+    end
+  end
+end

--- a/spec/models/migration/data_migration_spec.rb
+++ b/spec/models/migration/data_migration_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe Migration::DataMigration, :in_memory_rails_cache, type: :model do
       travel_to(1.day.ago) { create(:data_migration) }
       travel_to(3.days.ago) { create(:data_migration, :completed) }
       travel_to(5.days.ago) { create(:data_migration, :queued) }
+      travel_to(7.days.ago) { create(:data_migration, :with_failures) }
       create(:data_migration)
     end
 
@@ -44,6 +45,10 @@ RSpec.describe Migration::DataMigration, :in_memory_rails_cache, type: :model do
 
     describe ".queued" do
       it { expect(described_class.queued).to eq(described_class.where.not(queued_at: nil)) }
+    end
+
+    describe ".failed" do
+      it { expect(described_class.failed).to eq(described_class.where.not(failure_count: 0)) }
     end
   end
 


### PR DESCRIPTION
[Jira-3512](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-3512)

### Context

We want to refresh the migration DB every night so that we can run the migration on a schedule.

### Changes proposed in this pull request

- Refresh migration DB nightly

Refresh migration DB at midnight.

- Run migration nightly

We want to run the data migration on a nightly basis to monitor how it
performs/the results.

Run migration at 12:30am every morning; this is 30 minutes after the migration DBs are refreshed.
