### PR TITLE
[CPDNPQ-2170] Re-add the git sha check and include a sleep

### DIFF
--- a/bin/smoke
+++ b/bin/smoke
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+sleep 10 # Allow time for old app instances to drain
+
 url=$1
 if [[ -z $url ]]; then
   echo `date`" - smoke test failed (URL is missing)"
@@ -11,6 +13,13 @@ response_sha=$(jq ".git_commit_sha" <<< $response)
 current_commit_sha=\"$2\"
 if [[ -z $current_commit_sha ]]; then
   echo `date`" - smoke test failed (head sha is missing)"
+  exit 1
+fi
+
+if [[ $response_sha == $current_commit_sha ]]; then
+  echo "✅ Correct version deployed"
+else
+  echo "Fail: healthcheck sha is $response_sha but current commit is $current_commit_sha"
   exit 1
 fi
 


### PR DESCRIPTION
### Context

Ticket: [2170](https://dfedigital.atlassian.net/browse/CPDNPQ-2170)

Our deployments are not rolling rather than blue/green, this means there is a window when we may get a response from the old application. Ideally terraform wouldn't complete before the old apps had drained but that appears not to be the case so the check against the deployed version occasionally receives a response from the old app.

### Changes proposed in this pull request

1. Re-add the check against the deployed version
2. Add a `sleep` to delay checking the healthcheck endpoint to allow time for old apps to drain

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
