### PR TITLE
Amend test data generators to random created at

### DIFF
--- a/app/services/valid_test_data_generators/applications_populater.rb
+++ b/app/services/valid_test_data_generators/applications_populater.rb
@@ -59,7 +59,7 @@ module ValidTestDataGenerators
 
       return if Faker::Boolean.boolean(true_ratio: 0.3)
 
-      current_date = schedule.applies_from + rand(1..100)
+      current_date = schedule.applies_from + rand(5.days).seconds
 
       travel_to(current_date) do
         accept_application(application)


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-3609

We were getting duplicates in pagination due to data having very similar created_at across all test data. This makes the test data more random

### Changes proposed in this pull request

Add a random time to the schedule time selected


### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
