### PR TITLE
Fix `spec/services/statements/query_spec.rb` flakey test

### DIFF
--- a/spec/services/statements/query_spec.rb
+++ b/spec/services/statements/query_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe Statements::Query do
       before do
         create(:statement_item, statement: statement1)
         create(:statement_item, statement: statement1)
-        create(:contract, statement: statement1)
-        create(:contract, statement: statement1)
+        create(:contract, course: create(:course, :senior_leadership), statement: statement1)
+        create(:contract, course: create(:course, :leading_literacy), statement: statement1)
       end
 
       it "does not return duplicate statements" do


### PR DESCRIPTION
### Context

Ticket: N/A

This [spec](https://github.com/DFE-Digital/npq-registration/blob/main/spec/services/statements/query_spec.rb#L35) is failing due the same course potentially being selected for [L31](https://github.com/DFE-Digital/npq-registration/blob/main/spec/services/statements/query_spec.rb#L31) and [L32](https://github.com/DFE-Digital/npq-registration/blob/main/spec/services/statements/query_spec.rb#L32) resulting in a validation error being raised.

```
ActiveRecord::RecordInvalid:
       Validation failed: Course Can only have one contract for statement and course
```

### Changes proposed in this pull request

Make the course not dynamic in the lines mentioned above, so it fixes the flakey spec.