### PR TITLE
[CPDLP-3631] Ensure we migrate all relevant timestamps from ECF

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -11,7 +11,7 @@ class Application < ApplicationRecord
     establishment-ineligible
   ].freeze
 
-  has_paper_trail only: %i[lead_provider_approval_status participant_outcome_state]
+  has_paper_trail meta: { note: :version_note }
 
   belongs_to :user
   belongs_to :course
@@ -33,6 +33,8 @@ class Application < ApplicationRecord
   scope :accepted, -> { where(lead_provider_approval_status: "accepted") }
   scope :eligible_for_funding, -> { where(eligible_for_funding: true) }
   scope :with_targeted_delivery_funding_eligibility, -> { where(targeted_delivery_funding_eligibility: true) }
+
+  attr_accessor :version_note
 
   validate :schedule_cohort_matches
   # TODO: add constraints into the DB after separation

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   devise :omniauthable, omniauth_providers: [:tra_openid_connect]
 
+  has_paper_trail meta: { note: :version_note }
+
   has_many :applications, dependent: :destroy
   has_many :declarations, through: :applications
   has_many :ecf_sync_request_logs, as: :syncable, dependent: :destroy
@@ -37,6 +39,8 @@ class User < ApplicationRecord
   EMAIL_UPDATES_ALL_STATES = [:empty] + EMAIL_UPDATES_STATES
 
   enum email_updates_status: EMAIL_UPDATES_ALL_STATES, _suffix: true
+
+  attr_accessor :version_note
 
   def latest_participant_outcome(lead_provider, course_identifier)
     declarations.eligible_for_outcomes(lead_provider, course_identifier)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   devise :omniauthable, omniauth_providers: [:tra_openid_connect]
 
-  has_paper_trail meta: { note: :version_note }
+  has_paper_trail meta: { note: :version_note }, ignore: [:raw_tra_provider_data]
 
   has_many :applications, dependent: :destroy
   has_many :declarations, through: :applications

--- a/app/services/migration/migrators/application.rb
+++ b/app/services/migration/migrators/application.rb
@@ -26,7 +26,6 @@ module Migration::Migrators
       notes
       funded_place
       created_at
-      updated_at
     ].freeze
 
     class << self
@@ -63,6 +62,7 @@ module Migration::Migrators
 
         application ||= ::Application.new(ecf_id: ecf_npq_application.id)
 
+        application.updated_at = ecf_npq_application.updated_at
         application.cohort_id = find_cohort_id!(ecf_id: ecf_npq_application.cohort_id)
         application.itt_provider_id = find_itt_provider_id!(itt_provider: ecf_npq_application.itt_provider) if ecf_npq_application.itt_provider
         application.private_childcare_provider_id = find_private_childcare_provider_id!(provider_urn: ecf_npq_application.private_childcare_provider_urn) if ecf_npq_application.private_childcare_provider_urn
@@ -70,10 +70,11 @@ module Migration::Migrators
         if ecf_npq_application.school_urn.present?
           application.school_id = find_school_id!(urn: ecf_npq_application.school_urn)
 
-          if ecf_npq_application.school_ukprn && ecf_npq_application.school_ukprn.to_s == application.school.ukprn.to_s
+          if ecf_npq_application.school_ukprn.present? && ecf_npq_application.school_ukprn.to_s == application.school.ukprn.to_s
             application.ukprn = ecf_npq_application.school_ukprn
           elsif ecf_npq_application.school_ukprn.blank?
             application.ukprn = application.school.ukprn
+            application.updated_at = Time.zone.now
           else
             ecf_npq_application.errors.add(:base, "School UKPRN does not match")
             raise ActiveRecord::RecordInvalid, ecf_npq_application

--- a/app/services/migration/migrators/application.rb
+++ b/app/services/migration/migrators/application.rb
@@ -25,6 +25,8 @@ module Migration::Migrators
       teacher_catchment_country
       notes
       funded_place
+      created_at
+      updated_at
     ].freeze
 
     class << self
@@ -59,11 +61,7 @@ module Migration::Migrators
       migrate(self.class.ecf_npq_applications) do |ecf_npq_application|
         application = applications_by_ecf_id[ecf_npq_application.id]
 
-        application ||= ::Application.new(
-          ecf_id: ecf_npq_application.id,
-          created_at: ecf_npq_application.created_at,
-          updated_at: ecf_npq_application.updated_at,
-        )
+        application ||= ::Application.new(ecf_id: ecf_npq_application.id)
 
         application.cohort_id = find_cohort_id!(ecf_id: ecf_npq_application.cohort_id)
         application.itt_provider_id = find_itt_provider_id!(itt_provider: ecf_npq_application.itt_provider) if ecf_npq_application.itt_provider
@@ -94,6 +92,7 @@ module Migration::Migrators
         end
 
         application.user_id = find_user_id!(ecf_id: ecf_npq_application.user.id)
+        application.version_note = "Changes migrated from ECF to NPQ"
         application.update!(ecf_npq_application.attributes.slice(*ATTRIBUTES))
       end
     end

--- a/app/services/migration/migrators/cohort.rb
+++ b/app/services/migration/migrators/cohort.rb
@@ -20,6 +20,8 @@ module Migration::Migrators
         cohort.update!(
           start_year: ecf_cohort.start_year,
           registration_start_date: ecf_cohort.npq_registration_start_date.presence || ecf_cohort.registration_start_date,
+          created_at: ecf_cohort.created_at,
+          updated_at: ecf_cohort.updated_at,
         )
       end
     end

--- a/app/services/migration/migrators/participant_id_change.rb
+++ b/app/services/migration/migrators/participant_id_change.rb
@@ -29,6 +29,7 @@ module Migration::Migrators
           from_participant_id: ecf_participant_id_change.from_participant_id,
           to_participant_id: ecf_participant_id_change.to_participant_id,
           created_at: ecf_participant_id_change.created_at,
+          updated_at: ecf_participant_id_change.updated_at,
         )
       end
     end

--- a/app/services/migration/migrators/schedule.rb
+++ b/app/services/migration/migrators/schedule.rb
@@ -39,6 +39,8 @@ module Migration::Migrators
             applies_to: ecf_milestone.payment_date,
             name: ecf_schedule.name,
             allowed_declaration_types: ecf_schedule.milestones.pluck(:declaration_type),
+            created_at: ecf_schedule.created_at,
+            updated_at: ecf_schedule.updated_at,
           )
         end
       end

--- a/app/services/migration/migrators/statement.rb
+++ b/app/services/migration/migrators/statement.rb
@@ -34,6 +34,8 @@ module Migration::Migrators
           marked_as_paid_at: ecf_statement.marked_as_paid_at,
           reconcile_amount: ecf_statement.reconcile_amount,
           state: npq_state(ecf_statement),
+          created_at: ecf_statement.created_at,
+          updated_at: ecf_statement.updated_at,
         )
       end
     end

--- a/app/services/migration/migrators/user.rb
+++ b/app/services/migration/migrators/user.rb
@@ -52,6 +52,9 @@ module Migration::Migrators
           national_insurance_number: npq_application.nino || user.national_insurance_number,
           active_alert: npq_application.active_alert || user.active_alert,
           trn_verified: ecf_verified_trn.present? || (ecf_unverified_trn.blank? && user&.trn_verified),
+          created_at: ecf_user.created_at,
+          updated_at: ecf_user.updated_at,
+          version_note: "Changes migrated from ECF to NPQ",
         )
       end
     end

--- a/app/services/migration/migrators/user.rb
+++ b/app/services/migration/migrators/user.rb
@@ -43,7 +43,7 @@ module Migration::Migrators
         ecf_verified_trn = ecf_user.teacher_profile&.trn || application_trns_by_verified[true]&.first
         ecf_unverified_trn = application_trns_by_verified[false]&.first
 
-        user.update!(
+        attrs = {
           trn: ecf_verified_trn || ecf_unverified_trn || user.trn,
           full_name: ecf_user.full_name || user.full_name,
           email:,
@@ -55,7 +55,13 @@ module Migration::Migrators
           created_at: ecf_user.created_at,
           updated_at: ecf_user.updated_at,
           version_note: "Changes migrated from ECF to NPQ",
-        )
+        }
+
+        if changed_ecf_user_attrs?(attrs, ecf_user)
+          attrs[:updated_at] = Time.zone.now
+        end
+
+        user.update!(attrs)
       end
     end
 
@@ -88,6 +94,11 @@ module Migration::Migrators
 
       user.errors.add(:base, "There are multiple different, verified TRNs from NPQ applications")
       raise ActiveRecord::RecordInvalid, user
+    end
+
+    def changed_ecf_user_attrs?(attrs, ecf_user)
+      attrs[:trn] != ecf_user.teacher_profile&.trn ||
+        attrs[:email] != ecf_user.email
     end
   end
 end

--- a/db/migrate/20241023112339_change_object_type_to_json_for_versions.rb
+++ b/db/migrate/20241023112339_change_object_type_to_json_for_versions.rb
@@ -1,5 +1,5 @@
 class ChangeObjectTypeToJsonForVersions < ActiveRecord::Migration[7.1]
-  def change
+  def up
     change_column :versions, :object, :json, using: "object::text::json"
     add_column :versions, :object_changes, :json
   end

--- a/db/migrate/20241023112339_change_object_type_to_json_for_versions.rb
+++ b/db/migrate/20241023112339_change_object_type_to_json_for_versions.rb
@@ -1,0 +1,6 @@
+class ChangeObjectTypeToJsonForVersions < ActiveRecord::Migration[7.1]
+  def change
+    change_column :versions, :object, :json, using: "object::text::json"
+    add_column :versions, :object_changes, :json
+  end
+end

--- a/db/migrate/20241023113236_add_note_to_versions.rb
+++ b/db/migrate/20241023113236_add_note_to_versions.rb
@@ -1,0 +1,5 @@
+class AddNoteToVersions < ActiveRecord::Migration[7.1]
+  def change
+    add_column :versions, :note, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_22_161436) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_23_113236) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -545,8 +545,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_22_161436) do
     t.bigint "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"
-    t.text "object"
+    t.json "object"
     t.datetime "created_at", precision: nil
+    t.json "object_changes"
+    t.string "note"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -18,6 +18,28 @@ RSpec.describe Application do
     it { is_expected.to have_many(:declarations) }
   end
 
+  describe "paper_trail" do
+    subject { create(:application, lead_provider_approval_status: "pending") }
+
+    it "enables paper trail" do
+      expect(subject).to be_versioned
+    end
+
+    it "creates a version with a note" do
+      with_versioning do
+        expect(PaperTrail).to be_enabled
+
+        subject.update!(
+          lead_provider_approval_status: "rejected",
+          version_note: "This is a test",
+        )
+        version = subject.versions.last
+        expect(version.note).to eq("This is a test")
+        expect(version.object_changes["lead_provider_approval_status"]).to eq(%w[pending rejected])
+      end
+    end
+  end
+
   describe "validations" do
     context "when the schedule cohort does not match the application cohort" do
       subject do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,6 +10,28 @@ RSpec.describe User do
     it { is_expected.to have_many(:declarations).through(:applications) }
   end
 
+  describe "paper_trail" do
+    subject { create(:user, full_name: "Joe") }
+
+    it "enables paper trail" do
+      expect(subject).to be_versioned
+    end
+
+    it "creates a version with a note" do
+      with_versioning do
+        expect(PaperTrail).to be_enabled
+
+        subject.update!(
+          full_name: "Changed Name",
+          version_note: "This is a test",
+        )
+        version = subject.versions.last
+        expect(version.note).to eq("This is a test")
+        expect(version.object_changes["full_name"]).to eq(["Joe", "Changed Name"])
+      end
+    end
+  end
+
   describe "validations" do
     it { is_expected.to validate_presence_of(:full_name).with_message("Enter a full name") }
     it { is_expected.to validate_presence_of(:email).on(:npq_separation).with_message("Enter an email address") }

--- a/spec/services/migration/migrators/application_spec.rb
+++ b/spec/services/migration/migrators/application_spec.rb
@@ -37,27 +37,6 @@ RSpec.describe Migration::Migrators::Application do
         expect(application.accepted_at).to eq(ecf_resource1.profile.created_at)
       end
 
-      it "sets the timestamps from the ECF NPQApplication on the NPQ application" do
-        created_at = 10.days.ago
-        updated_at = 3.days.ago
-        ecf_resource1.update!(created_at:, updated_at:)
-
-        with_versioning do
-          expect(PaperTrail).to be_enabled
-
-          instance.call
-
-          application = ::Application.find_by_ecf_id!(ecf_resource1.id)
-          expect(application.created_at.to_s).to eq(created_at.to_s)
-          expect(application.updated_at.to_s).to eq(updated_at.to_s)
-
-          version = application.versions.last
-          expect(version.note).to eq("Changes migrated from ECF to NPQ")
-          expect(version.object_changes["created_at"].last).to eq(created_at.iso8601(3))
-          expect(version.object_changes["updated_at"].last).to eq(updated_at.iso8601(3))
-        end
-      end
-
       it "sets the schedule from the ECF NPQApplication on the NPQ application" do
         instance.call
 
@@ -193,6 +172,51 @@ RSpec.describe Migration::Migrators::Application do
           instance.call
 
           expect(application.reload.ukprn).to eq(application.school.ukprn)
+        end
+      end
+
+      context "when setting timestamps from ECF" do
+        let(:created_at) { 10.days.ago }
+        let(:updated_at) { 3.days.ago }
+
+        it "sets the timestamps from ECF when ukprn does not change" do
+          ecf_resource1.update!(created_at:, updated_at:)
+
+          with_versioning do
+            expect(PaperTrail).to be_enabled
+
+            instance.call
+
+            application = ::Application.find_by_ecf_id!(ecf_resource1.id)
+            expect(application.created_at.to_s).to eq(created_at.to_s)
+            expect(application.updated_at.to_s).to eq(updated_at.to_s)
+
+            version = application.versions.last
+            expect(version.note).to eq("Changes migrated from ECF to NPQ")
+            expect(version.object_changes["created_at"].last).to eq(created_at.iso8601(3))
+            expect(version.object_changes["updated_at"].last).to eq(updated_at.iso8601(3))
+          end
+        end
+
+        it "sets updated_at to now when ukprn is nil" do
+          ecf_resource1.update!(created_at:, updated_at:, school_ukprn: nil)
+
+          freeze_time do
+            with_versioning do
+              expect(PaperTrail).to be_enabled
+
+              instance.call
+
+              application = ::Application.find_by_ecf_id!(ecf_resource1.id)
+              expect(application.created_at.to_s).to eq(created_at.to_s)
+              expect(application.updated_at.to_s).to eq(Time.zone.now.to_s)
+
+              version = application.versions.last
+              expect(version.note).to eq("Changes migrated from ECF to NPQ")
+              expect(version.object_changes["created_at"].last).to eq(created_at.iso8601(3))
+              expect(version.object_changes["updated_at"].last).to eq(Time.zone.now.iso8601(3))
+            end
+          end
         end
       end
     end

--- a/spec/services/migration/migrators/cohort_spec.rb
+++ b/spec/services/migration/migrators/cohort_spec.rb
@@ -3,7 +3,9 @@ require "rails_helper"
 RSpec.describe Migration::Migrators::Cohort do
   it_behaves_like "a migrator", :cohort, [] do
     def create_ecf_resource
-      create(:ecf_migration_cohort, :with_sequential_start_year)
+      travel_to(rand(100).hours.ago) do
+        create(:ecf_migration_cohort, :with_sequential_start_year)
+      end
     end
 
     def create_npq_resource(ecf_resource)
@@ -20,6 +22,8 @@ RSpec.describe Migration::Migrators::Cohort do
         instance.call
         cohort = Cohort.find_by!(ecf_id: ecf_resource1.id)
         expect(cohort.attributes).to include(ecf_resource1.attributes.slice("start_year", "registration_start_date"))
+        expect(cohort.created_at.to_s).to eq(ecf_resource1.created_at.to_s)
+        expect(cohort.updated_at.to_s).to eq(ecf_resource1.updated_at.to_s)
       end
 
       context "when the npq_registration_start_date is set on the ECF cohort" do

--- a/spec/services/migration/migrators/participant_id_change_spec.rb
+++ b/spec/services/migration/migrators/participant_id_change_spec.rb
@@ -3,8 +3,10 @@ require "rails_helper"
 RSpec.describe Migration::Migrators::ParticipantIdChange do
   it_behaves_like "a migrator", :participant_id_change, %i[user] do
     def create_ecf_resource
-      user = create(:ecf_migration_user, :npq)
-      create(:ecf_migration_participant_id_change, user:)
+      travel_to(rand(100).hours.ago) do
+        user = create(:ecf_migration_user, :npq)
+        create(:ecf_migration_participant_id_change, user:)
+      end
     end
 
     def create_npq_resource(ecf_resource)
@@ -22,7 +24,7 @@ RSpec.describe Migration::Migrators::ParticipantIdChange do
     end
 
     describe "#call" do
-      it "sets the created ParticipantIdChange attributes correctly" do
+      it "sets the ParticipantIdChange attributes correctly" do
         instance.call
 
         participant_id_change = ParticipantIdChange.find_by!(ecf_id: ecf_resource1.id)
@@ -31,6 +33,7 @@ RSpec.describe Migration::Migrators::ParticipantIdChange do
           from_participant_id: ecf_resource1.from_participant_id,
           to_participant_id: ecf_resource1.to_participant_id,
           created_at: ecf_resource1.created_at,
+          updated_at: ecf_resource1.updated_at,
         })
       end
 

--- a/spec/services/migration/migrators/statement_spec.rb
+++ b/spec/services/migration/migrators/statement_spec.rb
@@ -3,7 +3,9 @@ require "rails_helper"
 RSpec.describe Migration::Migrators::Statement do
   it_behaves_like "a migrator", :statement, %i[cohort lead_provider] do
     def create_ecf_resource
-      create(:ecf_migration_statement, name: "March 2023")
+      travel_to(rand(100).hours.ago) do
+        create(:ecf_migration_statement, name: "March 2023")
+      end
     end
 
     def create_npq_resource(ecf_resource)
@@ -28,6 +30,8 @@ RSpec.describe Migration::Migrators::Statement do
         expect(statement.cohort.start_year).to eq(ecf_resource1.cohort.start_year)
         expect(statement.lead_provider.ecf_id).to eq(ecf_resource1.cpd_lead_provider.npq_lead_provider.id)
         expect(statement.state).to eq("open")
+        expect(statement.created_at.to_s).to eq(ecf_resource1.created_at.to_s)
+        expect(statement.updated_at.to_s).to eq(ecf_resource1.updated_at.to_s)
       end
     end
   end

--- a/spec/services/migration/migrators/user_spec.rb
+++ b/spec/services/migration/migrators/user_spec.rb
@@ -51,27 +51,6 @@ RSpec.describe Migration::Migrators::User do
         )
       end
 
-      it "sets the timestamps from the ECF User" do
-        created_at = 10.days.ago
-        updated_at = 3.days.ago
-        ecf_resource1.update!(created_at:, updated_at:)
-
-        with_versioning do
-          expect(PaperTrail).to be_enabled
-
-          instance.call
-
-          user = ::User.find_by_ecf_id!(ecf_resource1.id)
-          expect(user.created_at.to_s).to eq(created_at.to_s)
-          expect(user.updated_at.to_s).to eq(updated_at.to_s)
-
-          version = user.versions.last
-          expect(version.note).to eq("Changes migrated from ECF to NPQ")
-          expect(version.object_changes["created_at"].last).to eq(created_at.iso8601(3))
-          expect(version.object_changes["updated_at"].last).to eq(updated_at.iso8601(3))
-        end
-      end
-
       describe "TRN prioritisation" do
         it "records a failure when there are multiple, different/verified TRNs for the user's NPQApplications in ECF and no teacher profile TRN" do
           ecf_user = create(:ecf_migration_user, :npq).tap { |u| u.teacher_profile.update!(trn: nil) }
@@ -243,6 +222,73 @@ RSpec.describe Migration::Migrators::User do
 
               instance.call
               expect(failure_manager).to have_received(:record_failure).once.with(ecf_user, "Validation failed: User found with ecf_user.get_an_identity_id, but its user.ecf_id linked to another ecf_user that is not an orphan")
+            end
+          end
+        end
+      end
+
+      context "when setting timestamps from ECF" do
+        let(:created_at) { 10.days.ago }
+        let(:updated_at) { 3.days.ago }
+
+        it "sets the timestamps from the ECF User" do
+          ecf_resource1.update!(created_at:, updated_at:)
+
+          with_versioning do
+            expect(PaperTrail).to be_enabled
+
+            instance.call
+
+            user = ::User.find_by_ecf_id!(ecf_resource1.id)
+            expect(user.created_at.to_s).to eq(created_at.to_s)
+            expect(user.updated_at.to_s).to eq(updated_at.to_s)
+
+            version = user.versions.last
+            expect(version.note).to eq("Changes migrated from ECF to NPQ")
+            expect(version.object_changes["created_at"].last).to eq(created_at.iso8601(3))
+            expect(version.object_changes["updated_at"].last).to eq(updated_at.iso8601(3))
+          end
+        end
+
+        it "sets updated_at to now if trn has changed" do
+          ecf_resource1.update!(created_at:, updated_at:)
+          ecf_resource1.teacher_profile.update!(trn: nil)
+
+          freeze_time do
+            with_versioning do
+              expect(PaperTrail).to be_enabled
+
+              instance.call
+
+              user = ::User.find_by_ecf_id!(ecf_resource1.id)
+              expect(user.created_at.to_s).to eq(created_at.to_s)
+              expect(user.updated_at.to_s).to eq(Time.zone.now.to_s)
+
+              version = user.versions.last
+              expect(version.note).to eq("Changes migrated from ECF to NPQ")
+              expect(version.object_changes["created_at"].last).to eq(created_at.iso8601(3))
+              expect(version.object_changes["updated_at"].last).to eq(Time.zone.now.iso8601(3))
+            end
+          end
+        end
+
+        it "sets updated_at to now if email has changed" do
+          ecf_resource1.update!(created_at:, updated_at:, email: "some@thing.com")
+
+          freeze_time do
+            with_versioning do
+              expect(PaperTrail).to be_enabled
+
+              instance.call
+
+              user = ::User.find_by_ecf_id!(ecf_resource1.id)
+              expect(user.created_at.to_s).to eq(created_at.to_s)
+              expect(user.updated_at.to_s).to eq(Time.zone.now.to_s)
+
+              version = user.versions.last
+              expect(version.note).to eq("Changes migrated from ECF to NPQ")
+              expect(version.object_changes["created_at"].last).to eq(created_at.iso8601(3))
+              expect(version.object_changes["updated_at"].last).to eq(Time.zone.now.iso8601(3))
             end
           end
         end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-3631

### Changes proposed in this pull request

* `Cohort`, `Schedule`, `ParticipantIdChange` and `Statement` migrations will use timestamps from ECF
* Updated `paper_trail`
  * `object` field type is now `json`
  * `object_changes` added
  * added `note` field
* `Application` & `User`
  * Can now include `version_note` which adds `versions.note` entry into `versions`
  * Migration will use ECF timestamps and include a `version_note`
  * If there has been any changes from ECF attrs, we set `updated_at` to `Time.zone.now`