### PR TITLE
[CPDNPQ-2209] Avoid repeatedly reloading rails app during boot

### DIFF
--- a/terraform/application/config/review.tfvars.json
+++ b/terraform/application/config/review.tfvars.json
@@ -4,6 +4,6 @@
     "environment": "review",
     "deploy_azure_backing_services": false,
     "enable_postgres_ssl" : false,
-    "command": ["/bin/sh", "-c", "bundle exec rails db:environment:set RAILS_ENV=review && RAILS_ENV=review bundle exec rails db:schema:load && RAILS_ENV=review bundle exec rails db:seed && bundle exec rails server -b 0.0.0.0"],
+    "command": ["/bin/sh", "-c", "RAILS_ENV=review bundle exec rails db:environment:set db:schema:load db:seed && bundle exec rails server -b 0.0.0.0"],
     "enable_logit": true
 }


### PR DESCRIPTION
### Context

Ticket: [2209](https://dfedigital.atlassian.net/browse/CPDNPQ-2209)

Reduce boot time in review apps

### Changes proposed in this pull request

Only load the rails environment once to configure the db, load the schema and load the seeds.

Since the application is slow to boot due to bigquery gems - this should reduce doing the same reloading from 4 times to 2 times

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
