### PR TITLE
Disable nightly migration

### DIFF
--- a/.github/workflows/refresh_migration_database.yml
+++ b/.github/workflows/refresh_migration_database.yml
@@ -9,8 +9,9 @@ on:
         options:
           - production
         required: true
-  schedule:
-    - cron: "0 0 * * *" # Run at midnight.
+  # TEMP: disable while we do parity check analysis
+  # schedule:
+  #   - cron: "0 0 * * *" # Run at midnight.
 
 jobs:
   refresh-migration-db:

--- a/.github/workflows/run_nightly_migration.yml
+++ b/.github/workflows/run_nightly_migration.yml
@@ -10,8 +10,9 @@ on:
         options:
           - production
         required: true
-  schedule:
-    - cron: "30 0 * * *" # Run at 12:30am, daily
+  # TEMP: disable while we do parity check analysis
+  # schedule:
+  #   - cron: "30 0 * * *" # Run at 12:30am, daily
 
 jobs:
   run_migration:


### PR DESCRIPTION
We are kicking off a parity check and want to see the results in the morning.

Disable nightly migration to avoid wiping the results.
