### PR TITLE
[CPDNPQ-2289] Show ECF ID on statement details admin page

### DIFF
--- a/app/views/npq_separation/admin/finance/statements/show.html.erb
+++ b/app/views/npq_separation/admin/finance/statements/show.html.erb
@@ -10,6 +10,11 @@
     end
 
     summary_list.with_row do |row|
+      row.with_key(text: "ECF ID")
+      row.with_value(text: @statement.ecf_id)
+    end
+
+    summary_list.with_row do |row|
       row.with_key(text: "Lead provider")
       row.with_value(text: @statement.lead_provider.name)
     end

--- a/spec/features/npq_separation/admin/finance/statements_spec.rb
+++ b/spec/features/npq_separation/admin/finance/statements_spec.rb
@@ -43,6 +43,7 @@ RSpec.feature "Listing and viewing statements", :ecf_api_disabled, type: :featur
     within(".govuk-summary-list") do |summary_list|
       start_year = statement.cohort.start_year
       expect(summary_list).to have_summary_item("ID", statement.id)
+      expect(summary_list).to have_summary_item("ECF ID", statement.ecf_id)
       expect(summary_list).to have_summary_item("Lead provider", statement.lead_provider.name)
       expect(summary_list).to have_summary_item("Cohort", "#{start_year}/#{start_year.next - 2000}")
       expect(summary_list).to have_summary_item("Status", statement.state.humanize)


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2289

Currently the ECF ID for a statement is not shown in the Statement details page within the NPQ admin screen but needs to be since this is the 'external' ID lead providers will be aware of

### Changes proposed in this pull request

1. Added the ECF ID to the details summer list

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
