### PR TITLE
[CPDNPQ-2128] Keep the user TRN unchanged when TRA returns an empty TRN

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -65,18 +65,20 @@ class User < ApplicationRecord
     user_from_provider_data = find_or_initialize_by(provider: provider_data.provider, uid: provider_data.uid)
     user_from_provider_data.feature_flag_id = feature_flag_id
 
-    trn = provider_data.info.trn
+    provider_trn = provider_data.info.trn
 
     user_from_provider_data.assign_attributes(
       email: provider_data.info.email,
       date_of_birth: provider_data.info.date_of_birth,
-      trn:,
       trn_lookup_status: provider_data.info.trn_lookup_status,
-      trn_verified: trn.present?,
+      trn_verified: provider_trn.present?,
       full_name: provider_data.info.preferred_name || provider_data.info.name,
       raw_tra_provider_data: provider_data,
       updated_from_tra_at: Time.zone.now,
     )
+
+    # The user's TRN should remain unchanged if the TRA returns an empty TRN
+    user_from_provider_data.trn = provider_trn if provider_trn.present?
 
     user_from_provider_data.tap(&:save)
   end
@@ -86,19 +88,21 @@ class User < ApplicationRecord
 
     user_from_provider_data.feature_flag_id = feature_flag_id
 
-    trn = provider_data.info.trn
+    provider_trn = provider_data.info.trn
 
     user_from_provider_data.assign_attributes(
       provider: provider_data.provider,
       uid: provider_data.uid,
       date_of_birth: provider_data.info.date_of_birth,
-      trn:,
       trn_lookup_status: provider_data.info.trn_lookup_status,
-      trn_verified: trn.present?,
+      trn_verified: provider_trn.present?,
       full_name: provider_data.info.preferred_name || provider_data.info.name,
       raw_tra_provider_data: provider_data,
       updated_from_tra_at: Time.zone.now,
     )
+
+    # The user's TRN should remain unchanged if the TRA returns an empty TRN
+    user_from_provider_data.trn = provider_trn if provider_trn.present?
 
     unless user_from_provider_data.save
       Rails.logger.info("[GAI] User not persisted, #{user_from_provider_data.errors.full_messages.join(';')}, ID=#{user_from_provider_data.id}, UID=#{provider_data.uid}, trying to reclaim email failed")


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2128

Our code is currently overriding the user's data with their TRA record. When a user's TRN doesn't match a TRA record, we allow them to submit their application with the TRN they provided. However, this leads to the TRN being overwritten with a blank value.

We need to ensure the TRN is retained in such cases.

### Changes proposed in this pull request

Modify the User methods `find_or_create_from_tra_data_on_unclaimed_email` and `find_or_create_from_tra_data_on_uid` to update the TRN only when a TRN is returned by TRA.
