### PR TITLE
Fix rate limiting

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -61,6 +61,11 @@ class Rack::Attack
     auth_token(request) if api_request?(request) && !public_api_path?(request)
   end
 
+  # Throttle public /api requests by ip (300 requests per 5 minutes)
+  throttle("public API requests by ip", limit: 300, period: 5.minutes) do |request|
+    request.ip if public_api_path?(request)
+  end
+
   # Throttle non-api requests (300 requests per 5 minutes)
   throttle("non-API requests by ip", limit: 300, period: 5.minutes) do |request|
     request.ip unless api_request?(request)

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -17,32 +17,59 @@ class Rack::Attack
     "/api/docs",
   ].freeze
 
+  def self.api_request?(request)
+    request.path.starts_with?("/api/")
+  end
+
+  def self.public_api_path?(request)
+    PUBLIC_API_PATH_PREFIXES.any? { |prefix| request.path.starts_with?(prefix) }
+  end
+
+  def self.protected_path?(request)
+    PROTECTED_ROUTES.include?(request.path)
+  end
+
+  def self.csp_report_path?(request)
+    request.path == "/csp_reports"
+  end
+
+  def self.get_an_identity_webhook_path?(request)
+    request.path.starts_with?("/api/v1/get_an_identity/webhook_messages")
+  end
+
+  def self.auth_token(request)
+    request.get_header("HTTP_AUTHORIZATION")
+  end
+
   # Throttle protected routes by IP (5rpm)
   throttle("protected routes (hitting external services)", limit: 5, period: 1.minute) do |request|
-    request.ip if PROTECTED_ROUTES.include?(request.path)
+    request.ip if protected_path?(request)
   end
 
   # Throttle /csp_reports requests by IP (5rpm)
   throttle("csp_reports req/ip", limit: 5, period: 1.minute) do |request|
-    request.ip if request.path == "/csp_reports"
+    request.ip if csp_report_path?(request)
   end
 
   # Throttle /api/v1/get_an_identity/webhook_messages requests by IP (1000 requests per 5 minutes)
   throttle("API get an identity webhook message requests by ip", limit: 1000, period: 5.minutes) do |request|
-    request.ip if request.path.starts_with?("/api/v1/get_an_identity/webhook_messages")
+    request.ip if get_an_identity_webhook_path?(request)
   end
 
-  # Throttle /api requests by auth token (1000 requests per 5 minutes)
+  # Throttle private /api requests by auth token (1000 requests per 5 minutes)
   throttle("API requests by auth token", limit: 1000, period: 5.minutes) do |request|
-    public_api_path = PUBLIC_API_PATH_PREFIXES.any? { |prefix| request.path.starts_with?(prefix) }
-
-    if request.path.starts_with?("/api/") && !public_api_path
-      request.get_header("HTTP_AUTHORIZATION")
-    end
+    auth_token(request) if api_request?(request) && !public_api_path?(request)
   end
 
-  # Throttle all requests by IP (300 requests per 5 minutes)
-  throttle("general requests by ip", limit: 300, period: 5.minutes, &:ip)
+  # Throttle non-api requests (300 requests per 5 minutes)
+  throttle("non-API requests by ip", limit: 300, period: 5.minutes) do |request|
+    request.ip unless api_request?(request)
+  end
+
+  # Catch all/backstop; throttle all requests by IP (1500 requests per 5 minutes).
+  # Important: this should be a higher limit than the other throttles to ensure that
+  # it only comes into effect when the other throttles have been exhausted.
+  throttle("catch all requests by ip", limit: 1500, period: 5.minutes, &:ip)
 end
 
 ActiveSupport::Notifications.subscribe("throttle.rack_attack") do |_name, _start, _finish, request_id, payload|

--- a/spec/requests/rate_limiting_spec.rb
+++ b/spec/requests/rate_limiting_spec.rb
@@ -8,16 +8,6 @@ RSpec.describe "Rate limiting", :ecf_api_disabled do
 
   before { set_request_ip(ip) }
 
-  it_behaves_like "a rate limited endpoint", "general requests by ip" do
-    def perform_request
-      get root_path
-    end
-
-    def change_condition
-      set_request_ip(other_ip)
-    end
-  end
-
   [
     "/api/guidance",
     "/api/docs/v1",
@@ -27,7 +17,7 @@ RSpec.describe "Rate limiting", :ecf_api_disabled do
     context "when requesting the public API path #{public_api_path}" do
       let(:path) { public_api_path }
 
-      it_behaves_like "a rate limited endpoint", "general requests by ip" do
+      it_behaves_like "a rate limited endpoint", "catch all requests by ip" do
         def perform_request
           get path
         end
@@ -92,6 +82,26 @@ RSpec.describe "Rate limiting", :ecf_api_disabled do
 
     def change_condition
       set_auth_token(other_auth_token)
+    end
+  end
+
+  it_behaves_like "a rate limited endpoint", "non-API requests by ip" do
+    def perform_request
+      get root_path
+    end
+
+    def change_condition
+      set_request_ip(other_ip)
+    end
+  end
+
+  it_behaves_like "a rate limited endpoint", "catch all requests by ip" do
+    def perform_request
+      get root_path
+    end
+
+    def change_condition
+      set_request_ip(other_ip)
     end
   end
 

--- a/spec/requests/rate_limiting_spec.rb
+++ b/spec/requests/rate_limiting_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Rate limiting", :ecf_api_disabled do
     context "when requesting the public API path #{public_api_path}" do
       let(:path) { public_api_path }
 
-      it_behaves_like "a rate limited endpoint", "catch all requests by ip" do
+      it_behaves_like "a rate limited endpoint", "public API requests by ip" do
         def perform_request
           get path
         end


### PR DESCRIPTION
[Jira-3806](https://dfedigital.atlassian.net.mcas.ms/jira/software/projects/CPDLP/boards/87?selectedIssue=CPDLP-3806)

We had a catch-all/generic rate limit that was set to 300 requests/5 minutes. This is lower than all of our other throttles in RackAttack and was causing API requests to be throttled incorrectly.

Instead, we want to add an additional throttle for non-API requests at 300 requests/minute and a catch all/backstop throttle that will ensure no request to the service will exceed 1500 requests/5 minutes.
