### PR TITLE
[CPDLP-3518] Add migration queue only worker to NPQ

### DIFF
--- a/app/jobs/migration_job.rb
+++ b/app/jobs/migration_job.rb
@@ -1,5 +1,5 @@
 class MigrationJob < ApplicationJob
-  queue_as :high_priority
+  queue_as :migration
 
   def max_attempts
     1

--- a/app/jobs/migrator_job.rb
+++ b/app/jobs/migrator_job.rb
@@ -1,5 +1,5 @@
 class MigratorJob < ApplicationJob
-  queue_as :high_priority
+  queue_as :migration
 
   def max_attempts
     1

--- a/app/jobs/parity_check_job.rb
+++ b/app/jobs/parity_check_job.rb
@@ -1,5 +1,5 @@
 class ParityCheckJob < ApplicationJob
-  queue_as :migration
+  queue_as :high_priority
 
   def perform
     parity_check = Migration::ParityCheck.new

--- a/app/jobs/parity_check_job.rb
+++ b/app/jobs/parity_check_job.rb
@@ -1,5 +1,5 @@
 class ParityCheckJob < ApplicationJob
-  queue_as :high_priority
+  queue_as :migration
 
   def perform
     parity_check = Migration::ParityCheck.new

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,3 +1,7 @@
+# FYI currently we are specifying the queue list in terraform.
+# If you add a new queue, you'll need to update the file:
+# `terraform/application/application.tf` - line 72
+
 Delayed::Worker.queue_attributes = {
   high_priority: { priority: -10 },
   default: { priority: 0 },

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -3,4 +3,5 @@ Delayed::Worker.queue_attributes = {
   default: { priority: 0 },
   participant_outcomes: { priority: 5 },
   low_priority: { priority: 10 },
+  migration: { priority: 0 },
 }

--- a/spec/jobs/migration_job_spec.rb
+++ b/spec/jobs/migration_job_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe MigrationJob do
   end
 
   describe "#perform_later" do
-    it "enqueues the job exactly once" do
-      expect { described_class.perform_later }.to have_enqueued_job(described_class).exactly(:once).on_queue("high_priority")
+    it "enqueues the job exactly once on migration queue" do
+      expect { described_class.perform_later }.to have_enqueued_job(described_class).exactly(:once).on_queue("migration")
     end
   end
 end

--- a/spec/jobs/migrator_job_spec.rb
+++ b/spec/jobs/migrator_job_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe MigratorJob do
   end
 
   describe "#perform_later" do
-    it "enqueues the job exactly once" do
-      expect { described_class.perform_later(migrator:, worker:) }.to have_enqueued_job(described_class).exactly(:once).on_queue("high_priority")
+    it "enqueues the job exactly once on migration queue" do
+      expect { described_class.perform_later(migrator:, worker:) }.to have_enqueued_job(described_class).exactly(:once).on_queue("migration")
     end
   end
 end

--- a/spec/jobs/parity_check_job_spec.rb
+++ b/spec/jobs/parity_check_job_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ParityCheckJob do
     it "schedules job in migration queue" do
       expect {
         described_class.perform_later
-      }.to have_enqueued_job(described_class).on_queue("migration")
+      }.to have_enqueued_job(described_class).on_queue("high_priority")
     end
   end
 end

--- a/spec/jobs/parity_check_job_spec.rb
+++ b/spec/jobs/parity_check_job_spec.rb
@@ -15,4 +15,12 @@ RSpec.describe ParityCheckJob do
       expect(parity_check_double).to have_received(:run!).once
     end
   end
+
+  describe "#perform_later" do
+    it "schedules job in migration queue" do
+      expect {
+        described_class.perform_later
+      }.to have_enqueued_job(described_class).on_queue("migration")
+    end
+  end
 end

--- a/terraform/application/application.tf
+++ b/terraform/application/application.tf
@@ -83,7 +83,7 @@ module "migration_worker_application" {
 
   is_web = false
 
-  name = "migration_worker"
+  name = "migration-worker"
   namespace    = var.namespace
   environment  = local.environment
   service_name = var.service_name

--- a/terraform/application/application.tf
+++ b/terraform/application/application.tf
@@ -69,10 +69,35 @@ module "worker_application" {
 
   docker_image = var.docker_image
 
-  command       = ["bundle", "exec", "rake", "jobs:work"]
+  command       = ["/bin/sh", "-c", "QUEUES=default,low_priority,participant_outcomes bundle exec rake jobs:work"]
   probe_command = ["pgrep", "-f", "rake"]
 
   replicas   = var.worker_replicas
+  max_memory = var.worker_memory_max
+
+  enable_logit = var.enable_logit
+}
+
+module "migration_worker_application" {
+  source = "./vendor/modules/aks//aks/application"
+
+  is_web = false
+
+  name = "migration_worker"
+  namespace    = var.namespace
+  environment  = local.environment
+  service_name = var.service_name
+
+  cluster_configuration_map  = module.cluster_data.configuration_map
+  kubernetes_config_map_name = module.application_configuration.kubernetes_config_map_name
+  kubernetes_secret_name     = module.application_configuration.kubernetes_secret_name
+
+  docker_image = var.docker_image
+
+  command       = ["/bin/sh", "-c", "QUEUE=migration bundle exec rake jobs:work"]
+  probe_command = ["pgrep", "-f", "rake"]
+
+  replicas   = var.migration_worker_replicas
   max_memory = var.worker_memory_max
 
   enable_logit = var.enable_logit

--- a/terraform/application/config/migration.tfvars.json
+++ b/terraform/application/config/migration.tfvars.json
@@ -8,7 +8,8 @@
     "redis_cache_sku_name": "Basic",
     "enable_logit": true,
     "webapp_replicas": 3,
-    "worker_replicas": 30,
+    "worker_replicas": 4,
+    "migration_worker_replicas": 30,
     "webapp_memory_max": "4Gi",
     "worker_memory_max": "2Gi",
     "postgres_flexible_server_sku": "GP_Standard_D2ds_v5"

--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -7,6 +7,7 @@
   "enable_postgres_backup_storage" : true,
   "webapp_replicas": 6,
   "worker_replicas": 4,
+  "migration_worker_replicas": 0,
   "webapp_memory_max": "4Gi",
   "worker_memory_max": "2Gi",
   "enable_monitoring": true,

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -109,6 +109,11 @@ variable "worker_replicas" {
   default = 1
 }
 
+variable "migration_worker_replicas" {
+  type = number
+  default = 0
+}
+
 variable "postgres_flexible_server_sku" {
   type = string
   default = "B_Standard_B1ms"


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-3518

### Changes proposed in this pull request

* Migration jobs will use `migration` queue
* Existing worker runs the following queues: `default,low_priority,participant_outcomes`
* New migration worker runs `migration` queue only