### PR TITLE
Removed parameter from additional trn service links

### DIFF
--- a/app/views/registration_wizard/dont_have_teacher_reference_number.html.erb
+++ b/app/views/registration_wizard/dont_have_teacher_reference_number.html.erb
@@ -13,6 +13,6 @@
 
   <p class="govuk-body">If you’ve lost your TRN, you can use the <%= govuk_link_to("Find a lost TRN", "https://find-a-lost-trn.education.gov.uk/start") %> service.</p>
 
-  <p class="govuk-body">If you work in early years, further education, or qualified as a teacher outside England, you may need to <%= govuk_link_to("request a TRN", "https://authorise-access-to-a-teaching-record.education.gov.uk/request-trn?ffiid=55079c2e-a990-4ce6-9611-82e4ef46ddce") %> if you do not already have one.</p>
+  <p class="govuk-body">If you work in early years, further education, or qualified as a teacher outside England, you may need to <%= govuk_link_to("request a TRN", "https://authorise-access-to-a-teaching-record.education.gov.uk/request-trn") %> if you do not already have one.</p>
 
 <% end %>

--- a/app/views/registration_wizard/teacher_reference_number.html.erb
+++ b/app/views/registration_wizard/teacher_reference_number.html.erb
@@ -8,7 +8,7 @@
 
     <p class="govuk-body">If you’ve lost your TRN, you can use the <%= govuk_link_to("Find a lost TRN", "https://find-a-lost-trn.education.gov.uk/start") %> service.</p>
 
-    <p class="govuk-body">If you work in early years, further education, or qualified as a teacher outside England, you may need to <%= govuk_link_to("request a TRN", "https://authorise-access-to-a-teaching-record.education.gov.uk/request-trn?ffiid=55079c2e-a990-4ce6-9611-82e4ef46ddce") %> if you do not already have one.</p>
+    <p class="govuk-body">If you work in early years, further education, or qualified as a teacher outside England, you may need to <%= govuk_link_to("request a TRN", "https://authorise-access-to-a-teaching-record.education.gov.uk/request-trn") %> if you do not already have one.</p>
   </div>
 </div>
 


### PR DESCRIPTION
A continuation of https://github.com/DFE-Digital/npq-registration/pull/1793

The URL to request a trn contains a parameter which results in an infinite loop. Removing this parameter fixes the link.