### PR TITLE
[CPDLP-3712] Do not touch the declaration timestamp on DeclarationSupersededBy migrator

### DIFF
--- a/app/services/migration/migrators/declaration_superseded_by.rb
+++ b/app/services/migration/migrators/declaration_superseded_by.rb
@@ -21,10 +21,8 @@ module Migration::Migrators
     def call
       migrate(self.class.ecf_declarations) do |ecf_declaration|
         declaration = ::Declaration.find_by!(ecf_id: ecf_declaration.id)
-
-        declaration.update!(
-          superseded_by_id: find_declaration_id!(ecf_id: ecf_declaration.superseded_by_id),
-        )
+        declaration.superseded_by_id = find_declaration_id!(ecf_id: ecf_declaration.superseded_by_id)
+        declaration.save!(touch: false)
       end
     end
   end

--- a/spec/services/migration/migrators/declaration_superseded_by_spec.rb
+++ b/spec/services/migration/migrators/declaration_superseded_by_spec.rb
@@ -26,6 +26,15 @@ RSpec.describe Migration::Migrators::DeclarationSupersededBy do
         superseded_by_declaration = Declaration.find_by(ecf_id: ecf_resource1.superseded_by_id)
         expect(declaration.superseded_by_id).to eq(superseded_by_declaration.id)
       end
+
+      it "does not update the timestamp on the declarations" do
+        declaration = Declaration.find_by(ecf_id: ecf_resource1.id)
+        declaration_updated_at = declaration.updated_at
+
+        instance.call
+
+        expect(declaration_updated_at).to eq(declaration.reload.updated_at)
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

Ticket: [CPDLP-3712](https://dfedigital.atlassian.net/browse/CPDLP-3712)

The declaration superseded by migrator is updating the updated at timestamp on the declaration when setting the superseded declaration id.

### Changes proposed in this pull request

- Do not touch the declaration timestamp on `DeclarationSupersededBy` migrator.

[CPDLP-3712]: https://dfedigital.atlassian.net/browse/CPDLP-3712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ