### PR TITLE
Fix typo in key name for parity check tokens

### DIFF
--- a/app/services/migration/parity_check/token_provider.rb
+++ b/app/services/migration/parity_check/token_provider.rb
@@ -20,7 +20,7 @@ module Migration
   private
 
     def known_tokens_by_lead_provider_ecf_id
-      JSON.parse(ENV["PARITY-CHECK-KEYS"].to_s)
+      JSON.parse(ENV["PARITY_CHECK_KEYS"].to_s)
     rescue JSON::ParserError
       {}
     end

--- a/spec/services/migration/parity_check/token_provider_spec.rb
+++ b/spec/services/migration/parity_check/token_provider_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Migration::ParityCheck::TokenProvider do
     })
 
     allow(ENV).to receive(:[]).and_call_original
-    allow(ENV).to receive(:[]).with("PARITY-CHECK-KEYS").and_return(keys.to_json) if keys
+    allow(ENV).to receive(:[]).with("PARITY_CHECK_KEYS").and_return(keys.to_json) if keys
   end
 
   let(:instance) { described_class.new }

--- a/spec/services/migration/parity_check_spec.rb
+++ b/spec/services/migration/parity_check_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Migration::ParityCheck do
     end
 
     allow(ENV).to receive(:[]).and_call_original
-    allow(ENV).to receive(:[]).with("PARITY-CHECK-KEYS").and_return(keys.to_json)
+    allow(ENV).to receive(:[]).with("PARITY_CHECK_KEYS").and_return(keys.to_json)
   end
 
   describe(".run!") do


### PR DESCRIPTION
Fix typo in key name; its hyphens in the keyvault but they convert to underscores in the app.