### PR TITLE
Support pagination and filtering in parity check service

### DIFF
--- a/app/controllers/npq_separation/migration/parity_checks_controller.rb
+++ b/app/controllers/npq_separation/migration/parity_checks_controller.rb
@@ -16,7 +16,7 @@ class NpqSeparation::Migration::ParityChecksController < SuperAdminController
   end
 
   def response_comparison
-    @comparison = Migration::ParityCheck::ResponseComparison.with_differences.find(params[:id])
-    @response_body_diff = @comparison.response_body_diff
+    @comparison = Migration::ParityCheck::ResponseComparison.find(params[:id])
+    @matching_comparisons = Migration::ParityCheck::ResponseComparison.matching(@comparison)
   end
 end

--- a/app/models/migration/parity_check/response_comparison.rb
+++ b/app/models/migration/parity_check/response_comparison.rb
@@ -6,6 +6,7 @@ module Migration
 
     validates :lead_provider, presence: true
     validates :request_path, presence: true
+    validates :page, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
     validates :request_method, inclusion: { in: %w[get post put] }
     validates :ecf_response_status_code, inclusion: { in: 100..599 }
     validates :npq_response_status_code, inclusion: { in: 100..599 }

--- a/app/models/migration/parity_check/response_comparison.rb
+++ b/app/models/migration/parity_check/response_comparison.rb
@@ -17,11 +17,22 @@ module Migration
 
     delegate :name, to: :lead_provider, prefix: true
 
-    scope :with_differences, -> { where("ecf_response_status_code != npq_response_status_code OR ecf_response_body != npq_response_body") }
+    scope :matching, lambda { |comparison|
+      where(
+        lead_provider: comparison.lead_provider,
+        request_path: comparison.request_path,
+        request_method: comparison.request_method,
+      )
+      .order(page: :asc)
+    }
 
     class << self
       def by_lead_provider
-        includes(:lead_provider).group_by(&:lead_provider_name)
+        includes(:lead_provider)
+          .group_by(&:lead_provider_name)
+          .transform_values do |comparisons|
+            comparisons.group_by(&:description)
+          end
       end
 
       def response_times_by_path
@@ -52,12 +63,8 @@ module Migration
       "#{request_method.upcase} #{request_path}"
     end
 
-    def npq_slower?
-      npq_response_time_ms > ecf_response_time_ms
-    end
-
     def response_body_diff
-      Diffy::Diff.new(ecf_response_body, npq_response_body, context: 3)
+      @response_body_diff ||= Diffy::Diff.new(ecf_response_body, npq_response_body, context: 3)
     end
 
   private

--- a/app/services/migration/parity_check/client.rb
+++ b/app/services/migration/parity_check/client.rb
@@ -31,7 +31,7 @@ module Migration
       return false unless paginate?
 
       [ecf_response[:response].body, npq_response[:response].body].any? do |body|
-        JSON.parse(body)["data"].size == PAGINATION_PER_PAGE
+        JSON.parse(body)["data"]&.size == PAGINATION_PER_PAGE
       rescue JSON::ParserError
         false
       end

--- a/app/services/migration/parity_check/client.rb
+++ b/app/services/migration/parity_check/client.rb
@@ -1,0 +1,48 @@
+module Migration
+  class ParityCheck::Client
+    attr_reader :lead_provider, :method, :path, :options
+
+    def initialize(lead_provider:, method:, path:, options:)
+      @lead_provider = lead_provider
+      @method = method
+      @path = path
+      @options = options || {}
+    end
+
+    def make_requests(&block)
+      ecf_result = timed_response { send("#{method}_request", lead_provider:, path:, app: :ecf) }
+      npq_result = timed_response { send("#{method}_request", lead_provider:, path:, app: :npq) }
+
+      block.call(ecf_result, npq_result, nil)
+    end
+
+  private
+
+    def timed_response(&request)
+      response = nil
+      response_ms = Benchmark.realtime { response = request.call } * 1_000
+
+      { response:, response_ms: }
+    end
+
+    def get_request(lead_provider:, path:, app:)
+      HTTParty.get(url(app:, path:), headers: headers(token_provider.token(lead_provider:)))
+    end
+
+    def token_provider
+      @token_provider ||= Migration::ParityCheck::TokenProvider.new
+    end
+
+    def headers(token)
+      {
+        "Authorization" => "Bearer #{token}",
+        "Accept" => "application/json",
+        "Content-Type" => "application/json",
+      }
+    end
+
+    def url(app:, path:)
+      Rails.application.config.npq_separation[:parity_check]["#{app}_url".to_sym] + path
+    end
+  end
+end

--- a/app/services/migration/parity_check/client.rb
+++ b/app/services/migration/parity_check/client.rb
@@ -1,22 +1,45 @@
 module Migration
   class ParityCheck::Client
-    attr_reader :lead_provider, :method, :path, :options
+    attr_reader :lead_provider, :method, :path, :options, :page
+
+    PAGINATION_PER_PAGE = 10
 
     def initialize(lead_provider:, method:, path:, options:)
       @lead_provider = lead_provider
       @method = method
       @path = path
       @options = options || {}
+      @page = 1 if paginate?
     end
 
     def make_requests(&block)
-      ecf_result = timed_response { send("#{method}_request", lead_provider:, path:, app: :ecf) }
-      npq_result = timed_response { send("#{method}_request", lead_provider:, path:, app: :npq) }
+      loop do
+        ecf_result = timed_response { send("#{method}_request", app: :ecf) }
+        npq_result = timed_response { send("#{method}_request", app: :npq) }
 
-      block.call(ecf_result, npq_result, nil)
+        block.call(ecf_result, npq_result, page)
+
+        break unless next_page?(ecf_result, npq_result)
+
+        @page += 1
+      end
     end
 
   private
+
+    def next_page?(ecf_response, npq_response)
+      return false unless paginate?
+
+      [ecf_response[:response].body, npq_response[:response].body].any? do |body|
+        JSON.parse(body)["data"].size == PAGINATION_PER_PAGE
+      rescue JSON::ParserError
+        false
+      end
+    end
+
+    def paginate?
+      options[:paginate]
+    end
 
     def timed_response(&request)
       response = nil
@@ -25,17 +48,23 @@ module Migration
       { response:, response_ms: }
     end
 
-    def get_request(lead_provider:, path:, app:)
-      HTTParty.get(url(app:, path:), headers: headers(token_provider.token(lead_provider:)))
+    def get_request(app:)
+      HTTParty.get(url(app:, path:), query:, headers:)
     end
 
     def token_provider
       @token_provider ||= Migration::ParityCheck::TokenProvider.new
     end
 
-    def headers(token)
+    def query
+      return unless paginate?
+
+      { page: { page:, per_page: PAGINATION_PER_PAGE } }
+    end
+
+    def headers
       {
-        "Authorization" => "Bearer #{token}",
+        "Authorization" => "Bearer #{token_provider.token(lead_provider:)}",
         "Accept" => "application/json",
         "Content-Type" => "application/json",
       }

--- a/app/views/npq_separation/migration/parity_checks/_completed_parity_check.html.erb
+++ b/app/views/npq_separation/migration/parity_checks/_completed_parity_check.html.erb
@@ -8,13 +8,13 @@
 <canvas id="response-time-chart"></canvas>
 
 <%= govuk_accordion do |accordion|
-  @response_comparisons_by_lead_provider.each do |lead_provider_name, comparisons|
-    accordion.with_section(heading_text: lead_provider_name, expanded: comparisons.any?(&:different?)) do
+  @response_comparisons_by_lead_provider.each do |lead_provider_name, comparisons_by_description|
+    accordion.with_section(heading_text: lead_provider_name, expanded: comparisons_by_description.values.flatten.any?(&:different?)) do
       govuk_task_list do |task_list|
-        comparisons.each do |comparison|
+        comparisons_by_description.each do |description, comparisons|
           task_list.with_item do |item|
-            item.with_title(text: comparison.description, hint: response_comparison_performance(comparison), href: response_comparison_detail_path(comparison))
-            item.with_status(text: response_comparison_status_tag(comparison.different?))
+            item.with_title(text: description, hint: response_comparison_performance(comparisons), href: response_comparison_detail_path(comparisons))
+            item.with_status(text: response_comparison_status_tag(comparisons.any?(&:different?)))
           end
         end
       end

--- a/app/views/npq_separation/migration/parity_checks/_multiple_comparisons_summary.html.erb
+++ b/app/views/npq_separation/migration/parity_checks/_multiple_comparisons_summary.html.erb
@@ -1,0 +1,28 @@
+<%= govuk_table do |table|
+  table.with_caption(size: "m", text: "Overview (#{pluralize(comparisons.size, "pages")})")
+
+  table.with_head do |head|
+    head.with_row do |row|
+      row.with_cell(text: "Metric")
+      row.with_cell(text: "ECF")
+      row.with_cell(text: "NPQ")
+      row.with_cell(text: "Comparison")
+    end
+  end
+
+  table.with_body do |body|
+    body.with_row do |row|
+      row.with_cell(text: "Equality check")
+      row.with_cell(text: "-")
+      row.with_cell(text: "-")
+      row.with_cell(text: response_comparison_status_tag(comparisons.any?(&:different?)))
+    end
+
+    body.with_row do |row|
+      row.with_cell(text: "Average response time")
+      row.with_cell(text: response_comparison_response_duration_human_readable(comparisons, :ecf_response_time_ms))
+      row.with_cell(text: response_comparison_response_duration_human_readable(comparisons, :npq_response_time_ms))
+      row.with_cell(text: response_comparison_performance(comparisons))
+    end
+  end
+end %>

--- a/app/views/npq_separation/migration/parity_checks/_response_body_diff.html.erb
+++ b/app/views/npq_separation/migration/parity_checks/_response_body_diff.html.erb
@@ -1,0 +1,1 @@
+<%= response_body_diff.to_s.presence ? response_body_diff.to_s(:html).html_safe : tag.p("No difference", class: "govuk-body") %>

--- a/app/views/npq_separation/migration/parity_checks/_single_comparison_summary.html.erb
+++ b/app/views/npq_separation/migration/parity_checks/_single_comparison_summary.html.erb
@@ -1,0 +1,28 @@
+<%= govuk_table do |table|
+    table.with_caption(size: "m", text: "Response diff")
+
+    table.with_head do |head|
+      head.with_row do |row|
+        row.with_cell(text: "Metric")
+        row.with_cell(text: "ECF")
+        row.with_cell(text: "NPQ")
+        row.with_cell(text: "Comparison")
+      end
+    end
+
+    table.with_body do |body|
+      body.with_row do |row|
+        row.with_cell(text: "Response time")
+        row.with_cell(text: response_comparison_response_duration_human_readable(comparison, :ecf_response_time_ms))
+        row.with_cell(text: response_comparison_response_duration_human_readable(comparison, :npq_response_time_ms))
+        row.with_cell(text: response_comparison_performance(comparison))
+      end
+
+      body.with_row do |row|
+        row.with_cell(text: "Status code")
+        row.with_cell(text: response_comparison_status_code_tag(comparison.ecf_response_status_code))
+        row.with_cell(text: response_comparison_status_code_tag(comparison.npq_response_status_code))
+        row.with_cell(text: response_comparison_status_tag(comparison.ecf_response_status_code != comparison.npq_response_status_code))
+      end
+    end
+  end %>

--- a/app/views/npq_separation/migration/parity_checks/response_comparison.html.erb
+++ b/app/views/npq_separation/migration/parity_checks/response_comparison.html.erb
@@ -7,35 +7,21 @@
 <span class="govuk-caption-xl"><%= @comparison.lead_provider_name %></span>
 <h1 class="govuk-heading-xl"><%= @comparison.description %></h1>
 
-<%= govuk_table do |table|
-  table.with_caption(size: "m", text: "Overview")
+<% unless @matching_comparisons.one? %>
+  <%= render(partial: "multiple_comparisons_summary", locals: { comparisons: @matching_comparisons }) %>
+<% end %>
 
-  table.with_head do |head|
-    head.with_row do |row|
-      row.with_cell(text: "Metric")
-      row.with_cell(text: "ECF")
-      row.with_cell(text: "NPQ")
-      row.with_cell(text: "Comparison")
-    end
-  end
-
-  table.with_body do |body|
-    body.with_row do |row|
-      row.with_cell(text: "Response time")
-      row.with_cell(text: response_comparison_response_duration_human_readable(@comparison.ecf_response_time_ms))
-      row.with_cell(text: response_comparison_response_duration_human_readable(@comparison.npq_response_time_ms))
-      row.with_cell(text: response_comparison_performance(@comparison))
-    end
-
-    body.with_row do |row|
-      row.with_cell(text: "Status code")
-      row.with_cell(text: response_comparison_status_code_tag(@comparison.ecf_response_status_code))
-      row.with_cell(text: response_comparison_status_code_tag(@comparison.npq_response_status_code))
-      row.with_cell(text: response_comparison_status_tag(@comparison.ecf_response_status_code != @comparison.npq_response_status_code))
-    end
-  end
-end %>
-
-<h2 class="govuk-heading-m">Response body diff</h2>
-
-<%= @response_body_diff.to_s(:html).html_safe %>
+<% if @matching_comparisons.any?(&:different?) %>
+  <% if @matching_comparisons.one? %>
+    <%= render(partial: "single_comparison_summary", locals: { comparison: @comparison }) %>
+    <%= render(partial: "response_body_diff", locals: { response_body_diff: @comparison.response_body_diff }) %>
+  <% else %>
+    <%= govuk_accordion do |accordion|
+      @matching_comparisons.select(&:different?).each do |comparison|
+        accordion.with_section(heading_text: response_comparison_page_summary(comparison), expanded: comparison.different?) do
+          render(partial: "response_body_diff", locals: { response_body_diff: comparison.response_body_diff })
+        end
+      end
+    end %>
+  <% end %>
+<% end %>

--- a/config/parity_check_endpoints.yml
+++ b/config/parity_check_endpoints.yml
@@ -1,2 +1,3 @@
 get:
   "/api/v3/statements":
+    paginate: true

--- a/config/parity_check_endpoints.yml
+++ b/config/parity_check_endpoints.yml
@@ -1,3 +1,7 @@
 get:
   "/api/v3/statements":
     paginate: true
+  "/api/v3/statements?filter[cohort]=2021":
+    paginate: true
+  "/api/v3/statements?filter[updated_since]=2024-01-01T12:00:00Z":
+    paginate: true

--- a/db/migrate/20241021085312_add_page_to_response_comparisons.rb
+++ b/db/migrate/20241021085312_add_page_to_response_comparisons.rb
@@ -1,0 +1,5 @@
+class AddPageToResponseComparisons < ActiveRecord::Migration[7.1]
+  def change
+    add_column :response_comparisons, :page, :integer, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_16_122750) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_21_085312) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -408,6 +408,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_122750) do
     t.bigint "lead_provider_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "page"
     t.index ["lead_provider_id"], name: "index_response_comparisons_on_lead_provider_id"
   end
 

--- a/spec/features/parity_check_spec.rb
+++ b/spec/features/parity_check_spec.rb
@@ -59,12 +59,12 @@ RSpec.feature "Parity check", :in_memory_rails_cache, :rack_test_driver, type: :
 
       expect(page).to have_css("#response-time-chart")
 
-      Migration::ParityCheck::ResponseComparison.by_lead_provider.each do |lead_provider_name, comparisons|
+      Migration::ParityCheck::ResponseComparison.by_lead_provider.each do |lead_provider_name, comparisons_by_description|
         within("##{lead_provider_name.parameterize}-section") do
           expect(page).to have_text(lead_provider_name)
 
-          comparisons.each do |comparison|
-            expect(page).to have_text(comparison.description)
+          comparisons_by_description.each_key do |description|
+            expect(page).to have_text(description)
             expect(page).not_to have_link
             expect(page).to have_text("EQUAL")
           end
@@ -108,6 +108,8 @@ RSpec.feature "Parity check", :in_memory_rails_cache, :rack_test_driver, type: :
       expect(page).to have_css(".govuk-caption-xl", text: different_comparison.lead_provider_name)
       expect(page).to have_css("h1", text: different_comparison.description)
 
+      expect(page).to have_text("Response diff")
+
       within("tbody tr:first") do
         expect(page).to have_text("Response time")
         expect(page).to have_text(/\d(ms)/)
@@ -121,8 +123,49 @@ RSpec.feature "Parity check", :in_memory_rails_cache, :rack_test_driver, type: :
         expect(page).to have_text("DIFFERENT")
       end
 
-      expect(page).to have_text("Response body diff")
       expect(page).to have_css(".diff", text: "response1 response2")
+    end
+
+    scenario "viewing the details of a response comparison when there are multiple pages" do
+      visit npq_separation_migration_parity_checks_path
+
+      perform_enqueued_jobs do
+        click_button "Run parity check"
+      end
+
+      different_comparison = create(:response_comparison, :different, page: 1)
+      lead_provider = different_comparison.lead_provider
+      create(:response_comparison, :different, npq_response_body: "body", ecf_response_body: "body", page: 2, lead_provider:)
+      create(:response_comparison, :equal, page: 3, lead_provider:)
+
+      # Reload to display the different comparison created manually
+      visit current_path
+
+      click_link(different_comparison.description)
+
+      expect(page).to have_css(".govuk-caption-xl", text: different_comparison.lead_provider_name)
+      expect(page).to have_css("h1", text: different_comparison.description)
+
+      expect(page).to have_text("Overview (3 pages)")
+
+      within("tbody tr:first") do
+        expect(page).to have_text("Equality check")
+        expect(page).to have_text("DIFFERENT")
+      end
+
+      within("tbody tr:last") do
+        expect(page).to have_text("Average response time")
+        expect(page).to have_text("100ms")
+        expect(page).to have_text("50ms")
+        expect(page).to have_text("🚀 2x faster")
+      end
+
+      expect(page).to have_css(".govuk-grid-row", text: "Page 1\nECF: 200 NPQ: 201")
+
+      expect(page).to have_css(".govuk-grid-row", text: "Page 2\nECF: 200 NPQ: 201")
+      expect(page).to have_text("No difference")
+
+      expect(page).not_to have_text("Page 3")
     end
   end
 end

--- a/spec/fixtures/files/parity_check/get_endpoints.yml
+++ b/spec/fixtures/files/parity_check/get_endpoints.yml
@@ -1,2 +1,3 @@
 get:
   "/api/v3/statements":
+    paginate: true

--- a/spec/helpers/migration_helper_spec.rb
+++ b/spec/helpers/migration_helper_spec.rb
@@ -225,56 +225,89 @@ RSpec.describe MigrationHelper, type: :helper do
   end
 
   describe ".response_comparison_performance" do
-    subject { helper.response_comparison_performance(response_comparison) }
+    let(:comparisons) { [response_comparison1, response_comparison2] }
+
+    subject { helper.response_comparison_performance(comparisons) }
 
     context "when NPQ is slower" do
-      let(:response_comparison) { build(:response_comparison, npq_response_time_ms: 2, ecf_response_time_ms: 1) }
+      let(:response_comparison1) { build(:response_comparison, npq_response_time_ms: 2, ecf_response_time_ms: 1) }
+      let(:response_comparison2) { build(:response_comparison, npq_response_time_ms: 2, ecf_response_time_ms: 1) }
 
-      it { is_expected.to have_css("strong", text: "🐌 0.5x slower") }
+      it { is_expected.to have_css("strong", text: "🐌 0.5x as fast") }
     end
 
     context "when NPQ is faster" do
-      let(:response_comparison) { build(:response_comparison, npq_response_time_ms: 1, ecf_response_time_ms: 2) }
+      let(:response_comparison1) { build(:response_comparison, npq_response_time_ms: 1, ecf_response_time_ms: 2) }
+      let(:response_comparison2) { build(:response_comparison, npq_response_time_ms: 1, ecf_response_time_ms: 2) }
 
       it { is_expected.to have_css("i", text: "🚀 2x faster") }
+    end
+
+    context "when passed a single comparison" do
+      let(:comparisons) { create(:response_comparison, npq_response_time_ms: 1, ecf_response_time_ms: 3) }
+
+      it { is_expected.to have_css("i", text: "🚀 3x faster") }
     end
   end
 
   describe ".response_comparison_detail_path" do
-    subject { helper.response_comparison_detail_path(response_comparison) }
+    subject { helper.response_comparison_detail_path([response_comparison1, response_comparison2]) }
 
-    context "when different" do
-      let(:response_comparison) { create(:response_comparison, :different) }
+    context "when at least one is different" do
+      let(:response_comparison1) { create(:response_comparison, :different) }
+      let(:response_comparison2) { create(:response_comparison, :equal) }
 
-      it { is_expected.to include("/npq-separation/migration/parity_checks/response_comparisons/#{response_comparison.id}") }
+      it { is_expected.to include(%r{/npq-separation/migration/parity_checks/response_comparisons/(#{response_comparison1.id}|#{response_comparison2.id})}) }
     end
 
-    context "when equal" do
-      let(:response_comparison) { build(:response_comparison, :equal) }
+    context "when all are equal" do
+      let(:response_comparison1) { build(:response_comparison, :equal) }
+      let(:response_comparison2) { build(:response_comparison, :equal) }
 
       it { is_expected.to be_nil }
     end
   end
 
   describe ".response_comparison_response_duration_human_readable" do
-    subject { helper.response_comparison_response_duration_human_readable(duration_ms) }
+    subject { helper.response_comparison_response_duration_human_readable(comparisons, :ecf_response_time_ms) }
 
-    context "when the duration is less than 1 second" do
-      let(:duration_ms) { 500 }
+    context "when the average duration is less than 1 second" do
+      let(:comparisons) do
+        [
+          create(:response_comparison, ecf_response_time_ms: 600),
+          create(:response_comparison, ecf_response_time_ms: 400),
+        ]
+      end
 
       it { is_expected.to eq("500ms") }
     end
 
     context "when the duration is 1 second" do
-      let(:duration_ms) { 1_000 }
+      let(:comparisons) do
+        [
+          create(:response_comparison, ecf_response_time_ms: 1_000),
+          create(:response_comparison, ecf_response_time_ms: 1_000),
+        ]
+      end
 
       it { is_expected.to eq("1 second") }
     end
 
     context "when the duration is more than 1 second" do
-      let(:duration_ms) { 2_525 }
+      let(:comparisons) do
+        [
+          create(:response_comparison, ecf_response_time_ms: 2_000),
+          create(:response_comparison, ecf_response_time_ms: 2_200),
+        ]
+      end
 
       it { is_expected.to eq("2 seconds") }
+    end
+
+    context "when passed a single comparison" do
+      let(:comparisons) { create(:response_comparison, ecf_response_time_ms: 1_000) }
+
+      it { is_expected.to eq("1 second") }
     end
   end
 
@@ -298,5 +331,14 @@ RSpec.describe MigrationHelper, type: :helper do
 
       it { is_expected.to have_css("strong.govuk-tag.govuk-tag--red", text: "500") }
     end
+  end
+
+  describe ".response_comparison_page_summary" do
+    let(:comparison) { create(:response_comparison, :different, page: 1) }
+
+    subject { helper.response_comparison_page_summary(comparison) }
+
+    it { is_expected.to have_css(".govuk-grid-row .govuk-grid-column-two-thirds", text: "Page 1") }
+    it { is_expected.to have_css(".govuk-grid-row .govuk-grid-column-one-third", text: "ECF: 200 NPQ: 201") }
   end
 end

--- a/spec/models/migration/parity_check/response_comparison_spec.rb
+++ b/spec/models/migration/parity_check/response_comparison_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Migration::ParityCheck::ResponseComparison, type: :model do
     it { is_expected.to validate_inclusion_of(:npq_response_status_code).in_range(100..599) }
     it { is_expected.to validate_numericality_of(:ecf_response_time_ms).is_greater_than(0) }
     it { is_expected.to validate_numericality_of(:npq_response_time_ms).is_greater_than(0) }
+    it { is_expected.to validate_numericality_of(:page).only_integer.is_greater_than(0).allow_nil }
 
     context "when the response comparison is equal" do
       subject { create(:response_comparison, :equal) }

--- a/spec/requests/npq_separation/migration/parity_checks_controller_spec.rb
+++ b/spec/requests/npq_separation/migration/parity_checks_controller_spec.rb
@@ -81,12 +81,6 @@ RSpec.describe NpqSeparation::Migration::ParityChecksController, type: :request 
 
       it { expect(response).to be_successful }
 
-      context "when the response comparison is equal", :exceptions_app do
-        let(:comparison) { create(:response_comparison, :equal) }
-
-        it { expect(response).to be_not_found }
-      end
-
       context "when the response comparison is not found", :exceptions_app do
         let(:comparison) { OpenStruct.new(id: -1) }
 

--- a/spec/services/migration/parity_check/client_spec.rb
+++ b/spec/services/migration/parity_check/client_spec.rb
@@ -1,0 +1,89 @@
+require "rails_helper"
+
+RSpec.describe Migration::ParityCheck::Client do
+  let(:lead_provider) { create(:lead_provider) }
+  let(:path) { "/api/path" }
+  let(:method) { :get }
+  let(:options) { {} }
+  let(:instance) { described_class.new(lead_provider:, method:, path:, options:) }
+  let(:ecf_url) { "http://ecf.example.com" }
+  let(:npq_url) { "http://npq.example.com" }
+  let(:keys) { { lead_provider.ecf_id => SecureRandom.uuid } }
+
+  before do
+    allow(Rails.application.config).to receive(:npq_separation) do
+      {
+        parity_check: {
+          enabled: true,
+          ecf_url:,
+          npq_url:,
+        },
+      }
+    end
+
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with("PARITY_CHECK_KEYS").and_return(keys.to_json)
+  end
+
+  describe "#initialize" do
+    it { expect(instance.lead_provider).to eq(lead_provider) }
+    it { expect(instance.path).to eq(path) }
+    it { expect(instance.method).to eq(method) }
+    it { expect(instance.options).to eq(options) }
+
+    context "when options is nil" do
+      let(:options) { nil }
+
+      it { expect(instance.options).to eq({}) }
+    end
+  end
+
+  describe "#make_requests" do
+    let(:requests) { WebMock::RequestRegistry.instance.requested_signatures.hash.keys }
+    let(:ecf_requests) { requests.select { |r| r.uri.host.include?("ecf") } }
+    let(:npq_requests) { requests.select { |r| r.uri.host.include?("npq") } }
+
+    context "when making a GET request" do
+      let(:method) { :get }
+
+      before do
+        stub_request(:get, "#{ecf_url}#{path}").to_return(status: 200, body: "ecf_response_body")
+        stub_request(:get, "#{npq_url}#{path}").to_return(status: 201, body: "npq_response_body")
+      end
+
+      it "makes a request to ECF/NPQ with correct path and headers" do
+        instance.make_requests do
+          requests.each do |request|
+            expect(request.uri.path).to eq(path)
+            expect(request.headers["Accept"]).to eq("application/json")
+            expect(request.headers["Content-Type"]).to eq("application/json")
+          end
+        end
+      end
+
+      it "makes a request to ECF/NPQ with a valid authorization token for the lead provider" do
+        instance.make_requests do
+          ecf_token = ecf_requests.first.headers["Authorization"].partition("Bearer ").last
+          expect(ecf_token).to eq(keys[lead_provider.ecf_id])
+
+          npq_token = npq_requests.first.headers["Authorization"].partition("Bearer ").last
+          expect(npq_token).to eq(keys[lead_provider.ecf_id])
+        end
+      end
+
+      it "yeilds the result of each call to the block" do
+        instance.make_requests do |ecf_result, npq_result, page|
+          expect(ecf_result[:response].code).to eq(200)
+          expect(ecf_result[:response].body).to eq("ecf_response_body")
+          expect(ecf_result[:response_ms]).to be >= 0
+
+          expect(npq_result[:response].code).to eq(201)
+          expect(npq_result[:response].body).to eq("npq_response_body")
+          expect(npq_result[:response_ms]).to be >= 0
+
+          expect(page).to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Jira-3618](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345%2Cunassigned&selectedIssue=CPDLP-3618)

### Context

We want to support pagination and filtering in the parity check service, so that we can compare the responses across multiple pages and with different query parameters.

### Changes proposed in this pull request

- Add page attribute to ResponseComparison

We want to support pagination when calling certain endpoints as party of the parity check. To make it more managable, we're going to store the results of each page as a separate `ResponseComparison` instance.

Add `page` attribute to `ResponseComparison` model.

- Extract Client from ParityCheck service

To avoid overcomplicating the `ParityCheck` service, the request/response logic has been extracted to a separate `Client` model. This model will be expanded to support pagination and any other request/response behaviour.

- Support pagination

Update the `Client` to support paginating if the `options[:paginate]` us specified.

It will paginate until there are no pages left for either NPQ or ECF (determined by the resulting `data` count being less than the `per_page`).

- Update parity check UI to support pagination

Display comparison results grouped by description on the completion page (so comparisons with the same method/path and different page will be grouped together).

On the completion page we show one entry for paginated comparisons (if there is one difference across any page then its marked as different).

On the detail page we only show the different pages in the result, along with a summary of the average performance/response times.

The per page value is intentionally set as a low value for now so that we can see the pagination work on statements.

### Guidance for review

I've made the per-page low for now to demonstrate the UI, but we can increase it when we get to the endpoints with more records.

Best reviewed by-commit.

| Complete | Complete (expanded) | Multi page response | Multi page response (expanded) | Single response |
| -- | -- | -- | -- | -- |
| ![screencapture-0-0-0-0-3000-npq-separation-migration-parity-checks-2024-10-22-10_22_08](https://github.com/user-attachments/assets/cbdc74f5-a916-4d3c-b35f-f426483156de) | ![screencapture-0-0-0-0-3000-npq-separation-migration-parity-checks-2024-10-22-10_22_33](https://github.com/user-attachments/assets/8bab2c38-43c8-473e-ba96-4b277f76b3e9) | ![screencapture-0-0-0-0-3000-npq-separation-migration-parity-checks-response-comparisons-426-2024-10-22-10_22_57](https://github.com/user-attachments/assets/4df45540-b18a-47ff-aad1-21cd89b26edb) |  ![screencapture-0-0-0-0-3000-npq-separation-migration-parity-checks-response-comparisons-426-2024-10-22-10_24_10](https://github.com/user-attachments/assets/518e1a3d-b633-4418-92ac-01e01c29d305) | ![screencapture-0-0-0-0-3000-npq-separation-migration-parity-checks-response-comparisons-431-2024-10-22-10_23_37](https://github.com/user-attachments/assets/e90e0941-330d-4663-b8f9-e86eb15c0a64) |
