### PR TITLE
Surface duplicates in parity check

### DIFF
--- a/app/controllers/npq_separation/migration/parity_checks_controller.rb
+++ b/app/controllers/npq_separation/migration/parity_checks_controller.rb
@@ -18,5 +18,6 @@ class NpqSeparation::Migration::ParityChecksController < SuperAdminController
   def response_comparison
     @comparison = Migration::ParityCheck::ResponseComparison.find(params[:id])
     @matching_comparisons = Migration::ParityCheck::ResponseComparison.matching(@comparison)
+    @multiple_results = @matching_comparisons.one? && @comparison.page.nil?
   end
 end

--- a/app/helpers/migration_helper.rb
+++ b/app/helpers/migration_helper.rb
@@ -61,11 +61,11 @@ module MigrationHelper
     govuk_link_to("Failures report", download_report_npq_separation_migration_migrations_path(data_migrations.sample.model))
   end
 
-  def response_comparison_status_tag(different)
+  def response_comparison_status_tag(different, equal_text: "equal", different_text: "different")
     if different
-      govuk_tag(text: "DIFFERENT", colour: "red")
+      govuk_tag(text: different_text.upcase, colour: "red")
     else
-      govuk_tag(text: "EQUAL", colour: "green")
+      govuk_tag(text: equal_text.upcase, colour: "green")
     end
   end
 
@@ -118,5 +118,10 @@ module MigrationHelper
             response_comparison_status_code_tag(comparison.npq_response_status_code)
         end
     end
+  end
+
+  def contains_duplicate_ids?(comparisons, attribute)
+    ids = comparisons.map(&attribute).flatten
+    ids.size != ids.uniq.size
   end
 end

--- a/app/models/migration/parity_check/response_comparison.rb
+++ b/app/models/migration/parity_check/response_comparison.rb
@@ -2,7 +2,7 @@ module Migration
   class ParityCheck::ResponseComparison < ApplicationRecord
     attr_accessor :exclude
 
-    before_validation :digest_csv_response_bodies, :format_json_response_bodies, :clear_response_bodies_when_equal
+    before_validation :digest_csv_response_bodies, :format_json_response_bodies, :populate_response_body_ids, :clear_response_bodies_when_equal
 
     belongs_to :lead_provider
 
@@ -70,6 +70,11 @@ module Migration
     end
 
   private
+
+    def populate_response_body_ids
+      self.ecf_response_body_ids = Array.wrap(ecf_response_body_hash&.dig("data") || []).map { |record| record["id"] }
+      self.npq_response_body_ids = Array.wrap(npq_response_body_hash&.dig("data") || []).map { |record| record["id"] }
+    end
 
     def format_json_response_bodies
       self.ecf_response_body = pretty_format(ecf_response_body_hash) if ecf_response_body_hash

--- a/app/views/npq_separation/migration/parity_checks/_multiple_comparisons_summary.html.erb
+++ b/app/views/npq_separation/migration/parity_checks/_multiple_comparisons_summary.html.erb
@@ -1,5 +1,5 @@
 <%= govuk_table do |table|
-  table.with_caption(size: "m", text: "Overview (#{pluralize(comparisons.size, "pages")})")
+  table.with_caption(size: "m", text: "Overview (#{pluralize(comparisons.size, "page")})")
 
   table.with_head do |head|
     head.with_row do |row|
@@ -23,6 +23,28 @@
       row.with_cell(text: response_comparison_response_duration_human_readable(comparisons, :ecf_response_time_ms))
       row.with_cell(text: response_comparison_response_duration_human_readable(comparisons, :npq_response_time_ms))
       row.with_cell(text: response_comparison_performance(comparisons))
+    end
+
+    body.with_row do |row|
+      row.with_cell(text: "ID duplicates check")
+      
+      ecf_duplicates = contains_duplicate_ids?(comparisons, :ecf_response_body_ids)
+      npq_duplicates = contains_duplicate_ids?(comparisons, :npq_response_body_ids)
+    
+      row.with_cell(text: response_comparison_status_tag(ecf_duplicates, equal_text: "no", different_text: "yes"))
+      row.with_cell(text: response_comparison_status_tag(npq_duplicates, equal_text: "no", different_text: "yes"))
+      row.with_cell(text: response_comparison_status_tag(ecf_duplicates || npq_duplicates, equal_text: "unique", different_text: "duplicates"))
+    end
+
+    body.with_row do |row|
+      row.with_cell(text: "ID equality check")
+      
+      ecf_ids = comparisons.map(&:ecf_response_body_ids).flatten.sort
+      npq_ids = comparisons.map(&:npq_response_body_ids).flatten.sort
+    
+      row.with_cell(text: number_with_delimiter(ecf_ids.size))
+      row.with_cell(text: number_with_delimiter(npq_ids.size))
+      row.with_cell(text: response_comparison_status_tag(ecf_ids != npq_ids))
     end
   end
 end %>

--- a/app/views/npq_separation/migration/parity_checks/response_comparison.html.erb
+++ b/app/views/npq_separation/migration/parity_checks/response_comparison.html.erb
@@ -7,12 +7,12 @@
 <span class="govuk-caption-xl"><%= @comparison.lead_provider_name %></span>
 <h1 class="govuk-heading-xl"><%= @comparison.description %></h1>
 
-<% unless @matching_comparisons.one? %>
+<% unless @multiple_results %>
   <%= render(partial: "multiple_comparisons_summary", locals: { comparisons: @matching_comparisons }) %>
 <% end %>
 
 <% if @matching_comparisons.any?(&:different?) %>
-  <% if @matching_comparisons.one? %>
+  <% if @multiple_results %>
     <%= render(partial: "single_comparison_summary", locals: { comparison: @comparison }) %>
     <%= render(partial: "response_body_diff", locals: { response_body_diff: @comparison.response_body_diff }) %>
   <% else %>

--- a/db/migrate/20241024142323_add_ecf_npq_ids_to_response_comparison.rb
+++ b/db/migrate/20241024142323_add_ecf_npq_ids_to_response_comparison.rb
@@ -1,0 +1,6 @@
+class AddEcfNpqIdsToResponseComparison < ActiveRecord::Migration[7.1]
+  def change
+    add_column :response_comparisons, :npq_response_body_ids, :string, array: true, default: []
+    add_column :response_comparisons, :ecf_response_body_ids, :string, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_23_141630) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_24_142323) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -411,6 +411,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_23_141630) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "page"
+    t.string "npq_response_body_ids", default: [], array: true
+    t.string "ecf_response_body_ids", default: [], array: true
     t.index ["lead_provider_id"], name: "index_response_comparisons_on_lead_provider_id"
   end
 

--- a/spec/features/parity_check_spec.rb
+++ b/spec/features/parity_check_spec.rb
@@ -135,7 +135,8 @@ RSpec.feature "Parity check", :in_memory_rails_cache, :rack_test_driver, type: :
 
       different_comparison = create(:response_comparison, :different, page: 1)
       lead_provider = different_comparison.lead_provider
-      create(:response_comparison, :different, npq_response_body: "body", ecf_response_body: "body", page: 2, lead_provider:)
+      body = %({ "data": [{ "id": "1" }, { "id": "1" }] })
+      create(:response_comparison, :different, npq_response_body: body, ecf_response_body: body, page: 2, lead_provider:)
       create(:response_comparison, :equal, page: 3, lead_provider:)
 
       # Reload to display the different comparison created manually
@@ -153,11 +154,25 @@ RSpec.feature "Parity check", :in_memory_rails_cache, :rack_test_driver, type: :
         expect(page).to have_text("DIFFERENT")
       end
 
-      within("tbody tr:last") do
+      within("tbody tr:nth-of-type(2)") do
         expect(page).to have_text("Average response time")
         expect(page).to have_text("100ms")
         expect(page).to have_text("50ms")
         expect(page).to have_text("🚀 2x faster")
+      end
+
+      within("tbody tr:nth-of-type(3)") do
+        expect(page).to have_text("ID duplicates check")
+        expect(page).to have_text("YES")
+        expect(page).to have_text("YES")
+        expect(page).to have_text("DUPLICATES")
+      end
+
+      within("tbody tr:nth-of-type(4)") do
+        expect(page).to have_text("ID equality check")
+        expect(page).to have_text("2")
+        expect(page).to have_text("2")
+        expect(page).to have_text("EQUAL")
       end
 
       expect(page).to have_css(".govuk-grid-row", text: "Page 1\nECF: 200 NPQ: 201")

--- a/spec/helpers/migration_helper_spec.rb
+++ b/spec/helpers/migration_helper_spec.rb
@@ -215,12 +215,24 @@ RSpec.describe MigrationHelper, type: :helper do
       let(:different) { false }
 
       it { is_expected.to have_css("strong.govuk-tag.govuk-tag--green", text: "EQUAL") }
+
+      context "when equal_text is specified" do
+        subject { helper.response_comparison_status_tag(different, equal_text: "yes") }
+
+        it { is_expected.to have_css("strong.govuk-tag.govuk-tag--green", text: "YES") }
+      end
     end
 
     context "when different" do
       let(:different) { true }
 
       it { is_expected.to have_css("strong.govuk-tag.govuk-tag--red", text: "DIFFERENT") }
+
+      context "when different_text is specified" do
+        subject { helper.response_comparison_status_tag(different, different_text: "no") }
+
+        it { is_expected.to have_css("strong.govuk-tag.govuk-tag--red", text: "NO") }
+      end
     end
   end
 
@@ -340,5 +352,42 @@ RSpec.describe MigrationHelper, type: :helper do
 
     it { is_expected.to have_css(".govuk-grid-row .govuk-grid-column-two-thirds", text: "Page 1") }
     it { is_expected.to have_css(".govuk-grid-row .govuk-grid-column-one-third", text: "ECF: 200 NPQ: 201") }
+  end
+
+  describe ".contains_duplicate_ids?" do
+    subject { helper.contains_duplicate_ids?(comparisons, :npq_response_body_ids) }
+
+    context "when the comparisons contain duplicates across all comparisons" do
+      let(:comparisons) do
+        [
+          create(:response_comparison, :different, npq_response_body: %({ "data": [{ "id": "1" }, { "id": "2" }, { "id": "3" }] })),
+          create(:response_comparison, :different, npq_response_body: %({ "data": [{ "id": "1" }, { "id": "4" }, { "id": "5" }] })),
+        ]
+      end
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when the comparisons contain duplicates in individual comparisons" do
+      let(:comparisons) do
+        [
+          create(:response_comparison, :different, npq_response_body: %({ "data": [{ "id": "1" }, { "id": "1" }, { "id": "3" }] })),
+          create(:response_comparison, :different, npq_response_body: %({ "data": [{ "id": "4" }, { "id": "5" }, { "id": "6" }] })),
+        ]
+      end
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when the comparisons do not contain duplicates" do
+      let(:comparisons) do
+        [
+          create(:response_comparison, :different, npq_response_body: %({ "data": [{ "id": "1" }, { "id": "2" }, { "id": "3" }] })),
+          create(:response_comparison, :different, npq_response_body: %({ "data": [{ "id": "4" }, { "id": "5" }, { "id": "6" }] })),
+        ]
+      end
+
+      it { is_expected.to be(false) }
+    end
   end
 end

--- a/spec/models/migration/parity_check/response_comparison_spec.rb
+++ b/spec/models/migration/parity_check/response_comparison_spec.rb
@@ -106,6 +106,47 @@ RSpec.describe Migration::ParityCheck::ResponseComparison, type: :model do
         JSON
       )
     end
+
+    describe "populating response body ids" do
+      let(:instance) { build(:response_comparison, :different, ecf_response_body: response_body, npq_response_body: response_body) }
+
+      before { instance.valid? }
+
+      context "when the response body contains multiple results" do
+        let(:response_body) { %({ "data": [{ "id": "1" }, { "id": "2" }] }) }
+
+        it { expect(instance.ecf_response_body_ids).to contain_exactly("1", "2") }
+        it { expect(instance.npq_response_body_ids).to contain_exactly("1", "2") }
+      end
+
+      context "when the response body contains a single result" do
+        let(:response_body) { %({ "data": { "id": "1" } }) }
+
+        it { expect(instance.ecf_response_body_ids).to contain_exactly("1") }
+        it { expect(instance.npq_response_body_ids).to contain_exactly("1") }
+      end
+
+      context "when the response body is not in the expected format" do
+        let(:response_body) { %({ "foo": { "id": "1" } }) }
+
+        it { expect(instance.ecf_response_body_ids).to be_empty }
+        it { expect(instance.npq_response_body_ids).to be_empty }
+      end
+
+      context "when the response body is not JSON" do
+        let(:response_body) { %(Error!) }
+
+        it { expect(instance.ecf_response_body_ids).to be_empty }
+        it { expect(instance.npq_response_body_ids).to be_empty }
+      end
+
+      context "when the response body is nil" do
+        let(:response_body) { nil }
+
+        it { expect(instance.ecf_response_body_ids).to be_empty }
+        it { expect(instance.npq_response_body_ids).to be_empty }
+      end
+    end
   end
 
   describe "scopes" do


### PR DESCRIPTION
### Context

[Jira-3525](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345%2Cunassigned&selectedIssue=CPDLP-3525)

### Changes proposed in this pull request

- Add ecf/npq response body ids to ResponseComparison

We want to perform additional checks on the response IDs regardless of if the comparison was successful or not. We want to check for duplicate/mismatched ids across all requests for a comparison.

Add `ecf_response_body_ids` and `npq_response_body_ids` to `ResponseComparison`.

- Add duplicate/matching ID checks to overview page

When we return multiple results we want to check that the IDs in the results are consistent between ECF and NPQ reg and that there are no duplicate IDs returned.

Fix pluralisation bug in overview page title.

Always use multiple results partial even if only 1 page of results.

### Guidance for review

![screencapture-0-0-0-0-3000-npq-separation-migration-parity-checks-response-comparisons-132-2024-10-25-10_06_39](https://github.com/user-attachments/assets/583c0d89-a457-44dd-bff1-81a5bfbd247c)
