### PR TITLE
[CPDNPQ-2320] Fix admin/users#show with nil DOB

### DIFF
--- a/app/views/npq_separation/admin/users/show.html.erb
+++ b/app/views/npq_separation/admin/users/show.html.erb
@@ -31,7 +31,7 @@
 
     sl.with_row do |row|
       row.with_key(text: "Date of Birth")
-      row.with_value(text: @user.date_of_birth.to_fs(:govuk_short))
+      row.with_value(text: @user.date_of_birth.try(:to_fs, :govuk_short))
     end
 
     sl.with_row do |row|

--- a/spec/features/npq_separation/admin/users_spec.rb
+++ b/spec/features/npq_separation/admin/users_spec.rb
@@ -63,6 +63,15 @@ RSpec.feature "User administration", :ecf_api_disabled, type: :feature do
       end
     end
 
+    scenario "renders when attributes with method chains are nil" do
+      user.update!(date_of_birth: nil)
+      visit npq_separation_admin_user_path(user)
+
+      within(first(".govuk-summary-list")) do |summary_list|
+        expect(summary_list).to have_summary_item("Date of Birth", "")
+      end
+    end
+
     scenario "shows a message if the user has no applications" do
       visit npq_separation_admin_user_path(user)
 


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2320

Error: https://dfe-teacher-services.sentry.io/issues/6108161531

`User#date_of_birth` can be `nil`, in which case sending it `to_fs` throws `NoMethodError`.