### PR TITLE
Fix failing schedule migrator test

### DIFF
--- a/spec/services/migration/migrators/schedule_spec.rb
+++ b/spec/services/migration/migrators/schedule_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe Migration::Migrators::Schedule do
       create(:cohort, ecf_id: ecf_resource.cohort_id, start_year: ecf_resource.cohort.start_year)
       create(:course_group, name: :support)
 
-      create(:schedule, ecf_id: ecf_resource.id)
+      # Use relative dates to avoid flakey spec when the two schedule factory dates align.
+      create(:schedule, ecf_id: ecf_resource.id, applies_from: 2.months.ago, applies_to: 1.month.ago)
     end
 
     def setup_failure_state


### PR DESCRIPTION
The NPQ/ECF schedules factory dates happen to align today so that the test that checks the applies_from/to changes on migrating schedules is failing. Udpate to use relative dates so they will always be different/get updated during the test migration.
