### PR TITLE
[CPDLP-3695] Touch declaration if statement is changed on a statement item

### DIFF
--- a/app/models/statement_item.rb
+++ b/app/models/statement_item.rb
@@ -7,6 +7,8 @@ class StatementItem < ApplicationRecord
 
   validates :ecf_id, uniqueness: { case_sensitive: false }, allow_nil: true
 
+  after_commit :touch_declaration_if_changed, on: :update
+
   scope :billable, -> { where(state: BILLABLE_STATES) }
   scope :refundable, -> { where(state: REFUNDABLE_STATES) }
 
@@ -50,5 +52,13 @@ class StatementItem < ApplicationRecord
 
   def refundable?
     REFUNDABLE_STATES.include?(state)
+  end
+
+private
+
+  def touch_declaration_if_changed
+    return unless saved_change_to_statement_id?
+
+    declaration.touch(time: updated_at)
   end
 end

--- a/app/serializers/api/declaration_serializer.rb
+++ b/app/serializers/api/declaration_serializer.rb
@@ -38,7 +38,6 @@ module API
       field(:updated_at) do |declaration|
         (
           declaration.participant_outcomes.map(&:updated_at) +
-          declaration.statement_items.map(&:updated_at) +
           [declaration.updated_at]
         ).compact.max
       end

--- a/app/services/declarations/query.rb
+++ b/app/services/declarations/query.rb
@@ -39,8 +39,7 @@ module Declarations
 
       declarations_updated_since = Declaration.where(updated_at: updated_since..)
       participant_outcomes_updated_since = Declaration.where(participant_outcomes: { updated_at: updated_since.. })
-      statement_items_updated_since = Declaration.where(statement_items: { updated_at: updated_since.. })
-      scope.merge!(declarations_updated_since.or(participant_outcomes_updated_since).or(statement_items_updated_since))
+      scope.merge!(declarations_updated_since.or(participant_outcomes_updated_since))
     end
 
     def where_participant_ids_in(participant_ids)

--- a/spec/serializers/api/declaration_serializer_spec.rb
+++ b/spec/serializers/api/declaration_serializer_spec.rb
@@ -52,7 +52,6 @@ RSpec.describe API::DeclarationSerializer, type: :serializer do
             travel_to(old_datetime) do
               declaration
               create(:participant_outcome, declaration:)
-              create(:statement_item, declaration:)
             end
           end
 
@@ -66,12 +65,16 @@ RSpec.describe API::DeclarationSerializer, type: :serializer do
             end
           end
 
-          context "when statement_item is the latest" do
+          context "when a linked statement item is moved to another statement" do
+            let!(:statement_item) { create(:statement_item, declaration:) }
+
             before do
-              declaration.statement_items.first.update!(updated_at: latest_datetime)
+              travel_to(latest_datetime) do
+                statement_item.update!(statement: create(:statement))
+              end
             end
 
-            it "returns statement_item's `updated_at`" do
+            it "returns the updated declaration's `updated_at`" do
               expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
             end
           end

--- a/spec/services/declarations/query_spec.rb
+++ b/spec/services/declarations/query_spec.rb
@@ -26,8 +26,6 @@ RSpec.describe Declarations::Query do
       before do
         create(:participant_outcome, declaration: declaration1)
         create(:participant_outcome, declaration: declaration1)
-        create(:statement_item, declaration: declaration1)
-        create(:statement_item, declaration: declaration1)
       end
 
       it "does not return duplicate declarations" do
@@ -90,7 +88,6 @@ RSpec.describe Declarations::Query do
             travel_to(1.day.ago) do
               dec = create(:declaration)
               create(:participant_outcome, declaration: dec)
-              create(:statement_item, declaration: dec)
               dec
             end
           end
@@ -98,7 +95,6 @@ RSpec.describe Declarations::Query do
             travel_to(2.days.ago) do
               dec = create(:declaration)
               create(:participant_outcome, declaration: dec)
-              create(:statement_item, declaration: dec)
               dec
             end
           end
@@ -106,7 +102,6 @@ RSpec.describe Declarations::Query do
             travel_to(5.days.ago) do
               dec = create(:declaration)
               create(:participant_outcome, declaration: dec)
-              create(:statement_item, declaration: dec)
               dec
             end
           end
@@ -117,42 +112,6 @@ RSpec.describe Declarations::Query do
             expect(query.declarations).to contain_exactly(declaration2, declaration1)
 
             declaration3.participant_outcomes.first.update!(updated_at: Time.zone.now)
-            expect(query.declarations).to contain_exactly(declaration2, declaration1, declaration3)
-          end
-        end
-
-        context "when statement_item was updated recently" do
-          let!(:declaration1) do
-            travel_to(1.day.ago) do
-              dec = create(:declaration)
-              create(:participant_outcome, declaration: dec)
-              create(:statement_item, declaration: dec)
-              dec
-            end
-          end
-          let!(:declaration2) do
-            travel_to(2.days.ago) do
-              dec = create(:declaration)
-              create(:participant_outcome, declaration: dec)
-              create(:statement_item, declaration: dec)
-              dec
-            end
-          end
-          let!(:declaration3) do
-            travel_to(5.days.ago) do
-              dec = create(:declaration)
-              create(:participant_outcome, declaration: dec)
-              create(:statement_item, declaration: dec)
-              dec
-            end
-          end
-
-          it "filters by statement_item.updated_at" do
-            query = described_class.new(updated_since: 3.days.ago)
-
-            expect(query.declarations).to contain_exactly(declaration2, declaration1)
-
-            declaration3.statement_items.first.update!(updated_at: Time.zone.now)
             expect(query.declarations).to contain_exactly(declaration2, declaration1, declaration3)
           end
         end


### PR DESCRIPTION
### Context

Ticket: [CPDLP-3695](https://dfedigital.atlassian.net/browse/CPDLP-3695)

We currently use statement line items in the updated at on declaration serialiser to surface changes to statements linked to declarations. However after running the parity check we see the updated at all pulling in from when a statement item was marked as payable then paid. We only want to see a change if declarations were moved from one statement to another.

### Changes proposed in this pull request

- If statements are updated (not on creation) on a statement line item, touch the declaration it’s attached to
- Remove statement items from the serialiser and query in updated since for declarations

[CPDLP-3695]: https://dfedigital.atlassian.net/browse/CPDLP-3695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ