### PR TITLE
Add some fields from raw application data to analytics

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -199,6 +199,14 @@ class Application < ApplicationRecord
     declarations.completed.billable_or_voidable.latest_first.first&.participant_outcomes&.latest&.state
   end
 
+  def send_event(type, data)
+    allowed_attributes = %w[senco_in_role senco_in_role_status senco_start_date trn]
+    filtered_data = data[:data]["raw_application_data"].slice(*allowed_attributes)
+    data[:data]["raw_application_data"] = filtered_data
+
+    super
+  end
+
 private
 
   def funding_eligibility(with_funded_place:)

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -236,6 +236,7 @@ shared:
     - schedule_id
     - referred_by_return_to_teaching_adviser
     - accepted_at
+    - raw_application_data
   :users:
     - id
     - created_at

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -99,7 +99,6 @@ shared:
     - archived_email
     - raw_tra_provider_data
   :applications:
-    - raw_application_data
     - DEPRECATED_school_urn
     - DEPRECATED_private_childcare_provider_urn
     - DEPRECATED_itt_provider

--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -57,4 +57,5 @@ DfE::Analytics.configure do |config|
   config.excluded_models_proc = proc { |x| x.to_s =~ /Migration::/ }
 
   config.entity_table_checks_enabled = true
+  config.excluded_paths = ["/healthcheck"]
 end

--- a/spec/requests/dfe_analytics_spec.rb
+++ b/spec/requests/dfe_analytics_spec.rb
@@ -8,4 +8,8 @@ RSpec.describe "DfE Analytics", type: :request do
   it "does send DFE Analytics web request events" do
     expect { get root_path }.to have_sent_analytics_event_types(:web_request)
   end
+
+  it "does not send DFE Analytics web request events for healthcheck" do
+    expect { get "/healthcheck" }.not_to have_sent_analytics_event_types(:web_request)
+  end
 end


### PR DESCRIPTION
Adds `senco_in_role`, `senco_in_role_status`, `senco_start_date`, `trn` to analytics from `raw_application_data`.