### PR TITLE
[CPDNPQ-2197] update UCL provider name

### DIFF
--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -8,7 +8,7 @@ class LeadProvider < ApplicationRecord
     "School-Led Network" => "bc5e4e37-1d64-4149-a06b-ad10d3c55fd0",
     "Teacher Development Trust" => "30fd937e-b93c-4f81-8fff-3c27544193f1",
     "Teach First" => "a02ae582-f939-462f-90bc-cebf20fa8473",
-    "University College London (UCL) Institute of Education" => "ef687b3d-c1c0-4566-a295-16d6fa5d0fa7",
+    "UCL Institute of Education" => "ef687b3d-c1c0-4566-a295-16d6fa5d0fa7",
   }.freeze
 
   NPQH_SL_LT_LTD_LBC_PROVIDERS = [
@@ -19,7 +19,7 @@ class LeadProvider < ApplicationRecord
     "National Institute of Teaching",
     "Teacher Development Trust",
     "Teach First",
-    "University College London (UCL) Institute of Education",
+    "UCL Institute of Education",
   ].freeze
 
   NPQH_EHCO_PROVIDERS = [
@@ -30,7 +30,7 @@ class LeadProvider < ApplicationRecord
     "Teach First",
     "LLSE",
     "Teacher Development Trust",
-    "University College London (UCL) Institute of Education",
+    "UCL Institute of Education",
   ].freeze
 
   EYL_LL_PROVIDERS = [
@@ -38,7 +38,7 @@ class LeadProvider < ApplicationRecord
     "National Institute of Teaching",
     "Teacher Development Trust",
     "Teach First",
-    "University College London (UCL) Institute of Education",
+    "UCL Institute of Education",
   ].freeze
 
   EL_PROVIDERS = [
@@ -48,7 +48,7 @@ class LeadProvider < ApplicationRecord
     "LLSE",
     "National Institute of Teaching",
     "Teach First",
-    "University College London (UCL) Institute of Education",
+    "UCL Institute of Education",
   ].freeze
 
   LPM_PROVIDERS = [
@@ -56,7 +56,7 @@ class LeadProvider < ApplicationRecord
     "Church of England",
     "LLSE",
     "Teach First",
-    "University College London (UCL) Institute of Education",
+    "UCL Institute of Education",
     "National Institute of Teaching",
   ].freeze
 
@@ -66,7 +66,7 @@ class LeadProvider < ApplicationRecord
     "Church of England",
     "National Institute of Teaching",
     "Teach First",
-    "University College London (UCL) Institute of Education",
+    "UCL Institute of Education",
   ].freeze
 
   # TODO: Move all of this mapping into the database

--- a/db/migrate/20241112131533_update_ucl_provider_name.rb
+++ b/db/migrate/20241112131533_update_ucl_provider_name.rb
@@ -1,0 +1,9 @@
+class UpdateUclProviderName < ActiveRecord::Migration[7.1]
+  def up
+    LeadProvider.where(name: "University College London (UCL) Institute of Education").update_all(name: "UCL Institute of Education")
+  end
+
+  def down
+    LeadProvider.where(name: "UCL Institute of Education").update_all(name: "University College London (UCL) Institute of Education")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_30_181047) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_12_131533) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"

--- a/db/seeds/base/add_api_tokens.rb
+++ b/db/seeds/base/add_api_tokens.rb
@@ -3,7 +3,7 @@
   "Best Practice Network" => "best-practice-token",
   "Church of England" => "coe-token",
   "School-Led Network" => "school-led-token",
-  "University College London (UCL) Institute of Education" => "ucl-token",
+  "UCL Institute of Education" => "ucl-token",
   "Teacher Development Trust" => "tdt-token",
   "Teach First" => "teach-first-token",
   "National Institute of Teaching" => "niot-token",

--- a/db/seeds/separation_shared_data.yml
+++ b/db/seeds/separation_shared_data.yml
@@ -92,7 +92,7 @@ Teach First:
   :trn: '9999047'
   :date_of_birth: '1976-06-24'
   :ecf_id:
-University College London (UCL) Institute of Education:
+UCL Institute of Education:
 - :name: Seth Mann
   :email: seth_mann@howe.io
   :trn: '9999054'

--- a/spec/lib/questionnaires/choose_your_provider_spec.rb
+++ b/spec/lib/questionnaires/choose_your_provider_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Questionnaires::ChooseYourProvider, type: :model do
             "National Institute of Teaching",
             "Teacher Development Trust",
             "Teach First",
-            "University College London (UCL) Institute of Education",
+            "UCL Institute of Education",
           ])
         end
 
@@ -133,7 +133,7 @@ RSpec.describe Questionnaires::ChooseYourProvider, type: :model do
             "LLSE",
             "National Institute of Teaching",
             "Teach First",
-            "University College London (UCL) Institute of Education",
+            "UCL Institute of Education",
           ])
         end
 
@@ -169,7 +169,7 @@ RSpec.describe Questionnaires::ChooseYourProvider, type: :model do
             "National Institute of Teaching",
             "Teacher Development Trust",
             "Teach First",
-            "University College London (UCL) Institute of Education",
+            "UCL Institute of Education",
           ])
         end
 
@@ -328,7 +328,7 @@ RSpec.describe Questionnaires::ChooseYourProvider, type: :model do
             "National Institute of Teaching",
             "Teacher Development Trust",
             "Teach First",
-            "University College London (UCL) Institute of Education",
+            "UCL Institute of Education",
           ])
         end
 
@@ -349,7 +349,7 @@ RSpec.describe Questionnaires::ChooseYourProvider, type: :model do
             "LLSE",
             "National Institute of Teaching",
             "Teach First",
-            "University College London (UCL) Institute of Education",
+            "UCL Institute of Education",
           ])
         end
 
@@ -371,7 +371,7 @@ RSpec.describe Questionnaires::ChooseYourProvider, type: :model do
             "National Institute of Teaching",
             "Teacher Development Trust",
             "Teach First",
-            "University College London (UCL) Institute of Education",
+            "UCL Institute of Education",
           ])
         end
 
@@ -393,7 +393,7 @@ RSpec.describe Questionnaires::ChooseYourProvider, type: :model do
             "Teach First",
             "LLSE",
             "Teacher Development Trust",
-            "University College London (UCL) Institute of Education",
+            "UCL Institute of Education",
           ])
         end
 

--- a/spec/models/lead_provider_spec.rb
+++ b/spec/models/lead_provider_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe LeadProvider do
           "National Institute of Teaching",
           "Teacher Development Trust",
           "Teach First",
-          "University College London (UCL) Institute of Education",
+          "UCL Institute of Education",
         ])
       end
     end
@@ -68,7 +68,7 @@ RSpec.describe LeadProvider do
           "National Institute of Teaching",
           "Teacher Development Trust",
           "Teach First",
-          "University College London (UCL) Institute of Education",
+          "UCL Institute of Education",
         ])
       end
     end
@@ -85,7 +85,7 @@ RSpec.describe LeadProvider do
           "National Institute of Teaching",
           "Teacher Development Trust",
           "Teach First",
-          "University College London (UCL) Institute of Education",
+          "UCL Institute of Education",
         ])
       end
     end
@@ -102,7 +102,7 @@ RSpec.describe LeadProvider do
           "National Institute of Teaching",
           "Teacher Development Trust",
           "Teach First",
-          "University College London (UCL) Institute of Education",
+          "UCL Institute of Education",
         ])
       end
     end
@@ -119,7 +119,7 @@ RSpec.describe LeadProvider do
           "National Institute of Teaching",
           "Teacher Development Trust",
           "Teach First",
-          "University College London (UCL) Institute of Education",
+          "UCL Institute of Education",
         ])
       end
     end
@@ -136,7 +136,7 @@ RSpec.describe LeadProvider do
           "National Institute of Teaching",
           "Teacher Development Trust",
           "Teach First",
-          "University College London (UCL) Institute of Education",
+          "UCL Institute of Education",
         ])
       end
     end
@@ -153,7 +153,7 @@ RSpec.describe LeadProvider do
           "National Institute of Teaching",
           "Teacher Development Trust",
           "Teach First",
-          "University College London (UCL) Institute of Education",
+          "UCL Institute of Education",
         ])
       end
     end
@@ -167,7 +167,7 @@ RSpec.describe LeadProvider do
           "National Institute of Teaching",
           "Teacher Development Trust",
           "Teach First",
-          "University College London (UCL) Institute of Education",
+          "UCL Institute of Education",
         ])
       end
     end
@@ -181,7 +181,7 @@ RSpec.describe LeadProvider do
           "National Institute of Teaching",
           "Teacher Development Trust",
           "Teach First",
-          "University College London (UCL) Institute of Education",
+          "UCL Institute of Education",
         ])
       end
     end
@@ -197,7 +197,7 @@ RSpec.describe LeadProvider do
           "LLSE",
           "National Institute of Teaching",
           "Teach First",
-          "University College London (UCL) Institute of Education",
+          "UCL Institute of Education",
         ])
       end
     end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2197

The UCL provider name is different between ECF and NPQ - it needs to be the same

### Changes proposed in this pull request

Changing `University College London (UCL) Institute of Education` to `UCL Institute of Education` everywhere in the code,
and migrating the Lead Provider names too

