### PR TITLE
Change accepted scope to a check in the select body

### DIFF
--- a/app/serializers/api/participant_serializer.rb
+++ b/app/serializers/api/participant_serializer.rb
@@ -104,7 +104,7 @@ module API
         def applications(object, options)
           return Application.none unless options[:lead_provider]
 
-          object.applications.accepted.select { |application| application.lead_provider_id == options[:lead_provider].id }
+          object.applications.select { |application| application.accepted_lead_provider_approval_status? && application.lead_provider_id == options[:lead_provider].id }
         end
 
         def withdrawal(application:, lead_provider:)


### PR DESCRIPTION
### Context

The current accepted scope adds an n+1 to the API response for every participant as it generates a query. Instead add the check in the select body to avoid n+1s

### Changes proposed in this pull request

Change accepted scope to a check in the select body

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
