### PR TITLE
[CPDLP-3632] Ensure school ukprn matches school urn in application migrator

### DIFF
--- a/app/services/migration/migrators/application.rb
+++ b/app/services/migration/migrators/application.rb
@@ -72,8 +72,10 @@ module Migration::Migrators
         if ecf_npq_application.school_urn.present?
           application.school_id = find_school_id!(urn: ecf_npq_application.school_urn)
 
-          if application.school.ukprn.to_s == ecf_npq_application.school_ukprn.to_s
+          if ecf_npq_application.school_ukprn && ecf_npq_application.school_ukprn.to_s == application.school.ukprn.to_s
             application.ukprn = ecf_npq_application.school_ukprn
+          elsif ecf_npq_application.school_ukprn.blank?
+            application.ukprn = application.school.ukprn
           else
             ecf_npq_application.errors.add(:base, "School UKPRN does not match")
             raise ActiveRecord::RecordInvalid, ecf_npq_application

--- a/app/services/migration/migrators/application.rb
+++ b/app/services/migration/migrators/application.rb
@@ -71,6 +71,13 @@ module Migration::Migrators
 
         if ecf_npq_application.school_urn.present?
           application.school_id = find_school_id!(urn: ecf_npq_application.school_urn)
+
+          if application.school.ukprn.to_s == ecf_npq_application.school_ukprn.to_s
+            application.ukprn = ecf_npq_application.school_ukprn
+          else
+            ecf_npq_application.errors.add(:base, "School UKPRN does not match")
+            raise ActiveRecord::RecordInvalid, ecf_npq_application
+          end
         end
 
         application.lead_provider_id = find_lead_provider_id!(ecf_id: ecf_npq_application.npq_lead_provider_id)
@@ -84,7 +91,6 @@ module Migration::Migrators
           application.accepted_at = ecf_npq_application.profile.created_at
         end
 
-        application.ukprn = ecf_npq_application.school_ukprn
         application.user_id = find_user_id!(ecf_id: ecf_npq_application.user.id)
         application.update!(ecf_npq_application.attributes.slice(*ATTRIBUTES))
       end

--- a/spec/services/migration/migrators/application_spec.rb
+++ b/spec/services/migration/migrators/application_spec.rb
@@ -161,6 +161,19 @@ RSpec.describe Migration::Migrators::Application do
           expect(failure_manager).to have_received(:record_failure).once.with(ecf_resource1, /Validation failed: School UKPRN does not match/)
         end
       end
+
+      context "when the school ukprn pulled in from ECF is nil" do
+        before { ecf_resource1.update!(school_ukprn: nil) }
+
+        it "overrides ukprn from Schools table on the NPQ application" do
+          application = Application.find_by!(ecf_id: ecf_resource1.id)
+          expect(application.ukprn).to be_nil
+
+          instance.call
+
+          expect(application.reload.ukprn).to eq(application.school.ukprn)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

Ticket: [CPDLP-3632](https://dfedigital.atlassian.net/browse/CPDLP-3632)

We are not checking if the school urn and school ukprn come from the same school in the migration.

### Changes proposed in this pull request

Ensure that any value we pull in from ECF for school urn and school ukprn match the same school and should be aligned, otherwise raise a failure.

[CPDLP-3632]: https://dfedigital.atlassian.net/browse/CPDLP-3632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ