### PR TITLE
[CPDLP-3652] Add unique index to all models with ecf id in NPQ

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -37,8 +37,9 @@ class Application < ApplicationRecord
   attr_accessor :version_note
 
   validate :schedule_cohort_matches
-  # TODO: add constraints into the DB after separation
+  # TODO: remove "if" and "allow_nil" and add constraints into the DB after separation
   validates :ecf_id, presence: true, if: -> { Feature.ecf_api_disabled? }
+  validates :ecf_id, uniqueness: { case_sensitive: false }, allow_nil: !Feature.ecf_api_disabled?
 
   after_commit :touch_user_if_changed
 

--- a/app/models/application_state.rb
+++ b/app/models/application_state.rb
@@ -4,7 +4,6 @@ class ApplicationState < ApplicationRecord
   belongs_to :application
   belongs_to :lead_provider, optional: true
 
-  # TODO: remove "allow_nil" and add default value "gen_random_uuid()" and constraints into the DB after separation
   validates :ecf_id, uniqueness: { case_sensitive: false }, allow_nil: true
 
   enum state: {

--- a/app/models/application_state.rb
+++ b/app/models/application_state.rb
@@ -4,6 +4,9 @@ class ApplicationState < ApplicationRecord
   belongs_to :application
   belongs_to :lead_provider, optional: true
 
+  # TODO: remove "allow_nil" and add default value "gen_random_uuid()" and constraints into the DB after separation
+  validates :ecf_id, uniqueness: { case_sensitive: false }, allow_nil: true
+
   enum state: {
     active: "active",
     deferred: "deferred",

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -15,6 +15,9 @@ class Cohort < ApplicationRecord
               message: "Choose true or false for funding cap",
             }
 
+  # TODO: remove "allow_nil" and add default value "gen_random_uuid()" and constraints into the DB after separation
+  validates :ecf_id, uniqueness: { case_sensitive: false }, allow_nil: true
+
   def registration_start_date_matches_start_year
     return if registration_start_date.blank?
 

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -14,8 +14,6 @@ class Cohort < ApplicationRecord
               in: [true, false],
               message: "Choose true or false for funding cap",
             }
-
-  # TODO: remove "allow_nil" and add default value "gen_random_uuid()" and constraints into the DB after separation
   validates :ecf_id, uniqueness: { case_sensitive: false }, allow_nil: true
 
   def registration_start_date_matches_start_year

--- a/app/models/contract_template.rb
+++ b/app/models/contract_template.rb
@@ -18,4 +18,7 @@ class ContractTemplate < ApplicationRecord
               only_integer: true,
               greater_than: 0,
             }
+
+  # TODO: remove "allow_nil" and add default value "gen_random_uuid()" and constraints into the DB after separation
+  validates :ecf_id, uniqueness: { case_sensitive: false }, allow_nil: true
 end

--- a/app/models/contract_template.rb
+++ b/app/models/contract_template.rb
@@ -18,7 +18,5 @@ class ContractTemplate < ApplicationRecord
               only_integer: true,
               greater_than: 0,
             }
-
-  # TODO: remove "allow_nil" and add default value "gen_random_uuid()" and constraints into the DB after separation
   validates :ecf_id, uniqueness: { case_sensitive: false }, allow_nil: true
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -13,8 +13,6 @@ class Course < ApplicationRecord
   validates :identifier,
             presence: { message: "Enter a identifier" },
             uniqueness: { message: "Identifier already exists, enter a unique one" }
-
-  # TODO: remove "allow_nil" and add default value "gen_random_uuid()" and constraints into the DB after separation
   validates :ecf_id, uniqueness: { case_sensitive: false }, allow_nil: true
 
   # npq-additional-support-offer is replaced by npq-early-headship-coaching-offer

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -14,6 +14,9 @@ class Course < ApplicationRecord
             presence: { message: "Enter a identifier" },
             uniqueness: { message: "Identifier already exists, enter a unique one" }
 
+  # TODO: remove "allow_nil" and add default value "gen_random_uuid()" and constraints into the DB after separation
+  validates :ecf_id, uniqueness: { case_sensitive: false }, allow_nil: true
+
   # npq-additional-support-offer is replaced by npq-early-headship-coaching-offer
   IDENTIFIERS = %w[
     npq-senior-leadership

--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -91,6 +91,7 @@ class Declaration < ApplicationRecord
   validates :declaration_date, :declaration_type, presence: true
   validate :validate_declaration_date_within_schedule, if: -> { !skip_declaration_date_within_schedule_validation }
   validate :validate_declaration_date_not_in_the_future
+  validates :ecf_id, uniqueness: { case_sensitive: false }
 
   def billable_statement
     statement_items.find(&:billable?)&.statement

--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -91,9 +91,8 @@ class LeadProvider < ApplicationRecord
   has_many :applications
   has_many :statements
 
-  # TODO: remove "allow_nil" and add default value "gen_random_uuid()" and constraints into the DB after separation
-  validates :ecf_id, uniqueness: { case_sensitive: false }, allow_nil: true
   validates :name, presence: true
+  validates :ecf_id, uniqueness: { case_sensitive: false }, allow_nil: true
 
   scope :alphabetical, -> { order(name: :asc) }
 

--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -91,6 +91,10 @@ class LeadProvider < ApplicationRecord
   has_many :applications
   has_many :statements
 
+  # TODO: remove "allow_nil" and add default value "gen_random_uuid()" and constraints into the DB after separation
+  validates :ecf_id, uniqueness: { case_sensitive: false }, allow_nil: true
+  validates :name, presence: true
+
   scope :alphabetical, -> { order(name: :asc) }
 
   def next_output_fee_statement(cohort)

--- a/app/models/participant_id_change.rb
+++ b/app/models/participant_id_change.rb
@@ -4,6 +4,5 @@ class ParticipantIdChange < ApplicationRecord
   belongs_to :user
 
   validates :user, :from_participant_id, :to_participant_id, presence: true
-  # TODO: remove "allow_nil" and add default value "gen_random_uuid()" and constraints into the DB after separation
   validates :ecf_id, uniqueness: { case_sensitive: false }, allow_nil: true
 end

--- a/app/models/participant_id_change.rb
+++ b/app/models/participant_id_change.rb
@@ -4,4 +4,6 @@ class ParticipantIdChange < ApplicationRecord
   belongs_to :user
 
   validates :user, :from_participant_id, :to_participant_id, presence: true
+  # TODO: remove "allow_nil" and add default value "gen_random_uuid()" and constraints into the DB after separation
+  validates :ecf_id, uniqueness: { case_sensitive: false }, allow_nil: true
 end

--- a/app/models/participant_outcome.rb
+++ b/app/models/participant_outcome.rb
@@ -2,7 +2,7 @@ class ParticipantOutcome < ApplicationRecord
   belongs_to :declaration
   has_many :participant_outcome_api_requests
 
-  validates :ecf_id, uniqueness: true
+  validates :ecf_id, uniqueness: { case_sensitive: false }
   validates :state, presence: true
   validates :completion_date, presence: true
   validate :completion_date_not_in_the_future

--- a/app/models/participant_outcome_api_request.rb
+++ b/app/models/participant_outcome_api_request.rb
@@ -1,5 +1,5 @@
 class ParticipantOutcomeAPIRequest < ApplicationRecord
   belongs_to :participant_outcome
 
-  validates :ecf_id, presence: true, uniqueness: { case_sensitive: false }
+  validates :ecf_id, uniqueness: { case_sensitive: false }
 end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -18,6 +18,8 @@ class Schedule < ApplicationRecord
 
   validates :name, presence: true
   validates :identifier, presence: true, uniqueness: { scope: :cohort_id }
+  # TODO: remove "allow_nil" and add default value "gen_random_uuid()" and constraints into the DB after separation
+  validates :ecf_id, uniqueness: { case_sensitive: false }, allow_nil: true
 
   validates :applies_from, presence: true
   validates :applies_to, presence: true

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -18,9 +18,7 @@ class Schedule < ApplicationRecord
 
   validates :name, presence: true
   validates :identifier, presence: true, uniqueness: { scope: :cohort_id }
-  # TODO: remove "allow_nil" and add default value "gen_random_uuid()" and constraints into the DB after separation
   validates :ecf_id, uniqueness: { case_sensitive: false }, allow_nil: true
-
   validates :applies_from, presence: true
   validates :applies_to, presence: true
 end

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -23,8 +23,8 @@ class Statement < ApplicationRecord
               message: "Year must be a 4 digit number",
             }
 
-  validates :ecf_id, uniqueness: { case_sensitive: false }
   validate :validate_max_statement_items_count
+  validates :ecf_id, uniqueness: { case_sensitive: false }
 
   scope :with_output_fee, ->(output_fee: true) { where(output_fee:) }
   scope :with_state, ->(*state) { where(state:) }

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -22,13 +22,8 @@ class Statement < ApplicationRecord
               only_integer: true,
               message: "Year must be a 4 digit number",
             }
-  validates :ecf_id,
-            presence: { message: "Enter an ECF ID" },
-            uniqueness: {
-              case_sensitive: false,
-              message: "ECF ID must be unique",
-            }
 
+  validates :ecf_id, uniqueness: { case_sensitive: false }
   validate :validate_max_statement_items_count
 
   scope :with_output_fee, ->(output_fee: true) { where(output_fee:) }

--- a/app/models/statement_item.rb
+++ b/app/models/statement_item.rb
@@ -5,6 +5,9 @@ class StatementItem < ApplicationRecord
   belongs_to :statement
   belongs_to :declaration
 
+  # TODO: remove "allow_nil" and add default value "gen_random_uuid()" and constraints into the DB after separation
+  validates :ecf_id, uniqueness: { case_sensitive: false }, allow_nil: true
+
   scope :billable, -> { where(state: BILLABLE_STATES) }
   scope :refundable, -> { where(state: REFUNDABLE_STATES) }
 

--- a/app/models/statement_item.rb
+++ b/app/models/statement_item.rb
@@ -5,7 +5,6 @@ class StatementItem < ApplicationRecord
   belongs_to :statement
   belongs_to :declaration
 
-  # TODO: remove "allow_nil" and add default value "gen_random_uuid()" and constraints into the DB after separation
   validates :ecf_id, uniqueness: { case_sensitive: false }, allow_nil: true
 
   scope :billable, -> { where(state: BILLABLE_STATES) }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,6 +14,9 @@ en:
   errors:
     email:
       invalid: Enter a valid email address
+    ecf_id: &ecf_id
+      blank: "Enter an ECF ID"
+      taken: "ECF ID must be unique"
 
   application: &application
     blank: The entered '#/%{parameterized_attribute}' is missing from your request. Check details and try again.
@@ -126,17 +129,15 @@ en:
             funded_place:
               <<: *funded_place
             ecf_id:
-              blank: "Enter an ECF ID"
-        declaration:
+              *ecf_id
+        application_state:
           attributes:
-            declaration_date:
-              *declaration_date
-            declaration_type:
-              *declaration_type
-        participant_outcome:
+            ecf_id:
+              *ecf_id
+        cohort:
           attributes:
-            completion_date:
-              *completion_date
+            ecf_id:
+              *ecf_id
         contract_template:
           attributes:
             number_of_payment_periods: &integer_greater_than_or_equal_to_zero
@@ -156,14 +157,58 @@ en:
               not_a_number: "Must be an integer greater than zero"
               not_an_integer: "Must be an integer greater than zero"
               greater_than: "Must be an integer greater than zero"
+            ecf_id:
+              *ecf_id
         contract:
           attributes:
             course_id:
               taken: "Can only have one contract for statement and course"
+        course:
+          attributes:
+            ecf_id:
+              *ecf_id
+        declaration:
+          attributes:
+            declaration_date:
+              *declaration_date
+            declaration_type:
+              *declaration_type
+            ecf_id:
+              *ecf_id
+        lead_provider:
+          attributes:
+            ecf_id:
+              *ecf_id
+        participant_id_change:
+          attributes:
+            ecf_id:
+              *ecf_id
+        participant_outcome:
+          attributes:
+            completion_date:
+              *completion_date
+            ecf_id:
+              *ecf_id
+        participant_outcome_api_request:
+          attributes:
+            ecf_id:
+              *ecf_id
+        schedule:
+          attributes:
+            ecf_id:
+              *ecf_id
+        statement:
+          attributes:
+            ecf_id:
+              *ecf_id
+        statement_item:
+          attributes:
+            ecf_id:
+              *ecf_id
         user:
           attributes:
             ecf_id:
-              blank: "Enter an ECF ID"
+              *ecf_id
   activemodel:
     attributes:
       questionnaires/funding_your_npq:

--- a/db/migrate/20241023115016_add_unique_constraint_to_ecf_id_in_applications.rb
+++ b/db/migrate/20241023115016_add_unique_constraint_to_ecf_id_in_applications.rb
@@ -1,0 +1,13 @@
+class AddUniqueConstraintToEcfIdInApplications < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def up
+    remove_index :applications, :ecf_id
+    add_index :applications, :ecf_id, unique: true, algorithm: :concurrently
+  end
+
+  def down
+    remove_index :applications, :ecf_id
+    add_index :applications, :ecf_id, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20241023115036_add_unique_constraint_to_ecf_id_in_contract_templates.rb
+++ b/db/migrate/20241023115036_add_unique_constraint_to_ecf_id_in_contract_templates.rb
@@ -1,0 +1,13 @@
+class AddUniqueConstraintToEcfIdInContractTemplates < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def up
+    remove_index :contract_templates, :ecf_id
+    add_index :contract_templates, :ecf_id, unique: true, algorithm: :concurrently
+  end
+
+  def down
+    remove_index :contract_templates, :ecf_id
+    add_index :contract_templates, :ecf_id, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20241023115056_add_unique_constraint_to_ecf_id_in_courses.rb
+++ b/db/migrate/20241023115056_add_unique_constraint_to_ecf_id_in_courses.rb
@@ -1,0 +1,11 @@
+class AddUniqueConstraintToEcfIdInCourses < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def up
+    add_index :courses, :ecf_id, unique: true, algorithm: :concurrently
+  end
+
+  def down
+    remove_index :courses, :ecf_id
+  end
+end

--- a/db/migrate/20241023125017_add_unique_constraint_to_ecf_id_in_declarations.rb
+++ b/db/migrate/20241023125017_add_unique_constraint_to_ecf_id_in_declarations.rb
@@ -1,0 +1,13 @@
+class AddUniqueConstraintToEcfIdInDeclarations < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def up
+    remove_index :declarations, :ecf_id
+    add_index :declarations, :ecf_id, unique: true, algorithm: :concurrently
+  end
+
+  def down
+    remove_index :declarations, :ecf_id
+    add_index :declarations, :ecf_id, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20241023141116_add_unique_constraint_to_ecf_id_in_lead_providers.rb
+++ b/db/migrate/20241023141116_add_unique_constraint_to_ecf_id_in_lead_providers.rb
@@ -1,0 +1,11 @@
+class AddUniqueConstraintToEcfIdInLeadProviders < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def up
+    add_index :lead_providers, :ecf_id, unique: true, algorithm: :concurrently
+  end
+
+  def down
+    remove_index :lead_providers, :ecf_id
+  end
+end

--- a/db/migrate/20241023141630_add_unique_constraint_to_ecf_id_in_participant_id_changes.rb
+++ b/db/migrate/20241023141630_add_unique_constraint_to_ecf_id_in_participant_id_changes.rb
@@ -1,0 +1,13 @@
+class AddUniqueConstraintToEcfIdInParticipantIdChanges < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def up
+    remove_index :participant_id_changes, :ecf_id
+    add_index :participant_id_changes, :ecf_id, unique: true, algorithm: :concurrently
+  end
+
+  def down
+    remove_index :participant_id_changes, :ecf_id
+    add_index :participant_id_changes, :ecf_id, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_23_113236) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_23_141630) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -114,7 +114,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_23_113236) do
     t.datetime "accepted_at"
     t.index ["cohort_id"], name: "index_applications_on_cohort_id"
     t.index ["course_id"], name: "index_applications_on_course_id"
-    t.index ["ecf_id"], name: "index_applications_on_ecf_id"
+    t.index ["ecf_id"], name: "index_applications_on_ecf_id", unique: true
     t.index ["itt_provider_id"], name: "index_applications_on_itt_provider_id"
     t.index ["lead_provider_id"], name: "index_applications_on_lead_provider_id"
     t.index ["private_childcare_provider_id"], name: "index_applications_on_private_childcare_provider_id"
@@ -153,7 +153,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_23_113236) do
     t.uuid "ecf_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["ecf_id"], name: "index_contract_templates_on_ecf_id"
+    t.index ["ecf_id"], name: "index_contract_templates_on_ecf_id", unique: true
   end
 
   create_table "contracts", force: :cascade do |t|
@@ -186,6 +186,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_23_113236) do
     t.string "identifier"
     t.bigint "course_group_id"
     t.index ["course_group_id"], name: "index_courses_on_course_group_id"
+    t.index ["ecf_id"], name: "index_courses_on_ecf_id", unique: true
     t.index ["identifier"], name: "index_courses_on_identifier", unique: true
   end
 
@@ -216,7 +217,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_23_113236) do
     t.datetime "updated_at", null: false
     t.index ["application_id"], name: "index_declarations_on_application_id"
     t.index ["cohort_id"], name: "index_declarations_on_cohort_id"
-    t.index ["ecf_id"], name: "index_declarations_on_ecf_id"
+    t.index ["ecf_id"], name: "index_declarations_on_ecf_id", unique: true
     t.index ["lead_provider_id"], name: "index_declarations_on_lead_provider_id"
     t.index ["superseded_by_id"], name: "index_declarations_on_superseded_by_id"
   end
@@ -295,6 +296,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_23_113236) do
     t.datetime "updated_at", null: false
     t.uuid "ecf_id"
     t.string "hint"
+    t.index ["ecf_id"], name: "index_lead_providers_on_ecf_id", unique: true
   end
 
   create_table "local_authorities", force: :cascade do |t|
@@ -320,7 +322,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_23_113236) do
     t.uuid "ecf_id"
     t.uuid "from_participant_id", null: false
     t.uuid "to_participant_id", null: false
-    t.index ["ecf_id"], name: "index_participant_id_changes_on_ecf_id"
+    t.index ["ecf_id"], name: "index_participant_id_changes_on_ecf_id", unique: true
     t.index ["from_participant_id"], name: "index_participant_id_changes_on_from_participant_id"
     t.index ["to_participant_id"], name: "index_participant_id_changes_on_to_participant_id"
     t.index ["user_id"], name: "index_participant_id_changes_on_user_id"

--- a/spec/factories/declarations.rb
+++ b/spec/factories/declarations.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
     declaration_type { "started" }
     declaration_date { Date.current }
     state { "submitted" }
+    ecf_id { SecureRandom.uuid }
 
     trait :submitted_or_eligible do
       state do

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -91,6 +91,7 @@ RSpec.describe Application do
 
       # TODO: uncomment this when `before_validation` is removed from model, as `before_validation` is adding ecf_id regardless
       # it { is_expected.to validate_presence_of(:ecf_id).with_message("Enter an ECF ID") }
+      it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique") }
 
       it "ensures ecf_id is automatically populated" do
         application = build(:application, ecf_id: nil)

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -41,6 +41,8 @@ RSpec.describe Application do
   end
 
   describe "validations" do
+    it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique").allow_nil }
+
     context "when the schedule cohort does not match the application cohort" do
       subject do
         build(:application).tap do |application|

--- a/spec/models/application_state_spec.rb
+++ b/spec/models/application_state_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe ApplicationState do
     it { is_expected.to belong_to(:lead_provider).optional }
   end
 
+  describe "validations" do
+    it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique").allow_nil }
+  end
+
   describe "enums" do
     it {
       expect(subject).to define_enum_for(:state).with_values(

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Cohort, type: :model do
     it { is_expected.to validate_presence_of(:registration_start_date) }
     it { is_expected.to allow_value(%w[true false]).for(:funding_cap).with_message("Choose true or false for funding cap") }
     it { is_expected.not_to allow_value(nil).for(:funding_cap).with_message("Choose true or false for funding cap") }
+    it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique").allow_nil }
 
     describe "#registration_start_date_matches_start_year" do
       it "adds an error when the registration_start_date year does not match the start_year" do

--- a/spec/models/contract_template_spec.rb
+++ b/spec/models/contract_template_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe ContractTemplate, type: :model do
     it { is_expected.to validate_numericality_of(:output_payment_percentage).only_integer.is_greater_than_or_equal_to(0).with_message("Must be an integer greater than or equal to zero") }
     it { is_expected.to validate_numericality_of(:service_fee_installments).only_integer.is_greater_than_or_equal_to(0).with_message("Must be an integer greater than or equal to zero") }
     it { is_expected.to validate_numericality_of(:service_fee_percentage).only_integer.is_greater_than_or_equal_to(0).with_message("Must be an integer greater than or equal to zero") }
-
     it { is_expected.to validate_numericality_of(:per_participant).is_greater_than(0).with_message("Must be greater than zero") }
     it { is_expected.to validate_numericality_of(:recruitment_target).only_integer.is_greater_than(0).with_message("Must be an integer greater than zero") }
+    it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique").allow_nil }
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Course do
   describe "validations" do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_uniqueness_of(:identifier).with_message("Identifier already exists, enter a unique one") }
+    it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique").allow_nil }
   end
 
   describe "associations" do

--- a/spec/models/lead_provider_spec.rb
+++ b/spec/models/lead_provider_spec.rb
@@ -6,6 +6,11 @@ RSpec.describe LeadProvider do
     it { is_expected.to have_many(:statements) }
   end
 
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique").allow_nil }
+  end
+
   describe "#next_output_fee_statement" do
     let(:cohort) { create(:cohort, :current) }
     let(:lead_provider) { next_output_fee_statement.lead_provider }

--- a/spec/models/participant_id_change_spec.rb
+++ b/spec/models/participant_id_change_spec.rb
@@ -3,10 +3,13 @@
 require "rails_helper"
 
 RSpec.describe ParticipantIdChange, type: :model do
+  subject { build(:participant_id_change) }
+
   describe "validations" do
     it { is_expected.to validate_presence_of(:user) }
     it { is_expected.to validate_presence_of(:from_participant_id) }
     it { is_expected.to validate_presence_of(:to_participant_id) }
+    it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique").allow_nil }
   end
 
   describe "associations" do

--- a/spec/models/participant_outcome_api_request_spec.rb
+++ b/spec/models/participant_outcome_api_request_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe ParticipantOutcomeAPIRequest, type: :model do
   end
 
   describe "validations" do
-    it { is_expected.to validate_presence_of(:ecf_id) }
-    it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive }
+    it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique") }
   end
 end

--- a/spec/models/participant_outcome_spec.rb
+++ b/spec/models/participant_outcome_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe ParticipantOutcome, type: :model do
   end
 
   describe "validations" do
-    it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive }
+    it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique") }
     it { is_expected.to validate_presence_of(:state) }
     it { is_expected.to validate_presence_of(:completion_date) }
 

--- a/spec/models/schedule_spec.rb
+++ b/spec/models/schedule_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe Schedule, type: :model do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_presence_of(:identifier) }
     it { is_expected.to validate_uniqueness_of(:identifier).scoped_to(:cohort_id) }
-
     it { is_expected.to validate_presence_of(:applies_from) }
     it { is_expected.to validate_presence_of(:applies_to) }
+    it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique").allow_nil }
   end
 
   describe "associations" do

--- a/spec/models/statement_item_spec.rb
+++ b/spec/models/statement_item_spec.rb
@@ -1,12 +1,16 @@
 require "rails_helper"
 
 RSpec.describe StatementItem, type: :model do
+  subject { build(:statement_item) }
+
   describe "relationships" do
     it { is_expected.to belong_to(:statement).required }
     it { is_expected.to belong_to(:declaration).required }
   end
 
   describe "validations" do
+    it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique").allow_nil }
+
     context "when setting invalid state" do
       let(:statement_item) { build(:statement_item, state: "madeup") }
 

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe Statement, type: :model do
     it { is_expected.to validate_numericality_of(:year).only_integer.is_in(2020..2050).with_message("Year must be a 4 digit number") }
     it { is_expected.to allow_value(%w[true false]).for(:output_fee).with_message("Output fee must be true or false") }
     it { is_expected.not_to allow_value(nil).for(:output_fee).with_message("Choose yes or no for output fee") }
-    it { is_expected.to validate_presence_of(:ecf_id).with_message("Enter an ECF ID") }
     it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique") }
 
     describe "Validation for statement items count" do


### PR DESCRIPTION
### Context

Ticket: [CPDLP-3652](https://dfedigital.atlassian.net/browse/CPDLP-3652)

We currently do not have a unique index on models with `ecf_id` in NPQ. We will need to add those except for `Users` which needs fixing and is being done by the NPQ team.

### Changes proposed in this pull request

- Add a unique index on `ecf_id` all models with an `ecf_id` in NPQ (except for User) as well as a DB constraint;
- Ensure there is no data in all other envs: staging/sandbox/separation/production which will break this index, and fix the data;
- Ensure the indices added will run quickly and not block deployments;

Tested in snapshot db:

```
== 20241022204916 AddUniqueConstraintToEcfIdInApplications: migrating =========
-- remove_index(:applications, :ecf_id)
   -> 0.2731s
-- add_index(:applications, :ecf_id, {:unique=>true, :algorithm=>:concurrently})
   -> 0.4602s
== 20241022204916 AddUniqueConstraintToEcfIdInApplications: migrated (0.7378s) 

== 20241023093413 AddUniqueConstraintToEcfIdInContractTemplates: migrating ====
-- remove_index(:contract_templates, :ecf_id)
   -> 0.0660s
-- add_index(:contract_templates, :ecf_id, {:unique=>true, :algorithm=>:concurrently})
   -> 0.0399s
== 20241023093413 AddUniqueConstraintToEcfIdInContractTemplates: migrated (0.1065s) 

== 20241023093913 AddUniqueConstraintToEcfIdInCourses: migrating ==============
-- add_index(:courses, :ecf_id, {:unique=>true, :algorithm=>:concurrently})
   -> 0.0331s
== 20241023093913 AddUniqueConstraintToEcfIdInCourses: migrated (0.0334s) =====

== 20241023125017 AddUniqueConstraintToEcfIdInDeclarations: migrating =========
-- remove_index(:declarations, :ecf_id)
   -> 0.1625s
-- add_index(:declarations, :ecf_id, {:unique=>true, :algorithm=>:concurrently})
   -> 0.0510s
== 20241023125017 AddUniqueConstraintToEcfIdInDeclarations: migrated (0.2171s) 

== 20241023141116 AddUniqueConstraintToEcfIdInLeadProviders: migrating ========
-- add_index(:lead_providers, :ecf_id, {:unique=>true, :algorithm=>:concurrently})
   -> 0.0357s
== 20241023141116 AddUniqueConstraintToEcfIdInLeadProviders: migrated (0.0362s) 

== 20241023141630 AddUniqueConstraintToEcfIdInParticipantIdChanges: migrating =
-- remove_index(:participant_id_changes, :ecf_id)
   -> 0.1510s
-- add_index(:participant_id_changes, :ecf_id, {:unique=>true, :algorithm=>:concurrently})
   -> 0.0367s
== 20241023141630 AddUniqueConstraintToEcfIdInParticipantIdChanges: migrated (0.1898s)
```

Tested in the remaining envs:

```
=> [Application, ContractTemplate, Course, Declaration, LeadProvider, ParticipantIdChange].map do |klass|
  klass.where.not(ecf_id: nil).select(:ecf_id).group(:ecf_id).having("count(*) > 1").size
end
=> [{}, {}, {}, {}, {}, {}]
```
[CPDLP-3652]: https://dfedigital.atlassian.net/browse/CPDLP-3652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ