### PR TITLE
Add workflow_dispatch to migration report action

### DIFF
--- a/.github/workflows/report-migration-results.yml
+++ b/.github/workflows/report-migration-results.yml
@@ -1,6 +1,15 @@
 name: "Report migration results"
 
 on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: GitHub environment to report from
+        type: choice
+        default: migration
+        options:
+          - migration
+        required: true
   schedule:
     - cron: "0 8 * * *" # Run at 8am, daily
 


### PR DESCRIPTION
Enable manual testing of the action; needs to be in `main` before we can run it manually.