### PR TITLE
Schedule cron jobs on db rake tasks

### DIFF
--- a/lib/tasks/jobs.rake
+++ b/lib/tasks/jobs.rake
@@ -6,3 +6,12 @@ namespace :db do
     CronJob.subclasses.each(&:schedule)
   end
 end
+
+unless Rails.env.development? || Rails.env.test?
+  # invoke schedule_jobs automatically after every migration and schema load.
+  %w[db:migrate db:schema:load].each do |task|
+    Rake::Task[task].enhance do
+      Rake::Task["db:schedule_jobs"].invoke
+    end
+  end
+end


### PR DESCRIPTION
Currently, if we add a new cron job we need to remember to manually schedule it the first time or it won't ever run. To avoid this, the gem recommends hooking into the `db:migrate` and `db:schema:load` rake tasks to also run the cron scheduling (it will ignore jobs already scheduled and ensure new jobs are scheduled).

Set to run only on hosted environments. I manually ran the rake task in the migration environment to ensure it works and to get the migration cron job scheduled.
