### PR TITLE
Prevent double-seeding the review apps

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,13 +15,16 @@ end
 
 Rails.logger.info("Seeding database")
 
+# Ensure course/course group are first so the replant for
+# review apps doesn't cause the container to go into an
+# unhealthy state for too long (as courses are loaded in healthcheck).
 [
+  "add_course_groups.rb",
+  "add_courses.rb",
   "add_feature_flags.rb",
   "add_cohorts.rb",
   "add_childcare_providers.rb",
   "add_schools.rb",
-  "add_course_groups.rb",
-  "add_courses.rb",
   "add_schedules.rb",
   "add_lead_providers.rb",
   "add_itt_providers.rb",

--- a/lib/tasks/courses.rake
+++ b/lib/tasks/courses.rake
@@ -1,6 +1,15 @@
 namespace :courses do
   desc "Update courses"
   task update: :environment do
+    %w[
+      leadership
+      specialist
+      support
+      ehco
+    ].each do |name|
+      FactoryBot.create(:course_group, name:)
+    end
+
     CourseService::DefinitionLoader.call
   end
 end

--- a/terraform/application/config/review.tfvars.json
+++ b/terraform/application/config/review.tfvars.json
@@ -4,6 +4,6 @@
     "environment": "review",
     "deploy_azure_backing_services": false,
     "enable_postgres_ssl" : false,
-    "command": ["/bin/sh", "-c", "RAILS_ENV=review bundle exec rails db:environment:set db:schema:load db:seed && bundle exec rails server -b 0.0.0.0"],
+    "command": ["/bin/sh", "-c", "RAILS_ENV=review bundle exec rails db:environment:set db:schema:load && bundle exec rake courses:update && bundle exec rails server -b 0.0.0.0"],
     "enable_logit": true
 }


### PR DESCRIPTION
[Jira-3767](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345%2Cunassigned&selectedIssue=CPDLP-3767)

### Context

The review apps have become increasingly flakey, often failing to deploy for either timeouts or seed failures. We want to fix this to make them more reliable.

### Changes proposed in this pull request

- Prevent double-seeding the review apps

We currently run `db:seed` when the container boots and then immediately run a `db:seed:replant` in the following github action step. This can cause the healthcheck to fail as the courses are purged until the replant re-adds them. It results in the review app deploy being flakey.

Use existing rake task to seed courses on container boot (which will be fast and allow the healthcheck to pass) and then run a replant on the following step to add the remaining data once the container has started. Move course seed to be first so the replant doesn't cause the container to become unhealthy for too long (as the healthcheck checks the course table for data).

If we seed on container boot we may be triple seeding (if the worker seeds on boot, the web instance seeds on boot and then the replant happens immediately after boot) - though I haven't checked if this is the case.