### PR TITLE
[CPDLP-3675] Added rails validation to ecf_id in user model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,9 @@ class User < ApplicationRecord
   validates :uid, inclusion: { in: ->(user) { [user.uid_was] } }, on: :npq_separation, if: -> { uid_was.present? }
   # TODO: add constraints into the DB after separation
   validates :ecf_id, presence: true, if: -> { Feature.ecf_api_disabled? }
+  # rubocop:disable Rails/UniqueValidationWithoutIndex
+  validates :ecf_id, uniqueness: { allow_blank: true }
+  # rubocop:enable Rails/UniqueValidationWithoutIndex
 
   # TODO: remove this and add default: "gen_random_uuid()" in the DB after separation
   before_validation do

--- a/app/services/migration/users/creator.rb
+++ b/app/services/migration/users/creator.rb
@@ -45,8 +45,6 @@ module Migration
       end
 
       def find_primary_user
-        raise_on_multiple_ecf_users_with_same_ecf_id!
-
         if user_does_not_exist_on_npq?
           return nil
         end
@@ -131,13 +129,6 @@ module Migration
 
       def user_does_not_exist_on_npq?
         user_by_ecf_user_id.nil? && user_by_ecf_user_gai_id.nil?
-      end
-
-      def raise_on_multiple_ecf_users_with_same_ecf_id!
-        # user.ecf_id is not validated as unique, check for duplicates
-        return unless ::User.where(ecf_id: ecf_user.id).count > 1
-
-        raise_error("ecf_user.id has multiple users in NPQ")
       end
 
       def only_ecf_id_return_user?

--- a/spec/features/migration_spec.rb
+++ b/spec/features/migration_spec.rb
@@ -186,10 +186,10 @@ RSpec.feature "Migration", :in_memory_rails_cache, :rack_test_driver, type: :fea
         create(:user, :with_random_name, ecf_id: ecf_user1.id, email: ecf_user1.email)
         create(:user, :with_random_name, ecf_id: ecf_user2.id, email: ecf_user2.email)
 
-        # Duplicate users with ecf_id
-        ecf_user = create(:ecf_migration_user, :npq)
-        create(:user, ecf_id: ecf_user.id)
-        create(:user, ecf_id: ecf_user.id)
+        # Applications with similar validated trns
+        participant_identity = create(:ecf_migration_participant_identity)
+        create(:ecf_migration_npq_application, teacher_reference_number: "123456", teacher_reference_number_verified: true, participant_identity:)
+        create(:ecf_migration_npq_application, teacher_reference_number: "7891011", teacher_reference_number_verified: true, participant_identity:)
       end
 
       scenario "running a migration" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe User do
     it { is_expected.to validate_uniqueness_of(:email).case_insensitive.with_message("Email address must be unique") }
     it { is_expected.not_to allow_value("invalid-email").for(:email).on(:npq_separation) }
     it { is_expected.to validate_uniqueness_of(:uid).allow_blank }
-    it { is_expected.to validate_uniqueness_of(:ecf_id).allow_blank.case_insensitive.with_message("ECF ID has already been taken") }
+    it { is_expected.to validate_uniqueness_of(:ecf_id).allow_blank.case_insensitive.with_message("ECF ID must be unique") }
 
     it "does not allow a uid to change once set" do
       user = create(:user, uid: "123")

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe User do
     it { is_expected.to validate_uniqueness_of(:email).case_insensitive.with_message("Email address must be unique") }
     it { is_expected.not_to allow_value("invalid-email").for(:email).on(:npq_separation) }
     it { is_expected.to validate_uniqueness_of(:uid).allow_blank }
+    it { is_expected.to validate_uniqueness_of(:ecf_id).allow_blank.case_insensitive.with_message("ECF ID has already been taken") }
 
     it "does not allow a uid to change once set" do
       user = create(:user, uid: "123")

--- a/spec/services/migration/migrators/user_spec.rb
+++ b/spec/services/migration/migrators/user_spec.rb
@@ -15,10 +15,10 @@ RSpec.describe Migration::Migrators::User do
     end
 
     def setup_failure_state
-      # Duplicate users with ecf_id
-      ecf_user = create(:ecf_migration_user, :npq)
-      create(:user, ecf_id: ecf_user.id)
-      create(:user, ecf_id: ecf_user.id)
+      # Applications with similar validated trns
+      participant_identity = create(:ecf_migration_participant_identity)
+      create(:ecf_migration_npq_application, teacher_reference_number: "123456", teacher_reference_number_verified: true, participant_identity:)
+      create(:ecf_migration_npq_application, teacher_reference_number: "7891011", teacher_reference_number_verified: true, participant_identity:)
     end
 
     describe "#call" do
@@ -125,17 +125,6 @@ RSpec.describe Migration::Migrators::User do
           instance.call
           expect(failure_manager).not_to have_received(:record_failure)
           expect(existing_user.reload).to have_attributes(trn: "332245", trn_verified: false)
-        end
-      end
-
-      context "when there are multiple users with the same ecf_id" do
-        it "raises error" do
-          ecf_user = create(:ecf_migration_user, :npq, email: "email-1@example.com")
-          create(:user, ecf_id: ecf_user.id, email: "email-1@example.com")
-          create(:user, ecf_id: ecf_user.id, email: "email-2@example.com")
-
-          instance.call
-          expect(failure_manager).to have_received(:record_failure).with(ecf_user, /ecf_user.id has multiple users in NPQ/)
         end
       end
 

--- a/spec/services/migration/users/creator_spec.rb
+++ b/spec/services/migration/users/creator_spec.rb
@@ -152,17 +152,6 @@ RSpec.describe Migration::Users::Creator do
       end
     end
 
-    context "when multiple users have same ecf_user.id" do
-      it "raises error" do
-        create(:user, ecf_id: ecf_user.id)
-        create(:user, ecf_id: ecf_user.id)
-
-        expect {
-          subject.find_primary_user
-        }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: ecf_user.id has multiple users in NPQ")
-      end
-    end
-
     context "when ecf_user.id and ecf_user.get_an_identity_id return the same user" do
       it "returns user" do
         existing_user = create(:user, ecf_id: ecf_user.id, uid: ecf_user.get_an_identity_id)


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-3675


### Changes proposed in this pull request

- Adds a unique validation to the ecf_id field in the user model. This field should be unique. 
- Remove validation for ecf id in user migrator as it is no longer needed

 The user data is being cleaned up in advance of this PR. A unique constraint at the DB level will be added in a subsequent PR.

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
