### PR TITLE
[CPDLP-3521] Split contract migration into two migrators

### DIFF
--- a/app/services/migration/migrators/base.rb
+++ b/app/services/migration/migrators/base.rb
@@ -133,6 +133,10 @@ module Migration::Migrators
       schedule_ids_by_ecf_id[ecf_id] || raise(ActiveRecord::RecordNotFound, "Couldn't find Schedule")
     end
 
+    def find_contract_template_id!(ecf_id:)
+      contract_template_ids_by_ecf_id[ecf_id] || raise(ActiveRecord::RecordNotFound, "Couldn't find Contract Template")
+    end
+
     def course_groups_by_schedule_type(ecf_type)
       case ecf_type
       when "Finance::Schedule::NPQLeadership"
@@ -186,6 +190,10 @@ module Migration::Migrators
 
     def school_ids_by_urn
       @school_ids_by_urn ||= ::School.pluck(:urn, :id).to_h
+    end
+
+    def contract_template_ids_by_ecf_id
+      @contract_template_ids_by_ecf_id ||= ::ContractTemplate.pluck(:ecf_id, :id).to_h
     end
 
     def itt_provider_ids_by_legal_name_and_operating_name

--- a/app/services/migration/migrators/contract.rb
+++ b/app/services/migration/migrators/contract.rb
@@ -2,20 +2,6 @@ module Migration::Migrators
   class Contract < Base
     INFRA_WORKER_COUNT = 1
 
-    SHARED_ATTRIBUTES = %w[
-      created_at
-      updated_at
-      service_fee_percentage
-      output_payment_percentage
-      per_participant
-      number_of_payment_periods
-      recruitment_target
-      service_fee_installments
-      targeted_delivery_funding_per_participant
-      monthly_service_fee
-      special_course
-    ].freeze
-
     class << self
       def record_count
         ecf_contracts.count
@@ -30,7 +16,7 @@ module Migration::Migrators
       end
 
       def dependencies
-        %i[course statement]
+        %i[course statement contract_template]
       end
 
       def number_of_workers
@@ -48,36 +34,22 @@ module Migration::Migrators
 
     def call
       migrate(self.class.ecf_contracts) do |ecf_contract|
-        ApplicationRecord.transaction do
-          course_id = find_course_id!(identifier: ecf_contract.course_identifier)
+        course_id = find_course_id!(identifier: ecf_contract.course_identifier)
+        contract_template_id = find_contract_template_id!(ecf_id: ecf_contract.id)
+        statements_by_id = ::Statement.where(ecf_id: ecf_statements(ecf_contract).pluck(:id)).index_by(&:id)
 
-          contract_template = ::ContractTemplate.find_or_initialize_by(ecf_id: ecf_contract.id)
-          unless contract_template.persisted?
-            contract_template.update!(ecf_contract.attributes.slice(*SHARED_ATTRIBUTES))
-          end
-
-          statements_by_id = ::Statement.where(ecf_id: ecf_statements(ecf_contract).pluck(:id)).index_by(&:id)
-          statements_by_id.each_key do |statement_id|
-            contract = ::Contract.find_by(
-              statement_id:,
-              course_id:,
-            )
-
-            next if contract.present?
-
-            ::Contract.create!(
-              statement_id:,
-              course_id:,
-              contract_template:,
-            )
-          end
+        statements_by_id.each_key do |statement_id|
+          contract = ::Contract.find_or_initialize_by(
+            statement_id:,
+            course_id:,
+          )
+          contract.update!(contract_template_id:)
         end
       end
     end
 
     def ecf_statements(ecf_contract)
-      @ecf_statements ||= {}
-      @ecf_statements["#{ecf_contract.npq_lead_provider.cpd_lead_provider},#{ecf_contract.cohort},#{ecf_contract.version}"] ||= Migration::Ecf::Finance::Statement.where(
+      Migration::Ecf::Finance::Statement.where(
         cpd_lead_provider: ecf_contract.npq_lead_provider.cpd_lead_provider,
         cohort: ecf_contract.cohort,
         contract_version: ecf_contract.version,

--- a/app/services/migration/migrators/contract.rb
+++ b/app/services/migration/migrators/contract.rb
@@ -1,5 +1,7 @@
 module Migration::Migrators
   class Contract < Base
+    INFRA_WORKER_COUNT = 1
+
     SHARED_ATTRIBUTES = %w[
       created_at
       updated_at
@@ -29,6 +31,18 @@ module Migration::Migrators
 
       def dependencies
         %i[course statement]
+      end
+
+      def number_of_workers
+        return 1 if record_count > 1000
+
+        super
+      end
+
+      def records_per_worker
+        return record_count if record_count > 1000
+
+        super
       end
     end
 

--- a/app/services/migration/migrators/contract.rb
+++ b/app/services/migration/migrators/contract.rb
@@ -1,7 +1,5 @@
 module Migration::Migrators
   class Contract < Base
-    INFRA_WORKER_COUNT = 1
-
     class << self
       def record_count
         ecf_contracts.count
@@ -17,18 +15,6 @@ module Migration::Migrators
 
       def dependencies
         %i[course statement contract_template]
-      end
-
-      def number_of_workers
-        return 1 if record_count > 1000
-
-        super
-      end
-
-      def records_per_worker
-        return record_count if record_count > 1000
-
-        super
       end
     end
 

--- a/app/services/migration/migrators/contract_template.rb
+++ b/app/services/migration/migrators/contract_template.rb
@@ -1,0 +1,38 @@
+module Migration::Migrators
+  class ContractTemplate < Base
+    SHARED_ATTRIBUTES = %w[
+      created_at
+      updated_at
+      service_fee_percentage
+      output_payment_percentage
+      per_participant
+      number_of_payment_periods
+      recruitment_target
+      service_fee_installments
+      targeted_delivery_funding_per_participant
+      monthly_service_fee
+      special_course
+    ].freeze
+
+    class << self
+      def record_count
+        ecf_contracts.count
+      end
+
+      def model
+        :contract_template
+      end
+
+      def ecf_contracts
+        Migration::Ecf::NpqContract.includes(:cohort, npq_lead_provider: [:cpd_lead_provider])
+      end
+    end
+
+    def call
+      migrate(self.class.ecf_contracts) do |ecf_contract|
+        contract_template = ::ContractTemplate.find_or_initialize_by(ecf_id: ecf_contract.id)
+        contract_template.update!(ecf_contract.attributes.slice(*SHARED_ATTRIBUTES))
+      end
+    end
+  end
+end

--- a/spec/services/migration/migrators/contract_spec.rb
+++ b/spec/services/migration/migrators/contract_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Migration::Migrators::Contract do
-  it_behaves_like "a migrator", :contract, %i[course statement] do
+  it_behaves_like "a migrator", :contract, %i[course statement contract_template] do
     let(:records_per_worker_divider) { 2 }
 
     def create_ecf_resource
@@ -38,6 +38,7 @@ RSpec.describe Migration::Migrators::Contract do
         lead_provider:,
         cohort:,
       )
+      create(:contract_template, ecf_id: ecf_resource.id)
     end
 
     def setup_failure_state
@@ -82,9 +83,6 @@ RSpec.describe Migration::Migrators::Contract do
 
         contract_template = contract.contract_template
         expect(contract_template.ecf_id).to eq(ecf_resource1.id)
-
-        attrs = ecf_resource1.attributes.slice(*described_class::SHARED_ATTRIBUTES)
-        expect(contract_template).to have_attributes(attrs)
 
         expect(Contract.where(contract_template:).count).to eq(1)
       end

--- a/spec/services/migration/migrators/contract_spec.rb
+++ b/spec/services/migration/migrators/contract_spec.rb
@@ -28,25 +28,15 @@ RSpec.describe Migration::Migrators::Contract do
     end
 
     def create_npq_resource(ecf_resource)
+      create(:course, identifier: ecf_resource.course_identifier)
       lead_provider = create(:lead_provider, ecf_id: ecf_resource.npq_lead_provider.id)
       cohort = create(:cohort, start_year: ecf_resource.cohort.start_year)
-      course = create(:course, identifier: ecf_resource.course_identifier)
       ecf_statement = Migration::Ecf::Finance::Statement.where(cpd_lead_provider: ecf_resource.npq_lead_provider.cpd_lead_provider).first!
-      statement = create(
+      create(
         :statement,
         ecf_id: ecf_statement.id,
         lead_provider:,
         cohort:,
-      )
-      contract_template = create(
-        :contract_template,
-        ecf_id: ecf_resource.id,
-      )
-      create(
-        :contract,
-        statement:,
-        course:,
-        contract_template:,
       )
     end
 

--- a/spec/services/migration/migrators/contract_spec.rb
+++ b/spec/services/migration/migrators/contract_spec.rb
@@ -2,6 +2,8 @@ require "rails_helper"
 
 RSpec.describe Migration::Migrators::Contract do
   it_behaves_like "a migrator", :contract, %i[course statement] do
+    let(:records_per_worker_divider) { 2 }
+
     def create_ecf_resource
       cohort = create(:ecf_migration_cohort)
       npq_lead_provider = create(:ecf_migration_npq_lead_provider)

--- a/spec/services/migration/migrators/contract_spec.rb
+++ b/spec/services/migration/migrators/contract_spec.rb
@@ -2,8 +2,6 @@ require "rails_helper"
 
 RSpec.describe Migration::Migrators::Contract do
   it_behaves_like "a migrator", :contract, %i[course statement contract_template] do
-    let(:records_per_worker_divider) { 2 }
-
     def create_ecf_resource
       cohort = create(:ecf_migration_cohort)
       npq_lead_provider = create(:ecf_migration_npq_lead_provider)

--- a/spec/services/migration/migrators/contract_template_spec.rb
+++ b/spec/services/migration/migrators/contract_template_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe Migration::Migrators::ContractTemplate do
+  it_behaves_like "a migrator", :contract_template, [] do
+    def create_ecf_resource
+      cohort = create(:ecf_migration_cohort)
+      npq_lead_provider = create(:ecf_migration_npq_lead_provider)
+      course = create(:ecf_migration_npq_course)
+      version = rand(1..9)
+
+      create(
+        :ecf_migration_statement,
+        cpd_lead_provider: npq_lead_provider.cpd_lead_provider,
+        cohort:,
+        contract_version: "0.0.#{version}",
+      )
+      create(
+        :ecf_migration_npq_contract,
+        npq_lead_provider:,
+        cohort:,
+        course_identifier: course.identifier,
+        version: "0.0.#{version}",
+        created_at: rand(1..100).days.ago,
+        updated_at: rand(1..100).days.ago,
+      )
+    end
+
+    def create_npq_resource(ecf_resource); end
+
+    def setup_failure_state
+      # NPQ contract in ECF with a negative recruitment_target
+      create(
+        :ecf_migration_npq_contract,
+        recruitment_target: -300,
+      )
+    end
+
+    describe "#call" do
+      it "sets the created ContractTemplate attributes correctly" do
+        instance.call
+
+        contract_template = ContractTemplate.find_by!(ecf_id: ecf_resource1.id)
+        attrs = ecf_resource1.attributes.slice(*described_class::SHARED_ATTRIBUTES)
+        expect(contract_template).to have_attributes(attrs)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-3521

We're seeing `ERROR:  cached plan must not change result type` when migrating some contracts over.

### Changes proposed in this pull request

It's a concurrency issue, where a contract template is being created then a linked contract is being initialised multiple times as we have multiple workers trying to create the same contract. We're splitting contract migrator into two new migrators (contract template and contract). Also limiting the workers # for the contract migrator.

![image](https://github.com/user-attachments/assets/40bfe14d-327c-44f9-a917-d10ce61507da)

