### PR TITLE
[CPDLP-3608] Fix bug with duplicate records in NPQ

### DIFF
--- a/app/services/declarations/query.rb
+++ b/app/services/declarations/query.rb
@@ -57,6 +57,7 @@ module Declarations
 
     def all_declarations
       Declaration
+        .distinct
         .includes(
           :cohort,
           :lead_provider,

--- a/app/services/participant_outcomes/query.rb
+++ b/app/services/participant_outcomes/query.rb
@@ -38,7 +38,7 @@ module ParticipantOutcomes
     end
 
     def all_participant_outcomes
-      ParticipantOutcome.includes(
+      ParticipantOutcome.distinct.includes(
         declaration: {
           lead_provider: {},
           application: %i[course user],

--- a/app/services/participants/query.rb
+++ b/app/services/participants/query.rb
@@ -60,11 +60,12 @@ module Participants
     end
 
     def order_by
-      sort_order(sort:, model: User, default: { accepted_at: :asc })
+      sort_order(sort:, model: User, default: { created_at: :asc })
     end
 
     def all_participants
       User
+        .distinct
         .joins(:applications).merge(Application.accepted)
         .includes(
           :participant_id_changes,

--- a/app/services/statements/query.rb
+++ b/app/services/statements/query.rb
@@ -6,7 +6,7 @@ module Statements
     attr_reader :scope
 
     def initialize(lead_provider: :ignore, cohort_start_years: :ignore, updated_since: :ignore, state: :ignore, output_fee: true)
-      @scope = Statement.includes(:cohort)
+      @scope = Statement.distinct.includes(:cohort)
 
       where_lead_provider_is(lead_provider)
       where_cohort_start_year_in(cohort_start_years)

--- a/spec/services/declarations/query_spec.rb
+++ b/spec/services/declarations/query_spec.rb
@@ -19,6 +19,23 @@ RSpec.describe Declarations::Query do
       expect(query.declarations).to eq([declaration2, declaration3, declaration1])
     end
 
+    context "when declaration has multiple associated records" do
+      let!(:declaration1) { create(:declaration) }
+      let!(:declaration2) { create(:declaration) }
+
+      before do
+        create(:participant_outcome, declaration: declaration1)
+        create(:participant_outcome, declaration: declaration1)
+        create(:statement_item, declaration: declaration1)
+        create(:statement_item, declaration: declaration1)
+      end
+
+      it "does not return duplicate declarations" do
+        query = described_class.new
+        expect(query.declarations).to contain_exactly(declaration1, declaration2)
+      end
+    end
+
     describe "filtering" do
       describe "lead provider" do
         it "filters by lead provider" do

--- a/spec/services/participant_outcomes/query_spec.rb
+++ b/spec/services/participant_outcomes/query_spec.rb
@@ -19,6 +19,21 @@ RSpec.describe ParticipantOutcomes::Query do
       expect(query.participant_outcomes).to eq([outcome2, outcome3, outcome1])
     end
 
+    context "when outcome has multiple associated records" do
+      let!(:outcome1) { create(:participant_outcome) }
+      let!(:outcome2) { create(:participant_outcome) }
+
+      before do
+        create(:participant_outcome_api_request, participant_outcome: outcome1)
+        create(:participant_outcome_api_request, participant_outcome: outcome1)
+      end
+
+      it "does not return duplicate outcomes" do
+        query = described_class.new
+        expect(query.participant_outcomes).to contain_exactly(outcome1, outcome2)
+      end
+    end
+
     describe "filtering" do
       describe "lead provider" do
         it "filters by lead provider" do

--- a/spec/services/participants/query_spec.rb
+++ b/spec/services/participants/query_spec.rb
@@ -232,12 +232,6 @@ RSpec.describe Participants::Query do
 
       subject(:participants) { query.participants }
 
-      before do
-        participant1.applications.first.update!(accepted_at: 1.day.ago)
-        participant2.applications.first.update!(accepted_at: 10.days.ago)
-        participant3.applications.first.update!(accepted_at: 2.days.ago)
-      end
-
       it "by default orders by created_at in ascending order" do
         expect(query.participants).to eq([participant1, participant2, participant3])
       end

--- a/spec/services/participants/query_spec.rb
+++ b/spec/services/participants/query_spec.rb
@@ -35,6 +35,22 @@ RSpec.describe Participants::Query do
       expect(query.participants).to eq([participant1, participant2])
     end
 
+    context "when participant has multiple associated records" do
+      let(:application1) { create(:application, :accepted, lead_provider:) }
+      let!(:participant1) { application1.user }
+
+      before do
+        create(:participant_id_change, user: participant1, to_participant_id: participant1.ecf_id)
+        create(:participant_id_change, user: participant1, to_participant_id: participant1.ecf_id)
+        create(:application, :accepted, user: participant1, lead_provider:, cohort: application1.cohort)
+        create(:application, :accepted, user: participant1, lead_provider:, cohort: application1.cohort)
+      end
+
+      it "does not return duplicate participants" do
+        expect(query.participants).to contain_exactly(participant1, participant2)
+      end
+    end
+
     describe "filtering" do
       describe "lead provider" do
         context "when a lead provider is supplied" do
@@ -222,8 +238,8 @@ RSpec.describe Participants::Query do
         participant3.applications.first.update!(accepted_at: 2.days.ago)
       end
 
-      it "orders applications by accepted_at in ascending order" do
-        expect(query.participants).to eq([participant2, participant3, participant1])
+      it "by default orders by created_at in ascending order" do
+        expect(query.participants).to eq([participant1, participant2, participant3])
       end
 
       context "when sorting by created at, descending" do

--- a/spec/services/statements/query_spec.rb
+++ b/spec/services/statements/query_spec.rb
@@ -21,6 +21,23 @@ RSpec.describe Statements::Query do
       expect(query.statements).to eq([statement1, statement2, statement3])
     end
 
+    context "when statement has multiple associated records" do
+      let!(:statement1) { create(:statement) }
+      let!(:statement2) { create(:statement) }
+
+      before do
+        create(:statement_item, statement: statement1)
+        create(:statement_item, statement: statement1)
+        create(:contract, statement: statement1)
+        create(:contract, statement: statement1)
+      end
+
+      it "does not return duplicate statements" do
+        query = described_class.new
+        expect(query.statements).to contain_exactly(statement1, statement2)
+      end
+    end
+
     describe "filtering" do
       describe "by lead provider" do
         it "filters by lead provider" do


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-3608

### Changes proposed in this pull request

* `Participants::Query` now by default sorts by `created_at`
  * Adding `applications.accepted_at` to sorting forces query to return multiple `User` records as it has to join `Application`
* Added `distinct` to the query
* Added test to replicate the bug