### PR TITLE
Add pan/zoom functionality to Mermaid diagrams

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -10,6 +10,7 @@ import countryPicker from "./country-picker";
 import ittProviderPicker from "./itt-provider-picker.js";
 import cookieBanner from "./cookie-banner";
 import mermaid from 'mermaid';
+import svgPanZoom from 'svg-pan-zoom';
 
 Rails.start();
 import * as GOVUKFrontend from 'govuk-frontend'
@@ -47,7 +48,7 @@ if (document.querySelector('#private-childcare-provider-picker')) {
 }
 
 mermaid.initialize({
-  startOnLoad: true,
+  startOnLoad: false,
   theme: "base",
   fontSize: "19px",
   themeVariables: {
@@ -59,5 +60,22 @@ mermaid.initialize({
     noteBorderColor: "#B1B4B6",
     textColor: "#000000",
     fontFamily: '"GDS Transport", arial, sans-serif',
+  },
+});
+
+mermaid.run({
+  querySelector: ".mermaid",
+  postRenderCallback: (id) => {
+    const svg = document.querySelector(`#${id}`)
+    const svgHeight = svg.parentElement.offsetHeight
+    svg.style.height = svgHeight
+    svgPanZoom(svg, { 
+      controlIconsEnabled: true,
+      customEventsHandler: { init: () => {
+        // Position controls in the bottom left.
+        const controls = svg.querySelector("#svg-pan-zoom-controls")
+        controls.setAttribute("transform", `translate(0, ${svgHeight - 75}) scale(0.75, 0.75)`)
+      }, destroy: () => {}},
+    })
   }
 });

--- a/app/views/api/guidance/test.md
+++ b/app/views/api/guidance/test.md
@@ -1,0 +1,35 @@
+# Test Page
+
+A test page to demonstrate a Mermaid process diagram:
+
+<div class="mermaid">
+sequenceDiagram
+    participant teacher as Participant
+    participant provider as Provider
+    participant assessor as Assessor
+    participant dfe as DfE
+    participant tra as TRA
+
+    Note over teacher,tra: Assessment completion and submission
+    Note over teacher: #nbsp;Do course assessment#nbsp;
+    teacher->>+provider: Submit assessment to provider
+    Note over provider: #nbsp;Receive assessment#nbsp;
+    provider->>+assessor: Send assessment to Tribal (third-party assessor)
+    Note over teacher,tra: Assessment review
+    Note over assessor: #nbsp;Review assessment#nbsp;
+    assessor->>+provider: Send assessment result to provider
+    Note over provider: #nbsp;Receive outcome from assessor#nbsp;
+    Note over teacher,tra: Processing outcomes
+    Note over provider: #nbsp;Inform delivery partners of outcome#nbsp;
+    provider->>+dfe: Send completion declaration (pass/fail) to DfE via API
+    Note over dfe: #nbsp;Check completion declaration#nbsp;
+    Note over dfe: #nbsp;Update participant record#nbsp;
+    dfe->>+tra: Send passed outcomes to the Teaching Regulation Agency (TRA)
+    Note over tra: #nbsp;Process certificate#nbsp;
+    tra->>+dfe: Send course outcome to participant with link for them to get their certificate
+    Note over dfe: #nbsp;Add outcome to participant assessor#nbsp;
+    dfe->>+teacher: Get NPQ certificate
+    Note over teacher: #nbsp;NPQ course complete#nbsp;
+</div>
+
+Some more text around it

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "rails-ujs": "^5.2.8",
     "sass": "^1.79.3",
     "serialize-javascript": "^6.0.2",
+    "svg-pan-zoom": "^3.6.1",
     "swagger-ui-dist": "^5.17.14",
     "webpack": "^5.95.0",
     "webpack-cli": "^5.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2871,6 +2871,11 @@ supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz"
 
+svg-pan-zoom@^3.6.1:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/svg-pan-zoom/-/svg-pan-zoom-3.6.1.tgz#f880a1bb32d18e9c625d7715350bebc269b450cf"
+  integrity sha512-JaKkGHHfGvRrcMPdJWkssLBeWqM+Isg/a09H7kgNNajT1cX5AztDTNs+C8UzpCxjCTRrG34WbquwaovZbmSk9g==
+
 swagger-ui-dist@^5.17.14:
   version "5.17.14"
   resolved "https://registry.yarnpkg.com/swagger-ui-dist/-/swagger-ui-dist-5.17.14.tgz#e2c222e5bf9e15ccf80ec4bc08b4aaac09792fd6"


### PR DESCRIPTION
### Context

The Mermaid diagrams are quite small and hard to read due to them being shrunk to fit the width of the page. We would like to be able to pan and zoom in the diagrams to make them easier to view.

### Changes proposed in this pull request

- Add pan/zoom functionality to the Mermaid diagrams

Use the `svg-pan-zoom` node module to add pan/zoom controls to the Mermaid diagrams. We are using the default controls for now, but we could customise them if we wanted to in the future.

### Guidance for review

There is a [test page](https://npq-registration-review-1762-web.test.teacherservices.cloud/api/guidance/test) in the review app; I'll remove it prior to merging.

| Default | Zoomed in |
| -- | -- |
 | <img width="752" alt="Screenshot 2024-10-02 at 11 00 25" src="https://github.com/user-attachments/assets/0849eecf-9e93-4a6f-88c7-86d821e99fed"> | <img width="791" alt="Screenshot 2024-10-02 at 11 00 42" src="https://github.com/user-attachments/assets/ec264a62-6a2a-4485-935b-5c739f599bf4"> |

