### PR TITLE
[CPDNPQ-2143] Download declarations CSV

### DIFF
--- a/app/controllers/npq_separation/admin/finance/statements/assurance_reports_controller.rb
+++ b/app/controllers/npq_separation/admin/finance/statements/assurance_reports_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class NpqSeparation::Admin::Finance::Statements::AssuranceReportsController < NpqSeparation::AdminController
+  def show
+    @statement = Statement.find(params[:id])
+    @declarations = AssuranceReports::Query.new(@statement).declarations
+    @serializer = AssuranceReports::CsvSerializer.new(@declarations, @statement)
+
+    respond_to do |format|
+      format.csv do
+        render body: @serializer.serialize
+      end
+    end
+  end
+end

--- a/app/serializers/assurance_reports/csv_serializer.rb
+++ b/app/serializers/assurance_reports/csv_serializer.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "csv"
+
+class AssuranceReports::CsvSerializer
+  def initialize(scope, statement)
+    self.scope = scope
+    self.statement = statement
+  end
+
+  def filename
+    "NPQ-Declarations-#{npq_lead_provider.name.gsub(/\W/, '')}-Cohort#{statement.cohort.start_year}-#{statement.name.gsub(/\W/, '')}.csv"
+  end
+
+  def serialize
+    CSV.generate do |csv|
+      csv << csv_headers
+
+      scope.each do |record|
+        csv << to_row(record)
+      end
+    end
+  end
+
+  def csv_headers
+    [
+      "Participant ID",
+      "Participant Name",
+      "TRN",
+      "Course Identifier",
+      "Schedule",
+      "Eligible For Funding",
+      "Funded place",
+      "Lead Provider Name",
+      "School Urn",
+      "School Name",
+      "Training Status",
+      "Training Status Reason",
+      "Declaration ID",
+      "Declaration Status",
+      "Declaration Type",
+      "Declaration Date",
+      "Declaration Created At",
+      "Statement Name",
+      "Statement ID",
+      "Targeted Delivery Funding",
+    ].compact
+  end
+
+private
+
+  attr_accessor :scope, :statement
+
+  def to_row(record)
+    [
+      record.participant_id,
+      record.participant_name,
+      record.trn,
+      record.application_course_identifier,
+      record.schedule,
+      record.eligible_for_funding,
+      record.funded_place,
+      record.npq_lead_provider_name,
+      record.school_urn,
+      record.school_name,
+      record.training_status,
+      record.training_status_reason,
+      record.declaration_id,
+      record.declaration_status,
+      record.declaration_type,
+      record.declaration_date.iso8601,
+      record.declaration_created_at.iso8601,
+      format_statement_name(statement.month, statement.year),
+      record.statement_id,
+      record.targeted_delivery_funding,
+    ]
+  end
+
+  def npq_lead_provider
+    statement.npq_lead_provider
+  end
+
+  def format_statement_name(month, year)
+    date = Date.new(year, month)
+    date.strftime("%B %Y")
+  end
+end

--- a/app/services/assurance_reports/query.rb
+++ b/app/services/assurance_reports/query.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module AssuranceReports
+  class Query
+    def initialize(statement)
+      self.statement = statement
+    end
+
+    def declarations
+      Declaration.find_by_sql(sql)
+    end
+
+  private
+
+    attr_accessor :statement
+
+    def sql
+      <<~EOSQL
+        SELECT
+          d.id                                    AS id,
+          d.ecf_id                                AS ecf_id,
+          u.ecf_id                                AS participant_id,
+          u.full_name                             AS participant_name,
+          u.trn                                   AS trn,
+          c.identifier                            AS application_course_identifier,
+          sch.identifier                          AS schedule,
+          a.eligible_for_funding                  AS eligible_for_funding,
+          a.funded_place                          AS funded_place,
+          lp.name                                 AS npq_lead_provider_name,
+          lp.ecf_id                               AS npq_lead_provider_id,
+          sc.urn                                  AS school_urn,
+          sc.name                                 AS school_name,
+          a.training_status                       AS training_status,
+          st.reason                               AS training_status_reason,
+          d.ecf_id                                AS declaration_id,
+          si.state                                AS declaration_status,
+          d.declaration_type                      AS declaration_type,
+          d.declaration_date                      AS declaration_date,
+          d.created_at                            AS declaration_created_at,
+          s.ecf_id                                AS statement_id,
+          s.month                                 AS statement_month,
+          s.year                                  AS statement_year,
+          a.targeted_delivery_funding_eligibility AS targeted_delivery_funding
+        FROM declarations d
+        JOIN statement_items si             ON si.declaration_id = d.id
+        JOIN statements s                   ON s.id = si.statement_id
+        JOIN lead_providers lp              ON lp.id = d.lead_provider_id
+        JOIN applications a                 ON a.id = d.application_id
+        JOIN courses c                      ON c.id = a.course_id
+        JOIN users u                        ON u.id = a.user_id
+        JOIN schedules sch                  ON sch.id = a.schedule_id
+        LEFT OUTER JOIN schools sc          ON sc.id = a.school_id
+        LEFT OUTER JOIN (
+             SELECT DISTINCT ON (lead_provider_id) lead_provider_id, application_id, state, reason
+             FROM application_states
+             ORDER BY lead_provider_id, created_at DESC
+        ) AS st ON
+          st.application_id = a.id AND
+          st.lead_provider_id = d.lead_provider_id AND
+          st.state = 'withdrawn'
+        WHERE #{where_values}
+        ORDER BY u.full_name ASC
+      EOSQL
+    end
+
+    def where_values
+      Declaration.sanitize_sql_for_conditions(["lp.id = ? AND s.id = ?", statement.lead_provider_id, statement.id])
+    end
+  end
+end

--- a/app/services/assurance_reports/query.rb
+++ b/app/services/assurance_reports/query.rb
@@ -51,9 +51,9 @@ module AssuranceReports
         JOIN schedules sch                  ON sch.id = a.schedule_id
         LEFT OUTER JOIN schools sc          ON sc.id = a.school_id
         LEFT OUTER JOIN (
-             SELECT DISTINCT ON (lead_provider_id) lead_provider_id, application_id, state, reason
+             SELECT DISTINCT ON (lead_provider_id, application_id) lead_provider_id, application_id, state, reason
              FROM application_states
-             ORDER BY lead_provider_id, created_at DESC
+             ORDER BY lead_provider_id, application_id, created_at DESC
         ) AS st ON
           st.application_id = a.id AND
           st.lead_provider_id = d.lead_provider_id AND

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -244,6 +244,10 @@ Rails.application.routes.draw do
               resources :unpaid, controller: "statements/unpaid", only: "index"
               resources :paid, controller: "statements/paid", only: "index"
             end
+
+            member do
+              resource :assurance_report, controller: "statements/assurance_reports", only: "show"
+            end
           end
         end
 

--- a/spec/factories/application_states.rb
+++ b/spec/factories/application_states.rb
@@ -4,5 +4,16 @@ FactoryBot.define do
   factory :application_state do
     application
     lead_provider { LeadProvider.all.sample }
+    state { "active" }
+
+    trait :withdrawn do
+      state { ApplicationState.states[:withdrawn] }
+      reason { "other" }
+    end
+
+    trait :deferred do
+      state { ApplicationState.states[:deferred] }
+      reason { "other" }
+    end
   end
 end

--- a/spec/factories/applications.rb
+++ b/spec/factories/applications.rb
@@ -120,10 +120,9 @@ FactoryBot.define do
         application.update!(training_status: ApplicationState.states[:withdrawn])
 
         create(:application_state,
+               :withdrawn,
                application:,
-               lead_provider: application.lead_provider,
-               state: ApplicationState.states[:withdrawn],
-               reason: "other")
+               lead_provider: application.lead_provider)
       end
     end
 
@@ -132,10 +131,9 @@ FactoryBot.define do
         application.update!(training_status: ApplicationState.states[:deferred])
 
         create(:application_state,
+               :deferred,
                application:,
-               lead_provider: application.lead_provider,
-               state: ApplicationState.states[:deferred],
-               reason: "other")
+               lead_provider: application.lead_provider)
       end
     end
   end

--- a/spec/requests/npq_separation/admin/finance/statements/assurance_reports_controller_spec.rb
+++ b/spec/requests/npq_separation/admin/finance/statements/assurance_reports_controller_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe NpqSeparation::Admin::Finance::Statements::AssuranceReportsController, type: :request do
+  include Helpers::NPQSeparationAdminLogin
+
+  describe "#show" do
+    subject { response }
+
+    before do
+      declaration
+      sign_in_as_admin
+
+      get npq_separation_admin_finance_assurance_report_path(statement, format: :csv)
+    end
+
+    let(:lead_provider) { create(:lead_provider) }
+    let(:statement)     { create(:statement, lead_provider:) }
+
+    let :declaration do
+      travel_to(statement.deadline_date) do
+        create(:declaration, lead_provider:) do |declaration|
+          create(:statement_item, statement:, declaration:)
+        end
+      end
+    end
+
+    it { is_expected.to have_http_status :success }
+    it { is_expected.to have_attributes media_type: /csv/ }
+    it { is_expected.to have_attributes body: be_present }
+  end
+end

--- a/spec/serializers/assurance_reports/csv_serializer_spec.rb
+++ b/spec/serializers/assurance_reports/csv_serializer_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssuranceReports::CsvSerializer, type: :serializer do
+  subject(:instance) { described_class.new(data, statement) }
+
+  before { declaration }
+
+  let(:data)          { AssuranceReports::Query.new(statement).declarations }
+  let(:lead_provider) { create(:lead_provider) }
+  let(:statement)     { create(:statement, lead_provider:) }
+
+  let :declaration do
+    travel_to(statement.deadline_date) do
+      create(:declaration, lead_provider:) do |declaration|
+        create(:statement_item, statement:, declaration:)
+      end
+    end
+  end
+
+  describe "#serialize" do
+    let(:rows) { CSV.parse(instance.serialize, headers: true).to_a }
+
+    describe "header row" do
+      subject { rows.first }
+
+      let :expected_headers do
+        [
+          "Participant ID",
+          "Participant Name",
+          "TRN",
+          "Course Identifier",
+          "Schedule",
+          "Eligible For Funding",
+          "Funded place",
+          "Lead Provider Name",
+          "School Urn",
+          "School Name",
+          "Training Status",
+          "Training Status Reason",
+          "Declaration ID",
+          "Declaration Status",
+          "Declaration Type",
+          "Declaration Date",
+          "Declaration Created At",
+          "Statement Name",
+          "Statement ID",
+          "Targeted Delivery Funding",
+        ]
+      end
+
+      it { is_expected.to eq expected_headers }
+    end
+
+    describe "a data row" do
+      subject { rows.second }
+
+      let(:training_status)        { "active" }
+      let(:training_status_reason) { nil }
+
+      let :expected_data do
+        [
+          declaration.user.ecf_id,
+          declaration.user.full_name,
+          declaration.user.trn,
+          declaration.course.identifier,
+          declaration.application.schedule.identifier,
+          declaration.application.eligible_for_funding.to_s,
+          declaration.application.funded_place.to_s,
+          lead_provider.name,
+          declaration.application.school.urn,
+          declaration.application.school.name,
+          training_status,
+          training_status_reason,
+          declaration.ecf_id,
+          statement.statement_items.first.state,
+          declaration.declaration_type,
+          declaration.declaration_date.iso8601,
+          declaration.created_at.iso8601,
+          Date.new(statement.year, statement.month).strftime("%B %Y"),
+          statement.ecf_id,
+          declaration.application.targeted_delivery_funding_eligibility.to_s,
+        ]
+      end
+
+      it { is_expected.to eq expected_data }
+
+      context "when withdrawn" do
+        before do
+          declaration.application.update! training_status: "withdrawn"
+
+          create(:application_state, :withdrawn, application: declaration.application,
+                                                 lead_provider: declaration.lead_provider)
+        end
+
+        let(:training_status)        { "withdrawn" }
+        let(:training_status_reason) { "other" }
+
+        it { is_expected.to eq expected_data }
+      end
+
+      context "when deferred" do
+        before do
+          declaration.application.update! training_status: "deferred"
+
+          create(:application_state, :deferred, application: declaration.application,
+                                                lead_provider: declaration.lead_provider)
+        end
+
+        let(:training_status) { "deferred" }
+
+        it { is_expected.to eq expected_data }
+      end
+    end
+  end
+end

--- a/spec/services/assurance_reports/query_spec.rb
+++ b/spec/services/assurance_reports/query_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssuranceReports::Query do
+  subject(:query) { described_class.new(statement) }
+
+  before do
+    declaration && other_declaration && other_lead_provider_declaration
+  end
+
+  let(:assurance_report)    { query.declarations.first }
+  let(:lead_provider)       { create(:lead_provider) }
+  let(:other_lead_provider) { create(:lead_provider) }
+  let(:statement)           { create(:statement, lead_provider:) }
+
+  let :declaration do
+    travel_to(statement.deadline_date) do
+      create(:declaration, lead_provider:) do |declaration|
+        create(:statement_item, statement:, declaration:)
+      end
+    end
+  end
+
+  let :other_statement do
+    create(:statement, lead_provider:, deadline_date: statement.deadline_date + 1.day)
+  end
+
+  let :other_declaration do
+    travel_to(other_statement.deadline_date) do
+      create(:declaration, lead_provider:) do |declaration|
+        create(:statement_item, statement: other_statement, declaration:)
+      end
+    end
+  end
+
+  let :other_lead_provider_statement do
+    create(:statement, lead_provider: other_lead_provider,
+                       deadline_date: statement.deadline_date + 1.day)
+  end
+
+  let :other_lead_provider_declaration do
+    travel_to(other_lead_provider_statement.deadline_date) do
+      create(:declaration, lead_provider: other_lead_provider) do |declaration|
+        create(:statement_item, statement: other_lead_provider_statement, declaration:)
+      end
+    end
+  end
+
+  describe "#declarations" do
+    subject(:declarations) { query.declarations }
+
+    it "includes the declaration" do
+      expect(declarations).to eq([declaration])
+    end
+
+    describe "declaration attributes" do
+      subject { declarations.first }
+
+      it { is_expected.to have_attributes id: declaration.id }
+      it { is_expected.to have_attributes ecf_id: be_present }
+      it { is_expected.to have_attributes ecf_id: declaration.ecf_id }
+      it { is_expected.to have_attributes participant_id: be_present }
+      it { is_expected.to have_attributes participant_id: declaration.application.user.ecf_id }
+      it { is_expected.to have_attributes participant_name: declaration.application.user.full_name }
+      it { is_expected.to have_attributes trn: declaration.application.user.trn }
+      it { is_expected.to have_attributes application_course_identifier: declaration.course_identifier }
+      it { is_expected.to have_attributes eligible_for_funding: declaration.application.eligible_for_funding }
+      it { is_expected.to have_attributes funded_place: declaration.application.funded_place }
+      it { is_expected.to have_attributes npq_lead_provider_name: declaration.lead_provider.name }
+      it { is_expected.to have_attributes npq_lead_provider_id: be_present }
+      it { is_expected.to have_attributes npq_lead_provider_id: declaration.lead_provider.ecf_id }
+      it { is_expected.to have_attributes school_urn: declaration.application.school.urn }
+      it { is_expected.to have_attributes school_name: declaration.application.school.name }
+      it { is_expected.to have_attributes training_status: declaration.application.training_status }
+      it { is_expected.to have_attributes training_status_reason: be_nil }
+      it { is_expected.to have_attributes declaration_id: be_present }
+      it { is_expected.to have_attributes declaration_id: declaration.ecf_id }
+      it { is_expected.to have_attributes declaration_status: declaration.statement_items.first.state }
+      it { is_expected.to have_attributes declaration_type: declaration.declaration_type }
+      it { is_expected.to have_attributes declaration_date: declaration.declaration_date }
+      it { is_expected.to have_attributes declaration_created_at: declaration.created_at }
+      it { is_expected.to have_attributes statement_id: be_present }
+      it { is_expected.to have_attributes statement_id: statement.ecf_id }
+      it { is_expected.to have_attributes statement_month: statement.month }
+      it { is_expected.to have_attributes statement_year: statement.year }
+      it { is_expected.to have_attributes targeted_delivery_funding: declaration.application.targeted_delivery_funding_eligibility }
+
+      context "when last status update was 'withdrawn'" do
+        before do
+          declaration.application.update! training_status: "withdrawn"
+
+          create(:application_state, :withdrawn, application: declaration.application,
+                                                 lead_provider: declaration.lead_provider)
+        end
+
+        it { is_expected.to have_attributes training_status: "withdrawn" }
+        it { is_expected.to have_attributes training_status_reason: "other" }
+      end
+
+      context "when last status update was 'deferred'" do
+        before do
+          declaration.application.update! training_status: "deferred"
+
+          create(:application_state, :deferred, application: declaration.application,
+                                                lead_provider: declaration.lead_provider)
+        end
+
+        it { is_expected.to have_attributes training_status: "deferred" }
+        it { is_expected.to have_attributes training_status_reason: be_nil }
+      end
+    end
+  end
+end

--- a/spec/services/assurance_reports/query_spec.rb
+++ b/spec/services/assurance_reports/query_spec.rb
@@ -96,6 +96,27 @@ RSpec.describe AssuranceReports::Query do
 
         it { is_expected.to have_attributes training_status: "withdrawn" }
         it { is_expected.to have_attributes training_status_reason: "other" }
+
+        context "with later second declaration for same lead provider" do
+          before do
+            statement = create(:statement, lead_provider:)
+
+            travel_to(statement.deadline_date) do
+              create(:declaration, lead_provider:) do |declaration|
+                create(:statement_item, statement:, declaration:)
+
+                declaration.application.update! training_status: "withdrawn"
+
+                create(:application_state, :withdrawn, application: declaration.application,
+                                                       lead_provider: declaration.lead_provider,
+                                                       reason: "a different reason")
+              end
+            end
+          end
+
+          it { is_expected.to have_attributes training_status: "withdrawn" }
+          it { is_expected.to have_attributes training_status_reason: "other" }
+        end
       end
 
       context "when last status update was 'deferred'" do


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2143](https://dfedigital.atlassian.net/browse/CPDNPQ-2143)

We want to allow our admins to download the declarations relevant to a particular Statement

### Changes proposed in this pull request

* Added a Query service to fetch the data
* Added a Serializer to generate the CSV from the data
* Added a Controller and Route to allow downloading a CSV

### Notes

Rewriting query to use ActiveRecord instead of straight SQL is still WIP but it will only change the query implementation so putting this up for some early feedback

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
