### PR TITLE
Add `significantly_updated_at` attribute to `User`

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -54,7 +54,7 @@ class User < ApplicationRecord
 
   enum email_updates_status: EMAIL_UPDATES_ALL_STATES, _suffix: true
 
-  attr_accessor :version_note
+  attr_accessor :version_note, :skip_touch_significantly_updated_at
 
   def latest_participant_outcome(lead_provider, course_identifier)
     declarations.eligible_for_outcomes(lead_provider, course_identifier)
@@ -216,6 +216,8 @@ class User < ApplicationRecord
 private
 
   def touch_significantly_updated_at
+    return if skip_touch_significantly_updated_at
+
     changed_attributes = saved_changes.keys
 
     explicitly_updating_significantly_updated_at = changed_attributes.include?("significantly_updated_at")

--- a/app/serializers/api/application_serializer.rb
+++ b/app/serializers/api/application_serializer.rb
@@ -35,7 +35,7 @@ module API
       field(:created_at)
       field(:updated_at) do |a|
         [
-          a.user.updated_at,
+          a.user.significantly_updated_at,
           a.updated_at,
         ].compact.max
       end

--- a/app/serializers/api/participant_serializer.rb
+++ b/app/serializers/api/participant_serializer.rb
@@ -145,7 +145,7 @@ module API
           (
             (user.participant_id_changes || []).map(&:updated_at) +
             (user.applications || []).map(&:updated_at) +
-            [user.updated_at]
+            [user.significantly_updated_at]
           ).compact.max
         end
       end

--- a/app/services/applications/query.rb
+++ b/app/services/applications/query.rb
@@ -70,7 +70,7 @@ module Applications
       return if ignore?(filter: updated_since)
 
       applications_updated_since = Application.where(updated_at: updated_since..)
-      users_updated_since = Application.where(user: { updated_at: updated_since.. })
+      users_updated_since = Application.where(user: { significantly_updated_at: updated_since.. })
       scope.merge!(applications_updated_since.or(users_updated_since))
     end
 

--- a/app/services/migration/migrators/user.rb
+++ b/app/services/migration/migrators/user.rb
@@ -58,12 +58,14 @@ module Migration::Migrators
           active_alert: npq_application.active_alert || user.active_alert,
           trn_verified:,
           created_at: ecf_user.created_at,
+          updated_at: ecf_user.updated_at,
           significantly_updated_at: ecf_user.updated_at,
           version_note: "Changes migrated from ECF to NPQ",
         }
 
         if touch_updated_at?(attrs, npq_application)
           attrs[:significantly_updated_at] = Time.zone.now
+          attrs[:updated_at] = Time.zone.now
         end
 
         user.update!(attrs)

--- a/app/services/migration/migrators/user.rb
+++ b/app/services/migration/migrators/user.rb
@@ -68,7 +68,7 @@ module Migration::Migrators
           attrs[:updated_at] = Time.zone.now
         end
 
-        user.update!(attrs)
+        user.update!(attrs.merge(skip_touch_significantly_updated_at: true))
       end
     end
 

--- a/app/services/migration/migrators/user.rb
+++ b/app/services/migration/migrators/user.rb
@@ -58,12 +58,12 @@ module Migration::Migrators
           active_alert: npq_application.active_alert || user.active_alert,
           trn_verified:,
           created_at: ecf_user.created_at,
-          updated_at: ecf_user.updated_at,
+          significantly_updated_at: ecf_user.updated_at,
           version_note: "Changes migrated from ECF to NPQ",
         }
 
         if touch_updated_at?(attrs, npq_application)
-          attrs[:updated_at] = Time.zone.now
+          attrs[:significantly_updated_at] = Time.zone.now
         end
 
         user.update!(attrs)

--- a/app/services/participants/query.rb
+++ b/app/services/participants/query.rb
@@ -37,7 +37,7 @@ module Participants
     def where_updated_since(updated_since)
       return if ignore?(filter: updated_since)
 
-      users_updated_since = User.where(updated_at: updated_since..)
+      users_updated_since = User.where(significantly_updated_at: updated_since..)
       applications_updated_since = User.where(applications: { updated_at: updated_since.. })
       participant_id_changes_updated_since = User.where(participant_id_changes: { updated_at: updated_since.. })
       scope.merge!(users_updated_since.or(applications_updated_since).or(participant_id_changes_updated_since))

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -258,3 +258,4 @@ shared:
     - email_updates_status
     - email_updates_unsubscribe_key
     - archived_at
+    - significantly_updated_at

--- a/db/migrate/20241119074851_add_significantly_updated_at_to_users.rb
+++ b/db/migrate/20241119074851_add_significantly_updated_at_to_users.rb
@@ -1,0 +1,6 @@
+class AddSignificantlyUpdatedAtToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :significantly_updated_at, :datetime, null: false, default: -> { "CURRENT_TIMESTAMP" }
+    add_index :users, :significantly_updated_at
+  end
+end

--- a/db/migrate/20241122155145_backfill_significantly_updated_at.rb
+++ b/db/migrate/20241122155145_backfill_significantly_updated_at.rb
@@ -1,0 +1,7 @@
+class BackfillSignificantlyUpdatedAt < ActiveRecord::Migration[7.1]
+  def up
+    User.in_batches do |batch|
+      batch.update_all("significantly_updated_at = updated_at")
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -541,9 +541,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_20_082433) do
     t.string "email_updates_unsubscribe_key"
     t.string "archived_email"
     t.datetime "archived_at"
+    t.datetime "significantly_updated_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.index ["ecf_id"], name: "index_users_on_ecf_id", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["provider"], name: "index_users_on_provider"
+    t.index ["significantly_updated_at"], name: "index_users_on_significantly_updated_at"
     t.index ["uid"], name: "index_users_on_uid", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_11_20_082433) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_22_155145) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,6 +5,11 @@ FactoryBot.define do
     trn { sprintf("%07i", Random.random_number(9_999_999)) }
     date_of_birth { 30.years.ago }
     ecf_id { SecureRandom.uuid }
+    significantly_updated_at { Time.zone.now }
+
+    trait :without_significantly_updated_at do
+      significantly_updated_at { nil }
+    end
 
     trait :with_get_an_identity_id do
       transient do

--- a/spec/lib/services/handle_submission_for_store_spec.rb
+++ b/spec/lib/services/handle_submission_for_store_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe HandleSubmissionForStore do
 
   describe "#call" do
     def stable_as_json(record)
-      record.as_json(except: %i[id created_at updated_at updated_from_tra_at DEPRECATED_school_urn email_updates_status email_updates_unsubscribe_key])
+      record.as_json(except: %i[id created_at updated_at significantly_updated_at updated_from_tra_at DEPRECATED_school_urn email_updates_status email_updates_unsubscribe_key])
     end
 
     context "when store includes information from the school path" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -129,6 +129,14 @@ RSpec.describe User do
       user.update!(significant_change.merge(significantly_updated_at:))
       expect(user.significantly_updated_at).to be_within(1.second).of(significantly_updated_at)
     end
+
+    context "when skip_touch_user_if_changed is true" do
+      before { user.skip_touch_significantly_updated_at = true }
+
+      it "does not update significantly_updated_at" do
+        expect { user.touch(time: 1.day.from_now) }.not_to(change { user.reload.significantly_updated_at })
+      end
+    end
   end
 
   describe ".latest_participant_outcome" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -96,6 +96,41 @@ RSpec.describe User do
     it { expect(User.new).not_to be_null_user }
   end
 
+  describe "touch_significantly_updated_at" do
+    let(:user) { travel_to(1.day.ago) { create(:user) } }
+    let(:significant_change) { { full_name: "New Name" } }
+    let(:insignificant_change) { { raw_tra_provider_data: { foo: :bar } } }
+
+    it "sets significantly_updated_at on creation" do
+      expect(user.significantly_updated_at).to be_present
+    end
+
+    it "sets significantly_updated_at when a significant change is made" do
+      expect { user.update!(significant_change) }.to(change { user.reload.significantly_updated_at })
+      expect(user.significantly_updated_at).to eq(user.updated_at)
+    end
+
+    it "sets significantly_updated_at when a significant change is made alongside an insignificant change" do
+      expect { user.update!(significant_change.merge(insignificant_change)) }.to(change { user.reload.significantly_updated_at })
+      expect(user.significantly_updated_at).to eq(user.updated_at)
+    end
+
+    it "does not update significantly_updated_at when an insignificant change is made" do
+      expect { user.update!(insignificant_change) }.not_to(change { user.reload.significantly_updated_at })
+    end
+
+    it "updates significantly_updated_at when touched" do
+      expect { user.touch(time: 1.day.from_now) }.to(change { user.reload.significantly_updated_at })
+      expect(user.significantly_updated_at).to eq(user.updated_at)
+    end
+
+    it "does not override significantly_updated_at when setting it explicitly" do
+      significantly_updated_at = 1.month.from_now
+      user.update!(significant_change.merge(significantly_updated_at:))
+      expect(user.significantly_updated_at).to be_within(1.second).of(significantly_updated_at)
+    end
+  end
+
   describe ".latest_participant_outcome" do
     let(:user) { create(:user) }
     let(:lead_provider) { participant_outcome.lead_provider }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe User do
   end
 
   describe "touch_significantly_updated_at" do
-    let(:user) { travel_to(1.day.ago) { create(:user) } }
+    let(:user) { travel_to(1.day.ago) { create(:user, :without_significantly_updated_at) } }
     let(:significant_change) { { full_name: "New Name" } }
     let(:insignificant_change) { { raw_tra_provider_data: { foo: :bar } } }
 

--- a/spec/serializers/api/application_serializer_spec.rb
+++ b/spec/serializers/api/application_serializer_spec.rb
@@ -230,6 +230,7 @@ RSpec.describe API::ApplicationSerializer, type: :serializer do
       end
 
       it "serializes the `updated_at`" do
+        user.significantly_updated_at = Time.utc(2023, 7, 2, 11, 0, 0)
         application.updated_at = Time.utc(2023, 7, 2, 12, 0, 0)
 
         expect(attributes["updated_at"]).to eq("2023-07-02T12:00:00Z")
@@ -238,7 +239,7 @@ RSpec.describe API::ApplicationSerializer, type: :serializer do
       context "when the user was updated after the application" do
         it "serializes the `updated_at` as the user's updated_at" do
           application.updated_at = Time.utc(2023, 7, 2, 12, 0, 0)
-          user.updated_at = Time.utc(2024, 7, 2, 12, 0, 0)
+          user.significantly_updated_at = Time.utc(2024, 7, 2, 12, 0, 0)
 
           expect(attributes["updated_at"]).to eq("2024-07-02T12:00:00Z")
         end

--- a/spec/serializers/api/participant_serializer_spec.rb
+++ b/spec/serializers/api/participant_serializer_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe API::ParticipantSerializer, type: :serializer do
           it "serializes the `updated_at`" do
             application.update!(updated_at: old_datetime)
             participant_id_change.update!(updated_at: old_datetime)
-            participant.update!(updated_at: latest_datetime)
+            participant.update!(significantly_updated_at: latest_datetime)
 
             expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
           end
@@ -89,7 +89,7 @@ RSpec.describe API::ParticipantSerializer, type: :serializer do
           it "returns application's `updated_at`" do
             application.update!(updated_at: latest_datetime)
             participant_id_change.update!(updated_at: old_datetime)
-            participant.update!(updated_at: old_datetime)
+            participant.update!(significantly_updated_at: old_datetime)
 
             expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
           end
@@ -99,7 +99,7 @@ RSpec.describe API::ParticipantSerializer, type: :serializer do
           it "returns participant_id_change's `updated_at`" do
             application.update!(updated_at: old_datetime)
             participant_id_change.update!(updated_at: latest_datetime)
-            participant.update!(updated_at: old_datetime)
+            participant.update!(significantly_updated_at: old_datetime)
 
             expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
           end
@@ -142,7 +142,7 @@ RSpec.describe API::ParticipantSerializer, type: :serializer do
           it "serializes the `updated_at`" do
             application.update!(updated_at: old_datetime)
             participant_id_change.update!(updated_at: old_datetime)
-            participant.update!(updated_at: latest_datetime)
+            participant.update!(significantly_updated_at: latest_datetime)
 
             expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
           end
@@ -152,7 +152,7 @@ RSpec.describe API::ParticipantSerializer, type: :serializer do
           it "returns application's `updated_at`" do
             application.update!(updated_at: latest_datetime)
             participant_id_change.update!(updated_at: old_datetime)
-            participant.update!(updated_at: old_datetime)
+            participant.update!(significantly_updated_at: old_datetime)
 
             expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
           end
@@ -162,7 +162,7 @@ RSpec.describe API::ParticipantSerializer, type: :serializer do
           it "returns participant_id_change's `updated_at`" do
             application.update!(updated_at: old_datetime)
             participant_id_change.update!(updated_at: latest_datetime)
-            participant.update!(updated_at: old_datetime)
+            participant.update!(significantly_updated_at: old_datetime)
 
             expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
           end
@@ -226,7 +226,7 @@ RSpec.describe API::ParticipantSerializer, type: :serializer do
           it "serializes the `updated_at`" do
             application.update!(updated_at: old_datetime)
             participant_id_change.update!(updated_at: old_datetime)
-            participant.update!(updated_at: latest_datetime)
+            participant.update!(significantly_updated_at: latest_datetime)
 
             expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
           end
@@ -236,7 +236,7 @@ RSpec.describe API::ParticipantSerializer, type: :serializer do
           it "returns application's `updated_at`" do
             application.update!(updated_at: latest_datetime)
             participant_id_change.update!(updated_at: old_datetime)
-            participant.update!(updated_at: old_datetime)
+            participant.update!(significantly_updated_at: old_datetime)
 
             expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
           end
@@ -246,7 +246,7 @@ RSpec.describe API::ParticipantSerializer, type: :serializer do
           it "returns participant_id_change's `updated_at`" do
             application.update!(updated_at: old_datetime)
             participant_id_change.update!(updated_at: latest_datetime)
-            participant.update!(updated_at: old_datetime)
+            participant.update!(significantly_updated_at: old_datetime)
 
             expect(attributes["updated_at"]).to eq(latest_datetime.rfc3339)
           end

--- a/spec/services/applications/query_spec.rb
+++ b/spec/services/applications/query_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Applications::Query do
             query = described_class.new(lead_provider:, updated_since: 7.days.ago)
             expect(query.applications).to contain_exactly(application2)
 
-            application1.user.update!(updated_at: 1.day.ago)
+            application1.user.update!(updated_at: 12.days.ago, significantly_updated_at: 1.day.ago)
 
             query = described_class.new(lead_provider:, updated_since: 2.days.ago)
             expect(query.applications).to contain_exactly(application1)

--- a/spec/services/migration/migrators/user_spec.rb
+++ b/spec/services/migration/migrators/user_spec.rb
@@ -240,12 +240,14 @@ RSpec.describe Migration::Migrators::User do
 
             user = ::User.find_by_ecf_id!(ecf_resource1.id)
             expect(user.created_at.to_s).to eq(created_at.to_s)
+            expect(user.updated_at.to_s).to eq(updated_at.to_s)
             expect(user.significantly_updated_at.to_s).to eq(updated_at.to_s)
 
             version = user.versions.last
             expect(version.note).to eq("Changes migrated from ECF to NPQ")
             expect(version.object_changes["created_at"].last).to eq(created_at.iso8601(3))
             expect(version.object_changes["significantly_updated_at"].last).to eq(updated_at.iso8601(3))
+            expect(version.object_changes["updated_at"].last).to eq(updated_at.iso8601(3))
           end
         end
 
@@ -264,6 +266,7 @@ RSpec.describe Migration::Migrators::User do
                 user = ::User.find_by_ecf_id!(ecf_resource1.id)
                 expect(user.created_at.to_s).to eq(created_at.to_s)
                 expect(user.significantly_updated_at.to_s).to eq(Time.zone.now.to_s)
+                expect(user.updated_at.to_s).to eq(Time.zone.now.to_s)
               end
             end
           end
@@ -278,6 +281,7 @@ RSpec.describe Migration::Migrators::User do
                 user = ::User.find_by_ecf_id!(ecf_resource1.id)
                 expect(user.created_at.to_s).to eq(created_at.to_s)
                 expect(user.significantly_updated_at.to_s).to eq(Time.zone.now.to_s)
+                expect(user.updated_at.to_s).to eq(Time.zone.now.to_s)
               end
             end
           end
@@ -295,6 +299,7 @@ RSpec.describe Migration::Migrators::User do
               user = ::User.find_by_ecf_id!(ecf_resource1.id)
               expect(user.created_at.to_s).to eq(created_at.to_s)
               expect(user.significantly_updated_at.to_s).to eq(Time.zone.now.to_s)
+              expect(user.updated_at.to_s).to eq(Time.zone.now.to_s)
             end
           end
         end

--- a/spec/services/migration/migrators/user_spec.rb
+++ b/spec/services/migration/migrators/user_spec.rb
@@ -240,12 +240,12 @@ RSpec.describe Migration::Migrators::User do
 
             user = ::User.find_by_ecf_id!(ecf_resource1.id)
             expect(user.created_at.to_s).to eq(created_at.to_s)
-            expect(user.updated_at.to_s).to eq(updated_at.to_s)
+            expect(user.significantly_updated_at.to_s).to eq(updated_at.to_s)
 
             version = user.versions.last
             expect(version.note).to eq("Changes migrated from ECF to NPQ")
             expect(version.object_changes["created_at"].last).to eq(created_at.iso8601(3))
-            expect(version.object_changes["updated_at"].last).to eq(updated_at.iso8601(3))
+            expect(version.object_changes["significantly_updated_at"].last).to eq(updated_at.iso8601(3))
           end
         end
 
@@ -263,7 +263,7 @@ RSpec.describe Migration::Migrators::User do
 
                 user = ::User.find_by_ecf_id!(ecf_resource1.id)
                 expect(user.created_at.to_s).to eq(created_at.to_s)
-                expect(user.updated_at.to_s).to eq(Time.zone.now.to_s)
+                expect(user.significantly_updated_at.to_s).to eq(Time.zone.now.to_s)
               end
             end
           end
@@ -277,7 +277,7 @@ RSpec.describe Migration::Migrators::User do
 
                 user = ::User.find_by_ecf_id!(ecf_resource1.id)
                 expect(user.created_at.to_s).to eq(created_at.to_s)
-                expect(user.updated_at.to_s).to eq(Time.zone.now.to_s)
+                expect(user.significantly_updated_at.to_s).to eq(Time.zone.now.to_s)
               end
             end
           end
@@ -294,7 +294,7 @@ RSpec.describe Migration::Migrators::User do
 
               user = ::User.find_by_ecf_id!(ecf_resource1.id)
               expect(user.created_at.to_s).to eq(created_at.to_s)
-              expect(user.updated_at.to_s).to eq(Time.zone.now.to_s)
+              expect(user.significantly_updated_at.to_s).to eq(Time.zone.now.to_s)
             end
           end
         end

--- a/spec/services/participants/query_spec.rb
+++ b/spec/services/participants/query_spec.rb
@@ -89,6 +89,9 @@ RSpec.describe Participants::Query do
           it "filters by updated since" do
             travel_to(2.days.ago) do
               create(:user, :with_application, lead_provider:)
+              # User where the updated_at is in the filter range, but the
+              # significantly_updated_at is not.
+              create(:user).tap { |user| user.update_column(:updated_at, 2.days.from_now) }
             end
 
             expect(query.participants).to contain_exactly(participant1, participant2)

--- a/spec/support/helpers/journey_helper.rb
+++ b/spec/support/helpers/journey_helper.rb
@@ -9,11 +9,11 @@ module Helpers
     end
 
     def retrieve_latest_application_user_data
-      latest_application_user&.as_json(except: %i[id feature_flag_id created_at updated_at updated_from_tra_at email_updates_status email_updates_unsubscribe_key])
+      latest_application_user&.as_json(except: %i[id feature_flag_id created_at updated_at significantly_updated_at updated_from_tra_at email_updates_status email_updates_unsubscribe_key])
     end
 
     def retrieve_latest_application_data
-      latest_application&.as_json(except: %i[id created_at updated_at user_id DEPRECATED_school_urn DEPRECATED_private_childcare_provider_urn DEPRECATED_itt_provider])
+      latest_application&.as_json(except: %i[id created_at updated_at significantly_updated_at user_id DEPRECATED_school_urn DEPRECATED_private_childcare_provider_urn DEPRECATED_itt_provider])
     end
 
     def deep_compare_application_data(expected_data)


### PR DESCRIPTION
[Jira-3747](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=unassigned%2C712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3747)

### Context

At the moment, we use the `User#updated_at` to surface changes to lead providers via the API. The issue with this is that actions/changes that lead providers don't care about result in the user being marked as 'updated'. Instead, we want to have an additional `updated_at` attribute that we can use to surface the changes lead providers care about to the underlying `User` model.

### Changes proposed in this pull request

- Add significantly_udpated_at attribute to User 

We have an `updated_at` on the `User` model, however this is updated frequently and for actions that lead providers don't need to care about (such as when a user signs in).

We want to add a second `updarted_at` attribute that only updates when something significant changes with the `User`, such as their name, TRN, etc.

As the `Application` can touch a `User` we also need this attribute to update when the user is touched.

I opted for `significantly_updated_at` as the attribute name as opposed to `api_updated_at` to try and keep it more generic in case we want to surface it elsewhere.

Index the field to ensure endpoints that filter by `updated_at` will be performant when we switch them to  significantly_updated_at`.

- Switch User migrator to populate significantly_updated_at

We want to populate `significantly_udpated_at` instead of `updated_at` as we will be exposing this attribute in the serializers for the lead provider API.

- Update Participants::Query to use significantly_udpated_at

We want to filter by the `significantly_updated_at` attribute instead of the `updated_at` attribute when querying users for the lead provider API. This will prevent insignificant changes to a `User` resulting in them being re-surfaced in the API.

- Update ParticipantSerializer to use significant_updated_at

We want to surface the `sigificant_updated_at` attribute of participants in the lead provider API responses so that providers only see changes/updates when something they care about has changed with the user.

### Guidance to review

As it stands any users already in the NPQ reg database that aren't touched as part of the migration will end up with a default `significantly_updated_at` time of 'now' (when we roll this out). Do we want to backfill to match with the user `updated_at` for these records?
