### PR TITLE
Fix user timestamps not always updating

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -34,7 +34,7 @@ class Application < ApplicationRecord
   scope :eligible_for_funding, -> { where(eligible_for_funding: true) }
   scope :with_targeted_delivery_funding_eligibility, -> { where(targeted_delivery_funding_eligibility: true) }
 
-  attr_accessor :version_note
+  attr_accessor :version_note, :skip_touch_user_if_changed
 
   validate :schedule_cohort_matches
   # TODO: remove "if" and "allow_nil" and add constraints into the DB after separation
@@ -232,6 +232,7 @@ private
   end
 
   def touch_user_if_changed
+    return if skip_touch_user_if_changed
     return unless saved_change_to_lead_provider_approval_status?
 
     user.touch(time: updated_at)

--- a/app/services/migration/migrators/application.rb
+++ b/app/services/migration/migrators/application.rb
@@ -85,7 +85,7 @@ module Migration::Migrators
 
         application.user_id = find_user_id!(ecf_id: ecf_npq_application.user.id)
         application.version_note = "Changes migrated from ECF to NPQ"
-        application.update!(ecf_npq_application.attributes.slice(*ATTRIBUTES))
+        application.update!(ecf_npq_application.attributes.slice(*ATTRIBUTES).merge(skip_touch_user_if_changed: true))
       end
 
       run_once { backfill_ecf_ids }

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -502,6 +502,20 @@ RSpec.describe Application do
             expect(user.updated_at).to eq(Time.zone.now)
           end
         end
+
+        context "when skip_touch_user_if_changed is true" do
+          it "does not update user.updated_at" do
+            freeze_time do
+              expect(user.updated_at).to be_within(1.second).of(old_datetime)
+              expect(application.updated_at).to be_within(1.second).of(old_datetime)
+
+              application.update!(lead_provider_approval_status: "rejected", skip_touch_user_if_changed: true)
+
+              expect(application.updated_at).to eq(Time.zone.now)
+              expect(user.updated_at).to be_within(1.second).of(old_datetime)
+            end
+          end
+        end
       end
 
       context "when lead_provider_approval_status is not changed" do

--- a/spec/services/migration/migrators/application_spec.rb
+++ b/spec/services/migration/migrators/application_spec.rb
@@ -161,6 +161,15 @@ RSpec.describe Migration::Migrators::Application do
         end
       end
 
+      it "does not touch the user updated_at when the application has a different lead_provider_approval_status in ECF" do
+        ecf_application = travel_to(3.days.ago) { create_ecf_resource }
+        application = create_npq_resource(ecf_application).tap { |a| a.update!(lead_provider_approval_status: :rejected) }
+
+        expect(application.lead_provider_approval_status).not_to eq(ecf_application.lead_provider_approval_status)
+
+        expect { instance.call }.not_to(change { application.reload.user.updated_at })
+      end
+
       context "when backfilling existing applications" do
         it "sets `ecf_id`" do
           application = create(:application, ecf_id: nil)


### PR DESCRIPTION
### Context

The parity check tool is flagging that some user `updated_at` values are unexpected/changed. We want to find out why and make them consistent with ECF.

### Changes proposed in this pull request

- Skip user touch during migration when application changes

When an application changes and the `lead_provider_approval_status` is updated we are touching the user `updated_at`. We don't want to do this during the migration as it is causing user timestamps to change and differences in the parity check.

Add `skip_touch_user_if_changed` attribute to `Application` and set it to `true` for the migration `update!` call.

### Guidance for review

Tested on migration environment:


Before:

```
Migration::Ecf::NpqApplication.find("92464289-adc1-4d6c-a012-96da00a1d779").user.updated_at
=> Mon, 13 Feb 2023 16:06:38.148051000 UTC +00:00

Application.find_by(ecf_id: "92464289-adc1-4d6c-a012-96da00a1d779").user.updated_at
=> Tue, 10 Jan 2023 19:30:41.614983000 UTC +00:00
```

After:

```
Application.find_by(ecf_id: "92464289-adc1-4d6c-a012-96da00a1d779").user.updated_at
=> Mon, 13 Feb 2023 16:06:38.148051000 UTC +00:00

Migration::Ecf::NpqApplication.find("92464289-adc1-4d6c-a012-96da00a1d779").user.updated_at
=> Mon, 13 Feb 2023 16:06:38.148051000 UTC +00:00
```