### PR TITLE
Add POST/PUT endpoint support to parity check

### DIFF
--- a/app/controllers/npq_separation/migration/parity_checks_controller.rb
+++ b/app/controllers/npq_separation/migration/parity_checks_controller.rb
@@ -18,6 +18,6 @@ class NpqSeparation::Migration::ParityChecksController < SuperAdminController
   def response_comparison
     @comparison = Migration::ParityCheck::ResponseComparison.find(params[:id])
     @matching_comparisons = Migration::ParityCheck::ResponseComparison.matching(@comparison)
-    @multiple_results = @matching_comparisons.one? && @comparison.page.nil?
+    @multiple_results = @matching_comparisons.size > 1 || @comparison.page.present?
   end
 end

--- a/app/helpers/migration_helper.rb
+++ b/app/helpers/migration_helper.rb
@@ -92,7 +92,7 @@ module MigrationHelper
   end
 
   def response_comparison_detail_path(comparisons)
-    return unless comparisons.any?(&:different?)
+    return unless comparisons.any? { |c| c.different? || c.unexpected? }
 
     response_comparison_npq_separation_migration_parity_checks_path(comparisons.sample.id)
   end

--- a/app/models/migration/parity_check/response_comparison.rb
+++ b/app/models/migration/parity_check/response_comparison.rb
@@ -61,6 +61,14 @@ module Migration
       ecf_response_status_code != npq_response_status_code || ecf_response_body != npq_response_body
     end
 
+    def unexpected?
+      [ecf_response_status_code, npq_response_status_code].any? { |code| code != 200 }
+    end
+
+    def needs_review?
+      different? || unexpected?
+    end
+
     def description
       "#{request_method.upcase} #{request_path}"
     end

--- a/app/services/migration/parity_check/client.rb
+++ b/app/services/migration/parity_check/client.rb
@@ -146,11 +146,13 @@ module Migration
     end
 
     def body
-      return {} unless options.key?(:payload)
+      @body ||= begin
+        return {} unless options.key?(:payload)
 
-      data = options[:payload].is_a?(Hash) ? options[:payload] : send(options[:payload])
+        data = options[:payload].is_a?(Hash) ? options[:payload] : send(options[:payload])
 
-      { data: }.to_json
+        { data: }.to_json
+      end
     end
 
     def token_provider

--- a/app/views/npq_separation/migration/parity_checks/_completed_parity_check.html.erb
+++ b/app/views/npq_separation/migration/parity_checks/_completed_parity_check.html.erb
@@ -9,12 +9,16 @@
 
 <%= govuk_accordion do |accordion|
   @response_comparisons_by_lead_provider.each do |lead_provider_name, comparisons_by_description|
-    accordion.with_section(heading_text: lead_provider_name, expanded: comparisons_by_description.values.flatten.any?(&:different?)) do
+    accordion.with_section(heading_text: lead_provider_name, expanded: comparisons_by_description.values.flatten.any?(&:needs_review?)) do
       govuk_task_list do |task_list|
         comparisons_by_description.each do |description, comparisons|
           task_list.with_item do |item|
             item.with_title(text: description, hint: response_comparison_performance(comparisons), href: response_comparison_detail_path(comparisons))
-            item.with_status(text: response_comparison_status_tag(comparisons.any?(&:different?)))
+            if comparisons.any?(&:unexpected?)
+              item.with_status(text: response_comparison_status_tag(true, different_text: "unexpected"))
+            else
+              item.with_status(text: response_comparison_status_tag(comparisons.any?(&:different?)))
+            end
           end
         end
       end

--- a/app/views/npq_separation/migration/parity_checks/response_comparison.html.erb
+++ b/app/views/npq_separation/migration/parity_checks/response_comparison.html.erb
@@ -7,18 +7,18 @@
 <span class="govuk-caption-xl"><%= @comparison.lead_provider_name %></span>
 <h1 class="govuk-heading-xl"><%= @comparison.description %></h1>
 
-<% unless @multiple_results %>
+<% if @multiple_results %>
   <%= render(partial: "multiple_comparisons_summary", locals: { comparisons: @matching_comparisons }) %>
 <% end %>
 
-<% if @matching_comparisons.any?(&:different?) %>
-  <% if @multiple_results %>
+<% if @matching_comparisons.any?(&:needs_review?) %>
+  <% unless @multiple_results %>
     <%= render(partial: "single_comparison_summary", locals: { comparison: @comparison }) %>
     <%= render(partial: "response_body_diff", locals: { response_body_diff: @comparison.response_body_diff }) %>
   <% else %>
     <%= govuk_accordion do |accordion|
-      @matching_comparisons.select(&:different?).each do |comparison|
-        accordion.with_section(heading_text: response_comparison_page_summary(comparison), expanded: comparison.different?) do
+      @matching_comparisons.select(&:needs_review?).each do |comparison|
+        accordion.with_section(heading_text: response_comparison_page_summary(comparison), expanded: comparison.needs_review?) do
           render(partial: "response_body_diff", locals: { response_body_diff: comparison.response_body_diff })
         end
       end

--- a/config/parity_check_endpoints.yml
+++ b/config/parity_check_endpoints.yml
@@ -91,18 +91,24 @@ get:
 
 post:
   "/api/v1/npq-applications/:id/accept#with_funded_place":
+    exclude:
+      - updated_at
     id: application_ecf_id_for_accept_with_funded_place
     payload:
       type: "npq-application-accept"
       attributes:
         funded_place: true
   "/api/v2/npq-applications/:id/accept#with_funded_place":
+    exclude:
+      - updated_at
     id: application_ecf_id_for_accept_with_funded_place
     payload:
       type: "npq-application-accept"
       attributes:
         funded_place: true
   "/api/v3/npq-applications/:id/accept#with_funded_place":
+    exclude:
+      - updated_at
     id: application_ecf_id_for_accept_with_funded_place
     payload:
       type: "npq-application-accept"
@@ -110,18 +116,24 @@ post:
         funded_place: true
 
   "/api/v1/npq-applications/:id/accept#without_funded_place":
+    exclude:
+      - updated_at
     id: application_ecf_id_for_accept_without_funded_place
     payload:
       type: "npq-application-accept"
       attributes:
         funded_place: false
   "/api/v2/npq-applications/:id/accept#without_funded_place":
+    exclude:
+      - updated_at
     id: application_ecf_id_for_accept_without_funded_place
     payload:
       type: "npq-application-accept"
       attributes:
         funded_place: false
   "/api/v3/npq-applications/:id/accept#without_funded_place":
+    exclude:
+      - updated_at
     id: application_ecf_id_for_accept_without_funded_place
     payload:
       type: "npq-application-accept"
@@ -129,89 +141,179 @@ post:
         funded_place: false
 
   "/api/v1/npq-applications/:id/reject":
+    exclude:
+      - updated_at
     id: application_ecf_id_for_reject
   "/api/v2/npq-applications/:id/reject":
+    exclude:
+      - updated_at
     id: application_ecf_id_for_reject
   "/api/v3/npq-applications/:id/reject":
+    exclude:
+      - updated_at
     id: application_ecf_id_for_reject
 
   "/api/v1/participant-declarations":
+    exclude:
+      - id
+      - updated_at
+      - created_at
+      - mentor_id
+      - evidence_held
+      - delivery_partner_id
     payload: post_declaration_payload
   "/api/v2/participant-declarations":
+    exclude:
+      - id
+      - updated_at
+      - created_at
+      - mentor_id
+      - evidence_held
+      - delivery_partner_id
     payload: post_declaration_payload
   "/api/v3/participant-declarations":
+    exclude:
+      - id
+      - updated_at
+      - created_at
+      - mentor_id
+      - evidence_held
+      - delivery_partner_id
     payload: post_declaration_payload
 
   "/api/v1/participants/npq/:id/outcomes":
+    exclude:
+      - id
+      - created_at
     id: participant_ecf_id_for_create_outcome
     payload: post_participant_outcome_payload
   "/api/v2/participants/npq/:id/outcomes":
+    exclude:
+      - id
+      - created_at
     id: participant_ecf_id_for_create_outcome
     payload: post_participant_outcome_payload
   "/api/v3/participants/npq/:id/outcomes":
+    exclude:
+      - id
+      - created_at
     id: participant_ecf_id_for_create_outcome
     payload: post_participant_outcome_payload
 
 put:
   "/api/v1/npq-applications/:id/change-funded-place":
+    exclude:
+      - updated_at
     id: application_ecf_id_for_change_from_funded_place
     payload:
       type: "npq-application-change-funded-place"
       attributes:
         funded_place: false
   "/api/v2/npq-applications/:id/change-funded-place":
+    exclude:
+      - updated_at
     id: application_ecf_id_for_change_from_funded_place
     payload:
       type: "npq-application-change-funded-place"
       attributes:
         funded_place: false
   "/api/v3/npq-applications/:id/change-funded-place":
+    exclude:
+      - updated_at
     id: application_ecf_id_for_change_from_funded_place
     payload:
       type: "npq-application-change-funded-place"
       attributes:
         funded_place: false
 
-  "/api/v1/participant-declarations/:id/void":
+  "/api/v1/participant-declarations/:id/void#void":
+    exclude:
+      - updated_at
+      - mentor_id
+      - evidence_held
+      - delivery_partner_id
     id: declaration_ecf_id_for_void
-  "/api/v2/participant-declarations/:id/void":
+  "/api/v2/participant-declarations/:id/void#void":
+    exclude:
+      - updated_at
+      - mentor_id
+      - evidence_held
+      - delivery_partner_id
     id: declaration_ecf_id_for_void
-  "/api/v3/participant-declarations/:id/void":
+  "/api/v3/participant-declarations/:id/void#void":
+    exclude:
+      - updated_at
+      - mentor_id
+      - evidence_held
+      - delivery_partner_id
     id: declaration_ecf_id_for_void
 
-  "/api/v1/participant-declarations/:id/void":
+  "/api/v1/participant-declarations/:id/void#clawback":
+    exclude:
+      - updated_at
+      - mentor_id
+      - evidence_held
+      - delivery_partner_id
     id: declaration_ecf_id_for_clawback
-  "/api/v2/participant-declarations/:id/void":
+  "/api/v2/participant-declarations/:id/void#clawback":
+    exclude:
+      - updated_at
+      - mentor_id
+      - evidence_held
+      - delivery_partner_id
     id: declaration_ecf_id_for_clawback
-  "/api/v3/participant-declarations/:id/void":
+  "/api/v3/participant-declarations/:id/void#clawback":
+    exclude:
+      - updated_at
+      - mentor_id
+      - evidence_held
+      - delivery_partner_id
     id: declaration_ecf_id_for_clawback
 
   "/api/v1/participants/npq/:id/resume":
+    exclude:
+      - updated_at
     id: participant_ecf_id_for_resume
     payload: put_participant_resume_payload
   "/api/v2/participants/npq/:id/resume":
+    exclude:
+      - updated_at
     id: participant_ecf_id_for_resume
     payload: put_participant_resume_payload
   "/api/v3/participants/npq/:id/resume":
+    exclude:
+      - updated_at
     id: participant_ecf_id_for_resume
     payload: put_participant_resume_payload
 
   "/api/v1/participants/npq/:id/defer":
+    exclude:
+      - updated_at
     id: participant_ecf_id_for_defer
     payload: put_participant_defer_payload
   "/api/v2/participants/npq/:id/defer":
+    exclude:
+      - updated_at
     id: participant_ecf_id_for_defer
     payload: put_participant_defer_payload
   "/api/v3/participants/npq/:id/defer":
+    exclude:
+      - updated_at
     id: participant_ecf_id_for_defer
     payload: put_participant_defer_payload
 
   "/api/v1/participants/npq/:id/withdraw":
+    exclude:
+      - updated_at
     id: participant_ecf_id_for_withdraw
     payload: put_participant_withdraw_payload
   "/api/v2/participants/npq/:id/withdraw":
+    exclude:
+      - updated_at
     id: participant_ecf_id_for_withdraw
     payload: put_participant_withdraw_payload
   "/api/v3/participants/npq/:id/withdraw":
+    exclude:
+      - updated_at
     id: participant_ecf_id_for_withdraw
     payload: put_participant_withdraw_payload

--- a/config/parity_check_endpoints.yml
+++ b/config/parity_check_endpoints.yml
@@ -151,3 +151,67 @@ post:
   "/api/v3/participants/npq/:id/outcomes":
     id: participant_ecf_id_for_create_outcome
     payload: post_participant_outcome_payload
+
+put:
+  "/api/v1/npq-applications/:id/change-funded-place":
+    id: application_ecf_id_for_change_from_funded_place
+    payload:
+      type: "npq-application-change-funded-place"
+      attributes:
+        funded_place: false
+  "/api/v2/npq-applications/:id/change-funded-place":
+    id: application_ecf_id_for_change_from_funded_place
+    payload:
+      type: "npq-application-change-funded-place"
+      attributes:
+        funded_place: false
+  "/api/v3/npq-applications/:id/change-funded-place":
+    id: application_ecf_id_for_change_from_funded_place
+    payload:
+      type: "npq-application-change-funded-place"
+      attributes:
+        funded_place: false
+
+  "/api/v1/participant-declarations/:id/void":
+    id: declaration_ecf_id_for_void
+  "/api/v2/participant-declarations/:id/void":
+    id: declaration_ecf_id_for_void
+  "/api/v3/participant-declarations/:id/void":
+    id: declaration_ecf_id_for_void
+
+  "/api/v1/participant-declarations/:id/void":
+    id: declaration_ecf_id_for_clawback
+  "/api/v2/participant-declarations/:id/void":
+    id: declaration_ecf_id_for_clawback
+  "/api/v3/participant-declarations/:id/void":
+    id: declaration_ecf_id_for_clawback
+
+  "/api/v1/participants/npq/:id/resume":
+    id: participant_ecf_id_for_resume
+    payload: put_participant_resume_payload
+  "/api/v2/participants/npq/:id/resume":
+    id: participant_ecf_id_for_resume
+    payload: put_participant_resume_payload
+  "/api/v3/participants/npq/:id/resume":
+    id: participant_ecf_id_for_resume
+    payload: put_participant_resume_payload
+
+  "/api/v1/participants/npq/:id/defer":
+    id: participant_ecf_id_for_defer
+    payload: put_participant_defer_payload
+  "/api/v2/participants/npq/:id/defer":
+    id: participant_ecf_id_for_defer
+    payload: put_participant_defer_payload
+  "/api/v3/participants/npq/:id/defer":
+    id: participant_ecf_id_for_defer
+    payload: put_participant_defer_payload
+
+  "/api/v1/participants/npq/:id/withdraw":
+    id: participant_ecf_id_for_withdraw
+    payload: put_participant_withdraw_payload
+  "/api/v2/participants/npq/:id/withdraw":
+    id: participant_ecf_id_for_withdraw
+    payload: put_participant_withdraw_payload
+  "/api/v3/participants/npq/:id/withdraw":
+    id: participant_ecf_id_for_withdraw
+    payload: put_participant_withdraw_payload

--- a/config/parity_check_endpoints.yml
+++ b/config/parity_check_endpoints.yml
@@ -185,18 +185,21 @@ post:
     exclude:
       - id
       - created_at
+      - updated_at
     id: participant_ecf_id_for_create_outcome
     payload: post_participant_outcome_payload
   "/api/v2/participants/npq/:id/outcomes":
     exclude:
       - id
       - created_at
+      - updated_at
     id: participant_ecf_id_for_create_outcome
     payload: post_participant_outcome_payload
   "/api/v3/participants/npq/:id/outcomes":
     exclude:
       - id
       - created_at
+      - updated_at
     id: participant_ecf_id_for_create_outcome
     payload: post_participant_outcome_payload
 
@@ -294,6 +297,7 @@ put:
   "/api/v2/participants/npq/:id/defer":
     exclude:
       - updated_at
+      - date
     id: participant_ecf_id_for_defer
     payload: put_participant_defer_payload
   "/api/v3/participants/npq/:id/defer":

--- a/config/parity_check_endpoints.yml
+++ b/config/parity_check_endpoints.yml
@@ -88,3 +88,66 @@ get:
     id: statement_ecf_id
     exclude:
       - type
+
+post:
+  "/api/v1/npq-applications/:id/accept#with_funded_place":
+    id: application_ecf_id_for_accept_with_funded_place
+    payload:
+      type: "npq-application-accept"
+      attributes:
+        funded_place: true
+  "/api/v2/npq-applications/:id/accept#with_funded_place":
+    id: application_ecf_id_for_accept_with_funded_place
+    payload:
+      type: "npq-application-accept"
+      attributes:
+        funded_place: true
+  "/api/v3/npq-applications/:id/accept#with_funded_place":
+    id: application_ecf_id_for_accept_with_funded_place
+    payload:
+      type: "npq-application-accept"
+      attributes:
+        funded_place: true
+
+  "/api/v1/npq-applications/:id/accept#without_funded_place":
+    id: application_ecf_id_for_accept_without_funded_place
+    payload:
+      type: "npq-application-accept"
+      attributes:
+        funded_place: false
+  "/api/v2/npq-applications/:id/accept#without_funded_place":
+    id: application_ecf_id_for_accept_without_funded_place
+    payload:
+      type: "npq-application-accept"
+      attributes:
+        funded_place: false
+  "/api/v3/npq-applications/:id/accept#without_funded_place":
+    id: application_ecf_id_for_accept_without_funded_place
+    payload:
+      type: "npq-application-accept"
+      attributes:
+        funded_place: false
+
+  "/api/v1/npq-applications/:id/reject":
+    id: application_ecf_id_for_reject
+  "/api/v2/npq-applications/:id/reject":
+    id: application_ecf_id_for_reject
+  "/api/v3/npq-applications/:id/reject":
+    id: application_ecf_id_for_reject
+
+  "/api/v1/participant-declarations":
+    payload: post_declaration_payload
+  "/api/v2/participant-declarations":
+    payload: post_declaration_payload
+  "/api/v3/participant-declarations":
+    payload: post_declaration_payload
+
+  "/api/v1/participants/npq/:id/outcomes":
+    id: participant_ecf_id_for_create_outcome
+    payload: post_participant_outcome_payload
+  "/api/v2/participants/npq/:id/outcomes":
+    id: participant_ecf_id_for_create_outcome
+    payload: post_participant_outcome_payload
+  "/api/v3/participants/npq/:id/outcomes":
+    id: participant_ecf_id_for_create_outcome
+    payload: post_participant_outcome_payload

--- a/spec/factories/migration/parity_check/response_comparisons.rb
+++ b/spec/factories/migration/parity_check/response_comparisons.rb
@@ -16,9 +16,14 @@ FactoryBot.define do
 
     trait :different do
       ecf_response_status_code { 200 }
-      npq_response_status_code { 201 }
+      npq_response_status_code { 200 }
       ecf_response_body { "response1" }
       npq_response_body { "response2" }
+    end
+
+    trait :unexpected do
+      ecf_response_status_code { 500 }
+      npq_response_status_code { 500 }
     end
 
     after :create do |response_comparison|

--- a/spec/features/parity_check_spec.rb
+++ b/spec/features/parity_check_spec.rb
@@ -105,6 +105,25 @@ RSpec.feature "Parity check", :in_memory_rails_cache, :rack_test_driver, type: :
       end
     end
 
+    scenario "viewing the completed parity check when it contains unexpected response status codes" do
+      visit npq_separation_migration_parity_checks_path
+
+      perform_enqueued_jobs do
+        click_button "Run parity check"
+      end
+
+      unexpected_comparison = create(:response_comparison, :unexpected)
+
+      # Reload to display the unexpected comparison created manually
+      visit current_path
+
+      within("##{unexpected_comparison.lead_provider_name.parameterize}-section") do
+        details_path = response_comparison_npq_separation_migration_parity_checks_path(unexpected_comparison)
+        expect(page).to have_link(unexpected_comparison.description, href: details_path)
+        expect(page).to have_text("UNEXPECTED")
+      end
+    end
+
     scenario "viewing the details of a response comparison" do
       visit npq_separation_migration_parity_checks_path
 
@@ -133,8 +152,8 @@ RSpec.feature "Parity check", :in_memory_rails_cache, :rack_test_driver, type: :
       within("tbody tr:last") do
         expect(page).to have_text("Status code")
         expect(page).to have_text("200")
-        expect(page).to have_text("201")
-        expect(page).to have_text("DIFFERENT")
+        expect(page).to have_text("200")
+        expect(page).to have_text("EQUAL")
       end
 
       expect(page).to have_css(".diff", text: "response1 response2")
@@ -150,7 +169,7 @@ RSpec.feature "Parity check", :in_memory_rails_cache, :rack_test_driver, type: :
       different_comparison = create(:response_comparison, :different, page: 1)
       lead_provider = different_comparison.lead_provider
       body = %({ "data": [{ "id": "1" }, { "id": "1" }] })
-      create(:response_comparison, :different, npq_response_body: body, ecf_response_body: body, page: 2, lead_provider:)
+      create(:response_comparison, :unexpected, npq_response_body: body, ecf_response_body: body, page: 2, lead_provider:)
       create(:response_comparison, :equal, page: 3, lead_provider:)
 
       # Reload to display the different comparison created manually
@@ -189,9 +208,9 @@ RSpec.feature "Parity check", :in_memory_rails_cache, :rack_test_driver, type: :
         expect(page).to have_text("EQUAL")
       end
 
-      expect(page).to have_css(".govuk-grid-row", text: "Page 1\nECF: 200 NPQ: 201")
+      expect(page).to have_css(".govuk-grid-row", text: "Page 1\nECF: 200 NPQ: 200")
 
-      expect(page).to have_css(".govuk-grid-row", text: "Page 2\nECF: 200 NPQ: 201")
+      expect(page).to have_css(".govuk-grid-row", text: "Page 2\nECF: 500 NPQ: 500")
       expect(page).to have_text("No difference")
 
       expect(page).not_to have_text("Page 3")

--- a/spec/features/parity_check_spec.rb
+++ b/spec/features/parity_check_spec.rb
@@ -7,6 +7,20 @@ RSpec.feature "Parity check", :in_memory_rails_cache, :rack_test_driver, type: :
     create_matching_ecf_lead_providers
 
     stub_request(:get, %r{http://(npq|ecf).example.com/api/.*})
+    stub_request(:post, %r{http://(npq|ecf).example.com/api/.*})
+    stub_request(:put, %r{http://(npq|ecf).example.com/api/.*})
+
+    LeadProvider.find_each do |lead_provider|
+      create(:statement, lead_provider:)
+      create(:participant_outcome, declaration: create(:declaration, lead_provider:))
+      create(:application, lead_provider:, eligible_for_funding: false)
+      create(:declaration, :completed, application: create(:application, :accepted, lead_provider:))
+      create(:application, :accepted, lead_provider:, funded_place: true)
+      create(:declaration, :payable, lead_provider:)
+      create(:declaration, :paid, lead_provider:)
+      create(:application, :with_declaration, :accepted, :active, lead_provider:)
+      create(:application, :with_declaration, :accepted, :deferred, lead_provider:)
+    end
   end
 
   context "when not authenticated" do

--- a/spec/fixtures/files/parity_check/post_endpoints.yml
+++ b/spec/fixtures/files/parity_check/post_endpoints.yml
@@ -1,0 +1,7 @@
+post:
+  "/api/v1/npq-applications/:id/accept":
+    id: application_ecf_id_for_accept_with_funded_place
+    payload:
+      type: "npq-application-accept"
+      attributes:
+        funded_place: true

--- a/spec/fixtures/files/parity_check/put_endpoints.yml
+++ b/spec/fixtures/files/parity_check/put_endpoints.yml
@@ -1,0 +1,7 @@
+put:
+  "/api/v1/npq-applications/:id/change-funded-place":
+    id: application_ecf_id_for_change_to_funded_place
+    payload:
+      type: "npq-application-change-funded-place"
+      attributes:
+        funded_place: true

--- a/spec/helpers/migration_helper_spec.rb
+++ b/spec/helpers/migration_helper_spec.rb
@@ -272,6 +272,13 @@ RSpec.describe MigrationHelper, type: :helper do
       it { is_expected.to include(%r{/npq-separation/migration/parity_checks/response_comparisons/(#{response_comparison1.id}|#{response_comparison2.id})}) }
     end
 
+    context "when at least one is unexpected" do
+      let(:response_comparison1) { create(:response_comparison, :unexpected) }
+      let(:response_comparison2) { create(:response_comparison, :equal) }
+
+      it { is_expected.to include(%r{/npq-separation/migration/parity_checks/response_comparisons/(#{response_comparison1.id}|#{response_comparison2.id})}) }
+    end
+
     context "when all are equal" do
       let(:response_comparison1) { build(:response_comparison, :equal) }
       let(:response_comparison2) { build(:response_comparison, :equal) }
@@ -351,7 +358,7 @@ RSpec.describe MigrationHelper, type: :helper do
     subject { helper.response_comparison_page_summary(comparison) }
 
     it { is_expected.to have_css(".govuk-grid-row .govuk-grid-column-two-thirds", text: "Page 1") }
-    it { is_expected.to have_css(".govuk-grid-row .govuk-grid-column-one-third", text: "ECF: 200 NPQ: 201") }
+    it { is_expected.to have_css(".govuk-grid-row .govuk-grid-column-one-third", text: "ECF: 200 NPQ: 200") }
   end
 
   describe ".contains_duplicate_ids?" do

--- a/spec/models/migration/parity_check/response_comparison_spec.rb
+++ b/spec/models/migration/parity_check/response_comparison_spec.rb
@@ -298,4 +298,46 @@ RSpec.describe Migration::ParityCheck::ResponseComparison, type: :model do
       it { is_expected.to be_different }
     end
   end
+
+  describe "#unexpected?" do
+    subject(:instance) { build(:response_comparison) }
+
+    context "when the status codes are 200" do
+      before { instance.assign_attributes(ecf_response_status_code: 200, npq_response_status_code: 200) }
+
+      it { is_expected.not_to be_unexpected }
+    end
+
+    context "when neither status code is 200" do
+      before { instance.assign_attributes(ecf_response_status_code: 201, npq_response_status_code: 422) }
+
+      it { is_expected.to be_unexpected }
+    end
+
+    context "when one status code is not 200" do
+      before { instance.assign_attributes(ecf_response_status_code: 200, npq_response_status_code: 422) }
+
+      it { is_expected.to be_unexpected }
+    end
+  end
+
+  describe "#needs_review?" do
+    context "when different" do
+      subject(:instance) { build(:response_comparison, :different) }
+
+      it { is_expected.to be_needs_review }
+    end
+
+    context "when unexpected" do
+      subject(:instance) { build(:response_comparison, :unexpected) }
+
+      it { is_expected.to be_needs_review }
+    end
+
+    context "when equal" do
+      subject(:instance) { build(:response_comparison, :equal) }
+
+      it { is_expected.not_to be_needs_review }
+    end
+  end
 end

--- a/spec/services/migration/parity_check/client_spec.rb
+++ b/spec/services/migration/parity_check/client_spec.rb
@@ -489,7 +489,7 @@ RSpec.describe Migration::ParityCheck::Client do
 
       context "when using declaration_ecf_id_for_void" do
         let(:id) { "declaration_ecf_id_for_void" }
-        let(:resource) { create(:declaration, :payable, lead_provider:) }
+        let(:resource) { create(:declaration, :submitted, lead_provider:) }
 
         it "evaluates the id option and substitutes it into the path" do
           instance.make_requests do |_, _, formatted_path|

--- a/spec/services/migration/parity_check_spec.rb
+++ b/spec/services/migration/parity_check_spec.rb
@@ -205,6 +205,50 @@ RSpec.describe Migration::ParityCheck, :in_memory_rails_cache do
           }))
         end
       end
+
+      context "when there are PUT endpoints" do
+        let(:endpoints_file_path) { "spec/fixtures/files/parity_check/put_endpoints.yml" }
+
+        it "calls the client for each lead provider with the correct options" do
+          client_double = instance_double(Migration::ParityCheck::Client, make_requests: nil)
+          allow(Migration::ParityCheck::Client).to receive(:new) { client_double }
+
+          run
+
+          LeadProvider.find_each do |lead_provider|
+            expect(Migration::ParityCheck::Client).to have_received(:new).with(
+              lead_provider:,
+              method: "put",
+              path: "/api/v1/npq-applications/:id/change-funded-place",
+              options: { id: "application_ecf_id_for_change_to_funded_place", payload: { type: "npq-application-change-funded-place", attributes: { funded_place: true } } },
+            )
+          end
+          expect(client_double).to have_received(:make_requests).exactly(LeadProvider.count).times
+        end
+
+        it "saves response comparisons for each endpoint and lead provider" do
+          client_double = instance_double(Migration::ParityCheck::Client)
+          ecf_result_dpuble = { response: instance_double(HTTParty::Response, body: "ecf_response_body", code: 200), response_ms: 100 }
+          npq_result_double = { response: instance_double(HTTParty::Response, body: "npq_response_body", code: 201), response_ms: 150 }
+          allow(client_double).to receive(:make_requests).and_yield(ecf_result_dpuble, npq_result_double, "/formatted/path", nil)
+          allow(Migration::ParityCheck::Client).to receive(:new) { client_double }
+
+          expect { run }.to change(Migration::ParityCheck::ResponseComparison, :count).by(LeadProvider.count)
+
+          expect(Migration::ParityCheck::ResponseComparison.all).to all(have_attributes({
+            lead_provider: an_instance_of(LeadProvider),
+            request_path: "/formatted/path",
+            request_method: "put",
+            ecf_response_status_code: 200,
+            npq_response_status_code: 201,
+            ecf_response_body: "ecf_response_body",
+            npq_response_body: "npq_response_body",
+            ecf_response_time_ms: 100,
+            npq_response_time_ms: 150,
+            page: nil,
+          }))
+        end
+      end
     end
   end
 end

--- a/spec/services/migration/parity_check_spec.rb
+++ b/spec/services/migration/parity_check_spec.rb
@@ -161,6 +161,50 @@ RSpec.describe Migration::ParityCheck, :in_memory_rails_cache do
           }))
         end
       end
+
+      context "when there are POST endpoints" do
+        let(:endpoints_file_path) { "spec/fixtures/files/parity_check/post_endpoints.yml" }
+
+        it "calls the client for each lead provider with the correct options" do
+          client_double = instance_double(Migration::ParityCheck::Client, make_requests: nil)
+          allow(Migration::ParityCheck::Client).to receive(:new) { client_double }
+
+          run
+
+          LeadProvider.find_each do |lead_provider|
+            expect(Migration::ParityCheck::Client).to have_received(:new).with(
+              lead_provider:,
+              method: "post",
+              path: "/api/v1/npq-applications/:id/accept",
+              options: { id: "application_ecf_id_for_accept_with_funded_place", payload: { type: "npq-application-accept", attributes: { funded_place: true } } },
+            )
+          end
+          expect(client_double).to have_received(:make_requests).exactly(LeadProvider.count).times
+        end
+
+        it "saves response comparisons for each endpoint and lead provider" do
+          client_double = instance_double(Migration::ParityCheck::Client)
+          ecf_result_dpuble = { response: instance_double(HTTParty::Response, body: "ecf_response_body", code: 200), response_ms: 100 }
+          npq_result_double = { response: instance_double(HTTParty::Response, body: "npq_response_body", code: 201), response_ms: 150 }
+          allow(client_double).to receive(:make_requests).and_yield(ecf_result_dpuble, npq_result_double, "/formatted/path", nil)
+          allow(Migration::ParityCheck::Client).to receive(:new) { client_double }
+
+          expect { run }.to change(Migration::ParityCheck::ResponseComparison, :count).by(LeadProvider.count)
+
+          expect(Migration::ParityCheck::ResponseComparison.all).to all(have_attributes({
+            lead_provider: an_instance_of(LeadProvider),
+            request_path: "/formatted/path",
+            request_method: "post",
+            ecf_response_status_code: 200,
+            npq_response_status_code: 201,
+            ecf_response_body: "ecf_response_body",
+            npq_response_body: "npq_response_body",
+            ecf_response_time_ms: 100,
+            npq_response_time_ms: 150,
+            page: nil,
+          }))
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

We want to add POST and PUT endpoints to the parity check tool to ensure the responses and behaviour of the API is consistent between ECF and NPQ reg.

### Changes proposed in this pull request

- Add POST endpoints to parity check

Support `post` requests in the parity check tool. In order to do this we expand the `Client` to support POST requests and allow specifying a `payload` in the YAML for a path. This can either be a hash, which will be sent as the request body or it can be a method name that can construct a dynamic payload.

- Add PUT endpoints to parity check

Support `put` requests in the parity check tool. In order to do this we expand the `Client` to support PUT requests and add specific use cases to the YAML file/client.

- Memoize request body

To avoid issues with dynamic payloads and ensure both the NPQ and ECF requests use the exact same body we can memoize it.

- Exclude fields that will be different in POST/PUT

Mainly the updated/created attributes that will have different values.

Minor bug fixes to some of the `id` queries off the back of errors we got during testing.

- Fix feature specs

- Treat non-200 responses as needs review

Currently, if both services return a non-200 response and its the same then it will be flagged as equal. Whilst this is technically correct its not very helpful as it can hide issues with the calls themselves.

Instead, we want to raise these as 'unexpected' results so that we get an indication something is wrong.

- Minor bug fixes and tweaks

Small changes to get the POST/PUT comparison results looking better/more reliable.

### Guidance for review

Best reviewed by-commit.

![screencapture-0-0-0-0-3000-npq-separation-migration-parity-checks-2024-10-29-11_38_04](https://github.com/user-attachments/assets/4b186e45-88c3-4025-ad90-80a91e51a479)
