### PR TITLE
[CPDLP-3693] Data cleanup - lookup application directly by id in decl…

### DIFF
--- a/app/models/migration/ecf/participant_declaration.rb
+++ b/app/models/migration/ecf/participant_declaration.rb
@@ -6,6 +6,7 @@ module Migration::Ecf
     belongs_to :user
     belongs_to :cohort
     belongs_to :superseded_by, class_name: "Migration::Ecf::ParticipantDeclaration", optional: true
+    belongs_to :participant_profile
 
     has_many :declaration_states
     has_many :supersedes, class_name: "Migration::Ecf::ParticipantDeclaration", foreign_key: :superseded_by_id, inverse_of: :superseded_by

--- a/app/services/migration/migrators/declaration.rb
+++ b/app/services/migration/migrators/declaration.rb
@@ -10,7 +10,7 @@ module Migration::Migrators
       end
 
       def ecf_declarations
-        Migration::Ecf::ParticipantDeclaration.includes(:declaration_states, cpd_lead_provider: :npq_lead_provider)
+        Migration::Ecf::ParticipantDeclaration.includes(:declaration_states, cpd_lead_provider: :npq_lead_provider, participant_profile: :npq_application)
       end
 
       def dependencies
@@ -36,25 +36,9 @@ module Migration::Migrators
           state_reason: latest_declaration_state&.state_reason,
           cohort_id: find_cohort_id!(ecf_id: ecf_declaration.cohort_id),
           lead_provider_id: find_lead_provider_id!(ecf_id: ecf_declaration.cpd_lead_provider.npq_lead_provider.id),
-          application_id: find_application_id!(course_identifier: ecf_declaration.course_identifier, ecf_user_id: ecf_declaration.user_id),
+          application_id: find_application_id!(ecf_id: ecf_declaration.participant_profile.npq_application.id),
           skip_declaration_date_within_schedule_validation: true,
         )
-      end
-    end
-
-  private
-
-    def find_application_id!(course_identifier:, ecf_user_id:)
-      application_ids_by_course_identifier_and_ecf_user_id.dig(course_identifier.downcase, ecf_user_id) || raise(ActiveRecord::RecordNotFound, "Couldn't find Application")
-    end
-
-    def application_ids_by_course_identifier_and_ecf_user_id
-      @application_ids_by_course_identifier_and_ecf_user_id ||= begin
-        applications = ::Application.joins(:user, :course).pluck(:id, :identifier, "users.ecf_id")
-        applications.each_with_object({}) do |(id, course_identifier, ecf_user_id), hash|
-          hash[course_identifier.downcase] ||= {}
-          hash[course_identifier.downcase][ecf_user_id] = id
-        end
       end
     end
   end

--- a/spec/factories/migration/ecf/participant_declarations.rb
+++ b/spec/factories/migration/ecf/participant_declarations.rb
@@ -6,10 +6,11 @@ FactoryBot.define do
     state { Declaration.states.keys.sample }
     declaration_type { Declaration.declaration_types.keys.sample }
     type { "ParticipantDeclaration::NPQ" }
-    course_identifier { "course-identifier" }
-    user { create(:ecf_migration_user) }
-    cohort { create(:ecf_migration_cohort) }
-    cpd_lead_provider { create(:ecf_migration_npq_lead_provider).cpd_lead_provider }
+    participant_profile { create(:ecf_migration_npq_application, :accepted).profile }
+    course_identifier { participant_profile.npq_application.npq_course.identifier }
+    user { participant_profile.user }
+    cohort { participant_profile.npq_application.cohort }
+    cpd_lead_provider { participant_profile.npq_application.npq_lead_provider.cpd_lead_provider }
 
     trait :ineligible do
       after(:build) do |participant_declaration|

--- a/spec/services/migration/migrators/declaration_spec.rb
+++ b/spec/services/migration/migrators/declaration_spec.rb
@@ -32,6 +32,8 @@ RSpec.describe Migration::Migrators::Declaration do
         expect(declaration.state_reason).to eq(ecf_resource1.declaration_states.last.state_reason)
         expect(declaration.cohort.start_year).to eq(ecf_resource1.cohort.start_year)
         expect(declaration.lead_provider.ecf_id).to eq(ecf_resource1.cpd_lead_provider.npq_lead_provider.id)
+        expect(declaration.application.course.identifier.downcase).to eq(ecf_resource1.course_identifier.downcase)
+        expect(declaration.application.user.ecf_id).to eq(ecf_resource1.user.id)
         expect(declaration.application.ecf_id).to eq(ecf_resource1.participant_profile.npq_application.id)
         expect(declaration.created_at.to_s).to eq(ecf_resource1.created_at.to_s)
         expect(declaration.updated_at.to_s).to eq(ecf_resource1.updated_at.to_s)

--- a/spec/services/migration/migrators/declaration_spec.rb
+++ b/spec/services/migration/migrators/declaration_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Migration::Migrators::Declaration do
       cohort = create(:cohort, ecf_id: ecf_resource.cohort_id, start_year: ecf_resource.cohort.start_year)
       course = create(:course, identifier: ecf_resource.course_identifier.upcase)
       user = create(:user, ecf_id: ecf_resource.user.id)
-      application = create(:application, :accepted, course:, user:)
+      application = create(:application, :accepted, course:, user:, ecf_id: ecf_resource.participant_profile.npq_application.id)
       create(:declaration, ecf_id: ecf_resource.id, cohort:, lead_provider:, application:)
     end
 
@@ -32,8 +32,7 @@ RSpec.describe Migration::Migrators::Declaration do
         expect(declaration.state_reason).to eq(ecf_resource1.declaration_states.last.state_reason)
         expect(declaration.cohort.start_year).to eq(ecf_resource1.cohort.start_year)
         expect(declaration.lead_provider.ecf_id).to eq(ecf_resource1.cpd_lead_provider.npq_lead_provider.id)
-        expect(declaration.application.course.identifier.downcase).to eq(ecf_resource1.course_identifier.downcase)
-        expect(declaration.application.user.ecf_id).to eq(ecf_resource1.user.id)
+        expect(declaration.application.ecf_id).to eq(ecf_resource1.participant_profile.npq_application.id)
         expect(declaration.created_at.to_s).to eq(ecf_resource1.created_at.to_s)
         expect(declaration.updated_at.to_s).to eq(ecf_resource1.updated_at.to_s)
         expect(declaration.declaration_date.to_s).to eq(ecf_resource1.declaration_date.to_s)


### PR DESCRIPTION
…aration migrator

### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-3693

### Changes proposed in this pull request

* Use `ecf_id` from `participant_profile.npq_application.id` directly for declarations.