### PR TITLE
Ensure placeholder TRNs are unverified

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :user do
     sequence(:full_name) { |n| "John Doe #{n}" }
     sequence(:email) { Faker::Internet.email(name: full_name) }
-    trn { "1234567" }
+    trn { sprintf("%07i", Random.random_number(9_999_999)) }
     date_of_birth { 30.years.ago }
     ecf_id { SecureRandom.uuid }
 

--- a/spec/lib/services/get_an_identity_service/webhooks/user_updated_processor_spec.rb
+++ b/spec/lib/services/get_an_identity_service/webhooks/user_updated_processor_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe GetAnIdentityService::Webhooks::UserUpdatedProcessor do
         user.reload.slice(:email, :trn, :full_name, :date_of_birth, :updated_from_tra_at).as_json
       }.from(
         "email" => old_email,
-        "trn" => "1234567",
+        "trn" => user.trn,
         "full_name" => "John Doe",
         "date_of_birth" => old_date_of_birth.as_json,
         "updated_from_tra_at" => nil,
@@ -93,7 +93,7 @@ RSpec.describe GetAnIdentityService::Webhooks::UserUpdatedProcessor do
           user.reload.slice(:email, :trn, :full_name, :date_of_birth, :updated_from_tra_at).as_json
         }.from(
           "email" => old_email,
-          "trn" => "1234567",
+          "trn" => user.trn,
           "full_name" => "John Doe",
           "date_of_birth" => old_date_of_birth.as_json,
           "updated_from_tra_at" => nil,

--- a/spec/models/registration_wizard_spec.rb
+++ b/spec/models/registration_wizard_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe RegistrationWizard do
     before do
       mock_previous_funding_api_request(
         course_identifier: "npq-additional-support-offer",
-        trn: "1234567",
+        trn: user.trn,
         response: ecf_funding_lookup_response(previously_funded: false),
       )
     end

--- a/spec/services/migration/migrators/user_spec.rb
+++ b/spec/services/migration/migrators/user_spec.rb
@@ -60,8 +60,8 @@ RSpec.describe Migration::Migrators::User do
         end
 
         it "uses the teacher profile TRN if there are multiple/verified TRNs for the user's NPQApplications in ECF and there is also a teacher profile TRN" do
-          ecf_user = create(:ecf_migration_user, :npq).tap { |u| u.teacher_profile.update!(trn: "1234567") }
-          create(:ecf_migration_npq_application, teacher_reference_number: "123456", teacher_reference_number_verified: true, participant_identity: ecf_user.participant_identities.first)
+          ecf_user = create(:ecf_migration_user, :npq).tap { |u| u.teacher_profile.update!(trn: "4587452") }
+          create(:ecf_migration_npq_application, teacher_reference_number: "4587412", teacher_reference_number_verified: true, participant_identity: ecf_user.participant_identities.first)
           instance.call
           expect(failure_manager).not_to have_received(:record_failure)
           user = User.find_by(ecf_id: ecf_user.id)
@@ -125,6 +125,16 @@ RSpec.describe Migration::Migrators::User do
           instance.call
           expect(failure_manager).not_to have_received(:record_failure)
           expect(existing_user.reload).to have_attributes(trn: "332245", trn_verified: false)
+        end
+
+        described_class::PLACEHOLDER_TRNS.each do |trn|
+          it "sets TRN as unverified if it is the placeholder TRN #{trn}" do
+            ecf_user = create(:ecf_migration_user, :npq).tap { |u| u.teacher_profile.update!(trn:) }
+            instance.call
+            user = User.find_by(ecf_id: ecf_user.id)
+            expect(user.trn).to eq(trn)
+            expect(user).not_to be_trn_verified
+          end
         end
       end
 


### PR DESCRIPTION
[Jira-3763](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345%2Cunassigned&selectedIssue=CPDLP-3763)

### Context

We have a number of placeholder TRNs in the ECF dataset; we want to ensure when we migrate these that they are always in an unverified state.

### Changes proposed in this pull request

- Ensure placeholder TRNs are unverified

### Guidance for review

Checked on migration:

```
User.where(trn: %w[0000000 1234567], trn_verified: true).exists?
=> false
```