### PR TITLE
Fix bug in filtering in `Participants::Query`

### DIFF
--- a/app/services/participants/query.rb
+++ b/app/services/participants/query.rb
@@ -38,8 +38,8 @@ module Participants
       return if ignore?(filter: updated_since)
 
       users_updated_since = User.where(significantly_updated_at: updated_since..)
-      applications_updated_since = User.where(applications: { updated_at: updated_since.. })
-      participant_id_changes_updated_since = User.where(participant_id_changes: { updated_at: updated_since.. })
+      applications_updated_since = User.where(id: Application.where(updated_at: updated_since..).select(:user_id))
+      participant_id_changes_updated_since = User.where(id: ParticipantIdChange.where(updated_at: updated_since..).select(:user_id))
       scope.merge!(users_updated_since.or(applications_updated_since).or(participant_id_changes_updated_since))
     end
 


### PR DESCRIPTION
[Jira-3798](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?assignee=712020%3A5b5839dc-e4d6-4df5-9dd6-627cc49fe345%2Cunassigned&selectedIssue=CPDLP-3798)

### Context

When we filter on `includes` with ActiveRecord the included table is filtered down to the records that match the conditional. For the `Participants::Query` this means when filtering by `updated_since` the related applications/id
changes are filtered as well as the base users. Instead, we want the users to be filtered but retain all the applications and id changes in the preloaded association.

### Changes proposed in this pull request

- Fix bug in filtering in `Participants::Query`

To achieve this we can instead use a subquery to find the applications/id changes updated within the timeframe and filter on the selected `user_id` of those.

This will be a little less efficient, but is heaps simpler than trying to do an additional join on applications/id changes to try and get Rails to retain them all after filtering.

### Guidance for review

I checked the other queries for similar filtering and couldn't find anywhere else we filter on a to-many relationship that may cause the same issue.