### PR TITLE
[CPDNPQ-2170] Run smoke test during deployment

### DIFF
--- a/.github/actions/deploy-environment-to-aks/action.yml
+++ b/.github/actions/deploy-environment-to-aks/action.yml
@@ -14,10 +14,6 @@ inputs:
   pull-request-number:
     description: The pull request number which triggered this deploy. If set, this will automatically seed the database.
     required: false
-  # smoke-test-credentials-required:
-  #   description: Whether to run the smoke test with support credentials
-  #   required: false
-  #   default: "true"
   current-commit-sha:
     description: The commit sha for the current commit
     required: true
@@ -68,7 +64,7 @@ runs:
       env:
         PULL_REQUEST_NUMBER: ${{ inputs.pull-request-number }}
 
-    # - uses: ./.github/actions/smoke-test
-    #   with:
-    #     url: ${{ steps.apply-terraform.outputs.url }}
-    #     current-commit-sha: ${{ inputs.current-commit-sha }}
+    - uses: ./.github/actions/smoke-test
+      with:
+        url: ${{ steps.apply-terraform.outputs.url }}
+        current-commit-sha: ${{ inputs.current-commit-sha }}

--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -1,0 +1,19 @@
+name: Smoke test
+description: Run the smoke tests against a live environment.
+
+inputs:
+  url:
+    description: The URL of the deployed environment.
+    required: true
+
+  current-commit-sha:
+    description: The sha of the current commit
+    required: true
+
+runs:
+  using: composite
+
+  steps:
+    - name: Run smoke tests
+      shell: bash
+      run: bin/smoke ${{ inputs.url }} ${{ inputs.current-commit-sha }}

--- a/bin/smoke
+++ b/bin/smoke
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+url=$1
+if [[ -z $url ]]; then
+  echo `date`" - smoke test failed (URL is missing)"
+  exit 1
+fi
+response=$(curl -sL $url/healthcheck)
+response_sha=$(jq ".git_commit_sha" <<< $response)
+
+current_commit_sha=\"$2\"
+if [[ -z $current_commit_sha ]]; then
+  echo `date`" - smoke test failed (head sha is missing)"
+  exit 1
+fi
+
+if [[ $response_sha == $current_commit_sha ]]; then
+  echo "✅ Correct version deployed"
+else
+  echo "Fail: healthcheck sha is $response_sha but current commit is $current_commit_sha"
+  exit 1
+fi
+
+response_migration=$(jq ".database.migration_version" <<< $response)
+latest_migration=$(ls db/migrate/ | cut -d "_" -f1 | sort -nr | head -n1)
+
+if [[ $response_migration == $latest_migration ]]; then
+  echo "✅ Correct database migration version"
+else
+  echo "Fail: healthcheck migration version is $response_migration but latest is $latest_migration"
+  exit 1
+fi
+
+database_connected=$(jq ".database.connected" <<< $response)
+
+if [[ $database_connected == 'true' ]]; then
+  echo "✅ Database is connected"
+else
+  echo "Fail: database is not connected"
+  exit 1
+fi
+
+database_poplulated=$(jq ".database.populated" <<< $response)
+
+if [[ $database_poplulated == 'true' ]]; then
+  echo "✅ Database is populated"
+else
+  echo "Fail: database is not populated"
+  exit 1
+fi

--- a/bin/smoke
+++ b/bin/smoke
@@ -48,3 +48,11 @@ else
   echo "Fail: database is not populated"
   exit 1
 fi
+
+html_page_response=$(curl -sL --fail $url/)
+if [[ -n $html_page_response ]]; then
+  echo "✅ HTML response is successful"
+else
+  echo "Fail: HTML response is unsuccessful"
+  exit 1
+fi


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2170](https://dfedigital.atlassian.net/browse/CPDNPQ-2170)

Current the application does not run smoke tests during deployment - the healthchecks are tested as part of the AKS deployment module but only that they respond with success. This does additional checks such as ensuring the migrations have completed correctly

### Changes proposed in this pull request

1. Added a `bin/smoke` program to smoke test the new application
2. Added a github action to run the `bin/smoke` program to perform the smoke tests
3. Integrated the github action in (2) with the deploy_to_aks action so that smoke tests occur during deployment into all environments

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/


[CPDNPQ-2170]: https://dfedigital.atlassian.net/browse/CPDNPQ-2170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ