### PR TITLE
Fix failing specs due to declaration date

### DIFF
--- a/spec/factories/migration/ecf/participant_declarations.rb
+++ b/spec/factories/migration/ecf/participant_declarations.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :ecf_migration_participant_declaration, class: "Migration::Ecf::ParticipantDeclaration" do
-    declaration_date { 1.day.ago }
+    declaration_date { 1.hour.ago }
     state { Declaration.states.keys.sample }
     declaration_type { Declaration.declaration_types.keys.sample }
     type { "ParticipantDeclaration::NPQ" }

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Declaration, type: :model do
       end
 
       it "has an error on update" do
-        subject.declaration_date = 1.day.ago
+        subject.declaration_date = Time.zone.now
         expect(subject.save).to be_truthy
 
         subject.declaration_date = 1.day.from_now
@@ -353,7 +353,7 @@ RSpec.describe Declaration, type: :model do
       let(:course_identifier) { completed_declaration.course_identifier }
       let(:completed_declaration) { create(:declaration, :completed, :payable) }
       let(:course) { completed_declaration.course }
-      let(:older_completed_declaration) { travel_to(1.day.ago) { create(:declaration, :completed, :payable, course:, lead_provider:) } }
+      let(:older_completed_declaration) { travel_to(1.hour.ago) { create(:declaration, :completed, :payable, course:, lead_provider:) } }
 
       before do
         # Not a completed declaration.

--- a/spec/models/participant_outcome_spec.rb
+++ b/spec/models/participant_outcome_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ParticipantOutcome, type: :model do
 
     let!(:latest_outcome) { create(:participant_outcome) }
 
-    before { travel_to(1.day.ago) { create(:participant_outcome) } }
+    before { travel_to(1.hour.ago) { create(:participant_outcome) } }
 
     it { is_expected.to eq(latest_outcome) }
   end

--- a/spec/services/declarations/create_spec.rb
+++ b/spec/services/declarations/create_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Declarations::Create, type: :model do
   let(:participant) { application.user }
   let(:participant_id) { participant.ecf_id }
   let(:declaration_type) { "started" }
-  let(:declaration_date) { schedule.applies_from + 1.day }
+  let(:declaration_date) { schedule.applies_from + 1.hour }
   let(:course_identifier) { course.identifier }
   let(:has_passed) { true }
   let(:params) do
@@ -87,7 +87,7 @@ RSpec.describe Declarations::Create, type: :model do
     end
 
     context "when the declaration_date is in the past" do
-      before { params[:declaration_date] = 1.day.ago.rfc3339 }
+      before { params[:declaration_date] = 1.hour.ago.rfc3339 }
 
       it { is_expected.to be_valid }
     end


### PR DESCRIPTION
A number of tests setup the `declaration_date` to be `1.day.ago`; this is usually fine as the `applies_from` of the schedule is the start of the month; but when we're on the first day of the next month it causes the date to be too early/before the `applies_from`.

As a workaround we can go back `1.hour` instead of `1.day`, so the date is on the 1st of the month and not the previous month.

This gets the tests passing; we may want to find a better solution as they would still fail when ran between 12-1am on the 1st of a month.

