### PR TITLE
Fix race condition with `run_once`

### DIFF
--- a/app/services/migration/migrators/application.rb
+++ b/app/services/migration/migrators/application.rb
@@ -54,8 +54,6 @@ module Migration::Migrators
     end
 
     def call
-      run_once { report_applications_not_in_ecf_as_failures }
-
       applications_by_ecf_id = ::Application.where(ecf_id: self.class.ecf_npq_applications.pluck(:id)).index_by(&:ecf_id)
 
       migrate(self.class.ecf_npq_applications) do |ecf_npq_application|
@@ -95,10 +93,13 @@ module Migration::Migrators
 
         application.update!(attrs)
       end
+    end
 
-      run_once { backfill_ecf_ids }
-      run_once { backfill_cohorts }
-      run_once { backfill_lead_provider_approval_statuses }
+    def run_once_post_migration
+      report_applications_not_in_ecf_as_failures
+      backfill_ecf_ids
+      backfill_cohorts
+      backfill_lead_provider_approval_statuses
     end
 
   private

--- a/app/services/migration/migrators/user.rb
+++ b/app/services/migration/migrators/user.rb
@@ -63,8 +63,10 @@ module Migration::Migrators
 
         user.update!(attrs)
       end
+    end
 
-      run_once { backfill_ecf_ids }
+    def run_once_post_migration
+      backfill_ecf_ids
     end
 
   private

--- a/spec/services/migration/migrators/application_spec.rb
+++ b/spec/services/migration/migrators/application_spec.rb
@@ -186,15 +186,24 @@ RSpec.describe Migration::Migrators::Application do
         expect(failure_manager).not_to have_received(:record_failure)
       end
 
-      it "records a failure if applications exist in NPQ reg but not in ECF, but only on the first run" do
+      it "records a failure if applications exist in NPQ reg but not in ECF, but only on the last worker to finish" do
+        # Simulate two workers
+        allow(described_class).to receive(:record_count).and_return(records_per_worker + 1)
+
+        # Create two orphan applications that will fail the check.
         orphan_application1 = create(:application)
         orphan_application2 = create(:application)
 
+        # Stub the failure manager for the last worker.
+        data_migration = create(:data_migration, model: :application, worker: 1)
+        allow(Migration::FailureManager).to receive(:new).with(data_migration:) { failure_manager }
+
+        # Ensure first worker does not record a failure.
         described_class.new(worker: 0).call
+        expect(failure_manager).not_to have_received(:record_failure)
 
-        create(:data_migration, model: :application, worker: 1)
+        # Only the last worker should record the failures.
         described_class.new(worker: 1).call
-
         expect(failure_manager).to have_received(:record_failure).once.with(orphan_application1, /NPQApplication not found in ECF/)
         expect(failure_manager).to have_received(:record_failure).once.with(orphan_application2, /NPQApplication not found in ECF/)
       end


### PR DESCRIPTION
[Jira-3759](https://dfedigital.atlassian.net.mcas.ms/browse/CPDLP-3759)

### Context

We have noticed some application cohorts are being overwritten to the default/fallback cohort. This is due to the timing/ordering of the `run_once` code in the application migrator.

### Changes proposed in this pull request

- Fix race condition with run_once

There is a potential race condition in `run_once` migrator logic whereby if the `run_once` depends on data modified as part of the migration it might happen too early.

To avoid this, we can change the behaviour so the single-run code goes at the end and is ran by the last worker to complete. This way it ensures the migration for the model has fully completed before executing.

### Guidance for review

After running the migration:

```
Migration::Ecf::NpqApplication.find("fe026f85-1e68-453c-a191-e419a0b47982").cohort.start_year
=> 2022
irb(main):019> Application.find_by(ecf_id: "fe026f85-1e68-453c-a191-e419a0b47982").cohort.start_year
=> 2022
```

Check to ensure backfill happened:

```
Application.where(ecf_id: nil).exists?
=> false

irb(main):021> Application.where(cohort: nil).exists?
=> false

Application.where(lead_provider_approval_status: nil).exists?
=> false
```

![screencapture-npq-registration-migration-web-teacherservices-cloud-npq-separation-migration-migrations-2024-11-13-16_22_08](https://github.com/user-attachments/assets/b7b7cdd6-903e-4948-8d3e-d7acf435e063)
