### PR TITLE
[CPDNPQ-2270] port rake file and service from ECF (bulk script for revert to pending)

### DIFF
--- a/app/services/one_off/bulk_change_applications_to_pending.rb
+++ b/app/services/one_off/bulk_change_applications_to_pending.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module OneOff
+  class BulkChangeApplicationsToPending
+    attr_reader :application_ecf_ids
+
+    def initialize(application_ecf_ids:)
+      @application_ecf_ids = application_ecf_ids
+    end
+
+    def run!(dry_run: true)
+      result = {}
+      ActiveRecord::Base.transaction do
+        result = application_ecf_ids.each_with_object({}) do |application_ecf_id, hash|
+          application = Application.find_by(ecf_id: application_ecf_id)
+          revert_to_pending = Applications::RevertToPending.new(application:, change_status_to_pending: "yes")
+          success = application && revert_to_pending.revert
+          hash[application_ecf_id] = outcome(success, application, revert_to_pending.errors)
+        end
+
+        raise ActiveRecord::Rollback if dry_run
+      end
+
+      result
+    end
+
+  private
+
+    def outcome(success, application, errors)
+      return "Not found" if application.nil?
+      return "Changed to pending" if success
+
+      errors.map(&:message).join(", ")
+    end
+  end
+end

--- a/app/services/one_off/bulk_change_applications_to_pending.rb
+++ b/app/services/one_off/bulk_change_applications_to_pending.rb
@@ -14,7 +14,7 @@ module OneOff
         result = application_ecf_ids.each_with_object({}) do |application_ecf_id, hash|
           application = Application.find_by(ecf_id: application_ecf_id)
           revert_to_pending = Applications::RevertToPending.new(application:, change_status_to_pending: "yes")
-          success = application && revert_to_pending.revert
+          success = revert_to_pending.revert
           hash[application_ecf_id] = outcome(success, application, revert_to_pending.errors)
         end
 
@@ -30,7 +30,7 @@ module OneOff
       return "Not found" if application.nil?
       return "Changed to pending" if success
 
-      errors.map(&:message).join(", ")
+      errors.full_messages.to_sentence
     end
   end
 end

--- a/lib/tasks/bulk_change_applications_to_pending.rake
+++ b/lib/tasks/bulk_change_applications_to_pending.rake
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "rake"
-
 namespace :one_off do
   # Bulk change NPQ applications to pending.
   # Accepts a CSV of application (ecf) IDs (without a header row) and a dry run
@@ -21,7 +19,7 @@ namespace :one_off do
     dry_run = args[:dry_run] != "false"
     unless File.exist?(csv_file_path)
       logger.error "File not found: #{csv_file_path}"
-      return
+      exit 1
     end
 
     application_ecf_ids = CSV.read(csv_file_path, headers: false).flatten

--- a/lib/tasks/bulk_change_applications_to_pending.rake
+++ b/lib/tasks/bulk_change_applications_to_pending.rake
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rake"
+
+namespace :one_off do
+  # Bulk change NPQ applications to pending.
+  # Accepts a CSV of application (ecf) IDs (without a header row) and a dry run
+  # flag. If the dry run flag is true, or not set, the changes will not be performed
+  # but the changes that would be made will be logged. Set dry run to false
+  # to commit the changes.
+  #
+  # Example usage (dry run):
+  # bundle exec rake 'one_off:bulk_change_to_pending[applications.csv]'
+  #
+  # Example usage (perform change):
+  # bundle exec rake 'one_off:bulk_change_to_pending[applications.csv,false]'
+  desc "Change NPQ applications to pending"
+  task :bulk_change_to_pending, %i[file dry_run] => :environment do |_task, args|
+    logger = Logger.new($stdout)
+    csv_file_path = args[:file]
+    dry_run = args[:dry_run] != "false"
+    unless File.exist?(csv_file_path)
+      logger.error "File not found: #{csv_file_path}"
+      return
+    end
+
+    application_ecf_ids = CSV.read(csv_file_path, headers: false).flatten
+
+    logger.info "Bulk changing #{application_ecf_ids.size} applications to pending#{' (dry run)' if dry_run}..."
+
+    result = OneOff::BulkChangeApplicationsToPending.new(application_ecf_ids:).run!(dry_run:)
+
+    logger.info JSON.pretty_generate(result)
+  end
+end

--- a/spec/lib/tasks/one_off/bulk_change_applications_to_pending_spec.rb
+++ b/spec/lib/tasks/one_off/bulk_change_applications_to_pending_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+Rails.application.load_tasks
+
+RSpec.describe "one_off:bulk_change_to_pending" do
+  let(:csv_file) { Tempfile.new }
+
+  before do
+    create(:application, :accepted)
+    create(:application, :accepted)
+    csv_file.write(Application.all.pluck(:ecf_id).join("\n"))
+    csv_file.rewind
+  end
+
+  after do
+    Rake::Task["one_off:bulk_change_to_pending"].reenable
+  end
+
+  context "when dry run not specified" do
+    subject { Rake::Task["one_off:bulk_change_to_pending"].invoke(csv_file.path) }
+
+    it "does not update any applications" do
+      subject
+      expect(Application.all.pluck(:lead_provider_approval_status)).to eq %w[accepted accepted]
+    end
+  end
+
+  context "when dry run true" do
+    subject { Rake::Task["one_off:bulk_change_to_pending"].invoke(csv_file.path, "true") }
+
+    it "does not update any applications" do
+      subject
+      expect(Application.all.pluck(:lead_provider_approval_status)).to eq %w[accepted accepted]
+    end
+  end
+
+  context "when dry run false" do
+    subject { Rake::Task["one_off:bulk_change_to_pending"].invoke(csv_file.path, "false") }
+
+    it "updates applications to pending" do
+      subject
+      expect(Application.all.pluck(:lead_provider_approval_status)).to eq %w[pending pending]
+    end
+  end
+end

--- a/spec/lib/tasks/one_off/bulk_change_applications_to_pending_spec.rb
+++ b/spec/lib/tasks/one_off/bulk_change_applications_to_pending_spec.rb
@@ -4,6 +4,7 @@ Rails.application.load_tasks
 
 RSpec.describe "one_off:bulk_change_to_pending" do
   let(:csv_file) { Tempfile.new }
+  let(:csv_file_path) { csv_file.path }
 
   before do
     create(:application, :accepted)
@@ -17,29 +18,37 @@ RSpec.describe "one_off:bulk_change_to_pending" do
   end
 
   context "when dry run not specified" do
-    subject { Rake::Task["one_off:bulk_change_to_pending"].invoke(csv_file.path) }
+    subject(:run_task) { Rake::Task["one_off:bulk_change_to_pending"].invoke(csv_file_path) }
 
     it "does not update any applications" do
-      subject
+      run_task
       expect(Application.all.pluck(:lead_provider_approval_status)).to eq %w[accepted accepted]
     end
   end
 
   context "when dry run true" do
-    subject { Rake::Task["one_off:bulk_change_to_pending"].invoke(csv_file.path, "true") }
+    subject(:run_task) { Rake::Task["one_off:bulk_change_to_pending"].invoke(csv_file_path, "true") }
 
     it "does not update any applications" do
-      subject
+      run_task
       expect(Application.all.pluck(:lead_provider_approval_status)).to eq %w[accepted accepted]
     end
   end
 
   context "when dry run false" do
-    subject { Rake::Task["one_off:bulk_change_to_pending"].invoke(csv_file.path, "false") }
+    subject(:run_task) { Rake::Task["one_off:bulk_change_to_pending"].invoke(csv_file_path, "false") }
 
     it "updates applications to pending" do
-      subject
+      run_task
       expect(Application.all.pluck(:lead_provider_approval_status)).to eq %w[pending pending]
+    end
+  end
+
+  context "when the CSV file is not found" do
+    subject(:run_task) { Rake::Task["one_off:bulk_change_to_pending"].execute(file: "nonexistent_file") }
+
+    it "exits with error code 1" do
+      expect { run_task }.to raise_error(an_instance_of(SystemExit).and(having_attributes(status: 1)))
     end
   end
 end

--- a/spec/services/one_off/bulk_change_applications_to_pending_spec.rb
+++ b/spec/services/one_off/bulk_change_applications_to_pending_spec.rb
@@ -1,0 +1,87 @@
+require "rails_helper"
+
+RSpec.describe OneOff::BulkChangeApplicationsToPending do
+  let(:application_ecf_ids) { [application.ecf_id] }
+  let(:instance) { described_class.new(application_ecf_ids:) }
+
+  describe "#run!" do
+    let(:dry_run) { false }
+
+    subject(:run) { instance.run!(dry_run:) }
+
+    RSpec.shared_examples "changes to pending" do |initial_state|
+      it { expect { run }.to(change { application.reload.lead_provider_approval_status }.from(initial_state).to("pending")) }
+      it { expect(run[application.ecf_id]).to eq("Changed to pending") }
+    end
+
+    RSpec.shared_examples "does not change to pending" do |result|
+      it { expect { run }.not_to(change { application.reload.lead_provider_approval_status }) }
+      it { expect(run[application.ecf_id]).to match(result) }
+    end
+
+    context "when there is an accepted application" do
+      let(:application) { create(:application, :accepted) }
+
+      it_behaves_like "changes to pending", "accepted"
+    end
+
+    context "when there is a rejected application" do
+      let(:application) { create(:application, :rejected) }
+
+      it_behaves_like "changes to pending", "rejected"
+    end
+
+    %i[submitted voided ineligible].each do |state|
+      context "when the application has #{state} declarations" do
+        let(:declaration) { create(:declaration, state) }
+
+        context "when the application is accepted" do
+          let(:application) { declaration.application }
+
+          it_behaves_like "changes to pending", "accepted"
+        end
+
+        context "when the application is rejected" do
+          let(:application) do
+            declaration.application.tap do |application|
+              application.update!(lead_provider_approval_status: "rejected")
+            end
+          end
+
+          it_behaves_like "changes to pending", "rejected"
+        end
+      end
+    end
+
+    context "when the application is already pending" do
+      let(:application) { create(:application, :pending) }
+
+      it_behaves_like "does not change to pending", /lead provider approval status is not Accepted/
+    end
+
+    context "when the application doesn't exist" do
+      let(:application_ecf_id) { SecureRandom.uuid }
+      let(:application_ecf_ids) { [application_ecf_id] }
+
+      it { expect(run[application_ecf_id]).to eq("Not found") }
+    end
+
+    Declaration.states.keys.excluding("submitted", "voided", "ineligible").each do |state|
+      context "when the application has #{state} declarations" do
+        let(:declaration) { create(:declaration, state) }
+        let(:application) { declaration.application }
+
+        it_behaves_like "does not change to pending", /There are already declarations for this participant/
+      end
+    end
+
+    context "when dry_run is true" do
+      let(:dry_run) { true }
+
+      let(:application) { create(:application, :accepted) }
+
+      it { expect { run }.not_to(change { application.reload.lead_provider_approval_status }) }
+      it { expect(run[application.ecf_id]).to eq("Changed to pending") }
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2270

bulk script for revert to pending - rake file and service ported from ECF - updated to work with the NPQ `Applications::RevertToPending` service.