### PR TITLE
[CPDNPQ-2142] Integration with CPDNPQ-2141

### DIFF
--- a/app/components/npq_separation/admin/statement_details_component.rb
+++ b/app/components/npq_separation/admin/statement_details_component.rb
@@ -7,27 +7,7 @@ module NpqSeparation
 
       def initialize(statement:)
         @statement = statement
-        # FIXME: Replace with real calculator
-        @calculator = stub_calculator
-      end
-
-    private
-
-      def stub_calculator
-        OpenStruct.new(
-          total_output_payment: 1.0,
-          total_targeted_delivery_funding: 1.0,
-          total_service_fees: 1.0,
-          clawback_payments: 1.0,
-          total_targeted_delivery_funding_refundable: 1.0,
-          total_clawbacks: 1.0,
-          total_payment: 1.0,
-          total_starts: 1,
-          total_retained: 1,
-          total_completed: 1,
-          total_voided: 1,
-          show_targeted_delivery_funding?: false,
-        )
+        @calculator = ::Statements::SummaryCalculator.new(statement: @statement)
       end
     end
   end

--- a/app/components/npq_separation/admin/statement_details_component.rb
+++ b/app/components/npq_separation/admin/statement_details_component.rb
@@ -7,7 +7,7 @@ module NpqSeparation
 
       def initialize(statement:)
         @statement = statement
-        @calculator = ::Statements::SummaryCalculator.new(statement: @statement)
+        @calculator = ::Statements::SummaryCalculator.new(statement:)
       end
     end
   end

--- a/app/controllers/npq_separation/admin/finance/statements_controller.rb
+++ b/app/controllers/npq_separation/admin/finance/statements_controller.rb
@@ -22,6 +22,7 @@ class NpqSeparation::Admin::Finance::StatementsController < NpqSeparation::Admin
 
     @statement = scope.find(params[:id])
     @calculator = Statements::SummaryCalculator.new(statement: @statement)
+    show_authorising_statement_message(@statement)
 
     contracts = @statement.contracts.joins(:contract_template, :course).order(identifier: :asc)
     @contracts = contracts.where(contract_template: { special_course: false })
@@ -40,5 +41,16 @@ private
     return unless (period = params.delete(:statement))
 
     params[:year], params[:month] = period.split("-")
+  end
+
+  def show_authorising_statement_message(statement)
+    return unless statement.authorising_for_payment?
+
+    flash.now[:success_title] =
+      t("npq_separation.admin.finance.statements.payment_authorisations.banner.title")
+
+    flash.now[:success] =
+      t("npq_separation.admin.finance.statements.payment_authorisations.banner.content",
+        statement_marked_as_paid_at: statement.marked_as_paid_at.strftime("%-I:%M%P on %-e %b %Y"))
   end
 end

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -59,7 +59,11 @@ class Statement < ApplicationRecord
   end
 
   def allow_marking_as_paid?
-    output_fee && payable? && !marked_as_paid_at? && declarations.any?
+    output_fee &&
+      payable? &&
+      deadline_date.past? &&
+      !marked_as_paid_at? &&
+      declarations.any?
   end
 
   def authorising_for_payment?

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -62,6 +62,10 @@ class Statement < ApplicationRecord
     output_fee && payable? && !marked_as_paid_at? && declarations.any?
   end
 
+  def authorising_for_payment?
+    payable? && marked_as_paid_at?
+  end
+
   def show_targeted_delivery_funding?
     cohort.start_year >= 2022
   end

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -5,7 +5,6 @@ class Statement < ApplicationRecord
   belongs_to :cohort
   belongs_to :lead_provider
   has_many :statement_items
-  has_many :declarations, through: :statement_items
   has_many :contracts
   has_many :declarations, through: :statement_items
 

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -58,6 +58,10 @@ class Statement < ApplicationRecord
     marked_as_paid_at.present? && paid?
   end
 
+  def allow_marking_as_paid?
+    output_fee && payable? && !marked_as_paid_at? && declarations.any?
+  end
+
   def show_targeted_delivery_funding?
     cohort.start_year >= 2022
   end

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -61,7 +61,7 @@ class Statement < ApplicationRecord
   def allow_marking_as_paid?
     output_fee &&
       payable? &&
-      deadline_date.past? &&
+      !!deadline_date&.past? &&
       !marked_as_paid_at? &&
       declarations.any?
   end

--- a/app/views/npq_separation/admin/finance/statements/show.html.erb
+++ b/app/views/npq_separation/admin/finance/statements/show.html.erb
@@ -113,11 +113,12 @@
 
       <div class="govuk-grid-row govuk-!-padding-top-3">
         <div class="govuk-grid-column-one-half govuk-!-text-align-left">
-          <%# TODO: CPDNPQ-2142 %>
-          <% if false && authorise_for_payment_button_visible?(@statement) %>
-            <%= button_to t("npq_separation.admin.finance.statements.payment_authorisations.button"), new_finance_statement_payment_authorisation_path(@statement), method: :get, class: "govuk-button govuk-button--primary" %>
-          <% elsif @statement.marked_as_paid_at.present? %>
-            <%= govuk_tag(text: t("npq_separation.admin.finance.statements.payment_authorisations.tag.content", statement_marked_as_paid_at: @statement.marked_as_paid_at.in_time_zone("London").strftime("%-I:%M%P on %-e %b %Y"))) %>
+          <% if @statement.allow_marking_as_paid? %>
+            <%= govuk_button_link_to t("npq_separation.admin.finance.statements.payment_authorisations.new.button"),
+                                     new_npq_separation_admin_finance_payment_authorisation_path(@statement) %>
+          <% elsif @statement.marked_as_paid? %>
+            <%= govuk_tag(text: t("npq_separation.admin.finance.statements.payment_authorisations.tag.content",
+                                  statement_marked_as_paid_at: @statement.marked_as_paid_at.in_time_zone("London").strftime("%-I:%M%P on %-e %b %Y"))) %>
           <% else %>
             &nbsp;
           <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -675,9 +675,9 @@ en:
               checks_done_legend: Have all necessary assurance checks been done?
             tag:
               content: "Authorised for payment at %{statement_marked_as_paid_at}"
-            # banner:
-            #   title: "Authorising for payment"
-            #   content: "Requested at %{statement_marked_as_paid_at}. This may take up to 15 minutes. Refresh to see the updated statement."
+            banner:
+              title: "Authorising for payment"
+              content: "Requested at %{statement_marked_as_paid_at}. This may take up to 15 minutes. Refresh to see the updated statement."
 
   funding_details:
     ineligible_setting: "You’re not eligible for scholarship funding as you do not work in one of the eligible settings, such as state-funded schools."

--- a/spec/components/npq_separation/admin/statement_details_component_spec.rb
+++ b/spec/components/npq_separation/admin/statement_details_component_spec.rb
@@ -20,9 +20,9 @@ RSpec.describe NpqSeparation::Admin::StatementDetailsComponent, type: :component
 
   it { is_expected.to have_css "h4", text: "Totals" }
   it { is_expected.to have_css "p", text: "Output payment" }
-  it { is_expected.not_to have_css "p", text: "Targeted delivery funding" }
+  it { is_expected.to have_css "p", text: "Targeted delivery funding" }
   it { is_expected.to have_css "p", text: "Clawbacks" }
-  it { is_expected.to have_css "p", text: "Service fee" }
+  it { is_expected.not_to have_css "p", text: "Service fee" }
   it { is_expected.to have_css "p", text: "Total net VAT" }
   it { is_expected.to have_css "ul li strong", text: "Output payment cut off date" }
   it { is_expected.to have_css "ul li strong", text: "Total starts" }
@@ -33,9 +33,11 @@ RSpec.describe NpqSeparation::Admin::StatementDetailsComponent, type: :component
   context "with targeted delivery funding" do
     before do
       allow(instance.calculator)
-        .to receive(:show_targeted_delivery_funding?).and_return(true)
+        .to receive_messages(show_targeted_delivery_funding?: false,
+                             total_service_fees: 10.0)
     end
 
-    it { is_expected.to have_css "p", text: "Targeted delivery funding" }
+    it { is_expected.not_to have_css "p", text: "Targeted delivery funding" }
+    it { is_expected.to have_css "p", text: "Service fee" }
   end
 end

--- a/spec/factories/statements.rb
+++ b/spec/factories/statements.rb
@@ -32,7 +32,11 @@ FactoryBot.define do
     end
 
     trait(:open) { state { "open" } }
-    trait(:payable) { state { "payable" } }
+
+    trait :payable do
+      state { "payable" }
+      deadline_date { Time.zone.yesterday }
+    end
 
     trait(:with_existing_lead_provider) do
       lead_provider { LeadProvider.all.sample }

--- a/spec/factories/statements.rb
+++ b/spec/factories/statements.rb
@@ -1,11 +1,21 @@
 FactoryBot.define do
   factory :statement do
+    transient do
+      declaration {}
+    end
+
+    after(:create) do |statement, evaluator|
+      if evaluator.declaration
+        create(:statement_item, declaration: evaluator.declaration, statement:)
+      end
+    end
+
     month { Faker::Number.between(from: 1, to: 12) }
     year { Faker::Number.between(from: 2021, to: 2024) }
     deadline_date { Faker::Date.forward(days: 30) }
     payment_date { Faker::Date.forward(days: 30) }
     cohort { create(:cohort, :current) }
-    lead_provider
+    lead_provider { declaration&.lead_provider || build(:lead_provider) }
     reconcile_amount { Faker::Number.decimal(l_digits: 3, r_digits: 2) }
     state { "open" }
     ecf_id { SecureRandom.uuid }

--- a/spec/features/npq_separation/admin/finance/statements_spec.rb
+++ b/spec/features/npq_separation/admin/finance/statements_spec.rb
@@ -51,8 +51,7 @@ RSpec.feature "Listing and viewing statements", :ecf_api_disabled, type: :featur
 
   scenario "marking a statement as paid" do
     statement = Statement.order(payment_date: :asc).first.tap(&:mark_payable!)
-    declaration = create(:declaration)
-    create(:statement_item, statement:, declaration:)
+    create(:declaration, statement:)
 
     visit(npq_separation_admin_finance_statement_path(statement))
     expect(page).to have_css("h1", text: "Statement #{statement.id}")
@@ -72,8 +71,7 @@ RSpec.feature "Listing and viewing statements", :ecf_api_disabled, type: :featur
 
   scenario "marking a statement as paid before job has run" do
     statement = Statement.order(payment_date: :asc).first.tap(&:mark_payable!)
-    declaration = create(:declaration)
-    create(:statement_item, statement:, declaration:)
+    create(:declaration, statement:)
 
     visit(npq_separation_admin_finance_statement_path(statement))
     expect(page).to have_css("h1", text: "Statement #{statement.id}")

--- a/spec/features/npq_separation/admin/finance/statements_spec.rb
+++ b/spec/features/npq_separation/admin/finance/statements_spec.rb
@@ -50,7 +50,7 @@ RSpec.feature "Listing and viewing statements", :ecf_api_disabled, type: :featur
   end
 
   scenario "marking a statement as paid" do
-    statement = Statement.order(payment_date: :asc).first.tap(&:mark_payable!)
+    statement = create(:statement, :payable)
     create(:declaration, statement:)
 
     visit(npq_separation_admin_finance_statement_path(statement))
@@ -70,7 +70,7 @@ RSpec.feature "Listing and viewing statements", :ecf_api_disabled, type: :featur
   end
 
   scenario "marking a statement as paid before job has run" do
-    statement = Statement.order(payment_date: :asc).first.tap(&:mark_payable!)
+    statement = create(:statement, :payable)
     create(:declaration, statement:)
 
     visit(npq_separation_admin_finance_statement_path(statement))

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -197,4 +197,32 @@ RSpec.describe Statement, type: :model do
       it { is_expected.to be false }
     end
   end
+
+  describe "#authorising_for_payment?" do
+    subject { statement.authorising_for_payment? }
+
+    context "with payable statement with marked_as_paid_at set" do
+      let(:statement) { build(:statement, :payable, marked_as_paid_at: Time.zone.now) }
+
+      it { is_expected.to be true }
+    end
+
+    context "with payable statement without marked_as_paid_at set" do
+      let(:statement) { build(:statement, :payable, marked_as_paid_at: nil) }
+
+      it { is_expected.to be false }
+    end
+
+    context "with paid statement with marked_as_paid_at set" do
+      let(:statement) { build(:statement, :paid, marked_as_paid_at: Time.zone.now) }
+
+      it { is_expected.to be false }
+    end
+
+    context "with open statement with marked_as_paid_at_set" do
+      let(:statement) { build(:statement, :open, marked_as_paid_at: Time.zone.now) }
+
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -186,13 +186,25 @@ RSpec.describe Statement, type: :model do
     end
 
     context "with statement not in payable state" do
-      let(:statement) { create(:statement, :open, :next_output_fee, declaration:) }
+      let :statement do
+        create(:statement, :open, :next_output_fee, declaration:,
+                                                    deadline_date: Time.zone.yesterday)
+      end
 
       it { is_expected.to be false }
     end
 
     context "with statement without declarations" do
       let(:statement) { create(:statement, :next_output_fee, :payable) }
+
+      it { is_expected.to be false }
+    end
+
+    context "with statement with future deadline date" do
+      let :statement do
+        create(:statement, :next_output_fee, :payable, declaration:,
+                                                       deadline_date: Time.zone.today)
+      end
 
       it { is_expected.to be false }
     end

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -167,4 +167,34 @@ RSpec.describe Statement, type: :model do
       it { is_expected.not_to be_marked_as_paid }
     end
   end
+
+  describe "#allow_marking_as_paid?" do
+    subject { statement.allow_marking_as_paid? }
+
+    let(:declaration) { create(:declaration, :payable) }
+
+    context "with payable statement with declarations" do
+      let(:statement) { create(:statement, :next_output_fee, :payable, declaration:) }
+
+      it { is_expected.to be true }
+    end
+
+    context "with non output fee statement" do
+      let(:statement) { create(:statement, :payable, output_fee: false, declaration:) }
+
+      it { is_expected.to be false }
+    end
+
+    context "with statement not in payable state" do
+      let(:statement) { create(:statement, :open, :next_output_fee, declaration:) }
+
+      it { is_expected.to be false }
+    end
+
+    context "with statement without declarations" do
+      let(:statement) { create(:statement, :next_output_fee, :payable) }
+
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -200,10 +200,18 @@ RSpec.describe Statement, type: :model do
       it { is_expected.to be false }
     end
 
-    context "with statement with future deadline date" do
+    context "with future deadline date" do
       let :statement do
         create(:statement, :next_output_fee, :payable, declaration:,
                                                        deadline_date: Time.zone.today)
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "with nil deadline date" do
+      let :statement do
+        create(:statement, :next_output_fee, :payable, declaration:, deadline_date: nil)
       end
 
       it { is_expected.to be false }


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2142](https://dfedigital.atlassian.net/browse/CPDNPQ-2142)

The payment authorisation functionality is already present in the code base but is relying on a stubbed out calculator and is not connected to the statements screen.

### Changes proposed in this pull request

1. Show a button linking to the payment authorisations form from the statement summary screen
2. Use the new `Statements::SummaryCalculator` for the Payment Authorisations Form
3. Show a persistent flash message to say payment authorisation is in progress when a statement has a paid date set but is not yet transitioned to a paid state
4. Show an inline tag message to show when a payment happened once a statement has transitioned to a paid state

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/


[CPDNPQ-2142]: https://dfedigital.atlassian.net/browse/CPDNPQ-2142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ