### PR TITLE
[CPDLP-3519] Add contract for course validation to change schedule and declarations create services

### DIFF
--- a/app/services/declarations/create.rb
+++ b/app/services/declarations/create.rb
@@ -19,8 +19,7 @@ module Declarations
     validates :declaration_date, declaration_date: true
     validates :declaration_date, presence: true
     validates :declaration_type, presence: true
-    # TODO: we don't have NPQ Contract yet
-    # validates :cohort, contract_for_cohort_and_course: true
+    validates :cohort, contract_for_cohort_and_course: true
 
     validate :output_fee_statement_available
     validate :validate_has_passed_field, if: :validate_has_passed?

--- a/app/validators/contract_for_cohort_and_course_validator.rb
+++ b/app/validators/contract_for_cohort_and_course_validator.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class ContractForCohortAndCourseValidator < ActiveModel::Validator
+  def validate(record)
+    return if record.errors.any?
+    return unless contract_for_cohort_and_course(record).empty?
+
+    record.errors.add(:cohort, :missing_contract_for_cohort_and_course)
+  end
+
+private
+
+  def contract_for_cohort_and_course(record)
+    Contract.joins(:course, :statement).where(
+      courses: { identifier: record.course_identifier },
+      statements: {
+        cohort: record.cohort,
+        lead_provider: record.lead_provider,
+      },
+    )
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,6 +37,7 @@ en:
 
   cohort: &cohort
     cannot_change: "You cannot change the '#/%{parameterized_attribute}' field"
+    missing_contract_for_cohort_and_course: You cannot change a participant to this cohort as you do not have a contract for the cohort and course. Contact the DfE for assistance.
 
   schedule: &schedule
     cohort_mismatch: The schedule cohort must match the application cohort
@@ -399,6 +400,7 @@ en:
               <<: *lead_provider
             cohort:
               <<: *statement
+              missing_contract_for_cohort_and_course: You cannot submit a declaration for this participant as you do not have a contract for the cohort and course. Contact the DfE for assistance.
         participant_outcomes/create:
           attributes:
             base:

--- a/spec/requests/api/docs/v1/declarations_spec.rb
+++ b/spec/requests/api/docs/v1/declarations_spec.rb
@@ -71,6 +71,11 @@ RSpec.describe "Declarations endpoints", openapi_spec: "v1/swagger.yaml", type: 
       }
     end
 
+    before do
+      statement = create(:statement, cohort:, lead_provider:)
+      create(:contract, statement:, course:)
+    end
+
     it_behaves_like "an API create on resource endpoint documentation",
                     "/api/v1/participant-declarations",
                     "Participant declarations",

--- a/spec/requests/api/docs/v1/participants_spec.rb
+++ b/spec/requests/api/docs/v1/participants_spec.rb
@@ -23,6 +23,11 @@ RSpec.describe "NPQ Participants endpoint", openapi_spec: "v1/swagger.yaml", typ
   end
   let!(:participant) { application.user }
 
+  before do
+    statement = create(:statement, cohort:, lead_provider:)
+    create(:contract, statement:, course:)
+  end
+
   it_behaves_like "an API index endpoint documentation",
                   "/api/v1/participants/npq",
                   "NPQ Participants",

--- a/spec/requests/api/docs/v2/declarations_spec.rb
+++ b/spec/requests/api/docs/v2/declarations_spec.rb
@@ -70,6 +70,11 @@ RSpec.describe "Declarations endpoints", openapi_spec: "v2/swagger.yaml", type: 
       }
     end
 
+    before do
+      statement = create(:statement, cohort:, lead_provider:)
+      create(:contract, statement:, course:)
+    end
+
     it_behaves_like "an API create on resource endpoint documentation",
                     "/api/v2/participant-declarations",
                     "Participant declarations",

--- a/spec/requests/api/docs/v2/participants_spec.rb
+++ b/spec/requests/api/docs/v2/participants_spec.rb
@@ -23,6 +23,11 @@ RSpec.describe "NPQ Participants endpoint", openapi_spec: "v2/swagger.yaml", typ
   end
   let!(:participant) { application.user }
 
+  before do
+    statement = create(:statement, cohort:, lead_provider:)
+    create(:contract, statement:, course:)
+  end
+
   it_behaves_like "an API index endpoint documentation",
                   "/api/v2/participants/npq",
                   "NPQ Participants",

--- a/spec/requests/api/docs/v3/declarations_spec.rb
+++ b/spec/requests/api/docs/v3/declarations_spec.rb
@@ -61,6 +61,11 @@ RSpec.describe "Participant Declarations endpoint", openapi_spec: "v3/swagger.ya
       }
     end
 
+    before do
+      statement = create(:statement, cohort:, lead_provider:)
+      create(:contract, statement:, course:)
+    end
+
     it_behaves_like "an API create on resource endpoint documentation",
                     "/api/v3/participant-declarations",
                     "Participant declarations",

--- a/spec/requests/api/docs/v3/participants_spec.rb
+++ b/spec/requests/api/docs/v3/participants_spec.rb
@@ -23,6 +23,11 @@ RSpec.describe "NPQ Participants endpoint", openapi_spec: "v3/swagger.yaml", typ
   end
   let!(:participant) { application.user }
 
+  before do
+    statement = create(:statement, cohort:, lead_provider:)
+    create(:contract, statement:, course:)
+  end
+
   it_behaves_like "an API index endpoint documentation",
                   "/api/v3/participants/npq",
                   "NPQ Participants",

--- a/spec/services/declarations/create_spec.rb
+++ b/spec/services/declarations/create_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe Declarations::Create, type: :model do
       has_passed:,
     }
   end
-  let!(:statement) { create(:statement, cohort:, lead_provider:) }
+  let(:statement) { create(:statement, cohort:, lead_provider:) }
+  let!(:contract) { create(:contract, statement:, course:) }
 
   subject(:service) { described_class.new(**params) }
 
@@ -264,6 +265,12 @@ RSpec.describe Declarations::Create, type: :model do
 
         it { is_expected.to have_error(:cohort, :no_output_fee_statement, "You cannot submit or void declarations for the #{cohort.start_year} cohort. The funding contract for this cohort has ended. Get in touch if you need to discuss this with us.") }
       end
+    end
+
+    context "when lead provider has no contract for the cohort and course" do
+      before { contract.update!(course: create(:course, :leading_literacy)) }
+
+      it { is_expected.to have_error(:cohort, :missing_contract_for_cohort_and_course, "You cannot submit a declaration for this participant as you do not have a contract for the cohort and course. Contact the DfE for assistance.") }
     end
   end
 

--- a/spec/validators/contract_for_cohort_and_course_validator_spec.rb
+++ b/spec/validators/contract_for_cohort_and_course_validator_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ContractForCohortAndCourseValidator do
+  let(:klass) do
+    Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Validations
+
+      validates :cohort, contract_for_cohort_and_course: true
+
+      attr_reader :cohort, :lead_provider, :course_identifier
+
+      def self.model_name
+        ActiveModel::Name.new(self, nil, "declarations/create")
+      end
+
+      def initialize(cohort:, lead_provider:, course_identifier:)
+        @cohort = cohort
+        @lead_provider = lead_provider
+        @course_identifier = course_identifier
+      end
+    end
+  end
+
+  describe "#validate" do
+    subject { klass.new(**params) }
+
+    let(:params) { { cohort:, lead_provider:, course_identifier: } }
+
+    let(:lead_provider) { create(:lead_provider) }
+    let(:course) { create(:course, :senior_leadership) }
+    let(:cohort) { create(:cohort, :current) }
+    let(:statement) { create(:statement, cohort:, lead_provider:) }
+    let!(:contract) { create(:contract, statement:, course:) }
+    let(:course_identifier) { course.identifier }
+
+    it "is valid" do
+      expect(subject).to be_valid
+    end
+
+    context "when lead provider has no contract for the cohort and course" do
+      before { contract.update!(course: create(:course, :leading_literacy)) }
+
+      it { is_expected.to be_invalid }
+      it { is_expected.to have_error(:cohort, :missing_contract_for_cohort_and_course, "You cannot submit a declaration for this participant as you do not have a contract for the cohort and course. Contact the DfE for assistance.") }
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: [CPDLP-3519](https://dfedigital.atlassian.net/browse/CPDLP-3519)

We want to add current contract logic in record declaration and change schedules.

### Changes proposed in this pull request

Add contract for course validation to change schedule and declarations create services.

[CPDLP-3519]: https://dfedigital.atlassian.net/browse/CPDLP-3519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ