### PR TITLE
[CPDLP-3766] Fix validation on statements not be limit to 2 statement items

### DIFF
--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -93,6 +93,7 @@ class Declaration < ApplicationRecord
   validate :validate_declaration_date_within_schedule, if: -> { !skip_declaration_date_within_schedule_validation }
   validate :validate_declaration_date_not_in_the_future
   validates :ecf_id, uniqueness: { case_sensitive: false }
+  validate :validate_max_statement_items_count
 
   def billable_statement
     statement_items.find(&:billable?)&.statement
@@ -153,5 +154,11 @@ private
 
   def validate_declaration_date_not_in_the_future
     errors.add(:declaration_date, :future_declaration_date) if declaration_date&.future?
+  end
+
+  def validate_max_statement_items_count
+    if statement_items.count > 2
+      errors.add(:statement_items, :more_than_two_statement_items)
+    end
   end
 end

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -27,7 +27,6 @@ class Statement < ApplicationRecord
               message: "Year must be a 4 digit number",
             }
 
-  validate :validate_max_statement_items_count
   validates :ecf_id, uniqueness: { case_sensitive: false }
 
   scope :with_output_fee, ->(output_fee: true) { where(output_fee:) }
@@ -72,13 +71,5 @@ class Statement < ApplicationRecord
 
   def show_targeted_delivery_funding?
     cohort.start_year >= 2022
-  end
-
-private
-
-  def validate_max_statement_items_count
-    if statement_items.count > 2
-      errors.add(:statement_items, "There cannot be more than two items per statement")
-    end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -210,6 +210,8 @@ en:
               *declaration_type
             ecf_id:
               *ecf_id
+            statement_items:
+              more_than_two_statement_items: There cannot be more than two items per declaration
         lead_provider:
           attributes:
             ecf_id:

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -56,6 +56,22 @@ RSpec.describe Declaration, type: :model do
 
       it { is_expected.to be_valid }
     end
+
+    context "when declaration has two or fewer statement items" do
+      it "is valid" do
+        create_list(:statement_item, 2, declaration: subject)
+        expect(subject).to be_valid
+      end
+    end
+
+    context "when declaration has more than two statement items" do
+      it "is not valid" do
+        create_list(:statement_item, 3, declaration: subject)
+
+        expect(subject).not_to be_valid
+        expect(subject).to have_error(:statement_items, :more_than_two_statement_items, "There cannot be more than two items per declaration")
+      end
+    end
   end
 
   describe "delegations" do

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -19,24 +19,6 @@ RSpec.describe Statement, type: :model do
     it { is_expected.not_to allow_value(nil).for(:output_fee).with_message("Choose yes or no for output fee") }
     it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique") }
 
-    describe "Validation for statement items count" do
-      context "when the statement has two or fewer statement items" do
-        it "is valid" do
-          create_list(:statement_item, 2, statement:)
-          expect(statement.valid?).to be true
-        end
-      end
-
-      context "when the statement has more than two statement items" do
-        it "is not valid" do
-          create_list(:statement_item, 3, statement:)
-
-          expect(statement.valid?).to be false
-          expect(statement.errors[:statement_items]).to include("There cannot be more than two items per statement")
-        end
-      end
-    end
-
     describe "State validation" do
       context "when setting invalid state" do
         let(:statement) { build(:statement, state: "madeup") }

--- a/spec/services/statements/mark_as_paid_spec.rb
+++ b/spec/services/statements/mark_as_paid_spec.rb
@@ -12,7 +12,10 @@ RSpec.describe Statements::MarkAsPaid do
   let :statement do
     create(:statement, statement_state, lead_provider:) do |statement|
       create(:statement_item, :payable, statement:, declaration:)
+      create(:statement_item, :payable, statement:, declaration: create(:declaration, :payable, lead_provider:))
+      create(:statement_item, :payable, statement:, declaration: create(:declaration, :payable, lead_provider:))
       create(:statement_item, :awaiting_clawback, statement:, declaration: clawback_declaration)
+      create(:statement_item, :awaiting_clawback, statement:, declaration: create(:declaration, :awaiting_clawback, lead_provider:))
     end
   end
 
@@ -30,28 +33,28 @@ RSpec.describe Statements::MarkAsPaid do
       describe "declarations" do
         it "transitions the payable to paid" do
           expect { service.mark && statement.reload }
-            .to change(statement.declarations.payable_state, :count).from(1).to(0)
-            .and change(statement.declarations.paid_state, :count).from(0).to(1)
+            .to change(statement.declarations.payable_state, :count).from(3).to(0)
+            .and change(statement.declarations.paid_state, :count).from(0).to(3)
         end
 
         it "transitions the awaiting_clawback to clawed_back" do
           expect { service.mark && statement.reload }
-            .to change(statement.declarations.clawed_back_state, :count).from(0).to(1)
-            .and change(statement.declarations.awaiting_clawback_state, :count).from(1).to(0)
+            .to change(statement.declarations.clawed_back_state, :count).from(0).to(2)
+            .and change(statement.declarations.awaiting_clawback_state, :count).from(2).to(0)
         end
       end
 
       describe "statement items" do
         it "transitions the payable to paid" do
           expect { service.mark && statement.reload }
-            .to change(statement.statement_items.payable, :count).from(1).to(0)
-            .and change(statement.statement_items.paid, :count).from(0).to(1)
+            .to change(statement.statement_items.payable, :count).from(3).to(0)
+            .and change(statement.statement_items.paid, :count).from(0).to(3)
         end
 
         it "transitions the awaiting_clawback to clawed_back" do
           expect { service.mark && statement.reload }
-            .to change(statement.statement_items.awaiting_clawback, :count).from(1).to(0)
-            .and change(statement.statement_items.clawed_back, :count).from(0).to(1)
+            .to change(statement.statement_items.awaiting_clawback, :count).from(2).to(0)
+            .and change(statement.statement_items.clawed_back, :count).from(0).to(2)
         end
       end
 

--- a/spec/services/statements/mark_as_payable_spec.rb
+++ b/spec/services/statements/mark_as_payable_spec.rb
@@ -11,7 +11,11 @@ RSpec.describe Statements::MarkAsPayable do
 
   before do
     create(:statement_item, :eligible, statement:, declaration:)
+    create(:statement_item, :eligible, statement:)
+    create(:statement_item, :eligible, statement:)
     create(:statement_item, :voided, statement:, declaration: voided_declaration)
+    create(:statement_item, :voided, statement:)
+    create(:statement_item, :voided, statement:)
   end
 
   describe "#mark" do


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDLP-3766

### Changes proposed in this pull request

* Removed max statement items validation from Statement
* Added max statement items validation to Declaration
* Added multiple declarations to mark as payable/paid service specs.