### PR TITLE
[CPDLP-3743] Add Redis cache to production env

### DIFF
--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -18,5 +18,9 @@
     "start_minute": 0
   },
   "external_url": "https://register-national-professional-qualifications.education.gov.uk/healthcheck",
-  "enable_logit": true
+  "enable_logit": true,
+  "deploy_redis_cache": true,
+  "redis_cache_family": "P",
+  "redis_cache_capacity": 2,
+  "redis_cache_sku_name": "Premium"
 }

--- a/terraform/application/database.tf
+++ b/terraform/application/database.tf
@@ -4,7 +4,7 @@ module "redis-cache" {
   namespace                 = var.namespace
   environment               = local.environment
   azure_resource_prefix     = var.azure_resource_prefix
-  service_name              = local.service_name
+  service_name              = var.service_name
   service_short             = var.service_short
   config_short              = var.config_short
   azure_capacity            = var.redis_cache_capacity


### PR DESCRIPTION
### Context

Ticket: [CPDLP-3743](https://dfedigital.atlassian.net/browse/CPDLP-3743)

We currently use Redis in migration for the data migration, we need to set a similar one up in production.

### Changes proposed in this pull request

Add Redis cache to production env.

[CPDLP-3743]: https://dfedigital.atlassian.net/browse/CPDLP-3743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ