### PR TITLE
Add external domain to migration env

### DIFF
--- a/terraform/domains/environment_domains/config/migration.tfvars.json
+++ b/terraform/domains/environment_domains/config/migration.tfvars.json
@@ -1,0 +1,13 @@
+{
+  "hosted_zone": {
+    "register-national-professional-qualifications.education.gov.uk": {
+      "front_door_name": "s189p01-cpdnpqdomains-fd",
+      "resource_group_name": "s189p01-cpdnpqdomains-rg",
+      "domains": [
+        "mg"
+      ],
+      "environment_short": "mg",
+      "origin_hostname": "npq-registration-migration-web.teacherservices.cloud"
+    }
+  }
+}

--- a/terraform/domains/environment_domains/config/migration_Terrafile
+++ b/terraform/domains/environment_domains/config/migration_Terrafile
@@ -1,0 +1,3 @@
+domains:
+    source:  "https://github.com/DFE-Digital/terraform-modules"
+    version: "stable"


### PR DESCRIPTION
### Context

To add the maintenance page templates we need to ensure migration has an internal and external domain

### Changes proposed in this pull request

Setup environment domain for migration environment for an external domain

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
