### PR TITLE
[CPDLP-3638] Add backfill for ecf_ids and data in migration

### DIFF
--- a/spec/services/migration/migrators/application_spec.rb
+++ b/spec/services/migration/migrators/application_spec.rb
@@ -236,6 +236,14 @@ RSpec.describe Migration::Migrators::Application do
 
           expect(application.reload.cohort_id).to eq(::Cohort.current.id)
         end
+
+        it "sets `lead_provider_approval_status` to pending if not set" do
+          application = create(:application, cohort_id: nil, lead_provider_approval_status: nil)
+
+          instance.call
+
+          expect(application.reload.lead_provider_approval_status).to eq("pending")
+        end
       end
     end
   end

--- a/spec/services/migration/migrators/application_spec.rb
+++ b/spec/services/migration/migrators/application_spec.rb
@@ -219,6 +219,24 @@ RSpec.describe Migration::Migrators::Application do
           end
         end
       end
+
+      context "when backfilling existing applications" do
+        it "sets `ecf_id`" do
+          application = create(:application, ecf_id: nil)
+
+          instance.call
+
+          expect(application.reload.ecf_id).to be_present
+        end
+
+        it "sets `cohort_id` to current cohort when schedule is not set" do
+          application = create(:application, cohort_id: nil)
+
+          instance.call
+
+          expect(application.reload.cohort_id).to eq(::Cohort.current.id)
+        end
+      end
     end
   end
 end

--- a/spec/services/migration/migrators/user_spec.rb
+++ b/spec/services/migration/migrators/user_spec.rb
@@ -293,6 +293,24 @@ RSpec.describe Migration::Migrators::User do
           end
         end
       end
+
+      context "when backfilling existing users" do
+        it "sets `ecf_id` for users with application" do
+          user_with_application = create(:user, :with_application, ecf_id: nil)
+
+          instance.call
+
+          expect(user_with_application.reload.ecf_id).to be_present
+        end
+
+        it "does not set `ecf_id` for with no application" do
+          user_without_application = create(:user, ecf_id: nil)
+
+          instance.call
+
+          expect(user_without_application.reload.ecf_id).to be_nil
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-3638

### Changes proposed in this pull request

* `Application`
  * Backfill for `ecf_id`
  * Backfill for `cohort_id`
  * Backfill for `lead_provider_approval_status `
* `User`
  * Backfill for `ecf_id`