### PR TITLE
Run CI on all PRs but not all branch pushes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,10 +7,8 @@ concurrency:
 on:
   push:
     branches:
-      - '**'
+      - main
   pull_request:
-    branches:
-      - '**'
   merge_group:
 
 jobs:


### PR DESCRIPTION
### Context

Ticket: BAU

Currently CI is running on all branch pushes, including running for the push to `gh-read-only/*` branches used by the merge queue

Merge Queues are also re-running the same pipelines

I don't think we need to run for all branches, only for all pull requests - this would still give us the ability to stack PRs

### Changes proposed in this pull request

1) Revert to only running branch pushes to main
2) Run pull request merges irrespective of the branch they are merging into

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
