### PR TITLE
Only attach declarations to open statements

### DIFF
--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -33,7 +33,7 @@ class Statement < ApplicationRecord
   scope :with_state, ->(*state) { where(state:) }
   scope :unpaid, -> { with_state(%w[open payable]) }
   scope :paid, -> { with_state("paid") }
-  scope :next_output_fee_statements, -> { with_output_fee.order(:deadline_date).where("deadline_date >= ?", Date.current) }
+  scope :next_output_fee_statements, -> { with_state("open").with_output_fee.order(:deadline_date).where("deadline_date >= ?", Date.current) }
 
   state_machine :state, initial: :open do
     state :open

--- a/spec/models/lead_provider_spec.rb
+++ b/spec/models/lead_provider_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe LeadProvider do
     before do
       # Not output fee
       create(:statement, output_fee: false, cohort:, lead_provider:, deadline_date: 1.hour.from_now)
+      # Paid
+      create(:statement, :paid, :next_output_fee, cohort:, lead_provider:, deadline_date: 2.hours.from_now)
+      # Payable
+      create(:statement, :payable, :next_output_fee, cohort:, lead_provider:, deadline_date: 3.hours.from_now)
       # Deadline is later
       create(:statement, output_fee: true, cohort:, lead_provider:, deadline_date: 2.days.from_now)
       # Wrong cohort

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -61,9 +61,9 @@ RSpec.describe Statement, type: :model do
     end
 
     describe ".next_output_fee_statements" do
-      let(:next_output_fee_statement_1) { create(:statement, :next_output_fee, deadline_date: 5.days.from_now) }
-      let(:next_output_fee_statement_2) { create(:statement, :next_output_fee, deadline_date: 1.day.from_now) }
-      let(:next_output_fee_statement_3) { create(:statement, :next_output_fee, deadline_date: 2.days.from_now) }
+      let(:next_output_fee_statement_1) { create(:statement, :open, :next_output_fee, deadline_date: 5.days.from_now) }
+      let(:next_output_fee_statement_2) { create(:statement, :open, :next_output_fee, deadline_date: 1.day.from_now) }
+      let(:next_output_fee_statement_3) { create(:statement, :open, :next_output_fee, deadline_date: 2.days.from_now) }
 
       before do
         # Not output fee
@@ -75,6 +75,17 @@ RSpec.describe Statement, type: :model do
       subject { described_class.next_output_fee_statements }
 
       it { is_expected.to eq([next_output_fee_statement_2, next_output_fee_statement_3, next_output_fee_statement_1]) }
+
+      context "with statements that aren't open" do
+        before do
+          # Paid
+          create(:statement, :next_output_fee, :paid, deadline_date: 1.hour.from_now)
+          # Payable
+          create(:statement, :next_output_fee, :payable, deadline_date: 3.days.from_now)
+        end
+
+        it { is_expected.to eq([next_output_fee_statement_2, next_output_fee_statement_3, next_output_fee_statement_1]) }
+      end
     end
   end
 


### PR DESCRIPTION
### Context

We shouldn't be attaching declarations to payable/paid statements even if they match other criteria


Ticket: n/a

### Changes proposed in this pull request

Change scope to only look for "open" statements as the next output fee statements

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
