### PR TITLE
Bump web apps

### DIFF
--- a/terraform/application/config/migration.tfvars.json
+++ b/terraform/application/config/migration.tfvars.json
@@ -8,7 +8,7 @@
     "redis_cache_sku_name": "Basic",
     "enable_logit": true,
     "webapp_replicas": 12,
-    "worker_replicas": 4,
+    "worker_replicas": 6,
     "migration_worker_replicas": 30,
     "webapp_memory_max": "4Gi",
     "worker_memory_max": "2Gi",

--- a/terraform/application/config/migration.tfvars.json
+++ b/terraform/application/config/migration.tfvars.json
@@ -7,7 +7,7 @@
     "redis_cache_capacity": 0,
     "redis_cache_sku_name": "Basic",
     "enable_logit": true,
-    "webapp_replicas": 6,
+    "webapp_replicas": 12,
     "worker_replicas": 4,
     "migration_worker_replicas": 30,
     "webapp_memory_max": "4Gi",

--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -7,7 +7,7 @@
   "enable_postgres_backup_storage" : true,
   "webapp_replicas": 12,
   "worker_replicas": 4,
-  "migration_worker_replicas": 0,
+  "migration_worker_replicas": 30,
   "webapp_memory_max": "4Gi",
   "worker_memory_max": "2Gi",
   "enable_monitoring": true,

--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -6,7 +6,7 @@
   "environment": "production",
   "enable_postgres_backup_storage" : true,
   "webapp_replicas": 12,
-  "worker_replicas": 4,
+  "worker_replicas": 6,
   "migration_worker_replicas": 30,
   "webapp_memory_max": "4Gi",
   "worker_memory_max": "2Gi",

--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -5,7 +5,7 @@
   "namespace": "cpd-production",
   "environment": "production",
   "enable_postgres_backup_storage" : true,
-  "webapp_replicas": 6,
+  "webapp_replicas": 12,
   "worker_replicas": 4,
   "migration_worker_replicas": 0,
   "webapp_memory_max": "4Gi",


### PR DESCRIPTION
[Jira-3634](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=unassigned%2C712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3634)

We want to get the performance on par with ECF; during testing we're a bit slower and it seems the web apps are the bottleneck; going to 12 to see if that improves the situation in the short-term until we have time to optimise. Move to 6 workers now we are running 12 web apps.

Bump migration workers to 30 to match migration environment ahead of running migration in production.

