### PR TITLE
[CPDLP-3711] Touch declaration if new outcome added

### DIFF
--- a/app/serializers/api/declaration_serializer.rb
+++ b/app/serializers/api/declaration_serializer.rb
@@ -35,12 +35,7 @@ module API
         field(:created_at)
       end
 
-      field(:updated_at) do |declaration|
-        (
-          declaration.participant_outcomes.map(&:updated_at) +
-          [declaration.updated_at]
-        ).compact.max
-      end
+      field(:updated_at)
     end
 
     %i[v1 v2 v3].each do |version|

--- a/app/services/declarations/query.rb
+++ b/app/services/declarations/query.rb
@@ -38,8 +38,7 @@ module Declarations
       return if ignore?(filter: updated_since)
 
       declarations_updated_since = Declaration.where(updated_at: updated_since..)
-      participant_outcomes_updated_since = Declaration.where(participant_outcomes: { updated_at: updated_since.. })
-      scope.merge!(declarations_updated_since.or(participant_outcomes_updated_since))
+      scope.merge!(declarations_updated_since)
     end
 
     def where_participant_ids_in(participant_ids)

--- a/app/services/participant_outcomes/create.rb
+++ b/app/services/participant_outcomes/create.rb
@@ -35,7 +35,9 @@ module ParticipantOutcomes
         @created_outcome = if outcome_already_exists?
                              latest_existing_outcome
                            else
-                             build_outcome.tap(&:save!)
+                             new_outcome = build_outcome.tap(&:save!)
+                             new_outcome.declaration.touch(time: new_outcome.updated_at)
+                             new_outcome
                            end
       end
 

--- a/spec/serializers/api/declaration_serializer_spec.rb
+++ b/spec/serializers/api/declaration_serializer_spec.rb
@@ -55,16 +55,6 @@ RSpec.describe API::DeclarationSerializer, type: :serializer do
             end
           end
 
-          context "when participant_outcome is the latest" do
-            before do
-              declaration.participant_outcomes.first.update!(updated_at: latest_datetime)
-            end
-
-            it "returns participant_outcome's `updated_at`" do
-              expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
-            end
-          end
-
           context "when a linked statement item is moved to another statement" do
             let!(:statement_item) { create(:statement_item, declaration:) }
 

--- a/spec/services/declarations/query_spec.rb
+++ b/spec/services/declarations/query_spec.rb
@@ -82,39 +82,6 @@ RSpec.describe Declarations::Query do
 
           expect(query.scope.to_sql).not_to include(condition_string)
         end
-
-        context "when participant_outcome was updated recently" do
-          let!(:declaration1) do
-            travel_to(1.day.ago) do
-              dec = create(:declaration)
-              create(:participant_outcome, declaration: dec)
-              dec
-            end
-          end
-          let!(:declaration2) do
-            travel_to(2.days.ago) do
-              dec = create(:declaration)
-              create(:participant_outcome, declaration: dec)
-              dec
-            end
-          end
-          let!(:declaration3) do
-            travel_to(5.days.ago) do
-              dec = create(:declaration)
-              create(:participant_outcome, declaration: dec)
-              dec
-            end
-          end
-
-          it "filters by participant_outcome.updated_at" do
-            query = described_class.new(updated_since: 3.days.ago)
-
-            expect(query.declarations).to contain_exactly(declaration2, declaration1)
-
-            declaration3.participant_outcomes.first.update!(updated_at: Time.zone.now)
-            expect(query.declarations).to contain_exactly(declaration2, declaration1, declaration3)
-          end
-        end
       end
 
       context "when filtering by cohort" do


### PR DESCRIPTION
### Context

Ticket: [CPDLP-3711](https://dfedigital.atlassian.net/browse/CPDLP-3711)

We currently use outcomes in the updated at on the declaration serialiser to surface changes to has passed calculated from outcomes. However, after running the parity check we see the updated at changed on all declarations with an outcome which we are trying to minimise for providers

### Changes proposed in this pull request

- Touch the declaration if an outcome is created via the POST outcomes endpoint;
- Remove outcomes from the serialiser and query in updated since for declarations;

[CPDLP-3711]: https://dfedigital.atlassian.net/browse/CPDLP-3711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ