### PR TITLE
Fix migration race condition

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ gem "sprockets-rails", require: "sprockets/railtie"
 gem "state_machines-activerecord"
 gem "stimulus-rails"
 gem "whenever"
+gem "with_advisory_lock"
 
 gem "net-imap", "~> 0.5.1", require: false
 gem "net-pop", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -676,6 +676,9 @@ GEM
     websocket-extensions (0.1.5)
     whenever (1.0.0)
       chronic (>= 0.6.3)
+    with_advisory_lock (5.1.0)
+      activerecord (>= 6.1)
+      zeitwerk (>= 2.6)
     with_model (2.1.7)
       activerecord (>= 6.0)
     xpath (3.2.0)
@@ -778,6 +781,7 @@ DEPENDENCIES
   web-console (>= 3.3.0)
   webmock (~> 3.24)
   whenever
+  with_advisory_lock
   with_model (~> 2.1, >= 2.1.7)
 
 RUBY VERSION

--- a/spec/services/migration/coordinator_spec.rb
+++ b/spec/services/migration/coordinator_spec.rb
@@ -18,11 +18,14 @@ RSpec.describe Migration::Coordinator do
   describe "#migrate!" do
     subject(:migrate) { instance.migrate! }
 
-    it "runs the next runnable migrator" do
+    it "queues the next runnable migrators" do
       allow(described_class.migrators.first).to receive(:runnable?).and_return(false)
       allow(described_class.migrators.second).to receive(:runnable?).and_return(true)
+      allow(described_class.migrators.last).to receive(:runnable?).and_return(true)
 
+      expect(described_class.migrators.first).not_to receive(:queue)
       expect(described_class.migrators.second).to receive(:queue)
+      expect(described_class.migrators.last).to receive(:queue)
 
       migrate
     end


### PR DESCRIPTION
[Jira-3785](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=unassigned%2C712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345&selectedIssue=CPDLP-3785)

### Context

We occasionally find that the migration run stalls part way through; there are no job failures but also no active/in-progress jobs, which suggests there is a race condition around the logic for queueing the next set of workers. This seems to have become more prominent since we added the `run_once_post_migration` functionality.

### Changes proposed in this pull request

- Fix migration race condition

I believe the race condition occurs around how we check for the last worker and then updated the `completed_at` for the current worker; if the last two workers perform the check at the same time it could result in both of them believing they are not the last worker and they finish without queueing the follow up migration. Similarly, we could end up running the post-migration task multiple times in other timing scenarios.

To fix this we can wrap the check/completed_at update in a lock. We can also use locking in the coordinator so that we can queue multiple runnable migrators simultaneously and improve throughput (we avoided this previously as we found it can end up queueing the same migrator multiple times due to a race condition, but we have avoided that here with locking).

### Guidance for review

I've ran this 4 times in the migration environment and it completed each time. There were sometimes a few failures due to the cached plan issue we sometimes see, but this is expected. There is 1 user failure that seems like bad data:

```
? 'Validation failed: User not found with ecf_id or gai_id, user found with ecf_user_email.
  this user has a linked ecf_user which is not an orphan'
: - 0f1287d9-6911-449c-93e8-8ac717b89e7a
```
<img width="500" alt="Screenshot 2024-11-20 at 13 16 42" src="https://github.com/user-attachments/assets/1e241930-b50e-4bf5-b07c-b302881082ad">