### PR TITLE
[CPDLP-3607] Add logic to recalculate `participant_outcome_state` after separation

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -188,6 +188,12 @@ class Application < ApplicationRecord
     eligible_for_dfe_funding?(with_funded_place: true)
   end
 
+  def participant_outcome_state
+    return read_attribute(:participant_outcome_state) unless Feature.ecf_api_disabled?
+
+    declarations.completed.billable_or_voidable.latest_first.first&.participant_outcomes&.latest&.state
+  end
+
 private
 
   def funding_eligibility(with_funded_place:)

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -188,8 +188,8 @@ class Application < ApplicationRecord
     eligible_for_dfe_funding?(with_funded_place: true)
   end
 
-  def participant_outcome_state
-    return read_attribute(:participant_outcome_state) unless Feature.ecf_api_disabled?
+  def latest_participant_outcome_state
+    return participant_outcome_state unless Feature.ecf_api_disabled?
 
     declarations.completed.billable_or_voidable.latest_first.first&.participant_outcomes&.latest&.state
   end

--- a/app/views/accounts/_active_application_table.html.erb
+++ b/app/views/accounts/_active_application_table.html.erb
@@ -37,16 +37,16 @@
         </dd>
       </div>
 
-      <% if application.participant_outcome_state.present? && accepted?(application) %>
+      <% if application.latest_participant_outcome_state.present? && accepted?(application) %>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
             Course outcome
           </dt>
           <dd class="govuk-summary-list__value">
-              <% if application.participant_outcome_state.capitalize == "Passed" %>
+              <% if application.latest_participant_outcome_state.capitalize == "Passed" %>
                 <%= govuk_tag(text: "Passed", colour: "green") %>
                 <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= t("course.outcome.passed_html")  %></p>
-              <% elsif application.participant_outcome_state.capitalize == "Failed" %>
+              <% elsif application.latest_participant_outcome_state.capitalize == "Failed" %>
                 <%= govuk_tag(text: "Not passed", colour: "red") %>
                 <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= t("course.outcome.failed")  %></p>
               <% end %>

--- a/app/views/accounts/_course_details.html.erb
+++ b/app/views/accounts/_course_details.html.erb
@@ -82,16 +82,16 @@
         </div>
       <% end %>
 
-      <% if application.participant_outcome_state.present? && accepted?(application) %>
+      <% if application.latest_participant_outcome_state.present? && accepted?(application) %>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
             Course outcome
           </dt>
           <dd class="govuk-summary-list__value">
-              <% if application.participant_outcome_state.capitalize == "Passed" %>
+              <% if application.latest_participant_outcome_state.capitalize == "Passed" %>
                 <%= govuk_tag(text: "Passed", colour: "green") %>
                 <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= t("course.outcome.passed_html")  %></p>
-              <% elsif application.participant_outcome_state.capitalize == "Failed" %>
+              <% elsif application.latest_participant_outcome_state.capitalize == "Failed" %>
                 <%= govuk_tag(text: "Not passed", colour: "red") %>
                 <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= t("course.outcome.failed")  %></p>
               <% end %>

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -494,4 +494,32 @@ RSpec.describe Application do
       end
     end
   end
+
+  describe "#participant_outcome_state" do
+    subject { application.participant_outcome_state }
+
+    let(:application) { create(:application, :accepted, participant_outcome_state: "anything") }
+    let(:declaration) { create(:declaration, :completed, application:) }
+
+    before do
+      create(:participant_outcome, :failed, declaration:, created_at: 1.week.ago)
+      create(:participant_outcome, declaration:)
+    end
+
+    context "when ecf_api_disabled flag is toggled off" do
+      before { Flipper.disable(Feature::ECF_API_DISABLED) }
+
+      it "returns the attribute value" do
+        expect(subject).to eq("anything")
+      end
+    end
+
+    context "when ecf_api_disabled flag is toggled on" do
+      before { Flipper.enable(Feature::ECF_API_DISABLED) }
+
+      it "returns the state from latest outcome" do
+        expect(subject).to eq("passed")
+      end
+    end
+  end
 end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -495,16 +495,12 @@ RSpec.describe Application do
     end
   end
 
-  describe "#participant_outcome_state" do
-    subject { application.participant_outcome_state }
+  describe "#latest_participant_outcome_state" do
+    subject { application.latest_participant_outcome_state }
 
     let(:application) { create(:application, :accepted, participant_outcome_state: "anything") }
     let(:declaration) { create(:declaration, :completed, application:) }
-
-    before do
-      create(:participant_outcome, :failed, declaration:, created_at: 1.week.ago)
-      create(:participant_outcome, declaration:)
-    end
+    let!(:participant_outcome) { create(:participant_outcome, declaration:) }
 
     context "when ecf_api_disabled flag is toggled off" do
       before { Flipper.disable(Feature::ECF_API_DISABLED) }
@@ -519,6 +515,33 @@ RSpec.describe Application do
 
       it "returns the state from latest outcome" do
         expect(subject).to eq("passed")
+      end
+
+      context "when no completed declaration exists" do
+        before { declaration.update!(application: create(:application)) }
+
+        it "returns nil" do
+          expect(subject).to be_nil
+        end
+      end
+
+      context "when other type of declaration exists" do
+        before { declaration.update!(declaration_type: "retained-1") }
+
+        it "returns nil" do
+          expect(subject).to be_nil
+        end
+      end
+
+      context "when completed declaration is voided" do
+        before do
+          declaration.update!(state: "voided")
+          participant_outcome.update!(state: "voided")
+        end
+
+        it "returns nil" do
+          expect(subject).to be_nil
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-3607

NPQ currently through an internal API to ECF gets outcomes for users to surface on the accounts pages. We would like to retain the same logic when internal APIs are turned off

### Changes proposed in this pull request

- Currently `participant_outcome_state` is being updated via a scheduled job which will be disabled after separation.
- We have two services that creates outcomes, so do an application `participant_outcome_state` needs to be updated:
  - When a new declaration is created and then an outcome is created.
  - When a declaration is voided.