### PR TITLE
[CPDLP-3606] Upgrade postgres db tier in migration env

### DIFF
--- a/terraform/application/config/migration.tfvars.json
+++ b/terraform/application/config/migration.tfvars.json
@@ -12,5 +12,5 @@
     "migration_worker_replicas": 30,
     "webapp_memory_max": "4Gi",
     "worker_memory_max": "2Gi",
-    "postgres_flexible_server_sku": "GP_Standard_D2ds_v5"
+    "postgres_flexible_server_sku": "GP_Standard_D4ds_v4"
 }


### PR DESCRIPTION
### Context

Ticket: [CPDLP-3606](https://dfedigital.atlassian.net/browse/CPDLP-3606)

Currently, the NPQ migration DB tier is not the same as in ECF. 

### Changes proposed in this pull request

Align migration DB tier with ECF.

Note: Manually to be deployed to migration before merging this PR down.

[CPDLP-3606]: https://dfedigital.atlassian.net/browse/CPDLP-3606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ