### PR TITLE
[CPDLP-3640] Add retry limit into migration jobs

### DIFF
--- a/app/jobs/migration_job.rb
+++ b/app/jobs/migration_job.rb
@@ -1,6 +1,10 @@
 class MigrationJob < ApplicationJob
   queue_as :high_priority
 
+  def max_attempts
+    1
+  end
+
   def perform
     migrator = Migration::Coordinator.new
     migrator.migrate!

--- a/app/jobs/migrator_job.rb
+++ b/app/jobs/migrator_job.rb
@@ -1,6 +1,10 @@
 class MigratorJob < ApplicationJob
   queue_as :high_priority
 
+  def max_attempts
+    1
+  end
+
   def perform(migrator:, worker:)
     migrator.call(worker:)
   end

--- a/spec/jobs/migration_job_spec.rb
+++ b/spec/jobs/migration_job_spec.rb
@@ -15,4 +15,10 @@ RSpec.describe MigrationJob do
       expect(coordinator_double).to have_received(:migrate!).once
     end
   end
+
+  describe "#perform_later" do
+    it "enqueues the job exactly once" do
+      expect { described_class.perform_later }.to have_enqueued_job(described_class).exactly(:once).on_queue("high_priority")
+    end
+  end
 end

--- a/spec/jobs/migrator_job_spec.rb
+++ b/spec/jobs/migrator_job_spec.rb
@@ -2,11 +2,10 @@ require "rails_helper"
 
 RSpec.describe MigratorJob do
   let(:instance) { described_class.new }
+  let(:migrator) { Migration::Migrators::Cohort }
+  let(:worker) { 0 }
 
   describe "#perform" do
-    let(:migrator) { Migration::Migrators::Cohort }
-    let(:worker) { 0 }
-
     subject(:perform_migration) { instance.perform(migrator:, worker:) }
 
     before { Migration::Migrators::Cohort.prepare! }
@@ -15,6 +14,12 @@ RSpec.describe MigratorJob do
       expect(migrator).to receive(:call).with(worker:).once
 
       perform_migration
+    end
+  end
+
+  describe "#perform_later" do
+    it "enqueues the job exactly once" do
+      expect { described_class.perform_later(migrator:, worker:) }.to have_enqueued_job(described_class).exactly(:once).on_queue("high_priority")
     end
   end
 end


### PR DESCRIPTION
### Context

Ticket: [CPDLP-3640](https://dfedigital.atlassian.net/browse/CPDLP-3640)

We should stop migration workers from retrying if they fail to be safe, if they retry they might cause more issues with the

### Changes proposed in this pull request

On the migration jobs allow them to run only once without a retry. Add retry limit into migration jobs.