### PR TITLE
[CPDNPQ-2193] Generate bootsnap cache during Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,8 @@ RUN apk add --update --no-cache libpq tzdata ${EXTRA_PACKAGES} && \
 COPY --from=builder /app /app
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 
+RUN RAILS_ENV=production bundle exec bootsnap precompile --gemfile app/ lib/
+
 ARG COMMIT_SHA
 ENV AUTHORISED_HOSTS=127.0.0.1 \
     COMMIT_SHA=${COMMIT_SHA}


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2193

It should speed up booting the app during deployment

### Changes proposed in this pull request

Generate the bootsnap cache data during Docker image build

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
