### PR TITLE
Fix `Participants::Query` filtering on `training_status`

### DIFF
--- a/app/services/participants/query.rb
+++ b/app/services/participants/query.rb
@@ -50,7 +50,7 @@ module Participants
         raise API::Errors::FilterValidationError, I18n.t(:invalid_training_status, valid_training_status: Application.training_statuses.keys)
       end
 
-      scope.merge!(Application.where(training_status:))
+      scope.merge!(User.includes(:applications).where(applications: { training_status: }))
     end
 
     def where_from_participant_id_is(from_participant_id)

--- a/spec/services/participants/query_spec.rb
+++ b/spec/services/participants/query_spec.rb
@@ -156,6 +156,20 @@ RSpec.describe Participants::Query do
           end
         end
 
+        context "when the participant has multiple applications with different training statuses" do
+          let(:params) { { training_status: "withdrawn" } }
+
+          before do
+            participant1.applications.first.update!(training_status: ApplicationState.states[:withdrawn])
+            create(:application, :accepted, user: participant1, lead_provider:, training_status: :active)
+          end
+
+          it "filters the users by training status and only returns applications with the matching training status" do
+            expect(query.participants).to contain_exactly(participant1)
+            expect(query.participants.map(&:applications).flatten.map(&:training_status)).to all(eq("withdrawn"))
+          end
+        end
+
         context "when a training status is not supplied" do
           it "does not filter by training status" do
             condition_string = %("training_status")
@@ -192,6 +206,17 @@ RSpec.describe Participants::Query do
 
           it "filters by from participant id" do
             expect(query.participants).to contain_exactly(participant1)
+          end
+        end
+
+        context "when the participant has multiple id changes with different from_participant_id values" do
+          let(:params) { { from_participant_id: } }
+
+          before { create(:participant_id_change, user: participant1, to_participant_id: participant1.ecf_id) }
+
+          it "filters the users by from_participant_id and only returns id changes with the matching from_participant_id" do
+            expect(query.participants).to contain_exactly(participant1)
+            expect(query.participants.map(&:participant_id_changes).flatten.map(&:from_participant_id)).to all(eq(from_participant_id))
           end
         end
 


### PR DESCRIPTION
[Jira-3803](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-3803)

### Context

When filtering participants on `training_status` we were still returning all `applications` in the resulting relationship of each `User`. To be consistent with ECF we want to only return the applications that match the `training_status` we are filtering to.

### Changes proposed in this pull request

- Fix `Participants::Query` filtering on `training_status`

Fix filtering by `training_status` to only return matching applications in the resulting participants.

Add test to verify that filtering by `from_participant_id` behaves in the same way; we only want participant id changes that match the filter to be in the results.