### PR TITLE
[CPDNPQ-2219] Header link to separation admin

### DIFF
--- a/app/views/layouts/shared/_header.html.erb
+++ b/app/views/layouts/shared/_header.html.erb
@@ -1,7 +1,15 @@
 <% service_url = Feature.registration_closed?(current_user) ? "/registration/closed" : "/" %>
 <%=
   govuk_header(service_name: "Register for a national professional qualification", service_url: service_url) do |header|
-    if current_user.actual_user?
+    if current_admin
+      if Feature.ecf_api_disabled?
+        header.with_navigation_item(text: "Legacy Admin", href: admin_path)
+        header.with_navigation_item(text: "Separation Admin", href: npq_separation_admin_path)
+      else
+        header.with_navigation_item(text: "Admin", href: admin_path)
+      end
+      header.with_navigation_item(text: "Sign out", href: sign_out_user_path)
+    elsif current_user.actual_user?
       header.with_navigation_item(href: identity_link_uri(request.original_url), text: "DfE Identity account")
 
       if current_user.applications.any?
@@ -9,9 +17,6 @@
       end
 
       header.with_navigation_item(href: sign_out_user_path, text: "Sign out")
-    elsif current_admin
-      header.with_navigation_item(text: "Admin", href: admin_path)
-      header.with_navigation_item(text: "Sign out", href: sign_out_user_path)
     end
   end
 %>

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -376,4 +376,12 @@ RSpec.feature "admin", :rack_test_driver, type: :feature do
     expect(page).to have_current_path(root_path)
     expect(page).not_to have_link("Sign out")
   end
+
+  scenario "when logged in and ecf_api_disabled feature flag is enabled, it shows links to legacy and npq-separation admin" do
+    Feature.enable_ecf_api_disabled!
+    sign_in_as_admin
+
+    expect(page).to have_link("Legacy Admin", href: admin_path)
+    expect(page).to have_link("Separation Admin", href: npq_separation_admin_path)
+  end
 end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2219

>Post the go-live date of the separation, we will have 2 admin consoles for users: the current NPQ admin console, and the Separation admin console. 
>
>Until they are combined in one admin console, internal users will need to be able to easily switch between the two.
>
>**Suggestions to explore:**
>Adding a link or tile under the heading
>
>**Acceptance criteria/ outcomes**
>Have a way for users to easily switch between the two admin consoles (NPQ admin and separation finance admin) post-separation without having to change the URL manually.

---

### Before

<img width="987" alt="Screenshot 2024-11-25 at 11 34 07" src="https://github.com/user-attachments/assets/d1af0bfd-48cd-4d3c-b909-417c2500ea87">

---

### After

<img width="998" alt="Screenshot 2024-11-25 at 11 31 56" src="https://github.com/user-attachments/assets/ee8badac-bcf7-405c-a406-54700f399bee">
