### PR TITLE
Add maintenance banner

### DIFF
--- a/app/components/banners/maintenance_component.html.erb
+++ b/app/components/banners/maintenance_component.html.erb
@@ -1,0 +1,3 @@
+<div class="govuk-width-container govuk-!-margin-top-4">
+  <%= govuk_notification_banner(title_text:) { |banner| banner.with_heading(text:, link_text:, link_href:) } %>
+</div>

--- a/app/components/banners/maintenance_component.rb
+++ b/app/components/banners/maintenance_component.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Banners
+  class MaintenanceComponent < ViewComponent::Base
+    HOUR_FORMAT = "%-l%P"
+    DAY_FORMAT = "%-d %B"
+    MAINTENANCE_WINDOW = Time.zone.local(2024, 11, 27, 19)..Time.zone.local(2024, 11, 27, 22)
+
+    def render?
+      Feature.maintenance_banner_enabled? && maintenance_window_ends_in_future?
+    end
+
+  private
+
+    def title_text
+      "Important"
+    end
+
+    def text
+      maintenance_window_spans_days = maintenance_window_start_at.to_date != maintenance_window_end_at.to_date
+      maintenance_window_spans_days ? multi_day_window_text : single_day_window_text
+    end
+
+    def single_day_window_text
+      "This service will be unavailable from #{from_hour} to #{to_hour} on #{from_day}."
+    end
+
+    def multi_day_window_text
+      "This service will be unavailable from #{from_hour} on #{from_day} to #{to_hour} on #{to_day}."
+    end
+
+    def link_text
+      "Dismiss"
+    end
+
+    def from_hour
+      maintenance_window_start_at.strftime(HOUR_FORMAT)
+    end
+
+    def to_hour
+      maintenance_window_end_at.strftime(HOUR_FORMAT)
+    end
+
+    def from_day
+      maintenance_window_start_at.strftime(DAY_FORMAT)
+    end
+
+    def to_day
+      maintenance_window_end_at.strftime(DAY_FORMAT)
+    end
+
+    def link_href
+      maintenance_banner_dismiss_path
+    end
+
+    def maintenance_window_ends_in_future?
+      maintenance_window_end_at >= Time.zone.now
+    end
+
+    def maintenance_window_start_at
+      MAINTENANCE_WINDOW.first
+    end
+
+    def maintenance_window_end_at
+      MAINTENANCE_WINDOW.last
+    end
+  end
+end

--- a/app/controllers/maintenance_banners_controller.rb
+++ b/app/controllers/maintenance_banners_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class MaintenanceBannersController < ApplicationController
+  def dismiss
+    cookies[:dismiss_maintenance_banner_until] = 1.week.from_now
+
+    redirect_back(fallback_location: root_path)
+  end
+end

--- a/app/helpers/banner_helper.rb
+++ b/app/helpers/banner_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module BannerHelper
+  def maintenance_banner_dismissed?
+    cookie_value = cookies[:dismiss_maintenance_banner_until]
+    return unless cookie_value
+
+    dismissed_until = Time.zone.parse(cookie_value)
+    return unless dismissed_until
+
+    dismissed_until > Time.zone.now
+  end
+end

--- a/app/services/feature.rb
+++ b/app/services/feature.rb
@@ -9,11 +9,14 @@ class Feature
 
   ECF_API_DISABLED = "NPQ Separation ECF API disabled".freeze
 
+  MAINTENANCE_BANNER = "Maintenance banner".freeze
+
   FEATURE_FLAG_KEYS = [
     REGISTRATION_OPEN,
     CLOSED_REGISTRATION_ENABLED,
     SENCO_ENABLED,
     ECF_API_DISABLED,
+    MAINTENANCE_BANNER,
   ].freeze
 
   class << self
@@ -57,6 +60,10 @@ class Feature
 
     def ecf_api_disabled?
       Flipper.enabled?(ECF_API_DISABLED)
+    end
+
+    def maintenance_banner_enabled?
+      Flipper.enabled?(MAINTENANCE_BANNER)
     end
   end
 end

--- a/app/views/layouts/api_docs.html.erb
+++ b/app/views/layouts/api_docs.html.erb
@@ -21,6 +21,8 @@
 
     <%= render partial: "layouts/shared/header" %>
 
+    <%= render partial: "layouts/shared/maintenance_banner" %>
+
     <div class="govuk-width-container">
       <main class="govuk-main-wrapper" id="main-content">
         <%= render partial: "layouts/shared/messages" %>

--- a/app/views/layouts/api_guidance.html.erb
+++ b/app/views/layouts/api_guidance.html.erb
@@ -23,6 +23,8 @@
     </div>
   <% end %>
 
+  <%= render partial: "layouts/shared/maintenance_banner" %>
+
   <main id="main-content" class="api-guidance">
     <%= render partial: "layouts/shared/messages" %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,6 +19,8 @@
       ) %>
     </aside>
 
+    <%= render partial: "layouts/shared/maintenance_banner" %>
+
     <div class="govuk-width-container">
       <div role="navigation">
         <%= content_for(:before_content) %>

--- a/app/views/layouts/shared/_maintenance_banner.html.erb
+++ b/app/views/layouts/shared/_maintenance_banner.html.erb
@@ -1,0 +1,1 @@
+<%= render Banners::MaintenanceComponent.new unless maintenance_banner_dismissed? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -269,6 +269,8 @@ Rails.application.routes.draw do
 
   resource :csp_reports, only: %i[create]
 
+  get "maintenance_banners/dismiss", to: "maintenance_banners#dismiss", as: :maintenance_banner_dismiss
+
   get "/404", to: "errors#not_found", via: :all
   get "/422", to: "errors#unprocessable_entity", via: :all
   get "/500", to: "errors#internal_server_error", via: :all

--- a/spec/components/banners/maintenance_component_spec.rb
+++ b/spec/components/banners/maintenance_component_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Banners::MaintenanceComponent, type: :component do
+  include Rails.application.routes.url_helpers
+
+  let(:maintenance_window) { Time.zone.local(2050, 11, 27, 19)..Time.zone.local(2050, 11, 27, 21) }
+  let(:component) { described_class.new }
+
+  before do
+    Flipper.enable(Feature::MAINTENANCE_BANNER)
+    stub_const("Banners::MaintenanceComponent::MAINTENANCE_WINDOW", maintenance_window)
+  end
+
+  subject do
+    render_inline(component)
+    page
+  end
+
+  it { is_expected.to have_css(".govuk-width-container") }
+  it { is_expected.to have_css("h2", text: "Important") }
+  it { is_expected.to have_css(".govuk-notification-banner__heading", text: "This service will be unavailable from 7pm to 9pm on 27 November.") }
+  it { is_expected.to have_link("Dismiss", href: maintenance_banner_dismiss_path) }
+
+  context "when the maintenance window spans multiple days" do
+    let(:maintenance_window) { Time.zone.local(2050, 11, 27, 19)..Time.zone.local(2050, 11, 28, 21) }
+
+    it { is_expected.to have_css(".govuk-notification-banner__heading", text: "This service will be unavailable from 7pm on 27 November to 9pm on 28 November.") }
+  end
+
+  describe "#render?" do
+    subject { component }
+
+    it { is_expected.to be_render }
+
+    context "when the maintenance window has ended" do
+      let(:maintenance_window) { 2.days.ago..1.minute.ago }
+
+      it { is_expected.not_to be_render }
+    end
+
+    context "when the maintenance banner feature flag is not active" do
+      before { Flipper.disable(Feature::MAINTENANCE_BANNER) }
+
+      it { is_expected.not_to be_render }
+    end
+  end
+end

--- a/spec/features/maintenance_banner_spec.rb
+++ b/spec/features/maintenance_banner_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Maintenance banner" do
+  before do
+    Flipper.enable(Feature::MAINTENANCE_BANNER)
+    stub_const("Banners::MaintenanceComponent::MAINTENANCE_WINDOW", 1.day.ago..1.day.from_now)
+  end
+
+  scenario "viewing the root path" do
+    visit root_path
+    expect(page).to have_text(/This service will be unavailable from/)
+  end
+
+  scenario "viewing an API guidance path" do
+    visit api_guidance_path
+    expect(page).to have_text(/This service will be unavailable from/)
+  end
+
+  scenario "viewing an API docs path" do
+    visit api_documentation_path(version: "v1")
+    expect(page).to have_text(/This service will be unavailable from/)
+  end
+
+  context "when disabled" do
+    before { Flipper.disable(Feature::MAINTENANCE_BANNER) }
+
+    scenario "viewing the root path" do
+      visit root_path
+      expect(page).not_to have_text(/This service will be unavailable from/)
+    end
+
+    scenario "viewing an API guidance path" do
+      visit api_guidance_path
+      expect(page).not_to have_text(/This service will be unavailable from/)
+    end
+
+    scenario "viewing the API docs" do
+      visit api_documentation_path(version: "v1")
+      expect(page).not_to have_text(/This service will be unavailable from/)
+    end
+  end
+end

--- a/spec/helpers/banner_helper_spec.rb
+++ b/spec/helpers/banner_helper_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BannerHelper, type: :helper do
+  describe "#maintenance_banner_dismissed?" do
+    subject { helper }
+
+    context "when the dismissed_until cookie is not set" do
+      it { is_expected.not_to be_maintenance_banner_dismissed }
+    end
+
+    context "when the dismissed_until cookie is set to a future value" do
+      before { helper.request.cookies[:dismiss_maintenance_banner_until] = 1.day.from_now.to_s }
+
+      it { is_expected.to be_maintenance_banner_dismissed }
+    end
+
+    context "when the dismissed_until cookie is set to a past value" do
+      before { helper.request.cookies[:dismiss_maintenance_banner_until] = 1.day.ago.to_s }
+
+      it { is_expected.not_to be_maintenance_banner_dismissed }
+    end
+
+    context "when the dismissed_until cookie does not contain a valid time" do
+      before { helper.request.cookies[:dismiss_maintenance_banner_until] = "1 week from now" }
+
+      it { is_expected.not_to be_maintenance_banner_dismissed }
+    end
+  end
+end

--- a/spec/requests/maintenance_banner_spec.rb
+++ b/spec/requests/maintenance_banner_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Maintenance banner", type: :request do
+  describe "GET /maintenance_banners/dismiss" do
+    it "sets a cookie to dismiss the maintenance banner" do
+      get maintenance_banner_dismiss_path
+
+      cookie_value = response.cookies["dismiss_maintenance_banner_until"]
+      expect(cookie_value).to be_present
+      expect(Time.zone.parse(cookie_value)).to be_within(1.second).of(1.week.from_now)
+    end
+
+    it "redirects back to the root path if no referer is present" do
+      get maintenance_banner_dismiss_path
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "redirects back to the referer" do
+      get maintenance_banner_dismiss_path, params: {}, headers: { "HTTP_REFERER" => "/previous/page" }
+
+      expect(response).to redirect_to("/previous/page")
+    end
+  end
+end

--- a/spec/services/feature_spec.rb
+++ b/spec/services/feature_spec.rb
@@ -88,4 +88,20 @@ RSpec.describe Feature do
       end
     end
   end
+
+  describe "#maintenance_banner" do
+    subject { Feature }
+
+    context "when enabled" do
+      before { Flipper.enable(Feature::MAINTENANCE_BANNER) }
+
+      it { is_expected.to be_maintenance_banner_enabled }
+    end
+
+    context "when disabled" do
+      before { Flipper.disable(Feature::MAINTENANCE_BANNER) }
+
+      it { is_expected.not_to be_maintenance_banner_enabled }
+    end
+  end
 end


### PR DESCRIPTION
### Context

When we migrate the lead provider API to NPQ reg we will have downtime; we want to be able to inform our users of this ahead of time.

### Changes proposed in this pull request

- Add maintenance banner

Add a maintenance banner that we can use to alert users of upcoming downtime.

This is ported from ECF.

### Guidance for review

| Application layout | Guidance layout | API docs layout |
| -- | -- | -- |
| <img width="1485" alt="Screenshot 2024-10-30 at 10 07 08" src="https://github.com/user-attachments/assets/a0f66ee2-9b0e-4698-adf2-1e167afbc346"> | <img width="1485" alt="Screenshot 2024-10-30 at 10 08 59" src="https://github.com/user-attachments/assets/553c37c2-8f8c-41ad-a432-51fdecea1e18"> | <img width="1485" alt="Screenshot 2024-10-30 at 10 09 58" src="https://github.com/user-attachments/assets/89969a5c-bb67-4fa9-88d8-8c4755a87372"> |
