### PR TITLE
Run CI on all branches

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,10 +7,10 @@ concurrency:
 on:
   push:
     branches:
-      - main
+      - '**'
   pull_request:
     branches:
-      - main
+      - '**'
   merge_group:
 
 jobs:


### PR DESCRIPTION
When we branch off another branch the CI doesn't run; it would be better if it did so we get failures flagged before we rebase with `main`.