### PR TITLE
[CPDNPQ-2147] Add ECF fields to separated Admin/Applications#show

### DIFF
--- a/app/views/npq_separation/admin/applications/show.html.erb
+++ b/app/views/npq_separation/admin/applications/show.html.erb
@@ -2,6 +2,8 @@
 
 <h1 class="govuk-heading-l">Application for <%= @application.user.full_name %></h1>
 
+<h2 class="govuk-heading-m">Application details</h2>
+
 <%=
   govuk_summary_list do |sl|
     sl.with_row do |row|
@@ -15,8 +17,24 @@
     end
 
     sl.with_row do |row|
+      row.with_key(text: "User ID")
+      row.with_value(text: @application.user.id)
+      row.with_action(text: "View Participant", href: npq_separation_admin_user_path(@application.user))
+    end
+
+    sl.with_row do |row|
       row.with_key(text: "Email")
       row.with_value(text: @application.user.email)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: 'TRN')
+      row.with_value(text: @application.user.trn || '-')
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: 'TRN validated')
+      row.with_value { boolean_red_green_tag(@application.user.trn_verified) }
     end
 
     sl.with_row do |row|
@@ -35,29 +53,44 @@
     end
 
     sl.with_row do |row|
-      row.with_key(text: "Application submitted date")
+      row.with_key(text: "Created at")
       row.with_value(text: @application.created_at.to_fs(:govuk_short))
     end
 
     sl.with_row do |row|
-      row.with_key(text: "Last updated at")
+      row.with_key(text: "Updated at")
       row.with_value(text: @application.updated_at.to_fs(:govuk_short))
     end
   end
 %>
 
-<h2 class="govuk-heading-m govuk-!-margin-top-9">Scholarship funding</h2>
+<hr class="govuk-section-break govuk-section-break--l">
+
+<h2 class="govuk-heading-m">Employment details</h2>
 
 <%=
   govuk_summary_list do |sl|
     sl.with_row do |row|
-      row.with_key(text: "Eligible for funding")
-      row.with_value(text: boolean_red_green_tag(@application.eligible_for_funding?))
+      row.with_key(text: 'School URN')
+      row.with_value(text: @application.school_urn || '-')
+      if @application.school.present?
+        row.with_action(text: "View School", href: npq_separation_admin_school_path(@application.school))
+      end
     end
 
     sl.with_row do |row|
-      row.with_key(text: "Funding eligibility status code")
-      row.with_value(text: @application.funding_eligiblity_status_code&.humanize)
+      row.with_key(text: 'School UKPRN')
+      row.with_value(text: @application.school.ukprn || "-")
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: 'Private Childcare Provider URN')
+      row.with_value(text: @application.private_childcare_provider.try(:urn) || "-")
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: 'Headteacher status')
+      row.with_value(text: @application.headteacher_status || "-")
     end
 
     sl.with_row do |row|
@@ -73,6 +106,87 @@
     sl.with_row do |row|
       row.with_key(text: "Employment role")
       row.with_value(text: @application.employment_role&.humanize)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: 'ITT Lead mentor')
+      row.with_value { boolean_red_green_tag(@application.lead_mentor?) }
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: 'ITT provider')
+      row.with_value(text: @application.itt_provider.try(:operating_name) || "-")
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: 'Country')
+      row.with_value(text: @application.teacher_catchment_country || "-")
+    end
+  end
+%>
+
+
+<hr class="govuk-section-break govuk-section-break--l">
+
+<h2 class="govuk-heading-m">Funding eligibility</h2>
+
+<%=
+  govuk_summary_list do |sl|
+    sl.with_row do |row|
+      row.with_key(text: "Eligible for funding")
+      row.with_value(text: boolean_red_green_tag(@application.eligible_for_funding?))
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: 'Funded place')
+      row.with_value(text: boolean_red_green_nil_tag(@application.funded_place))
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Funding eligibility status code")
+      row.with_value(text: @application.funding_eligiblity_status_code&.humanize)
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: 'Primary establishment')
+      row.with_value{ boolean_red_green_tag(@application.primary_establishment) }
+      row.with_action
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: 'Number of pupils')
+      row.with_value(text: @application.number_of_pupils.to_i)
+      row.with_action
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: 'Targeted support funding primary plus eligibility')
+      row.with_value{ boolean_red_green_tag(@application.tsf_primary_plus_eligibility) }
+      row.with_action
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Targeted delivery funding eligibility")
+      row.with_value { boolean_red_green_tag(@application.targeted_delivery_funding_eligibility) }
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: 'Funding choice')
+      row.with_value(text: @application.funding_choice&.capitalize || "-")
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: "Schedule Cohort")
+      if @application.cohort.present?
+        row.with_value(text: @application.cohort.start_year)
+      else
+        row.with_value(text: "-" )
+      end
+    end
+
+    sl.with_row do |row|
+      row.with_key(text: 'Schedule identifier')
+      row.with_value(text: @application.schedule.try(:identifier) || '-')
     end
 
     sl.with_row do |row|

--- a/spec/features/npq_separation/admin/applications_spec.rb
+++ b/spec/features/npq_separation/admin/applications_spec.rb
@@ -53,24 +53,50 @@ RSpec.feature "Listing and viewing applications", type: :feature do
 
     summary_lists = all(".govuk-summary-list")
 
+    expect(page).to have_css("h2", text: "Application details")
+
     within(summary_lists[0]) do |summary_list|
       expect(summary_list).to have_summary_item("Application ID", application.id)
+      expect(summary_list).to have_summary_item("ECF ID", application.ecf_id)
+      expect(summary_list).to have_summary_item("User ID", application.user.id)
       expect(summary_list).to have_summary_item("Email", application.user.email)
+      expect(summary_list).to have_summary_item("TRN", application.user.trn)
+      expect(summary_list).to have_summary_item("TRN validated", "No")
       expect(summary_list).to have_summary_item("Course name", application.course.name)
       expect(summary_list).to have_summary_item("Lead provider name", application.lead_provider.name)
       expect(summary_list).to have_summary_item("Lead provider approval status", application.lead_provider_approval_status.humanize)
-      expect(summary_list).to have_summary_item("Application submitted date", application.created_at.to_fs(:govuk_short))
-      expect(summary_list).to have_summary_item("Last updated at", application.updated_at.to_fs(:govuk_short))
+      expect(summary_list).to have_summary_item("Created at", application.created_at.to_fs(:govuk_short))
+      expect(summary_list).to have_summary_item("Updated at", application.updated_at.to_fs(:govuk_short))
     end
 
-    expect(page).to have_css("h2", text: "Scholarship funding")
+    expect(page).to have_css("h2", text: "Employment details")
 
     within(summary_lists[1]) do |summary_list|
-      expect(summary_list).to have_summary_item("Eligible for funding", "Yes")
-      expect(summary_list).to have_summary_item("Funding eligibility status code", application.funding_eligiblity_status_code.humanize)
+      expect(summary_list).to have_summary_item("School URN", application.school_urn)
+      expect(summary_list).to have_summary_item("School UKPRN", application.school.ukprn)
+      expect(summary_list).to have_summary_item("Private Childcare Provider URN", "-")
+      expect(summary_list).to have_summary_item("Headteacher status", application.headteacher_status)
       expect(summary_list).to have_summary_item("Employment type", application.employment_type.humanize)
       expect(summary_list).to have_summary_item("Employer name", application.employer_name)
       expect(summary_list).to have_summary_item("Employment role", application.employment_role.humanize)
+      expect(summary_list).to have_summary_item("ITT Lead mentor", application.lead_mentor? ? "Yes" : "No")
+      expect(summary_list).to have_summary_item("ITT provider", application.itt_provider.operating_name)
+      expect(summary_list).to have_summary_item("Country", application.teacher_catchment_country)
+    end
+
+    expect(page).to have_css("h2", text: "Funding eligibility")
+
+    within(summary_lists[2]) do |summary_list|
+      expect(summary_list).to have_summary_item("Eligible for funding", "Yes")
+      expect(summary_list).to have_summary_item("Funded place", "")
+      expect(summary_list).to have_summary_item("Funding eligibility status code", application.funding_eligiblity_status_code.humanize)
+      expect(summary_list).to have_summary_item("Primary establishment", "No")
+      expect(summary_list).to have_summary_item("Number of pupils", application.number_of_pupils)
+      expect(summary_list).to have_summary_item("Targeted support funding primary plus eligibility", "No")
+      expect(summary_list).to have_summary_item("Targeted delivery funding eligibility", "No")
+      expect(summary_list).to have_summary_item("Funding choice", application.funding_choice&.capitalize)
+      expect(summary_list).to have_summary_item("Schedule Cohort", application.cohort.start_year)
+      expect(summary_list).to have_summary_item("Schedule identifier", "-")
       expect(summary_list).to have_summary_item("Notes", "No notes")
     end
   end


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2147](https://dfedigital.atlassian.net/browse/CPDNPQ-2147)

We need to provide the same information in the post separation Admin console as is currently available in the ECF dashboard

### Changes proposed in this pull request

* Extend the Application details screen with the additional fields currently only available on the ECF dashboard
* Extend the existing feature spec to cover the newly shown fields

[CPDNPQ-2147]: https://dfedigital.atlassian.net/browse/CPDNPQ-2147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ