### PR TITLE
Removed parameter from trn service link

### DIFF
--- a/app/views/pages/closed_registration_exception.html.erb
+++ b/app/views/pages/closed_registration_exception.html.erb
@@ -17,7 +17,7 @@
     </p>
 
     <p class="govuk-body">
-      If you’ve lost your TRN, you can use the <%= govuk_link_to("Find a lost TRN", "https://find-a-lost-trn.education.gov.uk/start") %> service. If you’ve never had one, use the <%= govuk_link_to("Get a TRN", "https://authorise-access-to-a-teaching-record.education.gov.uk/request-trn?ffiid=629f122b-54ef-41ca-b3b1-61142854ee11") %> service.
+      If you’ve lost your TRN, you can use the <%= govuk_link_to("Find a lost TRN", "https://find-a-lost-trn.education.gov.uk/start") %> service. If you’ve never had one, use the <%= govuk_link_to("Get a TRN", "https://authorise-access-to-a-teaching-record.education.gov.uk/request-trn") %> service.
     </p>
 
     <p class="govuk-body">

--- a/app/views/registration_wizard/start.html.erb
+++ b/app/views/registration_wizard/start.html.erb
@@ -29,7 +29,7 @@
     </p>
 
     <p class="govuk-body">
-      If you’ve lost your TRN, you can use the <%= govuk_link_to("Find a lost TRN", "https://find-a-lost-trn.education.gov.uk/start") %> service. If you’ve never had one, use the <%= govuk_link_to("Get a TRN", "https://authorise-access-to-a-teaching-record.education.gov.uk/request-trn?ffiid=629f122b-54ef-41ca-b3b1-61142854ee11") %> service.
+      If you’ve lost your TRN, you can use the <%= govuk_link_to("Find a lost TRN", "https://find-a-lost-trn.education.gov.uk/start") %> service. If you’ve never had one, use the <%= govuk_link_to("Get a TRN", "https://authorise-access-to-a-teaching-record.education.gov.uk/request-trn") %> service.
     </p>
 
     <p class="govuk-body">


### PR DESCRIPTION
The URL to request a trn contains a parameter which results in an infinite loop. Removing this parameter fixes the link