### PR TITLE
Re-instate SHA check on deploy

### DIFF
--- a/bin/smoke
+++ b/bin/smoke
@@ -1,20 +1,35 @@
 #!/usr/bin/env bash
 
-sleep 10 # Allow time for old app instances to drain
-
 url=$1
 if [[ -z $url ]]; then
   echo `date`" - smoke test failed (URL is missing)"
   exit 1
 fi
-response=$(curl -sL $url/healthcheck)
-response_sha=$(jq ".git_commit_sha" <<< $response)
 
 current_commit_sha=\"$2\"
 if [[ -z $current_commit_sha ]]; then
   echo `date`" - smoke test failed (head sha is missing)"
   exit 1
 fi
+
+max_retries=10
+
+for ((i=1; i<=max_retries; i++)); do
+  response=$(curl -sL $url/healthcheck)
+  response_sha=$(jq ".git_commit_sha" <<< $response)
+  
+  if [[ $response_sha == $current_commit_sha ]]; then
+    echo "✅ Correct version deployed"
+    break
+  fi
+
+  if [[ $i -eq $max_retries ]]; then
+    echo "Fail: healthcheck sha is $response_sha but current commit is $current_commit_sha"
+    exit 1
+  fi
+
+  sleep 1 # Wait for 1 second before retrying
+done
 
 response_migration=$(jq ".database.migration_version" <<< $response)
 latest_migration=$(ls db/migrate/ | cut -d "_" -f1 | sort -nr | head -n1)


### PR DESCRIPTION
### Context

We reverted #1905 due to seeing failures in the review app deployments (see #1973). We think these failures were caused by other flakiness/issues with the pipeline, so we want to re-instate the SHA check.

### Changes proposed in this pull request

- Re-instate SHA check on deploy

Re-instate the SHA check on deploy that was removed in case it was causing flakiness; we were seeing failures on the SHA check, but they appear to be related to other issues with the pipeline.

Check the correct SHA is deployed, once per second for a maximum of 10 seconds (to give time for the old pods to drain and new pods to spin up).
