### PR TITLE
Update latest release note formatting

### DIFF
--- a/app/models/release_notes.rb
+++ b/app/models/release_notes.rb
@@ -19,7 +19,7 @@ private
   end
 
   def regexp
-    /^## (.*?)\n\n(.*?)(?=\n##|\z)/m
+    /## (\d{1,2} [A-Za-z]+ \d{4})\n\n([^\n]+)/
   end
 
   def file_content

--- a/app/views/api/guidance/index.html.erb
+++ b/app/views/api/guidance/index.html.erb
@@ -28,7 +28,10 @@
           What's new
         </h2>
         <p class="govuk-body">
-          <%= @latest_release_note.date %>: <%= @latest_release_note.content %>
+          <%= govuk_link_to(@latest_release_note.date, api_guidance_page_path(page: "release-notes", anchor: @latest_release_note.date.parameterize)) %>
+        </p>
+        <p class="govuk-body">
+          <%= @latest_release_note.content %>
         </p>
         <p class="govuk-body">
           <%= govuk_link_to("Browse our latest release notes", api_guidance_page_path(page: "release-notes")) %>

--- a/spec/models/release_notes_spec.rb
+++ b/spec/models/release_notes_spec.rb
@@ -8,11 +8,13 @@ RSpec.describe ReleaseNotes do
 
         If you have any questions or comments...
 
-        ## 2021-10-10
+        ## 13 August 2024
 
-        First note
+        First paragraph
 
-        ## 2021-10-09
+        Second paragraph
+
+        ## 10 August 2024
 
         Second note
 
@@ -20,8 +22,8 @@ RSpec.describe ReleaseNotes do
     )
 
     latest = release_notes.latest
-    expect(latest.date).to eq("2021-10-10")
-    expect(latest.content).to eq("First note")
+    expect(latest.date).to eq("13 August 2024")
+    expect(latest.content).to eq("First paragraph")
   end
 
   it "parses release notes from a file" do


### PR DESCRIPTION
[Jira-3745](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345%2Cunassigned&selectedIssue=CPDLP-3745)

### Context

We want to update the latest release note formatting so that it's more user friendly.

### Changes proposed in this pull request

- Update latest release note formatting

Split date into new paragraph above release note text and link directly to the full release note. Only display the first paragraph of the release note under "What's new".

### Guidance to review

[Link to latest release note](https://npq-registration-review-1985-web.test.teacherservices.cloud/api/guidance)

<img width="946" alt="Screenshot 2024-11-18 at 13 54 48" src="https://github.com/user-attachments/assets/bb35a71b-1f2d-46c6-b082-e25ae444a631">
