### PR TITLE
[CPDLP-3636] Add mark statements as payable job

### DIFF
--- a/app/jobs/crons/mark_statements_as_payable_job.rb
+++ b/app/jobs/crons/mark_statements_as_payable_job.rb
@@ -1,0 +1,14 @@
+class Crons::MarkStatementsAsPayableJob < CronJob
+  include Sentry::Cron::MonitorCheckIns
+
+  # run at 12AM every day
+  self.cron_expression = "0 0 * * *"
+
+  sentry_monitor_check_ins slug: "mark-statements-as-payable"
+
+  def perform
+    Statement.where(state: "open", deadline_date: 1.day.ago.to_date).find_each do |statement|
+      ::Statements::MarkAsPayable.new(statement:).mark
+    end
+  end
+end

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -3,6 +3,7 @@ class Statement < ApplicationRecord
   belongs_to :lead_provider
   has_many :statement_items
   has_many :contracts
+  has_many :declarations, through: :statement_items
 
   validates :output_fee,
             inclusion: {

--- a/app/services/declarations/mark_as_payable.rb
+++ b/app/services/declarations/mark_as_payable.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Declarations
+  class MarkAsPayable
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :statement
+
+    def mark(declaration:)
+      ApplicationRecord.transaction do
+        declaration.mark_payable!
+
+        statement_item = statement
+                      .statement_items
+                      .find_by(declaration:)
+
+        statement_item.mark_payable! if statement_item
+      end
+    end
+  end
+end

--- a/app/services/statements/mark_as_payable.rb
+++ b/app/services/statements/mark_as_payable.rb
@@ -1,0 +1,27 @@
+module Statements
+  class MarkAsPayable
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :statement
+
+    def mark
+      ApplicationRecord.transaction do
+        declarations.find_each do |declaration|
+          declaration_mark_as_payable_service.mark(declaration:)
+        end
+        statement.mark_payable!
+      end
+    end
+
+  private
+
+    def declarations
+      statement.declarations.eligible_state
+    end
+
+    def declaration_mark_as_payable_service
+      @declaration_mark_as_payable_service ||= Declarations::MarkAsPayable.new(statement:)
+    end
+  end
+end

--- a/spec/factories/declarations.rb
+++ b/spec/factories/declarations.rb
@@ -38,5 +38,13 @@ FactoryBot.define do
     trait :from_ecf do
       ecf_id { SecureRandom.uuid }
     end
+
+    trait :awaiting_clawback do
+      state { :awaiting_clawback }
+    end
+
+    trait :voided do
+      state { :voided }
+    end
   end
 end

--- a/spec/factories/statement_items.rb
+++ b/spec/factories/statement_items.rb
@@ -23,5 +23,9 @@ FactoryBot.define do
     trait :clawed_back do
       state { "clawed_back" }
     end
+
+    trait :voided do
+      state { "voided" }
+    end
   end
 end

--- a/spec/jobs/crons/mark_statements_as_payable_job_spec.rb
+++ b/spec/jobs/crons/mark_statements_as_payable_job_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe Crons::MarkStatementsAsPayableJob, type: :job do
+  let(:application) { create(:application, :eligible_for_funded_place) }
+  let(:lead_provider) { application.lead_provider }
+  let(:statement) { create(:statement, :next_output_fee, lead_provider:) }
+
+  before do
+    ActiveJob::Base.queue_adapter.enqueued_jobs.clear
+    declaration = create(:declaration, :submitted_or_eligible, lead_provider:, application:)
+    create(:statement_item, :eligible, statement:, declaration:)
+    voided_declaration = create(:declaration, :voided, lead_provider:)
+    create(:statement_item, :voided, statement:, declaration: voided_declaration)
+  end
+
+  describe "#perform" do
+    it "transitions eligible statement/declarations to payable", :aggregate_failures do
+      expect {
+        travel_to(statement.deadline_date + 1.day) do
+          described_class.perform_now
+          statement.reload
+        end
+      }.to change(statement.declarations.payable_state, :count).from(0).to(1)
+
+      expect(statement.state).to eq("payable")
+    end
+
+    it "transitions statement items to payable" do
+      expect {
+        travel_to(statement.deadline_date + 1.day) do
+          described_class.perform_now
+          statement.reload
+        end
+      }.to change(statement.statement_items.where(state: "payable"), :count).from(0).to(1)
+    end
+  end
+
+  describe "#perform_later" do
+    it "enqueues the job exactly once" do
+      expect { described_class.perform_later }.to have_enqueued_job(described_class).exactly(:once).on_queue("default")
+    end
+  end
+end

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Statement, type: :model do
     it { is_expected.to belong_to(:lead_provider).required }
     it { is_expected.to have_many(:statement_items) }
     it { is_expected.to have_many(:contracts) }
+    it { is_expected.to have_many(:declarations).through(:statement_items) }
   end
 
   describe "validations" do

--- a/spec/services/declarations/mark_as_payable_spec.rb
+++ b/spec/services/declarations/mark_as_payable_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe Declarations::MarkAsPayable do
+  let(:application) { create(:application, :eligible_for_funded_place) }
+  let(:lead_provider) { application.lead_provider }
+  let(:statement) { create(:statement, :next_output_fee, lead_provider:) }
+  let(:declaration) { create(:declaration, :submitted_or_eligible, lead_provider:, application:) }
+  let!(:statement_item) { create(:statement_item, :eligible, statement:, declaration:) }
+  let!(:another_declaration_statement_item) { create(:statement_item, :eligible, statement:) }
+
+  subject { described_class.new(statement:) }
+
+  describe "#mark" do
+    it "transitions the declaration state itself" do
+      expect {
+        subject.mark(declaration:)
+        declaration.reload
+      }.to change(declaration, :state).from("eligible").to("payable")
+    end
+
+    it "transitions the correct statement item state" do
+      expect {
+        subject.mark(declaration:)
+        statement_item.reload
+        another_declaration_statement_item.reload
+      }.to change(statement_item, :state).from("eligible").to("payable")
+      .and(not_change { another_declaration_statement_item.state })
+    end
+  end
+end

--- a/spec/services/statements/mark_as_payable_spec.rb
+++ b/spec/services/statements/mark_as_payable_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe Statements::MarkAsPayable do
+  let(:application) { create(:application, :eligible_for_funded_place) }
+  let(:lead_provider) { application.lead_provider }
+  let(:statement) { create(:statement, :next_output_fee, lead_provider:) }
+  let!(:declaration) { create(:declaration, :submitted_or_eligible, lead_provider:, application:) }
+  let!(:voided_declaration) { create(:declaration, :voided, lead_provider:) }
+
+  subject { described_class.new(statement:) }
+
+  before do
+    create(:statement_item, :eligible, statement:, declaration:)
+    create(:statement_item, :voided, statement:, declaration: voided_declaration)
+  end
+
+  describe "#mark" do
+    let(:mock_declarations_mark_as_payable_service) { instance_double(Declarations::MarkAsPayable) }
+
+    before do
+      allow(Declarations::MarkAsPayable).to receive(:new).with(statement:).and_return(mock_declarations_mark_as_payable_service)
+      allow(mock_declarations_mark_as_payable_service).to receive(:mark).with(declaration:)
+    end
+
+    it "transitions the statement state itself" do
+      expect {
+        subject.mark
+        statement.reload
+      }.to change(statement, :state).from("open").to("payable")
+    end
+
+    it "calls Declarations::MarkAsPayable service with correct params" do
+      subject.mark
+
+      expect(Declarations::MarkAsPayable).to have_received(:new).with(statement:)
+      expect(mock_declarations_mark_as_payable_service).to have_received(:mark).with(declaration:)
+      expect(mock_declarations_mark_as_payable_service).not_to have_received(:mark).with(declaration: voided_declaration)
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: [CPDLP-3636](https://dfedigital.atlassian.net/browse/CPDLP-3636)

We have an existing job in ECF that marks statements and declarations as payable, we will need to bring this across to NPQ.

### Changes proposed in this pull request

Add mark statements as payable job.

[CPDLP-3636]: https://dfedigital.atlassian.net/browse/CPDLP-3636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ