### PR TITLE
[CPDLP-3716] Parity check - Change updated at setting in User migrator

### DIFF
--- a/app/services/migration/migrators/base.rb
+++ b/app/services/migration/migrators/base.rb
@@ -129,6 +129,10 @@ module Migration::Migrators
       user_ids_by_ecf_id[ecf_id] || raise(ActiveRecord::RecordNotFound, "Couldn't find User")
     end
 
+    def find_user_trn(ecf_id:)
+      user_trns_by_ecf_id[ecf_id]
+    end
+
     def find_schedule_id!(ecf_id:)
       schedule_ids_by_ecf_id[ecf_id] || raise(ActiveRecord::RecordNotFound, "Couldn't find Schedule")
     end
@@ -174,6 +178,10 @@ module Migration::Migrators
 
     def user_ids_by_ecf_id
       @user_ids_by_ecf_id ||= ::User.pluck(:ecf_id, :id).to_h
+    end
+
+    def user_trns_by_ecf_id
+      @user_trns_by_ecf_id ||= ::User.pluck(:ecf_id, :trn).to_h
     end
 
     def cohort_ids_by_ecf_id

--- a/app/services/migration/migrators/user.rb
+++ b/app/services/migration/migrators/user.rb
@@ -57,7 +57,7 @@ module Migration::Migrators
           version_note: "Changes migrated from ECF to NPQ",
         }
 
-        if changed_ecf_user_attrs?(attrs, ecf_user)
+        if touch_updated_at?(attrs, npq_application)
           attrs[:updated_at] = Time.zone.now
         end
 
@@ -98,9 +98,20 @@ module Migration::Migrators
       raise ActiveRecord::RecordInvalid, user
     end
 
-    def changed_ecf_user_attrs?(attrs, ecf_user)
-      attrs[:trn] != ecf_user.teacher_profile&.trn ||
-        attrs[:email] != ecf_user.email
+    def touch_updated_at?(attrs, npq_application)
+      if attrs[:email] != npq_application&.participant_identity&.email
+        return true
+      end
+
+      if npq_application&.profile && attrs[:email] != npq_application&.profile&.participant_identity&.email
+        return true
+      end
+
+      if attrs[:trn_verified] != npq_application&.teacher_reference_number_verified
+        return true
+      end
+
+      false
     end
 
     def backfill_ecf_ids


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-3716

### Changes proposed in this pull request

* Application migrator
  * Set `updated_at` if `trn` has changed
* User migrator
  * Set `updated_at` if email changed from `npq_application.participant_identity.email` and `npq_application.profile.participant_identity.email`
  * Set `updated_at` if `trn_verified` changed.