### PR TITLE
[CPDLP-3496] Populate `accepted_at` via application migrator

### DIFF
--- a/app/services/migration/migrators/application.rb
+++ b/app/services/migration/migrators/application.rb
@@ -61,9 +61,6 @@ module Migration::Migrators
 
         raise ActiveRecord::RecordNotFound, "Couldn't find Application" unless application
 
-        ecf_schedule = ecf_npq_application.profile&.schedule
-        application.schedule_id = find_schedule_id!(ecf_id: ecf_schedule.id) if ecf_schedule
-
         application.cohort_id = find_cohort_id!(ecf_id: ecf_npq_application.cohort_id)
         application.itt_provider_id = find_itt_provider_id!(itt_provider: ecf_npq_application.itt_provider) if ecf_npq_application.itt_provider
         application.private_childcare_provider_id = find_private_childcare_provider_id!(provider_urn: ecf_npq_application.private_childcare_provider_urn) if ecf_npq_application.private_childcare_provider_urn
@@ -71,14 +68,20 @@ module Migration::Migrators
         if ecf_npq_application.school_urn.present?
           application.school_id = find_school_id!(urn: ecf_npq_application.school_urn)
         end
+
         application.lead_provider_id = find_lead_provider_id!(ecf_id: ecf_npq_application.npq_lead_provider_id)
         application.course_id = find_course_id!(ecf_id: ecf_npq_application.npq_course_id)
 
-        application.training_status = ecf_npq_application.profile&.training_status if ecf_npq_application.profile
+        if ecf_npq_application.profile
+          ecf_schedule = ecf_npq_application.profile.schedule
+          application.schedule_id = find_schedule_id!(ecf_id: ecf_schedule.id) if ecf_schedule
+
+          application.training_status = ecf_npq_application.profile.training_status
+          application.accepted_at = ecf_npq_application.profile.created_at
+        end
+
         application.ukprn = ecf_npq_application.school_ukprn
-
         application.user_id = find_user_id!(ecf_id: ecf_npq_application.user.id)
-
         application.update!(ecf_npq_application.attributes.slice(*ATTRIBUTES))
       end
     end

--- a/spec/services/migration/migrators/application_spec.rb
+++ b/spec/services/migration/migrators/application_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe Migration::Migrators::Application do
         expect(application.training_status).to eq(ecf_resource1.profile.training_status)
         expect(application.ukprn).to eq(ecf_resource1.school_ukprn)
         expect(application.user.ecf_id).to eq(ecf_resource1.user.id)
+        expect(application.accepted_at).to eq(ecf_resource1.profile.created_at)
       end
 
       it "sets the schedule from the ECF NPQApplication on the NPQ application" do
@@ -114,7 +115,7 @@ RSpec.describe Migration::Migrators::Application do
         expect(failure_manager).to have_received(:record_failure).with(ecf_resource1, /Couldn't find PrivateChildcareProvider/)
       end
 
-      it "treats the schedule and training_status as optional (as profile can be nil)" do
+      it "treats the schedule, training_status and accepted_at as optional (as profile can be nil)" do
         ecf_resource1.profile.destroy!
         instance.call
         expect(failure_manager).not_to have_received(:record_failure)


### PR DESCRIPTION
### Context

Ticket: [CPDLP-3496](https://dfedigital.atlassian.net/browse/CPDLP-3496)

We currently surface the `accepted_at` in the participant serialiser. We need to make sure this value is populated from old records as well with participant profiles.

### Changes proposed in this pull request

When the application migrator runs, ensure that the `accepted_at` field is populated via the participant profile created at if the application is accepted.

[CPDLP-3496]: https://dfedigital.atlassian.net/browse/CPDLP-3496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ