### PR TITLE
Remove references to `primary` database

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,4 +76,4 @@ ENV PORT=8080
 
 EXPOSE ${PORT}
 
-CMD bundle exec rake db:migrate:primary && bundle exec whenever --update-crontab && bundle exec rails s -p ${PORT} --binding=0.0.0.0
+CMD bundle exec rake db:migrate && bundle exec whenever --update-crontab && bundle exec rails s -p ${PORT} --binding=0.0.0.0

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,5 +1,3 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
-
-  connects_to database: { writing: :primary, reading: :primary }
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -14,34 +14,27 @@ default_primary: &default_primary
   url: <%= ENV.fetch("DATABASE_URL", "postgres://localhost:5432") %>
 
 development:
-  primary:
-    <<: *default_primary
-    database: npq_registration_development
+  <<: *default_primary
+  database: npq_registration_development
 
 review:
-  primary:
-    <<: *default_primary
+  <<: *default_primary
 
 test:
-  primary:
-    <<: *default_primary
-    database: npq_registration_test<%= ENV['TEST_ENV_NUMBER'] %>
+  <<: *default_primary
+  database: npq_registration_test<%= ENV['TEST_ENV_NUMBER'] %>
 
 staging:
-  primary:
-    <<: *default_primary
+  <<: *default_primary
+
 sandbox:
-  primary:
-    <<: *default_primary
+  <<: *default_primary
 
 migration:
-  primary:
-    <<: *default_primary
+  <<: *default_primary
 
 separation:
-  primary:
-    <<: *default_primary
+  <<: *default_primary
 
 production:
-  primary:
-    <<: *default_primary
+  <<: *default_primary


### PR DESCRIPTION
As we only have a single database connection again we can drop the `primary` clarification from the rake tasks and the database configuration.
