### PR TITLE
[CPDLP-3730] Add `discard_on` method instead of `max_attempts` to jobs

### DIFF
--- a/app/jobs/crons/batch_send_latest_outcomes_job.rb
+++ b/app/jobs/crons/batch_send_latest_outcomes_job.rb
@@ -8,16 +8,16 @@ class Crons::BatchSendLatestOutcomesJob < CronJob
 
   sentry_monitor_check_ins slug: "batch-send-latest-outcomes"
 
+  discard_on StandardError do |_job, exception|
+    Sentry.capture_exception(exception)
+  end
+
   def perform(batch_size = DEFAULT_BATCH_SIZE)
     outcomes.first(batch_size).each { |outcome| SendToQualifiedTeachersAPIJob.perform_later(participant_outcome_id: outcome.id) }
   end
 
   def queue_name
     "participant_outcomes"
-  end
-
-  def max_attempts
-    1
   end
 
 private

--- a/app/jobs/migration_job.rb
+++ b/app/jobs/migration_job.rb
@@ -1,8 +1,8 @@
 class MigrationJob < ApplicationJob
   queue_as :migration
 
-  def max_attempts
-    1
+  discard_on StandardError do |_job, exception|
+    Sentry.capture_exception(exception)
   end
 
   def perform

--- a/app/jobs/migrator_job.rb
+++ b/app/jobs/migrator_job.rb
@@ -1,8 +1,8 @@
 class MigratorJob < ApplicationJob
   queue_as :migration
 
-  def max_attempts
-    1
+  discard_on StandardError do |_job, exception|
+    Sentry.capture_exception(exception)
   end
 
   def perform(migrator:, worker:)

--- a/spec/jobs/migration_job_spec.rb
+++ b/spec/jobs/migration_job_spec.rb
@@ -1,24 +1,51 @@
 require "rails_helper"
 
 RSpec.describe MigrationJob do
-  let(:instance) { described_class.new }
+  let(:coordinator_double) { instance_double(Migration::Coordinator, migrate!: nil) }
+
+  before { allow(Migration::Coordinator).to receive(:new).and_return(coordinator_double) }
 
   describe "#perform" do
-    subject(:perform_migration) { instance.perform }
-
-    let(:coordinator_double) { instance_double(Migration::Coordinator, migrate!: nil) }
-
-    before { allow(Migration::Coordinator).to receive(:new).and_return(coordinator_double) }
+    subject(:job) { described_class.new.perform }
 
     it "triggers a migration" do
-      perform_migration
+      job
+
       expect(coordinator_double).to have_received(:migrate!).once
     end
   end
 
   describe "#perform_later" do
-    it "enqueues the job exactly once on migration queue" do
-      expect { described_class.perform_later }.to have_enqueued_job(described_class).exactly(:once).on_queue("migration")
+    subject(:job) { described_class.perform_later }
+
+    before do
+      allow(coordinator_double).to receive(:migrate!).and_return(true)
+      allow(Rails.logger).to receive(:warn)
+      allow(Sentry).to receive(:capture_exception).and_return(true)
+    end
+
+    it "enqueues the job exactly once" do
+      expect { job }.to have_enqueued_job(described_class).exactly(:once).on_queue("migration")
+    end
+
+    context "with valid job" do
+      before do
+        perform_enqueued_jobs { job }
+      end
+
+      it { expect(Sentry).not_to have_received(:capture_exception) }
+      it { expect(Delayed::Job.count).to be_zero }
+    end
+
+    context "with invalid job" do
+      before do
+        allow(coordinator_double).to receive(:migrate!).and_raise(ActiveRecord::RecordInvalid)
+
+        perform_enqueued_jobs { job }
+      end
+
+      it { expect(Sentry).to have_received(:capture_exception) }
+      it { expect(Delayed::Job.count).to be_zero }
     end
   end
 end

--- a/spec/jobs/migrator_job_spec.rb
+++ b/spec/jobs/migrator_job_spec.rb
@@ -1,25 +1,52 @@
 require "rails_helper"
 
-RSpec.describe MigratorJob do
-  let(:instance) { described_class.new }
+RSpec.describe MigratorJob, type: :job do
   let(:migrator) { Migration::Migrators::Cohort }
   let(:worker) { 0 }
 
   describe "#perform" do
-    subject(:perform_migration) { instance.perform(migrator:, worker:) }
+    subject(:job) { described_class.new.perform(migrator:, worker:) }
 
     before { Migration::Migrators::Cohort.prepare! }
 
     it "runs a migrator" do
       expect(migrator).to receive(:call).with(worker:).once
 
-      perform_migration
+      job
     end
   end
 
   describe "#perform_later" do
-    it "enqueues the job exactly once on migration queue" do
-      expect { described_class.perform_later(migrator:, worker:) }.to have_enqueued_job(described_class).exactly(:once).on_queue("migration")
+    subject(:job) { described_class.perform_later(migrator:, worker:) }
+
+    before do
+      allow(migrator).to receive(:call).and_return(true)
+      allow(Rails.logger).to receive(:warn)
+      allow(Sentry).to receive(:capture_exception).and_return(true)
+    end
+
+    it "enqueues the job exactly once" do
+      expect { job }.to have_enqueued_job(described_class).exactly(:once).on_queue("migration")
+    end
+
+    context "with valid job" do
+      before do
+        perform_enqueued_jobs { job }
+      end
+
+      it { expect(Sentry).not_to have_received(:capture_exception) }
+      it { expect(Delayed::Job.count).to be_zero }
+    end
+
+    context "with invalid job" do
+      before do
+        allow(migrator).to receive(:call).and_raise(ActiveRecord::RecordInvalid)
+
+        perform_enqueued_jobs { job }
+      end
+
+      it { expect(Sentry).to have_received(:capture_exception) }
+      it { expect(Delayed::Job.count).to be_zero }
     end
   end
 end


### PR DESCRIPTION
### Context

Ticket: [CPDLP-3730](https://dfedigital.atlassian.net/browse/CPDLP-3730)

The `max_attempts` method doesn’t work currently in the Active jobs in NPQ. We need to use `discard_on` method instead.

### Changes proposed in this pull request

Add `discard_on` method instead of `max_attempts` to jobs.