### PR TITLE
[CPDLP-3520] Disable declaration validation on schedule in migration only

### DIFF
--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -86,8 +86,10 @@ class Declaration < ApplicationRecord
     duplicate: "duplicate",
   }, _suffix: true
 
+  attr_accessor :skip_declaration_date_within_schedule_validation
+
   validates :declaration_date, :declaration_type, presence: true
-  validate :validate_declaration_date_within_schedule
+  validate :validate_declaration_date_within_schedule, if: -> { !skip_declaration_date_within_schedule_validation }
   validate :validate_declaration_date_not_in_the_future
 
   def billable_statement

--- a/app/services/migration/migrators/declaration.rb
+++ b/app/services/migration/migrators/declaration.rb
@@ -22,7 +22,7 @@ module Migration::Migrators
       end
     end
 
-    def call
+    def call(skip_declaration_date_within_schedule_validation: true)
       migrate(self.class.ecf_declarations) do |ecf_declaration|
         declaration = ::Declaration.find_or_initialize_by(ecf_id: ecf_declaration.id)
         latest_declaration_state = ecf_declaration.declaration_states.detect(&:ineligible?)
@@ -37,6 +37,7 @@ module Migration::Migrators
           cohort_id: find_cohort_id!(ecf_id: ecf_declaration.cohort_id),
           lead_provider_id: find_lead_provider_id!(ecf_id: ecf_declaration.cpd_lead_provider.npq_lead_provider.id),
           application_id: find_application_id!(course_identifier: ecf_declaration.course_identifier, ecf_user_id: ecf_declaration.user_id),
+          skip_declaration_date_within_schedule_validation:,
         )
       end
     end

--- a/app/services/migration/migrators/declaration.rb
+++ b/app/services/migration/migrators/declaration.rb
@@ -22,7 +22,7 @@ module Migration::Migrators
       end
     end
 
-    def call(skip_declaration_date_within_schedule_validation: true)
+    def call
       migrate(self.class.ecf_declarations) do |ecf_declaration|
         declaration = ::Declaration.find_or_initialize_by(ecf_id: ecf_declaration.id)
         latest_declaration_state = ecf_declaration.declaration_states.detect(&:ineligible?)
@@ -37,7 +37,7 @@ module Migration::Migrators
           cohort_id: find_cohort_id!(ecf_id: ecf_declaration.cohort_id),
           lead_provider_id: find_lead_provider_id!(ecf_id: ecf_declaration.cpd_lead_provider.npq_lead_provider.id),
           application_id: find_application_id!(course_identifier: ecf_declaration.course_identifier, ecf_user_id: ecf_declaration.user_id),
-          skip_declaration_date_within_schedule_validation:,
+          skip_declaration_date_within_schedule_validation: true,
         )
       end
     end

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -42,6 +42,12 @@ RSpec.describe Declaration, type: :model do
         expect(subject).to be_invalid
         expect(subject).to have_error(:declaration_date, :declaration_before_schedule_start, "Enter a '#/declaration_date' that's on or after the schedule start.")
       end
+
+      context "when `skip_declaration_date_within_schedule_validation` is set to true" do
+        before { subject.skip_declaration_date_within_schedule_validation = true }
+
+        it { is_expected.to be_valid }
+      end
     end
 
     context "when declaration_date is at the schedule start" do

--- a/spec/services/migration/migrators/declaration_spec.rb
+++ b/spec/services/migration/migrators/declaration_spec.rb
@@ -45,22 +45,6 @@ RSpec.describe Migration::Migrators::Declaration do
 
           expect(failure_manager).not_to have_received(:record_failure)
         end
-
-        context "when `skip_declaration_date_within_schedule_validation` is set to nil" do
-          it "records a failure" do
-            instance.call(skip_declaration_date_within_schedule_validation: nil)
-
-            expect(failure_manager).to have_received(:record_failure).once.with(ecf_resource1, "Validation failed: Declaration date Enter a '#/declaration_date' that's on or after the schedule start.")
-          end
-        end
-
-        context "when `skip_declaration_date_within_schedule_validation` is set to false" do
-          it "records a failure" do
-            instance.call(skip_declaration_date_within_schedule_validation: false)
-
-            expect(failure_manager).to have_received(:record_failure).once.with(ecf_resource1, "Validation failed: Declaration date Enter a '#/declaration_date' that's on or after the schedule start.")
-          end
-        end
       end
     end
   end


### PR DESCRIPTION
### Context

Ticket: [CPDLP-3520](https://dfedigital.atlassian.net/browse/CPDLP-3520)

We have found old declarations that have invalid declaration dates in relation to the schedule start date. Those are legacy declarations in cohort 2021/2022 and will need to be taken away with contract managers, but we need to unblock migration so we should bring those across.

### Changes proposed in this pull request

- Change the declaration migrator/model validation to allow pulling in declarations that have invalid schedules only. 
- Only allowed on data migration only and nowhere else.

[CPDLP-3520]: https://dfedigital.atlassian.net/browse/CPDLP-3520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ