### PR TITLE
Remove n+1 in application query by including correct associations

### DIFF
--- a/app/services/applications/query.rb
+++ b/app/services/applications/query.rb
@@ -98,8 +98,8 @@ module Applications
           :user,
           :school,
           :cohort,
-          :private_childcare_provider,
-          :itt_provider,
+          :private_childcare_provider_including_disabled,
+          :itt_provider_including_disabled,
           :schedule,
         )
     end


### PR DESCRIPTION
### Context

Ticket: n/a

When changing associations in application serialiser we forgot to add the new ones to the query

### Changes proposed in this pull request

Amend includes to include the disabled private childcare provider and itt provider

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
