### PR TITLE
[CPDLP-3758] Check that a profile exists before touching `updated_at`on Application migrator

### DIFF
--- a/app/services/migration/migrators/application.rb
+++ b/app/services/migration/migrators/application.rb
@@ -112,7 +112,7 @@ module Migration::Migrators
         return true
       end
 
-      if ecf_npq_application.profile&.school_urn.presence != ecf_npq_application.school_urn
+      if ecf_npq_application.profile.present? && (ecf_npq_application.profile.school_urn != ecf_npq_application.school_urn)
         return true
       end
 

--- a/spec/services/migration/migrators/application_spec.rb
+++ b/spec/services/migration/migrators/application_spec.rb
@@ -126,6 +126,13 @@ RSpec.describe Migration::Migrators::Application do
             application = Application.find_by!(ecf_id: ecf_resource1.id)
             expect(application.school.urn).to eq(ecf_resource1.school_urn)
           end
+
+          it "does not update the `updated_at` of the application" do
+            instance.call
+
+            application = Application.find_by!(ecf_id: ecf_resource1.id)
+            expect(application.updated_at).to be_within(1.second).of(5.days.ago)
+          end
         end
 
         context "when school is not found" do


### PR DESCRIPTION
### Context

Ticket: [CPDLP-3758](https://dfedigital.atlassian.net/browse/CPDLP-3758)

Currently when checking that the school urn changed in the migrator for applications we aren’t checking if the profile exists, this means we might always trigger updates for unaccepted applications

### Changes proposed in this pull request

Change the school urn updated at logic to check that a profile exists before comparing equality.

[CPDLP-3758]: https://dfedigital.atlassian.net/browse/CPDLP-3758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ