### PR TITLE
Fix cache_store for non prod envs

### DIFF
--- a/config/environments/review.rb
+++ b/config/environments/review.rb
@@ -2,6 +2,7 @@ require Rails.root.join("config/environments/production")
 
 Rails.application.configure do
   config.ssl_options = { redirect: { exclude: ->(request) { request.path.include?("/healthcheck") } } }
+  config.cache_store = :null_store
 
   # Enable/disable aspects of the NPQ separation
   config.npq_separation = {

--- a/config/environments/sandbox.rb
+++ b/config/environments/sandbox.rb
@@ -3,6 +3,7 @@ require Rails.root.join("config/environments/production")
 Rails.application.configure do
   config.log_level = :info
   config.ssl_options = { redirect: { exclude: ->(request) { request.path.include?("/healthcheck") } } }
+  config.cache_store = :null_store
 
   # Enable/disable aspects of the NPQ separation
   config.npq_separation = {

--- a/config/environments/separation.rb
+++ b/config/environments/separation.rb
@@ -3,6 +3,7 @@ require Rails.root.join("config/environments/production")
 Rails.application.configure do
   config.log_level = :debug
   config.ssl_options = { redirect: { exclude: ->(request) { request.path.include?("/healthcheck") } } }
+  config.cache_store = :null_store
 
   # Enable/disable aspects of the NPQ separation
   config.npq_separation = {

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -3,6 +3,7 @@ require Rails.root.join("config/environments/production")
 Rails.application.configure do
   config.log_level = :debug
   config.ssl_options = { redirect: { exclude: ->(request) { request.path.include?("/healthcheck") } } }
+  config.cache_store = :null_store
 
   # Enable/disable aspects of the NPQ separation
   config.npq_separation = {


### PR DESCRIPTION
### Context

Ticket: N/A

Some Non prod env inherits `cache_store` from production. We need to set it back as `null_store`.

### Changes proposed in this pull request

Fix `cache_store` back to `null_store` for non prod envs.