### PR TITLE
Readded email uniqueness validation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,8 +13,7 @@ class User < ApplicationRecord
   validates :email,
             presence: { message: "Enter an email address" },
             uniqueness: { message: "Email address must be unique" },
-            notify_email: true,
-            on: :npq_separation
+            notify_email: true
   # rubocop:enable Rails/UniqueValidationWithoutIndex
 
   validates :uid, uniqueness: { allow_blank: true }

--- a/spec/lib/services/get_an_identity_service/webhooks/user_updated_processor_spec.rb
+++ b/spec/lib/services/get_an_identity_service/webhooks/user_updated_processor_spec.rb
@@ -60,6 +60,26 @@ RSpec.describe GetAnIdentityService::Webhooks::UserUpdatedProcessor do
       })
     end
 
+    context "when the new email is already in use" do
+      before do
+        create(:user, email: new_email)
+      end
+
+      it "marks the webhook_message as failed" do
+        expect {
+          described_class.call(webhook_message:)
+        }.to change {
+          webhook_message.reload.slice(:status, :status_comment)
+        }.from(
+          "status" => "pending",
+          "status_comment" => nil,
+        ).to({
+          "status" => "failed",
+          "status_comment" => "Email Email address must be unique",
+        })
+      end
+    end
+
     context "when the trn is not present" do
       let(:new_trn) { nil }
       let(:new_trn_status) { "not_found" }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe User do
   describe "validations" do
     it { is_expected.to validate_presence_of(:full_name).with_message("Enter a full name") }
     it { is_expected.to validate_presence_of(:email).on(:npq_separation).with_message("Enter an email address") }
-    it { is_expected.to validate_uniqueness_of(:email).on(:npq_separation).case_insensitive.with_message("Email address must be unique") }
+    it { is_expected.to validate_uniqueness_of(:email).case_insensitive.with_message("Email address must be unique") }
     it { is_expected.not_to allow_value("invalid-email").for(:email).on(:npq_separation) }
     it { is_expected.to validate_uniqueness_of(:uid).allow_blank }
 


### PR DESCRIPTION
Email uniqueness validations were removed in https://github.com/DFE-Digital/npq-registration/pull/989

This was a quick fix to resolve errors from users trying to login with their Get an Identity accounts.

We now need to clean up the duplicate user records that have crept in since then and then re-add the validation. This will enable a smooth migration of data from ECF to NPQ. Work is currently underway to cleanup the data dn we can then add the validation when ready.