### PR TITLE
Add extra fields to db when saving an application

### DIFF
--- a/app/services/handle_submission_for_store.rb
+++ b/app/services/handle_submission_for_store.rb
@@ -37,6 +37,9 @@ class HandleSubmissionForStore
         itt_provider: itt_provider.present? && IttProvider.find_by(legal_name: itt_provider),
         referred_by_return_to_teaching_adviser: store["referred_by_return_to_teaching_adviser"],
         raw_application_data: raw_application_data.except("current_user"),
+        senco_in_role: store["senco_in_role"],
+        senco_start_date: store["senco_start_date"],
+        on_submission_trn: store["trn"],
       )
 
       if Feature.ecf_api_disabled?

--- a/spec/features/journeys/happy_paths/when_get_an_identity_returns_no_trn_spec.rb
+++ b/spec/features/journeys/happy_paths/when_get_an_identity_returns_no_trn_spec.rb
@@ -226,7 +226,7 @@ RSpec.feature "Happy journeys", type: :feature do
       "work_setting" => "a_school",
       "senco_in_role" => nil,
       "senco_start_date" => nil,
-      "on_submission_trn" => nil,
+      "on_submission_trn" => manually_entered_trn,
       "raw_application_data" => {
         "active_alert" => false,
         "can_share_choices" => "1",

--- a/spec/lib/services/handle_submission_for_store_spec.rb
+++ b/spec/lib/services/handle_submission_for_store_spec.rb
@@ -51,9 +51,9 @@ RSpec.describe HandleSubmissionForStore do
           "teacher_catchment" => "england",
           "work_setting" => "a_school",
           "referred_by_return_to_teaching_adviser" => "no",
-          "senco_in_role" => nil,
-          "senco_start_date" => nil,
-          "on_submission_trn" => nil,
+          "senco_in_role" => "yes",
+          "senco_start_date" => "2024-12-12",
+          "trn" => "1234321",
         }
       end
 
@@ -148,9 +148,9 @@ RSpec.describe HandleSubmissionForStore do
           "raw_application_data" => store.except("current_user"),
           "referred_by_return_to_teaching_adviser" => "no",
           "accepted_at" => nil,
-          "senco_in_role" => nil,
-          "senco_start_date" => nil,
-          "on_submission_trn" => nil,
+          "senco_in_role" => "yes",
+          "senco_start_date" => "2024-12-12",
+          "on_submission_trn" => "1234321",
         })
       end
     end


### PR DESCRIPTION
Adds
* `senco_in_role`
* `senco_start_date`
* `on_submission_trn`
to the application when its saved.