### PR TITLE
[CPDNQT-2152] Resend outcome to api

### DIFF
--- a/app/components/npq_separation/admin/outcomes_table_component.rb
+++ b/app/components/npq_separation/admin/outcomes_table_component.rb
@@ -52,7 +52,9 @@ module NpqSeparation
       def tra_api_resend_link(outcome)
         return "" unless outcome.allow_resending_to_qualified_teachers_api?
 
-        govuk_link_to("Resend", resend_npq_separation_admin_participant_outcome_path(outcome))
+        govuk_button_to("Resend",
+                        resend_npq_separation_admin_participant_outcome_path(outcome),
+                        class: "govuk-!-margin-bottom-0")
       end
     end
   end

--- a/app/components/npq_separation/admin/outcomes_table_component.rb
+++ b/app/components/npq_separation/admin/outcomes_table_component.rb
@@ -4,11 +4,13 @@ module NpqSeparation
       attr_reader :outcomes
 
       def initialize(outcomes)
-        @outcomes = outcomes
+        @outcomes = outcomes.sort_by(&:created_at).reverse
       end
 
       def call
-        render GovukComponent::TableComponent.new(head:, rows:)
+        render GovukComponent::TableComponent.new(head:, rows:) do |table|
+          table.with_caption(size: "s", text: caption_text, classes: "govuk-heading-s")
+        end
       end
 
     private
@@ -25,12 +27,13 @@ module NpqSeparation
       end
 
       def rows
-        outcomes.sort_by(&:created_at).reverse.map do |outcome|
+        outcomes.map do |outcome|
           [
             outcome.state.humanize,
             outcome.completion_date.to_fs(:govuk_short),
             outcome.created_at.to_date.to_fs(:govuk_short),
-            outcome.sent_to_qualified_teachers_api_at&.to_date&.to_fs(:govuk_short) || "N/A",
+            outcome.sent_to_qualified_teachers_api_at&.to_date&.to_fs(:govuk_short) ||
+              t("participant_outcomes.na"),
             recorded_by_tra_api(outcome),
             tra_api_resend_link(outcome),
           ]
@@ -40,9 +43,9 @@ module NpqSeparation
       def recorded_by_tra_api(outcome)
         if outcome.qualified_teachers_api_request_successful.nil?
           if outcome.latest_for_declaration?
-            tag.strong("Pending", class: "govuk-tag govuk-tag--blue")
+            tag.strong(t("participant_outcomes.pending"), class: "govuk-tag govuk-tag--blue")
           else
-            tag.strong("N/A", class: "govuk-tag govuk-tag--yellow")
+            tag.strong(t("participant_outcomes.na"), class: "govuk-tag govuk-tag--yellow")
           end
         else
           helpers.boolean_red_green_tag(outcome.qualified_teachers_api_request_successful)
@@ -52,9 +55,50 @@ module NpqSeparation
       def tra_api_resend_link(outcome)
         return "" unless outcome.allow_resending_to_qualified_teachers_api?
 
-        govuk_button_to("Resend",
+        govuk_button_to(t("participant_outcomes.resend"),
                         resend_npq_separation_admin_participant_outcome_path(outcome),
                         class: "govuk-!-margin-bottom-0")
+      end
+
+      def caption_text
+        title = t("participant_outcomes.declaration_outcomes")
+        latest = outcomes.first
+
+        return title if latest.nil?
+
+        outcome_description = if latest.has_passed?
+                                success_sent_state_message(latest)
+                              elsif latest.has_failed?
+                                failed_sent_state_message(latest)
+                              else
+                                latest.state.capitalize
+                              end
+
+        "#{title}: #{outcome_description}"
+      end
+
+      def success_sent_state_message(outcome)
+        if outcome.not_sent?
+          t("participant_outcomes.passed")
+        elsif outcome.sent_and_recorded?
+          t("participant_outcomes.passed_and_recorded")
+        elsif outcome.sent_but_not_recorded?
+          t("participant_outcomes.passed_but_not_recorded")
+        else
+          outcome.state.capitalize
+        end
+      end
+
+      def failed_sent_state_message(outcome)
+        if outcome.not_sent?
+          t("participant_outcomes.failed")
+        elsif outcome.sent_and_recorded?
+          t("participant_outcomes.failed_and_recorded")
+        elsif outcome.sent_but_not_recorded?
+          t("participant_outcomes.failed_but_not_recorded")
+        else
+          outcome.state.capitalize
+        end
       end
     end
   end

--- a/app/components/npq_separation/admin/outcomes_table_component.rb
+++ b/app/components/npq_separation/admin/outcomes_table_component.rb
@@ -19,7 +19,8 @@ module NpqSeparation
           "Completion date",
           "Submitted by provider",
           "Sent to TRA API",
-          "Recorded by TRA API",
+          "Recorded by API",
+          "",
         ]
       end
 
@@ -28,9 +29,10 @@ module NpqSeparation
           [
             outcome.state.humanize,
             outcome.completion_date.to_fs(:govuk_short),
-            outcome.created_at.to_date.to_fs(:govuk),
-            outcome.sent_to_qualified_teachers_api_at.try(:to_fs, :govuk_short).presence || "N/A",
+            outcome.created_at.to_date.to_fs(:govuk_short),
+            outcome.sent_to_qualified_teachers_api_at&.to_date&.to_fs(:govuk_short) || "N/A",
             recorded_by_tra_api(outcome),
+            tra_api_resend_link(outcome),
           ]
         end
       end
@@ -45,6 +47,12 @@ module NpqSeparation
         else
           helpers.boolean_red_green_tag(outcome.qualified_teachers_api_request_successful)
         end
+      end
+
+      def tra_api_resend_link(outcome)
+        return "" unless outcome.allow_resending_to_qualified_teachers_api?
+
+        govuk_link_to("Resend", resend_npq_separation_admin_participant_outcome_path(outcome))
       end
     end
   end

--- a/app/controllers/npq_separation/admin/participant_outcomes_controller.rb
+++ b/app/controllers/npq_separation/admin/participant_outcomes_controller.rb
@@ -1,0 +1,17 @@
+class NpqSeparation::Admin::ParticipantOutcomesController < NpqSeparation::AdminController
+  def resend
+    if participant_outcome.resend_to_qualified_teachers_api!
+      flash[:success] = "Rescheduled for delivery to Teacher Services"
+    else
+      flash[:error] = "Not suitable for resending to Teacher Services"
+    end
+
+    redirect_to npq_separation_admin_application_path(participant_outcome.application_id)
+  end
+
+private
+
+  def participant_outcome
+    @participant_outcome ||= ParticipantOutcome.find(params[:id])
+  end
+end

--- a/app/models/participant_outcome.rb
+++ b/app/models/participant_outcome.rb
@@ -65,8 +65,8 @@ class ParticipantOutcome < ApplicationRecord
 
   def allow_resending_to_qualified_teachers_api?
     sent_to_qualified_teachers_api_at? &&
-      !qualified_teachers_api_request_successful.nil? &&
-      !qualified_teachers_api_request_successful?
+      qualified_teachers_api_request_successful == false &&
+      latest_for_declaration?
   end
 
   def resend_to_qualified_teachers_api!

--- a/app/models/participant_outcome.rb
+++ b/app/models/participant_outcome.rb
@@ -63,6 +63,19 @@ class ParticipantOutcome < ApplicationRecord
     declaration.participant_outcomes.latest == self
   end
 
+  def allow_resending_to_qualified_teachers_api?
+    sent_to_qualified_teachers_api_at? &&
+      !qualified_teachers_api_request_successful.nil? &&
+      !qualified_teachers_api_request_successful?
+  end
+
+  def resend_to_qualified_teachers_api!
+    return false unless allow_resending_to_qualified_teachers_api?
+
+    update!(qualified_teachers_api_request_successful: nil,
+            sent_to_qualified_teachers_api_at: nil)
+  end
+
 private
 
   def completion_date_not_in_the_future

--- a/app/models/participant_outcome.rb
+++ b/app/models/participant_outcome.rb
@@ -59,14 +59,30 @@ class ParticipantOutcome < ApplicationRecord
     passed_state?
   end
 
+  def has_failed?
+    return nil if voided_state?
+
+    failed_state?
+  end
+
+  def not_sent?
+    sent_to_qualified_teachers_api_at.nil?
+  end
+
+  def sent_and_recorded?
+    sent_to_qualified_teachers_api_at? && qualified_teachers_api_request_successful?
+  end
+
+  def sent_but_not_recorded?
+    sent_to_qualified_teachers_api_at? && qualified_teachers_api_request_successful == false
+  end
+
   def latest_for_declaration?
     declaration.participant_outcomes.latest == self
   end
 
   def allow_resending_to_qualified_teachers_api?
-    sent_to_qualified_teachers_api_at? &&
-      qualified_teachers_api_request_successful == false &&
-      latest_for_declaration?
+    sent_but_not_recorded? && latest_for_declaration?
   end
 
   def resend_to_qualified_teachers_api!

--- a/app/models/participant_outcome.rb
+++ b/app/models/participant_outcome.rb
@@ -78,7 +78,7 @@ class ParticipantOutcome < ApplicationRecord
   end
 
   def latest_for_declaration?
-    declaration.participant_outcomes.latest == self
+    self == declaration.participant_outcomes.max_by(&:created_at)
   end
 
   def allow_resending_to_qualified_teachers_api?

--- a/app/models/participant_outcome.rb
+++ b/app/models/participant_outcome.rb
@@ -7,7 +7,7 @@ class ParticipantOutcome < ApplicationRecord
   validates :completion_date, presence: true
   validate :completion_date_not_in_the_future
 
-  delegate :user, :lead_provider, :course, to: :declaration
+  delegate :user, :lead_provider, :course, :application_id, to: :declaration
 
   enum state: {
     passed: "passed",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,6 +100,18 @@ en:
     blank: "The '#/%{parameterized_attribute}' is missing from your request. Please include a 'passed' or 'failed' value and try again."
     inclusion: "The attribute '#/%{parameterized_attribute}' can only include 'passed' or 'failed' values. If you need to void an outcome, you will need to void the associated 'completed' declaration."
 
+  participant_outcomes:
+    na: "N/A"
+    declaration_outcomes: "Declaration Outcomes"
+    passed: "Passed"
+    failed: "Failed"
+    passed_and_recorded: "Passed and recorded"
+    failed_and_recorded: "Failed and recorded"
+    passed_but_not_recorded: "Passed but not recorded"
+    failed_but_not_recorded: "Failed but not recorded"
+    pending: "Pending"
+    resend: "Resend"
+
   time:
     formats:
       admin: "%R on %d/%m/%Y"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -235,7 +235,7 @@ Rails.application.routes.draw do
         resources :users, only: %i[index show]
 
         resources :participant_outcomes, only: %i[] do
-          member { get :resend }
+          member { post :resend }
         end
 
         namespace :finance do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -234,6 +234,10 @@ Rails.application.routes.draw do
         resources :courses, only: %i[index show]
         resources :users, only: %i[index show]
 
+        resources :participant_outcomes, only: %i[] do
+          member { get :resend }
+        end
+
         namespace :finance do
           resources :statements, only: %i[index show] do
             collection do

--- a/spec/components/npq_separation/admin/outcomes_table_component_spec.rb
+++ b/spec/components/npq_separation/admin/outcomes_table_component_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe NpqSeparation::Admin::OutcomesTableComponent, type: :component do
+  subject { page }
+
   before do
     render_inline(described_class.new(outcomes))
   end
@@ -93,8 +95,10 @@ RSpec.describe NpqSeparation::Admin::OutcomesTableComponent, type: :component do
              .resend_npq_separation_admin_participant_outcome_path(outcomes.first)
       end
 
-      it "renders a resend link" do
-        expect(resend_cell).to have_link("Resend", href: resend_path)
+      it "renders a resend button" do
+        within(%(tbody tr td:nth-child(6) form[action="#{resend_path}")) do |form|
+          expect(form).to have_button("Resend")
+        end
       end
     end
 

--- a/spec/components/npq_separation/admin/outcomes_table_component_spec.rb
+++ b/spec/components/npq_separation/admin/outcomes_table_component_spec.rb
@@ -35,14 +35,14 @@ RSpec.describe NpqSeparation::Admin::OutcomesTableComponent, type: :component do
       let(:outcomes) { [create(:participant_outcome, :sent_to_qualified_teachers_api)] }
 
       it "renders the timestamp" do
-        expected = outcomes.first.sent_to_qualified_teachers_api_at.to_fs(:govuk_short)
+        expected = outcomes.first.sent_to_qualified_teachers_api_at.to_date.to_fs(:govuk_short)
 
         expect(Time.zone.parse(cell_text)).to eq(expected)
       end
     end
   end
 
-  describe "'Recorded by TRA API' column" do
+  describe "'Recorded by API' column" do
     let(:cell_text) { page.find("tbody tr td:nth-child(5)").text }
 
     context "when the outcome has not been sent to TRA" do
@@ -74,6 +74,37 @@ RSpec.describe NpqSeparation::Admin::OutcomesTableComponent, type: :component do
 
       it "renders yes" do
         expect(cell_text).to eq("Yes")
+      end
+    end
+  end
+
+  describe "Resend column" do
+    let(:resend_cell) { page.find("tbody tr td:nth-child(6)") }
+
+    context "when the outcome can be resent" do
+      let :outcomes do
+        create_list(:participant_outcome, 1, :unsuccessfully_sent_to_qualified_teachers_api)
+      end
+
+      let :resend_path do
+        Rails.application
+             .routes
+             .url_helpers
+             .resend_npq_separation_admin_participant_outcome_path(outcomes.first)
+      end
+
+      it "renders a resend link" do
+        expect(resend_cell).to have_link("Resend", href: resend_path)
+      end
+    end
+
+    context "when the outcome cannot be resent" do
+      let :outcomes do
+        create_list(:participant_outcome, 1, :unsuccessfully_sent_to_qualified_teachers_api)
+      end
+
+      it "renders a blank cell" do
+        expect(resend_cell).to have_text("")
       end
     end
   end

--- a/spec/components/npq_separation/admin/outcomes_table_component_spec.rb
+++ b/spec/components/npq_separation/admin/outcomes_table_component_spec.rb
@@ -22,6 +22,56 @@ RSpec.describe NpqSeparation::Admin::OutcomesTableComponent, type: :component do
     end
   end
 
+  describe "Table caption text" do
+    context "when passed but not sent" do
+      let :outcomes do
+        create_list(:participant_outcome, 1, :passed)
+      end
+
+      it { is_expected.to have_css "caption", text: "Declaration Outcomes: Passed" }
+    end
+
+    context "when failed but not sent" do
+      let :outcomes do
+        create_list(:participant_outcome, 1, :failed)
+      end
+
+      it { is_expected.to have_css "caption", text: "Declaration Outcomes: Failed" }
+    end
+
+    context "when passed and sent and recorded" do
+      let :outcomes do
+        create_list(:participant_outcome, 1, :passed, :successfully_sent_to_qualified_teachers_api)
+      end
+
+      it { is_expected.to have_css "caption", text: "Declaration Outcomes: Passed and recorded" }
+    end
+
+    context "when failed and sent and recorded" do
+      let :outcomes do
+        create_list(:participant_outcome, 1, :failed, :successfully_sent_to_qualified_teachers_api)
+      end
+
+      it { is_expected.to have_css "caption", text: "Declaration Outcomes: Failed and recorded" }
+    end
+
+    context "when passed and sent but not recorded" do
+      let :outcomes do
+        create_list(:participant_outcome, 1, :passed, :unsuccessfully_sent_to_qualified_teachers_api)
+      end
+
+      it { is_expected.to have_css "caption", text: "Declaration Outcomes: Passed but not recorded" }
+    end
+
+    context "when failed and sent but not recored" do
+      let :outcomes do
+        create_list(:participant_outcome, 1, :failed, :unsuccessfully_sent_to_qualified_teachers_api)
+      end
+
+      it { is_expected.to have_css "caption", text: "Declaration Outcomes: Failed but not recorded" }
+    end
+  end
+
   describe "'Sent to TRA API' column" do
     let(:cell_text) { page.find("tbody tr td:nth-child(4)").text }
 

--- a/spec/factories/participant_outcomes.rb
+++ b/spec/factories/participant_outcomes.rb
@@ -24,7 +24,7 @@ FactoryBot.define do
     end
 
     trait :sent_to_qualified_teachers_api do
-      sent_to_qualified_teachers_api_at { Time.zone.now - 1.hour }
+      sent_to_qualified_teachers_api_at { 1.hour.ago }
     end
 
     trait :not_sent_to_qualified_teachers_api do

--- a/spec/features/npq_separation/admin/applications_spec.rb
+++ b/spec/features/npq_separation/admin/applications_spec.rb
@@ -171,4 +171,21 @@ RSpec.feature "Listing and viewing applications", type: :feature do
 
     expect(page).to have_css("h1", text: school.name)
   end
+
+  scenario "resending outcome to qualified teachers api" do
+    outcome = create(:participant_outcome, :unsuccessfully_sent_to_qualified_teachers_api)
+
+    visit npq_separation_admin_application_path(outcome.application_id)
+
+    expect(page).to have_css("h1", text: "Application for #{outcome.user.full_name}")
+
+    within(".govuk-table tbody tr:first-of-type td:last-of-type") do |action_cell|
+      expect(action_cell).to have_link("Resend")
+
+      click_link("Resend")
+    end
+
+    expect(page).to have_css("h1", text: "Application for #{outcome.user.full_name}")
+    expect(page).to have_css(".govuk-notification-banner--success", text: /rescheduled/i)
+  end
 end

--- a/spec/features/npq_separation/admin/applications_spec.rb
+++ b/spec/features/npq_separation/admin/applications_spec.rb
@@ -180,9 +180,9 @@ RSpec.feature "Listing and viewing applications", type: :feature do
     expect(page).to have_css("h1", text: "Application for #{outcome.user.full_name}")
 
     within(".govuk-table tbody tr:first-of-type td:last-of-type") do |action_cell|
-      expect(action_cell).to have_link("Resend")
+      expect(action_cell).to have_button("Resend")
 
-      click_link("Resend")
+      click_button("Resend")
     end
 
     expect(page).to have_css("h1", text: "Application for #{outcome.user.full_name}")

--- a/spec/models/participant_outcome_spec.rb
+++ b/spec/models/participant_outcome_spec.rb
@@ -279,30 +279,38 @@ RSpec.describe ParticipantOutcome, type: :model do
   end
 
   describe "#resend_to_qualified_teachers_api!" do
-    subject { outcome.resend_to_qualified_teachers_api! }
+    subject(:resend) { outcome.resend_to_qualified_teachers_api! }
 
     context "with successfully delivery" do
       let(:outcome) { create(:participant_outcome, :successfully_sent_to_qualified_teachers_api) }
 
       it { is_expected.to be false }
+      it { expect { resend }.not_to change(outcome.reload, :sent_to_qualified_teachers_api_at) }
+      it { expect { resend }.not_to change(outcome.reload, :qualified_teachers_api_request_successful) }
     end
 
     context "with failed delivery" do
       let(:outcome) { create(:participant_outcome, :unsuccessfully_sent_to_qualified_teachers_api) }
 
       it { is_expected.to be true }
+      it { expect { resend }.to change(outcome.reload, :sent_to_qualified_teachers_api_at).to(nil) }
+      it { expect { resend }.to change(outcome.reload, :qualified_teachers_api_request_successful).to(nil) }
     end
 
     context "with incomplete delivery" do
       let(:outcome) { create(:participant_outcome, :sent_to_qualified_teachers_api) }
 
       it { is_expected.to be false }
+      it { expect { resend }.not_to change(outcome.reload, :sent_to_qualified_teachers_api_at) }
+      it { expect { resend }.not_to change(outcome.reload, :qualified_teachers_api_request_successful) }
     end
 
     context "with undelivered" do
       let(:outcome) { create(:participant_outcome, :not_sent_to_qualified_teachers_api) }
 
       it { is_expected.to be false }
+      it { expect { resend }.not_to change(outcome.reload, :sent_to_qualified_teachers_api_at) }
+      it { expect { resend }.not_to change(outcome.reload, :qualified_teachers_api_request_successful) }
     end
   end
 end

--- a/spec/models/participant_outcome_spec.rb
+++ b/spec/models/participant_outcome_spec.rb
@@ -238,4 +238,60 @@ RSpec.describe ParticipantOutcome, type: :model do
       it { is_expected.to contain_exactly(outcome_1.id, outcome_2.id) }
     end
   end
+
+  describe "#allow_resending_to_qualified_teachers_api?" do
+    subject { outcome.allow_resending_to_qualified_teachers_api? }
+
+    context "with successfully delivery" do
+      let(:outcome) { create(:participant_outcome, :successfully_sent_to_qualified_teachers_api) }
+
+      it { is_expected.to be false }
+    end
+
+    context "with failed delivery" do
+      let(:outcome) { create(:participant_outcome, :unsuccessfully_sent_to_qualified_teachers_api) }
+
+      it { is_expected.to be true }
+    end
+
+    context "with incomplete delivery" do
+      let(:outcome) { create(:participant_outcome, :sent_to_qualified_teachers_api) }
+
+      it { is_expected.to be false }
+    end
+
+    context "with undelivered" do
+      let(:outcome) { create(:participant_outcome, :not_sent_to_qualified_teachers_api) }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe "#resend_to_qualified_teachers_api!" do
+    subject { outcome.resend_to_qualified_teachers_api! }
+
+    context "with successfully delivery" do
+      let(:outcome) { create(:participant_outcome, :successfully_sent_to_qualified_teachers_api) }
+
+      it { is_expected.to be false }
+    end
+
+    context "with failed delivery" do
+      let(:outcome) { create(:participant_outcome, :unsuccessfully_sent_to_qualified_teachers_api) }
+
+      it { is_expected.to be true }
+    end
+
+    context "with incomplete delivery" do
+      let(:outcome) { create(:participant_outcome, :sent_to_qualified_teachers_api) }
+
+      it { is_expected.to be false }
+    end
+
+    context "with undelivered" do
+      let(:outcome) { create(:participant_outcome, :not_sent_to_qualified_teachers_api) }
+
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/models/participant_outcome_spec.rb
+++ b/spec/models/participant_outcome_spec.rb
@@ -265,6 +265,17 @@ RSpec.describe ParticipantOutcome, type: :model do
 
       it { is_expected.to be false }
     end
+
+    context "when not latest outcome" do
+      before do
+        create(:participant_outcome, :failed, declaration: outcome.declaration,
+                                              created_at: 3.minutes.from_now)
+      end
+
+      let(:outcome) { create(:participant_outcome, :unsuccessfully_sent_to_qualified_teachers_api) }
+
+      it { is_expected.to be false }
+    end
   end
 
   describe "#resend_to_qualified_teachers_api!" do

--- a/spec/requests/npq_separation/admin/participant_outcomes_controller_spec.rb
+++ b/spec/requests/npq_separation/admin/participant_outcomes_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe NpqSeparation::Admin::ParticipantOutcomesController, type: :reque
   describe "/npq_separation/admin/participant_outcomes/:id/resend" do
     subject :do_request do
       sign_in_as_admin
-      get resend_npq_separation_admin_participant_outcome_path(participant_outcome)
+      post resend_npq_separation_admin_participant_outcome_path(participant_outcome)
       response
     end
 

--- a/spec/requests/npq_separation/admin/participant_outcomes_controller_spec.rb
+++ b/spec/requests/npq_separation/admin/participant_outcomes_controller_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe NpqSeparation::Admin::ParticipantOutcomesController, type: :request do
+  include Helpers::NPQSeparationAdminLogin
+
+  describe "/npq_separation/admin/participant_outcomes/:id/resend" do
+    subject :do_request do
+      sign_in_as_admin
+      get resend_npq_separation_admin_participant_outcome_path(participant_outcome)
+      response
+    end
+
+    let :participant_outcome do
+      create(:participant_outcome, :unsuccessfully_sent_to_qualified_teachers_api)
+    end
+
+    it "redirects back to the applications page" do
+      expect(do_request).to redirect_to \
+        npq_separation_admin_application_path(participant_outcome.application_id)
+    end
+
+    it "confirms requeuing delivery of the api request" do
+      do_request
+
+      expect(flash[:success]).to match(/rescheduled/i)
+    end
+
+    it "requeues delivery of the api request" do
+      expect {
+        do_request
+        participant_outcome.reload
+      }.to change(participant_outcome, :sent_to_qualified_teachers_api_at?)
+    end
+
+    context "with already successfully sent participant outcome" do
+      let :participant_outcome do
+        create(:participant_outcome, :successfully_sent_to_qualified_teachers_api)
+      end
+
+      it "redirects back to the applications page" do
+        expect(do_request).to redirect_to \
+          npq_separation_admin_application_path(participant_outcome.application_id)
+      end
+
+      it "refuses requeuing delivery of the api request" do
+        do_request
+
+        expect(flash[:error]).to match(/not suitable/i)
+      end
+
+      it "does not requeue delivery of the api request" do
+        expect {
+          do_request
+          participant_outcome.reload
+        }.not_to change(participant_outcome, :sent_to_qualified_teachers_api_at?)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2152](https://dfedigital.atlassian.net/browse/CPDNPQ-2152)

We want to allow admin users to reschedule delivery of outcomes to the qualified teachers API

### Changes proposed in this pull request

* Added logic for whether to allow rescheduling to the ParticipantOutcome model
* Added a method to `nil` out the relevant ParticipantOutcome attributes, which will trigger rescheduling
* Extended the ParticipantOutcomes component table to add a resend link
* Shortened some of the other columns in ParticipantOutcomes table to make space for the `Resend` link
* Added feature specs covering the above
* Refactored the existing method to determine whether an Outcome is the most recent to work with relationships instead of doing a query directly, this allows it to benefit from eager loaded data. The number of outcomes per declaration should be low so this shouldn't result in significant data being loaded for the `applications#show` screen.
* Extended the OutcomesTableComponent to include caption_text described the latest outcome
* Swapped the OutcomesTableComponent to store strings in translations yaml file

### Screenshots

![image](https://github.com/user-attachments/assets/b849d7ba-2d87-406a-9945-24261df37351)

[CPDNPQ-2144]: https://dfedigital.atlassian.net/browse/CPDNPQ-2144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CPDNPQ-2152]: https://dfedigital.atlassian.net/browse/CPDNPQ-2152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ