### PR TITLE
[CPDLP-3509] Ensure ECF ID generation on all new records in NPQ

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -36,22 +36,13 @@ class Application < ApplicationRecord
 
   validate :schedule_cohort_matches
   # TODO: add constraints into the DB after separation
-  validates :ecf_id,
-            presence: { message: "Enter an ECF ID" },
-            uniqueness: {
-              case_sensitive: false,
-              message: "ECF ID must be unique",
-            }, if: -> { Feature.ecf_api_disabled? }
+  validates :ecf_id, presence: true, if: -> { Feature.ecf_api_disabled? }
 
   after_commit :touch_user_if_changed
 
   # TODO: remove this and add default: "gen_random_uuid()" in the DB after separation
-  before_validation(on: :create) do
-    self.ecf_id = if Feature.ecf_api_disabled? & !ecf_id
-                    SecureRandom.uuid
-                  else
-                    ecf_id
-                  end
+  before_validation do
+    self.ecf_id ||= SecureRandom.uuid if Feature.ecf_api_disabled? && ecf_id.blank?
   end
 
   enum kind_of_nursery: {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,20 +20,11 @@ class User < ApplicationRecord
   validates :uid, uniqueness: { allow_blank: true }
   validates :uid, inclusion: { in: ->(user) { [user.uid_was] } }, on: :npq_separation, if: -> { uid_was.present? }
   # TODO: add constraints into the DB after separation
-  validates :ecf_id,
-            presence: { message: "Enter an ECF ID" },
-            uniqueness: {
-              case_sensitive: false,
-              message: "ECF ID must be unique",
-            }, if: -> { Feature.ecf_api_disabled? }
+  validates :ecf_id, presence: true, if: -> { Feature.ecf_api_disabled? }
 
   # TODO: remove this and add default: "gen_random_uuid()" in the DB after separation
-  before_validation(on: :create) do
-    self.ecf_id = if Feature.ecf_api_disabled? & !ecf_id
-                    SecureRandom.uuid
-                  else
-                    ecf_id
-                  end
+  before_validation do
+    self.ecf_id ||= SecureRandom.uuid if Feature.ecf_api_disabled? && ecf_id.blank?
   end
 
   scope :admins, -> { where(admin: true) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,22 @@ class User < ApplicationRecord
 
   validates :uid, uniqueness: { allow_blank: true }
   validates :uid, inclusion: { in: ->(user) { [user.uid_was] } }, on: :npq_separation, if: -> { uid_was.present? }
+  # TODO: add constraints into the DB after separation
+  validates :ecf_id,
+            presence: { message: "Enter an ECF ID" },
+            uniqueness: {
+              case_sensitive: false,
+              message: "ECF ID must be unique",
+            }, if: -> { Feature.ecf_api_disabled? }
+
+  # TODO: remove this and add default: "gen_random_uuid()" in the DB after separation
+  before_validation(on: :create) do
+    self.ecf_id = if Feature.ecf_api_disabled? & !ecf_id
+                    SecureRandom.uuid
+                  else
+                    ecf_id
+                  end
+  end
 
   scope :admins, -> { where(admin: true) }
   scope :unsynced, -> { where(ecf_id: nil) }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -112,6 +112,8 @@ en:
               <<: *schedule
             funded_place:
               <<: *funded_place
+            ecf_id:
+              blank: "Enter an ECF ID"
         declaration:
           attributes:
             declaration_date:
@@ -145,7 +147,10 @@ en:
           attributes:
             course_id:
               taken: "Can only have one contract for statement and course"
-
+        user:
+          attributes:
+            ecf_id:
+              blank: "Enter an ECF ID"
   activemodel:
     attributes:
       questionnaires/funding_your_npq:
@@ -575,7 +580,7 @@ en:
     not_eligible_for_funding: "If your provider does not confirm you've started the course before %{date}, your registration will expire. You can register again later."
 
   helpers:
-    warnings: 
+    warnings:
       registration_wizard:
         check_provider_is_open: "Before selecting your provider, you must check that they are currently open to accepting NPQ applications."
     title:

--- a/db/migrate/20230720141121_update_approved_itt_provider.rb
+++ b/db/migrate/20230720141121_update_approved_itt_provider.rb
@@ -1,6 +1,6 @@
 class UpdateApprovedIttProvider < ActiveRecord::Migration[6.1]
   def change
-    itt_provider = IttProvider.find_by(legal_name: "St Michael’s Church of England Primary School")
+    itt_provider = IttProvider.unscoped.find_by(legal_name: "St Michael’s Church of England Primary School")
     itt_provider.update!(legal_name: "Christ Church Primary School Hampstead") if itt_provider.present?
   end
 end

--- a/db/migrate/20241001144636_remove_default_from_ecf_id_in_contract_templates.rb
+++ b/db/migrate/20241001144636_remove_default_from_ecf_id_in_contract_templates.rb
@@ -1,0 +1,8 @@
+class RemoveDefaultFromEcfIdInContractTemplates < ActiveRecord::Migration[7.1]
+  def change
+    change_column_default :contract_templates, :ecf_id, from: "gen_random_uuid()", to: nil
+    change_column_null :contract_templates, :ecf_id, true
+    remove_index :contract_templates, :ecf_id, unique: true
+    add_index :contract_templates, :ecf_id
+  end
+end

--- a/db/migrate/20241001200634_add_index_to_applications.rb
+++ b/db/migrate/20241001200634_add_index_to_applications.rb
@@ -1,0 +1,5 @@
+class AddIndexToApplications < ActiveRecord::Migration[7.1]
+  def change
+    add_index :applications, :ecf_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_18_145749) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_01_200634) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -114,6 +114,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_18_145749) do
     t.datetime "accepted_at"
     t.index ["cohort_id"], name: "index_applications_on_cohort_id"
     t.index ["course_id"], name: "index_applications_on_course_id"
+    t.index ["ecf_id"], name: "index_applications_on_ecf_id"
     t.index ["itt_provider_id"], name: "index_applications_on_itt_provider_id"
     t.index ["lead_provider_id"], name: "index_applications_on_lead_provider_id"
     t.index ["private_childcare_provider_id"], name: "index_applications_on_private_childcare_provider_id"
@@ -149,10 +150,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_18_145749) do
     t.decimal "monthly_service_fee", default: "0.0"
     t.decimal "targeted_delivery_funding_per_participant", default: "100.0"
     t.boolean "special_course", default: false, null: false
-    t.uuid "ecf_id", default: -> { "gen_random_uuid()" }, null: false
+    t.uuid "ecf_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["ecf_id"], name: "index_contract_templates_on_ecf_id", unique: true
+    t.index ["ecf_id"], name: "index_contract_templates_on_ecf_id"
   end
 
   create_table "contracts", force: :cascade do |t|

--- a/spec/lib/services/handle_submission_for_store_spec.rb
+++ b/spec/lib/services/handle_submission_for_store_spec.rb
@@ -393,7 +393,7 @@ RSpec.describe HandleSubmissionForStore do
         expect(stable_as_json(user.applications.last)).to match({
           "course_id" => course.id,
           "schedule_id" => nil,
-          "ecf_id" => nil,
+          "ecf_id" => user.applications.last.ecf_id,
           "eligible_for_funding" => true,
           "employer_name" => nil,
           "employment_type" => nil,
@@ -460,7 +460,7 @@ RSpec.describe HandleSubmissionForStore do
           expect(stable_as_json(user.applications.last)).to match({
             "course_id" => course.id,
             "schedule_id" => nil,
-            "ecf_id" => nil,
+            "ecf_id" => user.applications.last.ecf_id,
             "eligible_for_funding" => false,
             "employer_name" => nil,
             "employment_type" => nil,
@@ -528,7 +528,7 @@ RSpec.describe HandleSubmissionForStore do
           expect(stable_as_json(user.applications.last)).to match({
             "course_id" => course.id,
             "schedule_id" => nil,
-            "ecf_id" => nil,
+            "ecf_id" => user.applications.last.ecf_id,
             "eligible_for_funding" => false,
             "employer_name" => nil,
             "employment_type" => nil,
@@ -606,7 +606,7 @@ RSpec.describe HandleSubmissionForStore do
           expect(stable_as_json(user.applications.last)).to match({
             "course_id" => course.id,
             "schedule_id" => nil,
-            "ecf_id" => nil,
+            "ecf_id" => user.applications.last.ecf_id,
             "eligible_for_funding" => false,
             "employer_name" => nil,
             "employment_type" => nil,

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Application do
+  subject { create(:application) }
+
   describe "relationships" do
     it { is_expected.to belong_to(:user) }
     it { is_expected.to belong_to(:course) }
@@ -58,6 +60,26 @@ RSpec.describe Application do
           expect(subject).to have_error(:schedule, :invalid_for_course, "Selected schedule is not valid for the course", :npq_separation)
         end
       end
+    end
+
+    context "when ecf_api_disabled flag is toggled on" do
+      before { Flipper.enable(Feature::ECF_API_DISABLED) }
+
+      it { is_expected.to validate_presence_of(:ecf_id).with_message("Enter an ECF ID") }
+      it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique") }
+
+      it "ensures ecf_id is populated" do
+        application = build(:application, ecf_id: nil)
+        application.valid?
+        expect(application.ecf_id).not_to be_nil
+      end
+    end
+
+    context "when ecf_api_disabled flag is toggled off" do
+      before { Flipper.disable(Feature::ECF_API_DISABLED) }
+
+      it { is_expected.not_to validate_presence_of(:ecf_id) }
+      it { is_expected.not_to validate_uniqueness_of(:ecf_id) }
     end
   end
 

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -65,13 +65,20 @@ RSpec.describe Application do
     context "when ecf_api_disabled flag is toggled on" do
       before { Flipper.enable(Feature::ECF_API_DISABLED) }
 
-      it { is_expected.to validate_presence_of(:ecf_id).with_message("Enter an ECF ID") }
-      it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique") }
+      # TODO: uncomment this when `before_validation` is removed from model, as `before_validation` is adding ecf_id regardless
+      # it { is_expected.to validate_presence_of(:ecf_id).with_message("Enter an ECF ID") }
 
-      it "ensures ecf_id is populated" do
+      it "ensures ecf_id is automatically populated" do
         application = build(:application, ecf_id: nil)
         application.valid?
         expect(application.ecf_id).not_to be_nil
+      end
+
+      it "ensures ecf_id does not change on validation" do
+        ecf_id = SecureRandom.uuid
+        application = build(:application, ecf_id:)
+        application.valid?
+        expect(application.ecf_id).to eq(ecf_id)
       end
     end
 
@@ -79,7 +86,12 @@ RSpec.describe Application do
       before { Flipper.disable(Feature::ECF_API_DISABLED) }
 
       it { is_expected.not_to validate_presence_of(:ecf_id) }
-      it { is_expected.not_to validate_uniqueness_of(:ecf_id) }
+
+      it "ensures ecf_id is not automatically populated" do
+        application = build(:application, ecf_id: nil)
+        application.valid?
+        expect(application.ecf_id).to be_nil
+      end
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -28,13 +28,20 @@ RSpec.describe User do
     context "when ecf_api_disabled flag is toggled on" do
       before { Flipper.enable(Feature::ECF_API_DISABLED) }
 
-      it { is_expected.to validate_presence_of(:ecf_id).with_message("Enter an ECF ID") }
-      it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique") }
+      # TODO: uncomment this when `before_validation` is removed from model, as `before_validation` is adding ecf_id regardless
+      # it { is_expected.to validate_presence_of(:ecf_id).with_message("Enter an ECF ID") }
 
-      it "ensures ecf_id is populated" do
+      it "ensures ecf_id is automatically populated" do
         user = build(:user, ecf_id: nil)
         user.valid?
         expect(user.ecf_id).not_to be_nil
+      end
+
+      it "ensures ecf_id does not change on validation" do
+        ecf_id = SecureRandom.uuid
+        application = build(:application, ecf_id:)
+        application.valid?
+        expect(application.ecf_id).to eq(ecf_id)
       end
     end
 
@@ -42,7 +49,12 @@ RSpec.describe User do
       before { Flipper.disable(Feature::ECF_API_DISABLED) }
 
       it { is_expected.not_to validate_presence_of(:ecf_id) }
-      it { is_expected.not_to validate_uniqueness_of(:ecf_id) }
+
+      it "ensures ecf_id is not automatically populated" do
+        application = build(:application, ecf_id: nil)
+        application.valid?
+        expect(application.ecf_id).to be_nil
+      end
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe User do
+  subject { create(:user) }
+
   describe "relationships" do
     it { is_expected.to have_many(:applications).dependent(:destroy) }
     it { is_expected.to have_many(:ecf_sync_request_logs).dependent(:destroy) }
@@ -10,11 +12,9 @@ RSpec.describe User do
 
   describe "validations" do
     it { is_expected.to validate_presence_of(:full_name).with_message("Enter a full name") }
-
     it { is_expected.to validate_presence_of(:email).on(:npq_separation).with_message("Enter an email address") }
     it { is_expected.to validate_uniqueness_of(:email).on(:npq_separation).case_insensitive.with_message("Email address must be unique") }
     it { is_expected.not_to allow_value("invalid-email").for(:email).on(:npq_separation) }
-
     it { is_expected.to validate_uniqueness_of(:uid).allow_blank }
 
     it "does not allow a uid to change once set" do
@@ -23,6 +23,26 @@ RSpec.describe User do
 
       expect(user).to be_invalid(:npq_separation)
       expect(user.errors[:uid]).to be_present
+    end
+
+    context "when ecf_api_disabled flag is toggled on" do
+      before { Flipper.enable(Feature::ECF_API_DISABLED) }
+
+      it { is_expected.to validate_presence_of(:ecf_id).with_message("Enter an ECF ID") }
+      it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique") }
+
+      it "ensures ecf_id is populated" do
+        user = build(:user, ecf_id: nil)
+        user.valid?
+        expect(user.ecf_id).not_to be_nil
+      end
+    end
+
+    context "when ecf_api_disabled flag is toggled off" do
+      before { Flipper.disable(Feature::ECF_API_DISABLED) }
+
+      it { is_expected.not_to validate_presence_of(:ecf_id) }
+      it { is_expected.not_to validate_uniqueness_of(:ecf_id) }
     end
   end
 


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-3509

We would like to ensure that after separation, any new records created for the API in the db have a UUID which will be surfaced correctly.

### Changes proposed in this pull request

- Ensure ecf id is populated for new applications and users after separation
- Ensure ecf id is required for applications and users after separation
- Fix migrations (db recreation was failing due a default scope added to IttProvider
- Remove default from contract templates db table
- Add missing index to application