### PR TITLE
[CPDLP-3635] Swap out NPQ api config for feature flags

### DIFF
--- a/.github/workflows/refresh_migration_database.yml
+++ b/.github/workflows/refresh_migration_database.yml
@@ -45,5 +45,5 @@ jobs:
       - name: Generate known keys
         shell: bash
         run: |
-          kubectl -n cpd-production exec -ti --tty deployment/npq-registration-migration-web -- /bin/sh -c "cd /app && bundle exec rails runner \"Migration::ParityCheck::TokenProvider.new.generate!\""
-          
+          kubectl -n cpd-production exec -ti --tty deployment/npq-registration-migration-web -- /bin/sh -c "cd /app && bundle exec rails runner 'Migration::ParityCheck::TokenProvider.new.generate!' && bundle exec rails runner 'Feature.enable_ecf_api_disabled'"
+

--- a/.github/workflows/refresh_migration_database.yml
+++ b/.github/workflows/refresh_migration_database.yml
@@ -45,5 +45,9 @@ jobs:
       - name: Generate known keys
         shell: bash
         run: |
-          kubectl -n cpd-production exec -ti --tty deployment/npq-registration-migration-web -- /bin/sh -c "cd /app && bundle exec rails runner 'Migration::ParityCheck::TokenProvider.new.generate!' && bundle exec rails runner 'Feature.enable_ecf_api_disabled'"
+          kubectl -n cpd-production exec -ti --tty deployment/npq-registration-migration-web -- /bin/sh -c "cd /app && bundle exec rails runner \"Migration::ParityCheck::TokenProvider.new.generate!\""
 
+      - name: Enable 'ecf_api_disabled' feature
+        shell: bash
+        run: |
+          kubectl -n cpd-production exec -ti --tty deployment/npq-registration-migration-web -- /bin/sh -c "cd /app && bundle exec rails runner \"Feature.enable_ecf_api_disabled!\""

--- a/app/services/feature.rb
+++ b/app/services/feature.rb
@@ -66,7 +66,7 @@ class Feature
       Flipper.enabled?(MAINTENANCE_BANNER)
     end
 
-    def enable_ecf_api_disabled
+    def enable_ecf_api_disabled!
       Flipper.enable(ECF_API_DISABLED)
     end
   end

--- a/app/services/feature.rb
+++ b/app/services/feature.rb
@@ -65,5 +65,9 @@ class Feature
     def maintenance_banner_enabled?
       Flipper.enabled?(MAINTENANCE_BANNER)
     end
+
+    def enable_ecf_api_disabled
+      Flipper.enable(ECF_API_DISABLED)
+    end
   end
 end

--- a/app/services/migration/coordinator.rb
+++ b/app/services/migration/coordinator.rb
@@ -25,9 +25,7 @@ module Migration
   private
 
     def check_environment!
-      migration_enabled = Rails.application.config.npq_separation[:migration_enabled]
-
-      raise UnsupportedEnvironmentError, "The migration functionality is disabled for this environment" unless migration_enabled
+      raise UnsupportedEnvironmentError, "The migration functionality is disabled for this environment" unless Feature.ecf_api_disabled?
     end
 
     def run_migration

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -84,10 +84,6 @@ Rails.application.configure do
 
   # Enable/disable aspects of the NPQ separation
   config.npq_separation = {
-    admin_portal_enabled: true,
-    api_enabled: true,
-    migration_enabled: true,
-    ecf_api_disabled: false,
     parity_check: {
       enabled: true,
     },

--- a/config/environments/migration.rb
+++ b/config/environments/migration.rb
@@ -8,10 +8,6 @@ Rails.application.configure do
 
   # Enable/disable aspects of the NPQ separation
   config.npq_separation = {
-    admin_portal_enabled: true,
-    api_enabled: true,
-    migration_enabled: true,
-    ecf_api_disabled: true,
     parity_check: {
       enabled: true,
       npq_url: "https://npq-registration-migration-web.teacherservices.cloud",

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -107,10 +107,6 @@ Rails.application.configure do
 
   # Enable/disable aspects of the NPQ separation
   config.npq_separation = {
-    admin_portal_enabled: false,
-    api_enabled: false,
-    migration_enabled: false,
-    ecf_api_disabled: false,
     parity_check: {
       enabled: false,
     },

--- a/config/environments/review.rb
+++ b/config/environments/review.rb
@@ -5,10 +5,6 @@ Rails.application.configure do
 
   # Enable/disable aspects of the NPQ separation
   config.npq_separation = {
-    admin_portal_enabled: true,
-    api_enabled: true,
-    migration_enabled: false,
-    ecf_api_disabled: false,
     parity_check: {
       enabled: false,
     },

--- a/config/environments/sandbox.rb
+++ b/config/environments/sandbox.rb
@@ -6,10 +6,6 @@ Rails.application.configure do
 
   # Enable/disable aspects of the NPQ separation
   config.npq_separation = {
-    admin_portal_enabled: false,
-    api_enabled: false,
-    migration_enabled: false,
-    ecf_api_disabled: false,
     parity_check: {
       enabled: false,
     },

--- a/config/environments/separation.rb
+++ b/config/environments/separation.rb
@@ -6,10 +6,6 @@ Rails.application.configure do
 
   # Enable/disable aspects of the NPQ separation
   config.npq_separation = {
-    admin_portal_enabled: true,
-    api_enabled: true,
-    migration_enabled: false,
-    ecf_api_disabled: true,
     parity_check: {
       enabled: false,
     },

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -6,10 +6,6 @@ Rails.application.configure do
 
   # Enable/disable aspects of the NPQ separation
   config.npq_separation = {
-    admin_portal_enabled: true,
-    api_enabled: true,
-    migration_enabled: false,
-    ecf_api_disabled: false,
     parity_check: {
       enabled: false,
     },

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -72,10 +72,6 @@ Rails.application.configure do
 
   # Enable/disable aspects of the NPQ separation
   config.npq_separation = {
-    admin_portal_enabled: true,
-    api_enabled: true,
-    migration_enabled: true,
-    ecf_api_disabled: false,
     parity_check: {
       enabled: true,
       npq_url: "http://ecf.example.com",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,7 +109,7 @@ Rails.application.routes.draw do
   get "/admin", to: "admin#show"
 
   namespace :api do
-    constraints -> { Rails.application.config.npq_separation[:api_enabled] } do
+    constraints -> { Feature.ecf_api_disabled? } do
       get :guidance, to: "guidance#index"
       get "guidance/*page", to: "guidance#show", as: :guidance_page
       get "docs/:version", to: "documentation#index", as: :documentation
@@ -120,7 +120,7 @@ Rails.application.routes.draw do
         resource :webhook_messages, only: %i[create]
       end
 
-      constraints -> { Rails.application.config.npq_separation[:api_enabled] } do
+      constraints -> { Feature.ecf_api_disabled? } do
         defaults format: :json do
           resources :applications, path: "npq-applications", only: %i[index show], param: :ecf_id do
             member do
@@ -154,7 +154,7 @@ Rails.application.routes.draw do
       end
     end
 
-    namespace :v2, defaults: { format: :json }, constraints: ->(_request) { Rails.application.config.npq_separation[:api_enabled] } do
+    namespace :v2, defaults: { format: :json }, constraints: -> { Feature.ecf_api_disabled? } do
       resources :applications, path: "npq-applications", only: %i[index show], param: :ecf_id do
         member do
           post :reject, path: "reject"
@@ -187,7 +187,7 @@ Rails.application.routes.draw do
       end
     end
 
-    namespace :v3, defaults: { format: :json }, constraints: ->(_request) { Rails.application.config.npq_separation[:api_enabled] } do
+    namespace :v3, defaults: { format: :json }, constraints: -> { Feature.ecf_api_disabled? } do
       resources :applications, path: "npq-applications", only: %i[index show], param: :ecf_id do
         member do
           post :reject, path: "reject"
@@ -222,7 +222,7 @@ Rails.application.routes.draw do
   end
 
   namespace :npq_separation, path: "npq-separation" do
-    constraints(->(_request) { Rails.application.config.npq_separation[:admin_portal_enabled] }) do
+    constraints(-> { Feature.ecf_api_disabled? }) do
       get "admin", to: "admin/dashboards/summary#show"
       namespace :admin do
         namespace :dashboards do
@@ -256,7 +256,7 @@ Rails.application.routes.draw do
       end
     end
 
-    namespace :migration, constraints: ->(_request) { Rails.application.config.npq_separation[:migration_enabled] } do
+    namespace :migration, constraints: -> { Feature.ecf_api_disabled? } do
       resources :migrations, only: %i[index create] do
         get "download_report/:model", on: :collection, action: :download_report, as: :download_report
       end

--- a/lib/middleware/api_request_middleware.rb
+++ b/lib/middleware/api_request_middleware.rb
@@ -68,7 +68,7 @@ module Middleware
     end
 
     def trace_request?
-      Rails.application.config.npq_separation[:api_enabled] && Rails.env.in?(%w[migration review sandbox separation staging production]) && vendor_api_path?
+      Feature.ecf_api_disabled? && Rails.env.in?(%w[migration review sandbox separation staging production]) && vendor_api_path?
     end
 
     def vendor_api_path?

--- a/spec/features/api/documentation_spec.rb
+++ b/spec/features/api/documentation_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "api/version"
 
-RSpec.feature "API documentation", type: :feature do
+RSpec.feature "API documentation", :ecf_api_disabled, type: :feature do
   API::Version.all.each do |version|
     scenario "viewing the #{version} API documentation" do
       visit "/api/docs/#{version}"

--- a/spec/features/guidance_spec.rb
+++ b/spec/features/guidance_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Guidance", type: :feature do
+RSpec.feature "Guidance", :ecf_api_disabled, type: :feature do
   describe "Back link navigation" do
     it "renders a working back link on non-index guidance pages" do
       visit "/api/guidance"

--- a/spec/features/maintenance_banner_spec.rb
+++ b/spec/features/maintenance_banner_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Maintenance banner" do
+RSpec.feature "Maintenance banner", :ecf_api_disabled do
   before do
     Flipper.enable(Feature::MAINTENANCE_BANNER)
     stub_const("Banners::MaintenanceComponent::MAINTENANCE_WINDOW", 1.day.ago..1.day.from_now)

--- a/spec/features/migration_spec.rb
+++ b/spec/features/migration_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Migration", :in_memory_rails_cache, :rack_test_driver, type: :feature do
+RSpec.feature "Migration", :ecf_api_disabled, :in_memory_rails_cache, :rack_test_driver, type: :feature do
   include Helpers::AdminLogin
 
   context "when not authenticated" do

--- a/spec/features/npq_separation/admin/applications_spec.rb
+++ b/spec/features/npq_separation/admin/applications_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Listing and viewing applications", type: :feature do
+RSpec.feature "Listing and viewing applications", :ecf_api_disabled, type: :feature do
   include Helpers::AdminLogin
 
   let(:applications_per_page) { Pagy::DEFAULT[:limit] }

--- a/spec/features/npq_separation/admin/courses_spec.rb
+++ b/spec/features/npq_separation/admin/courses_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Listing and viewing courses", type: :feature do
+RSpec.feature "Listing and viewing courses", :ecf_api_disabled, type: :feature do
   include Helpers::AdminLogin
 
   let(:courses_per_page) { Pagy::DEFAULT[:limit] }

--- a/spec/features/npq_separation/admin/dashboards/summary_spec.rb
+++ b/spec/features/npq_separation/admin/dashboards/summary_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Viewing summary dashboard", type: :feature do
+RSpec.feature "Viewing summary dashboard", :ecf_api_disabled, type: :feature do
   include Helpers::AdminLogin
 
   before do

--- a/spec/features/npq_separation/admin/finance/statements_spec.rb
+++ b/spec/features/npq_separation/admin/finance/statements_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Listing and viewing statements", type: :feature do
+RSpec.feature "Listing and viewing statements", :ecf_api_disabled, type: :feature do
   include Helpers::AdminLogin
 
   let(:statements_per_page) { Pagy::DEFAULT[:limit] }

--- a/spec/features/npq_separation/admin/lead_providers_spec.rb
+++ b/spec/features/npq_separation/admin/lead_providers_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Listing and viewing lead providers", type: :feature do
+RSpec.feature "Listing and viewing lead providers", :ecf_api_disabled, type: :feature do
   include Helpers::AdminLogin
 
   before do

--- a/spec/features/npq_separation/admin/schools_spec.rb
+++ b/spec/features/npq_separation/admin/schools_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Listing and viewing schools", type: :feature do
+RSpec.feature "Listing and viewing schools", :ecf_api_disabled, type: :feature do
   include Helpers::AdminLogin
 
   let(:schools_per_page) { Pagy::DEFAULT[:limit] }

--- a/spec/features/npq_separation/admin/users_spec.rb
+++ b/spec/features/npq_separation/admin/users_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "User administration", type: :feature do
+RSpec.feature "User administration", :ecf_api_disabled, type: :feature do
   include Helpers::AdminLogin
 
   let(:users_per_page) { Pagy::DEFAULT[:limit] }

--- a/spec/features/parity_check_spec.rb
+++ b/spec/features/parity_check_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Parity check", :in_memory_rails_cache, :rack_test_driver, type: :feature do
+RSpec.feature "Parity check", :ecf_api_disabled, :in_memory_rails_cache, :rack_test_driver, type: :feature do
   include Helpers::AdminLogin
 
   before do

--- a/spec/lib/middleware/api_request_middleware_spec.rb
+++ b/spec/lib/middleware/api_request_middleware_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "middleware/api_request_middleware"
 
-RSpec.describe Middleware::ApiRequestMiddleware, type: :request do
+RSpec.describe Middleware::ApiRequestMiddleware, :ecf_api_disabled, type: :request do
   let(:status) { 200 }
   let(:request) { Rack::MockRequest.new(subject) }
   let(:headers) { { "HEADER" => "Yeah!" } }
@@ -94,8 +94,8 @@ RSpec.describe Middleware::ApiRequestMiddleware, type: :request do
     end
   end
 
-  context "when `api_enabled` flag is false" do
-    before { allow(Rails.application.config).to receive(:npq_separation).and_return({ api_enabled: false }) }
+  context "when `ecf_api_disabled` feature is false" do
+    before { allow(Feature).to receive(:ecf_api_disabled?).and_return(false) }
 
     it "does not fire StreamAPIRequestsToBigQueryJob" do
       request.get "/api/v1/participants/npq", params: { foo: "bar" }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -129,6 +129,10 @@ RSpec.configure do |config|
     Flipper.enable(Feature::REGISTRATION_OPEN)
   end
 
+  config.before(:each, :ecf_api_disabled) do
+    Feature.enable_ecf_api_disabled
+  end
+
   config.before(:each, :exceptions_app) do
     # Make the app behave how it does in non dev/test environments and use the
     # ErrorsController via config.exceptions_app = routes in config/application.rb

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -130,7 +130,7 @@ RSpec.configure do |config|
   end
 
   config.before(:each, :ecf_api_disabled) do
-    Feature.enable_ecf_api_disabled
+    Feature.enable_ecf_api_disabled!
   end
 
   config.before(:each, :exceptions_app) do

--- a/spec/requests/api/docs/v1/applications_spec.rb
+++ b/spec/requests/api/docs/v1/applications_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "swagger_helper"
 
-RSpec.describe "NPQ Applications endpoint", openapi_spec: "v1/swagger.yaml", type: :request do
+RSpec.describe "NPQ Applications endpoint", :ecf_api_disabled, openapi_spec: "v1/swagger.yaml", type: :request do
   include_context "with authorization for api doc request"
 
   let(:course_group) { CourseGroup.find_by(name: "leadership") || create(:course_group, name: "leadership") }

--- a/spec/requests/api/docs/v1/declarations_spec.rb
+++ b/spec/requests/api/docs/v1/declarations_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "swagger_helper"
 
-RSpec.describe "Declarations endpoints", openapi_spec: "v1/swagger.yaml", type: :request do
+RSpec.describe "Declarations endpoints", :ecf_api_disabled, openapi_spec: "v1/swagger.yaml", type: :request do
   include_context "with authorization for api doc request"
 
   it_behaves_like "an API index Csv endpoint documentation",

--- a/spec/requests/api/docs/v1/participant_outcomes_spec.rb
+++ b/spec/requests/api/docs/v1/participant_outcomes_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "swagger_helper"
 
-RSpec.describe "NPQ Participant Outcomes endpoint", openapi_spec: "v1/swagger.yaml", type: :request do
+RSpec.describe "NPQ Participant Outcomes endpoint", :ecf_api_disabled, openapi_spec: "v1/swagger.yaml", type: :request do
   include_context "with authorization for api doc request"
 
   let(:course_group) { CourseGroup.find_by(name: "leadership") || create(:course_group, name: "leadership") }

--- a/spec/requests/api/docs/v1/participants/outcomes_spec.rb
+++ b/spec/requests/api/docs/v1/participants/outcomes_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "swagger_helper"
 
-RSpec.describe "NPQ Participant Outcomes endpoint", openapi_spec: "v1/swagger.yaml", type: :request do
+RSpec.describe "NPQ Participant Outcomes endpoint", :ecf_api_disabled, openapi_spec: "v1/swagger.yaml", type: :request do
   include_context "with authorization for api doc request"
 
   let(:course_group) { CourseGroup.find_by(name: "leadership") || create(:course_group, name: "leadership") }

--- a/spec/requests/api/docs/v1/participants_spec.rb
+++ b/spec/requests/api/docs/v1/participants_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "swagger_helper"
 
-RSpec.describe "NPQ Participants endpoint", openapi_spec: "v1/swagger.yaml", type: :request do
+RSpec.describe "NPQ Participants endpoint", :ecf_api_disabled, openapi_spec: "v1/swagger.yaml", type: :request do
   include_context "with authorization for api doc request"
 
   let(:course) { create(:course, :early_headship_coaching_offer) }

--- a/spec/requests/api/docs/v2/applications_spec.rb
+++ b/spec/requests/api/docs/v2/applications_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "swagger_helper"
 
-RSpec.describe "NPQ Applications endpoint", openapi_spec: "v2/swagger.yaml", type: :request do
+RSpec.describe "NPQ Applications endpoint", :ecf_api_disabled, openapi_spec: "v2/swagger.yaml", type: :request do
   include_context "with authorization for api doc request"
 
   let(:course_group) { CourseGroup.find_by(name: "leadership") || create(:course_group, name: "leadership") }

--- a/spec/requests/api/docs/v2/declarations_spec.rb
+++ b/spec/requests/api/docs/v2/declarations_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "swagger_helper"
 
-RSpec.describe "Declarations endpoints", openapi_spec: "v2/swagger.yaml", type: :request do
+RSpec.describe "Declarations endpoints", :ecf_api_disabled, openapi_spec: "v2/swagger.yaml", type: :request do
   include_context "with authorization for api doc request"
 
   it_behaves_like "an API index Csv endpoint documentation",

--- a/spec/requests/api/docs/v2/enrolments_spec.rb
+++ b/spec/requests/api/docs/v2/enrolments_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "swagger_helper"
 
-RSpec.describe "NPQ enrolments endpoint", openapi_spec: "v2/swagger.yaml", type: :request do
+RSpec.describe "NPQ enrolments endpoint", :ecf_api_disabled, openapi_spec: "v2/swagger.yaml", type: :request do
   include_context "with authorization for api doc request"
 
   it_behaves_like "an API index Csv endpoint documentation",

--- a/spec/requests/api/docs/v2/participant_outcomes_spec.rb
+++ b/spec/requests/api/docs/v2/participant_outcomes_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "swagger_helper"
 
-RSpec.describe "NPQ Participant Outcomes endpoint", openapi_spec: "v2/swagger.yaml", type: :request do
+RSpec.describe "NPQ Participant Outcomes endpoint", :ecf_api_disabled, openapi_spec: "v2/swagger.yaml", type: :request do
   include_context "with authorization for api doc request"
 
   let(:course_group) { CourseGroup.find_by(name: "leadership") || create(:course_group, name: "leadership") }

--- a/spec/requests/api/docs/v2/participants/outcomes_spec.rb
+++ b/spec/requests/api/docs/v2/participants/outcomes_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "swagger_helper"
 
-RSpec.describe "NPQ Participant Outcomes endpoint", openapi_spec: "v2/swagger.yaml", type: :request do
+RSpec.describe "NPQ Participant Outcomes endpoint", :ecf_api_disabled, openapi_spec: "v2/swagger.yaml", type: :request do
   include_context "with authorization for api doc request"
 
   let(:course_group) { CourseGroup.find_by(name: "leadership") || create(:course_group, name: "leadership") }

--- a/spec/requests/api/docs/v2/participants_spec.rb
+++ b/spec/requests/api/docs/v2/participants_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "swagger_helper"
 
-RSpec.describe "NPQ Participants endpoint", openapi_spec: "v2/swagger.yaml", type: :request do
+RSpec.describe "NPQ Participants endpoint", :ecf_api_disabled, openapi_spec: "v2/swagger.yaml", type: :request do
   include_context "with authorization for api doc request"
 
   let(:course) { create(:course, :early_headship_coaching_offer) }

--- a/spec/requests/api/docs/v3/applications_spec.rb
+++ b/spec/requests/api/docs/v3/applications_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "swagger_helper"
 
-RSpec.describe "NPQ Applications endpoint", openapi_spec: "v3/swagger.yaml", type: :request do
+RSpec.describe "NPQ Applications endpoint", :ecf_api_disabled, openapi_spec: "v3/swagger.yaml", type: :request do
   include_context "with authorization for api doc request"
 
   let(:course_group) { CourseGroup.find_by(name: "leadership") || create(:course_group, name: "leadership") }

--- a/spec/requests/api/docs/v3/declarations_spec.rb
+++ b/spec/requests/api/docs/v3/declarations_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "swagger_helper"
 
-RSpec.describe "Participant Declarations endpoint", openapi_spec: "v3/swagger.yaml", type: :request do
+RSpec.describe "Participant Declarations endpoint", :ecf_api_disabled, openapi_spec: "v3/swagger.yaml", type: :request do
   include_context "with authorization for api doc request"
 
   it_behaves_like "an API index endpoint documentation",

--- a/spec/requests/api/docs/v3/participant_outcomes_spec.rb
+++ b/spec/requests/api/docs/v3/participant_outcomes_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "swagger_helper"
 
-RSpec.describe "NPQ Participant Outcomes endpoint", openapi_spec: "v3/swagger.yaml", type: :request do
+RSpec.describe "NPQ Participant Outcomes endpoint", :ecf_api_disabled, openapi_spec: "v3/swagger.yaml", type: :request do
   include_context "with authorization for api doc request"
 
   let(:course_group) { CourseGroup.find_by(name: "leadership") || create(:course_group, name: "leadership") }

--- a/spec/requests/api/docs/v3/participants/outcomes_spec.rb
+++ b/spec/requests/api/docs/v3/participants/outcomes_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "swagger_helper"
 
-RSpec.describe "NPQ Participant Outcomes endpoint", openapi_spec: "v3/swagger.yaml", type: :request do
+RSpec.describe "NPQ Participant Outcomes endpoint", :ecf_api_disabled, openapi_spec: "v3/swagger.yaml", type: :request do
   include_context "with authorization for api doc request"
 
   let(:course_group) { CourseGroup.find_by(name: "leadership") || create(:course_group, name: "leadership") }

--- a/spec/requests/api/docs/v3/participants_spec.rb
+++ b/spec/requests/api/docs/v3/participants_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "swagger_helper"
 
-RSpec.describe "NPQ Participants endpoint", openapi_spec: "v3/swagger.yaml", type: :request do
+RSpec.describe "NPQ Participants endpoint", :ecf_api_disabled, openapi_spec: "v3/swagger.yaml", type: :request do
   include_context "with authorization for api doc request"
 
   let(:course) { create(:course, :early_headship_coaching_offer) }

--- a/spec/requests/api/docs/v3/statements_spec.rb
+++ b/spec/requests/api/docs/v3/statements_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "swagger_helper"
 
-RSpec.describe "Statements endpoint", :exceptions_app, openapi_spec: "v3/swagger.yaml", type: :request do
+RSpec.describe "Statements endpoint", :ecf_api_disabled, :exceptions_app, openapi_spec: "v3/swagger.yaml", type: :request do
   include_context "with authorization for api doc request"
 
   let(:statement) { create(:statement, lead_provider:) }

--- a/spec/requests/api/documentation_spec.rb
+++ b/spec/requests/api/documentation_spec.rb
@@ -1,9 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "API documentation", type: :request do
-  let(:api_enabled) { true }
-
-  before { allow(Rails.application.config).to receive(:npq_separation) { { api_enabled: } } }
+  before { allow(Feature).to receive(:ecf_api_disabled?).and_return(true) }
 
   describe "GET /api/docs/:version" do
     subject(:perform_request) do
@@ -21,8 +19,8 @@ RSpec.describe "API documentation", type: :request do
       it { expect { perform_request }.to raise_error(ActionController::RoutingError, "Not found") }
     end
 
-    context "when api_enabled is false" do
-      let(:api_enabled) { false }
+    context "when ecf_api_disabled feature is false" do
+      before { allow(Feature).to receive(:ecf_api_disabled?).and_return(false) }
 
       it { expect { perform_request }.to raise_error(ActionController::RoutingError) }
     end

--- a/spec/requests/api/v1/applications_spec.rb
+++ b/spec/requests/api/v1/applications_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Application endpoints", type: :request do
+RSpec.describe "Application endpoints", :ecf_api_disabled, type: :request do
   let(:current_lead_provider) { create(:lead_provider) }
   let(:query) { Applications::Query }
   let(:serializer) { API::ApplicationSerializer }

--- a/spec/requests/api/v1/declarations_spec.rb
+++ b/spec/requests/api/v1/declarations_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Declaration endpoints", type: :request do
+RSpec.describe "Declaration endpoints", :ecf_api_disabled, type: :request do
   let(:current_lead_provider) { create(:lead_provider) }
   let(:query) { Declarations::Query }
   let(:serializer) { API::DeclarationSerializer }

--- a/spec/requests/api/v1/participant_outcomes_spec.rb
+++ b/spec/requests/api/v1/participant_outcomes_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Participant outcome endpoints", type: :request do
+RSpec.describe "Participant outcome endpoints", :ecf_api_disabled, type: :request do
   let(:current_lead_provider) { create(:lead_provider) }
   let(:query) { ParticipantOutcomes::Query }
   let(:serializer) { API::ParticipantOutcomeSerializer }

--- a/spec/requests/api/v1/participants/outcomes_spec.rb
+++ b/spec/requests/api/v1/participants/outcomes_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Participants outcome endpoints", type: :request do
+RSpec.describe "Participants outcome endpoints", :ecf_api_disabled, type: :request do
   let(:current_lead_provider) { create(:lead_provider) }
   let(:query) { ParticipantOutcomes::Query }
   let(:serializer) { API::ParticipantOutcomeSerializer }

--- a/spec/requests/api/v1/participants_spec.rb
+++ b/spec/requests/api/v1/participants_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Participant endpoints", type: :request do
+RSpec.describe "Participant endpoints", :ecf_api_disabled, type: :request do
   let(:current_lead_provider) { create(:lead_provider) }
   let(:query) { Participants::Query }
   let(:serializer) { API::ParticipantSerializer }

--- a/spec/requests/api/v2/applications_spec.rb
+++ b/spec/requests/api/v2/applications_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Application endpoints", type: :request do
+RSpec.describe "Application endpoints", :ecf_api_disabled, type: :request do
   let(:current_lead_provider) { create(:lead_provider) }
   let(:query) { Applications::Query }
   let(:serializer) { API::ApplicationSerializer }

--- a/spec/requests/api/v2/declarations_spec.rb
+++ b/spec/requests/api/v2/declarations_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Declaration endpoints", type: :request do
+RSpec.describe "Declaration endpoints", :ecf_api_disabled, type: :request do
   let(:current_lead_provider) { create(:lead_provider) }
   let(:query) { Declarations::Query }
   let(:serializer) { API::DeclarationSerializer }

--- a/spec/requests/api/v2/enrolments_spec.rb
+++ b/spec/requests/api/v2/enrolments_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Enrolment endpoints", type: :request do
+RSpec.describe "Enrolment endpoints", :ecf_api_disabled, type: :request do
   let(:current_lead_provider) { create(:lead_provider) }
   let(:query) { Applications::Query }
 

--- a/spec/requests/api/v2/participant_outcomes_spec.rb
+++ b/spec/requests/api/v2/participant_outcomes_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Participant outcome endpoints", type: :request do
+RSpec.describe "Participant outcome endpoints", :ecf_api_disabled, type: :request do
   let(:current_lead_provider) { create(:lead_provider) }
   let(:query) { ParticipantOutcomes::Query }
   let(:serializer) { API::ParticipantOutcomeSerializer }

--- a/spec/requests/api/v2/participants/outcomes_spec.rb
+++ b/spec/requests/api/v2/participants/outcomes_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Participants outcome endpoints", type: :request do
+RSpec.describe "Participants outcome endpoints", :ecf_api_disabled, type: :request do
   let(:current_lead_provider) { create(:lead_provider) }
   let(:query) { ParticipantOutcomes::Query }
   let(:serializer) { API::ParticipantOutcomeSerializer }

--- a/spec/requests/api/v2/participants_spec.rb
+++ b/spec/requests/api/v2/participants_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Participant endpoints", type: :request do
+RSpec.describe "Participant endpoints", :ecf_api_disabled, type: :request do
   let(:current_lead_provider) { create(:lead_provider) }
   let(:query) { Participants::Query }
   let(:serializer) { API::ParticipantSerializer }

--- a/spec/requests/api/v3/applications_spec.rb
+++ b/spec/requests/api/v3/applications_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Application endpoints", type: :request do
+RSpec.describe "Application endpoints", :ecf_api_disabled, type: :request do
   let(:current_lead_provider) { create(:lead_provider) }
   let(:query) { Applications::Query }
   let(:serializer) { API::ApplicationSerializer }

--- a/spec/requests/api/v3/declarations_spec.rb
+++ b/spec/requests/api/v3/declarations_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Declaration endpoints", type: :request do
+RSpec.describe "Declaration endpoints", :ecf_api_disabled, type: :request do
   let(:current_lead_provider) { create(:lead_provider) }
   let(:query) { Declarations::Query }
   let(:serializer) { API::DeclarationSerializer }

--- a/spec/requests/api/v3/participant_outcomes_spec.rb
+++ b/spec/requests/api/v3/participant_outcomes_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Participant outcome endpoints", type: :request do
+RSpec.describe "Participant outcome endpoints", :ecf_api_disabled, type: :request do
   let(:current_lead_provider) { create(:lead_provider) }
   let(:query) { ParticipantOutcomes::Query }
   let(:serializer) { API::ParticipantOutcomeSerializer }

--- a/spec/requests/api/v3/participants/outcomes_spec.rb
+++ b/spec/requests/api/v3/participants/outcomes_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Participants outcome endpoints", type: :request do
+RSpec.describe "Participants outcome endpoints", :ecf_api_disabled, type: :request do
   let(:current_lead_provider) { create(:lead_provider) }
   let(:query) { ParticipantOutcomes::Query }
   let(:serializer) { API::ParticipantOutcomeSerializer }

--- a/spec/requests/api/v3/participants_spec.rb
+++ b/spec/requests/api/v3/participants_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Participant endpoints", type: :request do
+RSpec.describe "Participant endpoints", :ecf_api_disabled, type: :request do
   let(:current_lead_provider) { create(:lead_provider) }
   let(:query) { Participants::Query }
   let(:serializer) { API::ParticipantSerializer }

--- a/spec/requests/api/v3/statements_spec.rb
+++ b/spec/requests/api/v3/statements_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Statements endpoint", type: "request" do
+RSpec.describe "Statements endpoint", :ecf_api_disabled, type: "request" do
   let(:current_lead_provider) { create(:lead_provider) }
   let(:query) { Statements::Query }
   let(:serializer) { API::StatementSerializer }

--- a/spec/requests/npq_separation/admin/admins_controller_spec.rb
+++ b/spec/requests/npq_separation/admin/admins_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe NpqSeparation::Admin::AdminsController, type: :request do
+RSpec.describe NpqSeparation::Admin::AdminsController, :ecf_api_disabled, type: :request do
   describe("index") do
     before { get(npq_separation_admin_admins_path) }
 

--- a/spec/requests/npq_separation/admin/applications_controller_spec.rb
+++ b/spec/requests/npq_separation/admin/applications_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe NpqSeparation::Admin::ApplicationsController, type: :request do
+RSpec.describe NpqSeparation::Admin::ApplicationsController, :ecf_api_disabled, type: :request do
   include Helpers::NPQSeparationAdminLogin
 
   before { sign_in_as_admin }

--- a/spec/requests/npq_separation/admin/courses_controller_spec.rb
+++ b/spec/requests/npq_separation/admin/courses_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe NpqSeparation::Admin::CoursesController, type: :request do
+RSpec.describe NpqSeparation::Admin::CoursesController, :ecf_api_disabled, type: :request do
   include Helpers::NPQSeparationAdminLogin
 
   before { sign_in_as_admin }

--- a/spec/requests/npq_separation/admin/finance/statements/assurance_reports_controller_spec.rb
+++ b/spec/requests/npq_separation/admin/finance/statements/assurance_reports_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe NpqSeparation::Admin::Finance::Statements::AssuranceReportsController, type: :request do
+RSpec.describe NpqSeparation::Admin::Finance::Statements::AssuranceReportsController, :ecf_api_disabled, type: :request do
   include Helpers::NPQSeparationAdminLogin
 
   describe "#show" do

--- a/spec/requests/npq_separation/admin/finance/statements/paid_controller_spec.rb
+++ b/spec/requests/npq_separation/admin/finance/statements/paid_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe NpqSeparation::Admin::Finance::Statements::PaidController, type: :request do
+RSpec.describe NpqSeparation::Admin::Finance::Statements::PaidController, :ecf_api_disabled, type: :request do
   include Helpers::NPQSeparationAdminLogin
 
   describe "/npq_separation/admin/statements/paid" do

--- a/spec/requests/npq_separation/admin/finance/statements/unpaid_controller_spec.rb
+++ b/spec/requests/npq_separation/admin/finance/statements/unpaid_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe NpqSeparation::Admin::Finance::Statements::UnpaidController, type: :request do
+RSpec.describe NpqSeparation::Admin::Finance::Statements::UnpaidController, :ecf_api_disabled, type: :request do
   include Helpers::NPQSeparationAdminLogin
 
   describe "/npq_separation/admin/statements/unpaid" do

--- a/spec/requests/npq_separation/admin/finance/statements_controller_spec.rb
+++ b/spec/requests/npq_separation/admin/finance/statements_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe NpqSeparation::Admin::Finance::StatementsController, type: :request do
+RSpec.describe NpqSeparation::Admin::Finance::StatementsController, :ecf_api_disabled, type: :request do
   include Helpers::NPQSeparationAdminLogin
 
   describe "/npq_separation/admin/statements" do

--- a/spec/requests/npq_separation/admin/participant_outcomes_controller_spec.rb
+++ b/spec/requests/npq_separation/admin/participant_outcomes_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe NpqSeparation::Admin::ParticipantOutcomesController, type: :request do
+RSpec.describe NpqSeparation::Admin::ParticipantOutcomesController, :ecf_api_disabled, type: :request do
   include Helpers::NPQSeparationAdminLogin
 
   describe "/npq_separation/admin/participant_outcomes/:id/resend" do

--- a/spec/requests/npq_separation/admin/schools_controller_spec.rb
+++ b/spec/requests/npq_separation/admin/schools_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe NpqSeparation::Admin::SchoolsController, type: :request do
+RSpec.describe NpqSeparation::Admin::SchoolsController, :ecf_api_disabled, type: :request do
   include Helpers::NPQSeparationAdminLogin
 
   before { sign_in_as_admin }

--- a/spec/requests/npq_separation/admin/users_controller_spec.rb
+++ b/spec/requests/npq_separation/admin/users_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe NpqSeparation::Admin::UsersController, type: :request do
+RSpec.describe NpqSeparation::Admin::UsersController, :ecf_api_disabled, type: :request do
   include Helpers::NPQSeparationAdminLogin
 
   before { sign_in_as_admin }

--- a/spec/requests/npq_separation/admin_controller_spec.rb
+++ b/spec/requests/npq_separation/admin_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe NpqSeparation::AdminController, type: :request do
+RSpec.describe NpqSeparation::AdminController, :ecf_api_disabled, type: :request do
   include Helpers::NPQSeparationAdminLogin
 
   context "when admin is not logged in" do

--- a/spec/requests/npq_separation/migration/migrations_controller_spec.rb
+++ b/spec/requests/npq_separation/migration/migrations_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe NpqSeparation::Migration::MigrationsController, type: :request do
+RSpec.describe NpqSeparation::Migration::MigrationsController, :ecf_api_disabled, type: :request do
   include Helpers::NPQSeparationAdminLogin
 
   before do

--- a/spec/requests/npq_separation/migration/parity_checks_controller_spec.rb
+++ b/spec/requests/npq_separation/migration/parity_checks_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe NpqSeparation::Migration::ParityChecksController, type: :request do
+RSpec.describe NpqSeparation::Migration::ParityChecksController, :ecf_api_disabled, type: :request do
   include Helpers::NPQSeparationAdminLogin
 
   before do

--- a/spec/requests/rate_limiting_spec.rb
+++ b/spec/requests/rate_limiting_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Rate limiting" do
+RSpec.describe "Rate limiting", :ecf_api_disabled do
   let(:ip) { "1.2.3.4" }
   let(:other_ip) { "9.8.7.6" }
 

--- a/spec/routing/npq_separation_routes_spec.rb
+++ b/spec/routing/npq_separation_routes_spec.rb
@@ -1,65 +1,31 @@
 require "rails_helper"
 
 RSpec.describe "NPQ separation routes" do
-  let(:api_enabled) { true }
-  let(:admin_portal_enabled) { true }
-  let(:migration_enabled) { true }
-
-  before do
-    allow(Rails.application.config).to receive(:npq_separation) do
-      {
-        api_enabled:,
-        admin_portal_enabled:,
-        migration_enabled:,
-      }
-    end
-  end
+  before { allow(Feature).to receive(:ecf_api_disabled?).and_return(true) }
 
   it { expect(get(api_v1_applications_path)).to route_to("api/v1/applications#index", format: :json) }
   it { expect(get(api_v2_applications_path)).to route_to("api/v2/applications#index", format: :json) }
   it { expect(get(api_v3_applications_path)).to route_to("api/v3/applications#index", format: :json) }
+
   it { expect(get(npq_separation_admin_admins_path)).to route_to("npq_separation/admin/admins#index") }
   it { expect(get(npq_separation_migration_migrations_path)).to route_to("npq_separation/migration/migrations#index") }
+
   it { expect(get(api_guidance_path)).to route_to("api/guidance#index") }
   it { expect(get(api_guidance_page_path(page: "the-page"))).to route_to("api/guidance#show", page: "the-page") }
   it { expect(get(download_report_npq_separation_migration_migrations_path("model"))).to route_to("npq_separation/migration/migrations#download_report", model: "model") }
 
-  context "when api_enabled is false" do
-    let(:api_enabled) { false }
+  context "when ecf_api_disabled feature is false" do
+    before { allow(Feature).to receive(:ecf_api_disabled?).and_return(false) }
 
     it { expect(get(api_v1_applications_path)).not_to be_routable }
     it { expect(get(api_v2_applications_path)).not_to be_routable }
     it { expect(get(api_v3_applications_path)).not_to be_routable }
 
+    it { expect(get(npq_separation_admin_admins_path)).not_to be_routable }
+    it { expect(get(npq_separation_migration_migrations_path)).not_to be_routable }
+
     it { expect(get(api_guidance_path)).not_to be_routable }
     it { expect(get(api_guidance_page_path(page: "the-page"))).not_to route_to("api/guidance#show", page: "the-page") }
-
-    it { expect(get(npq_separation_admin_admins_path)).to be_routable }
-    it { expect(get(npq_separation_migration_migrations_path)).to be_routable }
-    it { expect(get(download_report_npq_separation_migration_migrations_path(1))).to be_routable }
-  end
-
-  context "when admin_portal_enabled is false" do
-    let(:admin_portal_enabled) { false }
-
-    it { expect(get(npq_separation_admin_admins_path)).not_to be_routable }
-
-    it { expect(get(api_v1_applications_path)).to be_routable }
-    it { expect(get(api_v2_applications_path)).to be_routable }
-    it { expect(get(api_v3_applications_path)).to be_routable }
-    it { expect(get(npq_separation_migration_migrations_path)).to be_routable }
-    it { expect(get(download_report_npq_separation_migration_migrations_path(1))).to be_routable }
-  end
-
-  context "when migration_enabled is false" do
-    let(:migration_enabled) { false }
-
-    it { expect(get(npq_separation_migration_migrations_path)).not_to be_routable }
     it { expect(get(download_report_npq_separation_migration_migrations_path(1))).not_to be_routable }
-
-    it { expect(get(api_v1_applications_path)).to be_routable }
-    it { expect(get(api_v2_applications_path)).to be_routable }
-    it { expect(get(api_v3_applications_path)).to be_routable }
-    it { expect(get(npq_separation_admin_admins_path)).to be_routable }
   end
 end

--- a/spec/services/feature_spec.rb
+++ b/spec/services/feature_spec.rb
@@ -104,4 +104,12 @@ RSpec.describe Feature do
       it { is_expected.not_to be_maintenance_banner_enabled }
     end
   end
+
+  describe "#enable_ecf_api_disabled" do
+    it "enables ecf_api_disabled feature" do
+      expect(Flipper.enabled?(Feature::ECF_API_DISABLED)).to be(false)
+      Feature.enable_ecf_api_disabled
+      expect(Flipper.enabled?(Feature::ECF_API_DISABLED)).to be(true)
+    end
+  end
 end

--- a/spec/services/feature_spec.rb
+++ b/spec/services/feature_spec.rb
@@ -105,10 +105,10 @@ RSpec.describe Feature do
     end
   end
 
-  describe "#enable_ecf_api_disabled" do
+  describe "#enable_ecf_api_disabled!" do
     it "enables ecf_api_disabled feature" do
       expect(Flipper.enabled?(Feature::ECF_API_DISABLED)).to be(false)
-      Feature.enable_ecf_api_disabled
+      Feature.enable_ecf_api_disabled!
       expect(Flipper.enabled?(Feature::ECF_API_DISABLED)).to be(true)
     end
   end

--- a/spec/services/migration/coordinator_spec.rb
+++ b/spec/services/migration/coordinator_spec.rb
@@ -3,10 +3,9 @@ require "rails_helper"
 RSpec.describe Migration::Coordinator do
   include ActiveJob::TestHelper
 
-  let(:migration_enabled) { true }
   let(:instance) { described_class.new }
 
-  before { allow(Rails.application.config).to receive(:npq_separation) { { migration_enabled: } } }
+  before { allow(Feature).to receive(:ecf_api_disabled?).and_return(true) }
 
   describe ".prepare_for_migration" do
     it "calls prepare! on each migrator" do
@@ -29,7 +28,7 @@ RSpec.describe Migration::Coordinator do
     end
 
     context "when migration is disabled" do
-      let(:migration_enabled) { false }
+      before { allow(Feature).to receive(:ecf_api_disabled?).and_return(false) }
 
       it { expect { migrate }.to raise_error(described_class::UnsupportedEnvironmentError, "The migration functionality is disabled for this environment") }
     end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-3635

### Changes proposed in this pull request

* Replaced `admin_portal_enabled` , `api_enabled`, `ecf_api_disabled` and `migration_enabled` to the feature flag `Feature.ecf_api_disabled?`
* Added runner for refresh migration action so it enables the feature for the `migration` env.