### PR TITLE
[CPDLP-3675] Add db constraint for user `ecf_id` unique validation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,9 +20,7 @@ class User < ApplicationRecord
   validates :uid, inclusion: { in: ->(user) { [user.uid_was] } }, on: :npq_separation, if: -> { uid_was.present? }
   # TODO: add constraints into the DB after separation
   validates :ecf_id, presence: true, if: -> { Feature.ecf_api_disabled? }
-  # rubocop:disable Rails/UniqueValidationWithoutIndex
   validates :ecf_id, uniqueness: { allow_blank: true }
-  # rubocop:enable Rails/UniqueValidationWithoutIndex
 
   # TODO: remove this and add default: "gen_random_uuid()" in the DB after separation
   before_validation do

--- a/db/migrate/20241030181047_add_unique_ecf_id_constraint_to_users.rb
+++ b/db/migrate/20241030181047_add_unique_ecf_id_constraint_to_users.rb
@@ -1,0 +1,13 @@
+class AddUniqueEcfIdConstraintToUsers < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def up
+    remove_index :users, :ecf_id
+    add_index :users, :ecf_id, unique: true, algorithm: :concurrently
+  end
+
+  def down
+    remove_index :users, :ecf_id
+    add_index :users, :ecf_id, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_24_142323) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_30_181047) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -538,7 +538,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_24_142323) do
     t.string "email_updates_unsubscribe_key"
     t.string "archived_email"
     t.datetime "archived_at"
-    t.index ["ecf_id"], name: "index_users_on_ecf_id"
+    t.index ["ecf_id"], name: "index_users_on_ecf_id", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["provider"], name: "index_users_on_provider"
     t.index ["uid"], name: "index_users_on_uid", unique: true


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-3675

We've added the unique validation to the model in https://github.com/DFE-Digital/npq-registration/pull/1860 now we need to add it in the database

### Changes proposed in this pull request

Add unique ecf id constraint to the user table in the database.
This will be merged after we cleanup the data/merge the validation on the model, and then do a final check on the data

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
