### PR TITLE
Fix bug with providers not populating in serializers

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -18,7 +18,9 @@ class Application < ApplicationRecord
   belongs_to :lead_provider
   belongs_to :school, optional: true
   belongs_to :private_childcare_provider, optional: true
+  belongs_to :private_childcare_provider_including_disabled, -> { including_disabled }, optional: true, class_name: "PrivateChildcareProvider", foreign_key: :private_childcare_provider_id
   belongs_to :itt_provider, optional: true
+  belongs_to :itt_provider_including_disabled, -> { including_disabled }, optional: true, class_name: "IttProvider", foreign_key: :itt_provider_id
   belongs_to :cohort, optional: true
   belongs_to :schedule, optional: true
 

--- a/app/serializers/api/application_serializer.rb
+++ b/app/serializers/api/application_serializer.rb
@@ -16,7 +16,7 @@ module API
       field(:headteacher_status)
       field(:ineligible_for_funding_reason)
       field(:participant_id) { |a| a.user.ecf_id }
-      field(:private_childcare_provider_urn) { |a| a.private_childcare_provider&.provider_urn }
+      field(:private_childcare_provider_urn) { |a| a.private_childcare_provider_including_disabled&.provider_urn }
       field(:teacher_reference_number) { |a| a.user.trn }
       field(:teacher_reference_number_validated) { |a| a.user.trn_verified }
       field(:school_urn) { |a| a.school&.urn }
@@ -29,7 +29,7 @@ module API
       field(:inside_uk_catchment?, name: :teacher_catchment)
       field(:teacher_catchment_country)
       field(:teacher_catchment_iso_country_code)
-      field(:itt_provider) { |a| a.itt_provider&.legal_name }
+      field(:itt_provider) { |a| a.itt_provider_including_disabled&.legal_name }
       field(:lead_mentor)
       field(:funded_place)
       field(:created_at)

--- a/app/serializers/api/applications_csv_serializer.rb
+++ b/app/serializers/api/applications_csv_serializer.rb
@@ -65,7 +65,7 @@ module API
         application.user.trn_verified,
         application.school&.urn,
         application.ukprn,
-        application.private_childcare_provider&.provider_urn,
+        application.private_childcare_provider_including_disabled&.provider_urn,
         application.headteacher_status,
         application.eligible_for_funding,
         application.funded_place,
@@ -83,7 +83,7 @@ module API
         teacher_catchment(application),
         application.teacher_catchment_country,
         application.teacher_catchment_iso_country_code,
-        application.itt_provider&.legal_name,
+        application.itt_provider_including_disabled&.legal_name,
         application.lead_mentor,
       ]
     end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -9,13 +9,27 @@ RSpec.describe Application do
     it { is_expected.to belong_to(:lead_provider) }
     it { is_expected.to belong_to(:school).optional }
     it { is_expected.to belong_to(:private_childcare_provider).optional }
+    it { is_expected.to belong_to(:private_childcare_provider_including_disabled).optional.class_name("PrivateChildcareProvider").with_foreign_key(:private_childcare_provider_id) }
     it { is_expected.to belong_to(:itt_provider).optional }
+    it { is_expected.to belong_to(:itt_provider_including_disabled).optional.class_name("IttProvider").with_foreign_key(:itt_provider_id) }
     it { is_expected.to belong_to(:cohort).optional }
     it { is_expected.to belong_to(:schedule).optional }
     it { is_expected.to have_many(:ecf_sync_request_logs).dependent(:destroy) }
     it { is_expected.to have_many(:participant_id_changes).through(:user) }
     it { is_expected.to have_many(:application_states) }
     it { is_expected.to have_many(:declarations) }
+
+    context "when the providers are disabled" do
+      let(:private_childcare_provider) { create(:private_childcare_provider, :disabled) }
+      let(:itt_provider) { create(:itt_provider, :disabled) }
+      let(:application) { create(:application, private_childcare_provider:, itt_provider:).reload }
+
+      it { expect(application.itt_provider).to be_nil }
+      it { expect(application.private_childcare_provider).to be_nil }
+
+      it { expect(application.itt_provider_including_disabled).to eq(itt_provider) }
+      it { expect(application.private_childcare_provider_including_disabled).to eq(private_childcare_provider) }
+    end
   end
 
   describe "paper_trail" do

--- a/spec/serializers/api/application_serializer_spec.rb
+++ b/spec/serializers/api/application_serializer_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe API::ApplicationSerializer, type: :serializer do
 
       subject(:attributes) { JSON.parse(described_class.render(application.reload))["attributes"] }
 
-      context "when the `itt_provider`` is set" do
+      context "when the `itt_provider` is set" do
         let(:itt_provider) { create(:itt_provider) }
 
         it "serializes the `itt_provider`" do

--- a/spec/serializers/api/application_serializer_spec.rb
+++ b/spec/serializers/api/application_serializer_spec.rb
@@ -110,9 +110,18 @@ RSpec.describe API::ApplicationSerializer, type: :serializer do
     end
 
     describe "itt_provider serialization" do
-      it "serializes the `itt_provider`" do
-        itt_provider.legal_name = "provider"
-        expect(attributes["itt_provider"]).to eq(itt_provider.legal_name)
+      # We need to persist and then reload the application
+      # to ensure the default scope is applied/accounted for.
+      before { application.save! }
+
+      subject(:attributes) { JSON.parse(described_class.render(application.reload))["attributes"] }
+
+      context "when the `itt_provider`` is set" do
+        let(:itt_provider) { create(:itt_provider) }
+
+        it "serializes the `itt_provider`" do
+          expect(attributes["itt_provider"]).to eq(itt_provider.legal_name)
+        end
       end
 
       context "when `itt_provider` is `nil`" do
@@ -122,10 +131,9 @@ RSpec.describe API::ApplicationSerializer, type: :serializer do
       end
 
       context "when the `itt_provider` is disabled" do
-        let(:itt_provider) { build(:itt_provider, :disabled) }
+        let(:itt_provider) { create(:itt_provider, :disabled, legal_name: "disabled provider") }
 
         it "serializes the `itt_provider`" do
-          itt_provider.legal_name = "provider"
           expect(attributes["itt_provider"]).to eq(itt_provider.legal_name)
         end
       end
@@ -158,9 +166,18 @@ RSpec.describe API::ApplicationSerializer, type: :serializer do
     end
 
     describe "private_childcare_provider serialization" do
-      it "serializes the `private_childcare_provider_urn`" do
-        private_childcare_provider.provider_urn = "2345678"
-        expect(attributes["private_childcare_provider_urn"]).to eq(private_childcare_provider.provider_urn)
+      # We need to persist and then reload the application
+      # to ensure the default scope is applied/accounted for.
+      before { application.save! }
+
+      subject(:attributes) { JSON.parse(described_class.render(application.reload))["attributes"] }
+
+      context "when the `private_childcare_provider` is set" do
+        let(:private_childcare_provider) { create(:private_childcare_provider) }
+
+        it "serializes the `private_childcare_provider_urn`" do
+          expect(attributes["private_childcare_provider_urn"]).to eq(private_childcare_provider.provider_urn)
+        end
       end
 
       context "when `private_childcare_provider` is `nil`" do
@@ -170,10 +187,9 @@ RSpec.describe API::ApplicationSerializer, type: :serializer do
       end
 
       context "when the `private_childcare_provider` is disabled" do
-        let(:private_childcare_provider) { build(:private_childcare_provider, :disabled) }
+        let(:private_childcare_provider) { create(:private_childcare_provider, :disabled, provider_urn: "disabled urn") }
 
-        it "serializes the `private_childcare_provider_urn`" do
-          private_childcare_provider.provider_urn = "2345678"
+        it "serializes the `private_childcare_provider`" do
           expect(attributes["private_childcare_provider_urn"]).to eq(private_childcare_provider.provider_urn)
         end
       end

--- a/spec/services/migration/migrators/application_spec.rb
+++ b/spec/services/migration/migrators/application_spec.rb
@@ -143,6 +143,28 @@ RSpec.describe Migration::Migrators::Application do
         expect(failure_manager).to have_received(:record_failure).once.with(orphan_application2, /NPQApplication not found in ECF/)
       end
 
+      context "when a provider is set in NPQ reg but not ECF" do
+        it "updates the updated_at of the application to now if the private_childcare_provider is set" do
+          ecf_resource1.update!(updated_at: 10.days.ago, private_childcare_provider_urn: nil)
+          application = Application.find_by(ecf_id: ecf_resource1.id)
+          application.update!(private_childcare_provider: create(:private_childcare_provider, :disabled))
+
+          instance.call
+
+          expect(application.reload.updated_at).to be_within(5.seconds).of(Time.zone.now)
+        end
+
+        it "updates the updated_at of the application to now if the itt_provider is set" do
+          ecf_resource1.update!(updated_at: 10.days.ago, itt_provider: nil)
+          application = Application.find_by(ecf_id: ecf_resource1.id)
+          application.update!(itt_provider: create(:itt_provider, :disabled))
+
+          instance.call
+
+          expect(application.reload.updated_at).to be_within(5.seconds).of(Time.zone.now)
+        end
+      end
+
       context "when application does not exist on NPQ" do
         it "creates application" do
           created_at = 10.days.ago


### PR DESCRIPTION
[Jira-3713](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-3713)

### Context

We are finding that some ITT providers and private childcare providers are coming back as `nil` in the API response where they should be populated (as they are in ECF).

We also want to ensure that the `updated_at` of the application in NPQ reg is set to the current date if there is a provider in NPQ reg but not in ECF, so that the change in data will be surfaced to lead providers.

### Changes proposed in this pull request

- Ensure disabled providers are included in serializers

We have a default scope on the providers that omits disabled providers by default. This is causing the providers to be `nil` in the serializers, but the tests are passing as the scope is bypassed due to the providers being preloaded in the spec already.

Update specs to ensure the application is reloaded and the default scopes are correctly applied.

Update `Application` to descope via new `belongs_to` associations suffixed with `including_disabled` so we return disabled providers when accessed via the application.

Improve test coverage of nullable values in `ApplicationCsvSerializer`.

- Update updated_at of application if provider only in NPQ reg

If we migrate an application from ECF that doesn't have a private childcare provider and/or itt provider, but the corresponding application in NPQ reg does have one of these set, we want to ensure the `updated_at` is updated to the current time so that the change will be surfaced to providers.

I've opted to include disabled providers here for consistency, but all the
current providers in NPQ reg should be active.
