### PR TITLE
[CPDLP-3674] Fix attributes slice syntax

### DIFF
--- a/app/services/migration/migrators/statement_item.rb
+++ b/app/services/migration/migrators/statement_item.rb
@@ -31,7 +31,7 @@ module Migration::Migrators
         statement_item = ::StatementItem.find_or_initialize_by(ecf_id: ecf_statement_item.id)
 
         statement_item.update!(
-          ecf_statement_item.attributes.slice(:state, :created_at, :updated_at).merge(statement_id:, declaration_id:),
+          ecf_statement_item.attributes.slice("state", "created_at", "updated_at").merge(statement_id:, declaration_id:),
         )
       end
     end

--- a/spec/services/migration/migrators/course_spec.rb
+++ b/spec/services/migration/migrators/course_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Migration::Migrators::Course do
       it "sets the created Course attributes correctly" do
         instance.call
         course = Course.find_by(ecf_id: ecf_resource1.id)
-        expect(course).to have_attributes(ecf_resource1.attributes.slice(:identifier, :name))
+        expect(course).to have_attributes(ecf_resource1.attributes.slice("identifier", "name"))
         expect(course.course_group.name).to eq(Courses::DEFINITIONS.find { |d| d[:identifier] == ecf_resource1.identifier }[:course_group_name])
       end
 

--- a/spec/services/migration/migrators/declaration_spec.rb
+++ b/spec/services/migration/migrators/declaration_spec.rb
@@ -5,7 +5,9 @@ RSpec.describe Migration::Migrators::Declaration do
     let(:records_per_worker_divider) { 2 }
 
     def create_ecf_resource
-      create(:ecf_migration_participant_declaration, :ineligible)
+      travel_to(rand(100).hours.ago) do
+        create(:ecf_migration_participant_declaration, :ineligible)
+      end
     end
 
     def create_npq_resource(ecf_resource)
@@ -26,12 +28,15 @@ RSpec.describe Migration::Migrators::Declaration do
       it "sets the created Declaration attributes correctly" do
         instance.call
         declaration = Declaration.find_by(ecf_id: ecf_resource1.id)
-        expect(declaration).to have_attributes(ecf_resource1.attributes.slice(:created_at, :udpated_at, :declaration_date, :declaration_type, :state))
+        expect(declaration).to have_attributes(ecf_resource1.attributes.slice("declaration_type", "state"))
         expect(declaration.state_reason).to eq(ecf_resource1.declaration_states.last.state_reason)
         expect(declaration.cohort.start_year).to eq(ecf_resource1.cohort.start_year)
         expect(declaration.lead_provider.ecf_id).to eq(ecf_resource1.cpd_lead_provider.npq_lead_provider.id)
         expect(declaration.application.course.identifier.downcase).to eq(ecf_resource1.course_identifier.downcase)
         expect(declaration.application.user.ecf_id).to eq(ecf_resource1.user.id)
+        expect(declaration.created_at.to_s).to eq(ecf_resource1.created_at.to_s)
+        expect(declaration.updated_at.to_s).to eq(ecf_resource1.updated_at.to_s)
+        expect(declaration.declaration_date.to_s).to eq(ecf_resource1.declaration_date.to_s)
       end
 
       context "when declaration date is before the schedule start" do

--- a/spec/services/migration/migrators/statement_item_spec.rb
+++ b/spec/services/migration/migrators/statement_item_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Migration::Migrators::StatementItem do
         instance.call
 
         statement_item = StatementItem.includes(:statement, :declaration).find_by(ecf_id: ecf_resource1.id)
-        expect(statement_item).to have_attributes(ecf_resource1.attributes.slice(:state, :created_at, :updated_at))
+        expect(statement_item).to have_attributes(ecf_resource1.attributes.slice("state", "created_at", "updated_at"))
         expect(statement_item.declaration.ecf_id).to eq(ecf_resource1.participant_declaration_id)
         expect(statement_item.statement.ecf_id).to eq(ecf_resource1.statement_id)
       end

--- a/spec/services/migration/migrators/statement_spec.rb
+++ b/spec/services/migration/migrators/statement_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Migration::Migrators::Statement do
       it "sets the created Statement attributes correctly" do
         instance.call
         statement = Statement.find_by(ecf_id: ecf_resource1.id)
-        expect(statement).to have_attributes(ecf_resource1.attributes.slice(:deadline_date, :payment_date, :output_fee, :marked_as_paid_at, :reconcile_amount))
+        expect(statement).to have_attributes(ecf_resource1.attributes.slice("deadline_date", "payment_date", "output_fee", "marked_as_paid_at", "reconcile_amount"))
         expect(statement.month).to eq(3)
         expect(statement.year).to eq(2023)
         expect(statement.cohort.start_year).to eq(ecf_resource1.cohort.start_year)

--- a/spec/services/migration/migrators/user_spec.rb
+++ b/spec/services/migration/migrators/user_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Migration::Migrators::User do
         instance.call
 
         user = User.find_by(ecf_id: ecf_resource1.id)
-        expect(user).to have_attributes(ecf_resource1.attributes.slice(:trn, :full_name, :get_an_identity_id))
+        expect(user).to have_attributes(ecf_resource1.attributes.slice("trn", "full_name", "get_an_identity_id"))
         expect(user).to have_attributes(
           email: "email-3@example.com",
           date_of_birth: "1980-01-01".to_date,


### PR DESCRIPTION
### Context

Ticket: [CPDLP-3674](https://dfedigital.atlassian.net/browse/CPDLP-3674)

The declarations `updated_at` timestamps is being changed in migrations when it shouldn’t be.

### Changes proposed in this pull request

The `attributes` method returns a hash which keys are string, not symbol.. so it was not setting `statement_items` timestamps correctly in the statement item migrator, causing the [declarations serializer updated_at](https://github.com/DFE-Digital/npq-registration/blob/main/app/serializers/api/declaration_serializer.rb#L41) to return the wrong value.

```
User.last.attributes.slice(:id) => {}
User.last.attributes.slice("id") => {"id"=>216}
```

[CPDLP-3674]: https://dfedigital.atlassian.net/browse/CPDLP-3674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ