### PR TITLE
[CPDNPQ-2178] admin change TRN

### DIFF
--- a/app/controllers/npq_separation/admin/users/change_trn_controller.rb
+++ b/app/controllers/npq_separation/admin/users/change_trn_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module NpqSeparation
+  module Admin
+    module Users
+      class ChangeTrnController < NpqSeparation::AdminController
+        before_action :set_user, :set_service
+
+        def create
+          if @change_trn.call
+            redirect_to npq_separation_admin_user_path(@user)
+          else
+            render :show, status: :unprocessable_entity
+          end
+        end
+
+      private
+
+        def set_user
+          @user = User.find(params[:id])
+        end
+
+        def set_service
+          @change_trn = Participants::ChangeTrn.new(user: @user, trn:)
+        end
+
+        def trn
+          params.fetch(:participants_change_trn, {})[:trn]
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/npq_separation/admin/users/change_trn_controller.rb
+++ b/app/controllers/npq_separation/admin/users/change_trn_controller.rb
@@ -7,7 +7,7 @@ module NpqSeparation
         before_action :set_user, :set_service
 
         def create
-          if @change_trn.call
+          if @change_trn.change_trn
             redirect_to npq_separation_admin_user_path(@user)
           else
             render :show, status: :unprocessable_entity

--- a/app/forms/questionnaires/qualified_teacher_check.rb
+++ b/app/forms/questionnaires/qualified_teacher_check.rb
@@ -2,8 +2,6 @@ module Questionnaires
   class QualifiedTeacherCheck < Base
     include ActiveRecord::AttributeAssignment
 
-    FORBIDDEN_TRNS = %w[0000000].freeze
-
     attr_accessor :trn, :full_name, :national_insurance_number
 
     attr_reader :date_of_birth
@@ -21,8 +19,7 @@ module Questionnaires
     before_validation :strip_ni_number_whitespace
     before_validation :strip_title_prefixes
 
-    validates :trn, presence: true
-    validate :validate_processed_trn
+    validates :trn, valid_trn: true
 
     validates :full_name, presence: true, length: { maximum: 128 }
 
@@ -67,10 +64,6 @@ module Questionnaires
     def requirements_met?
       # The user has to have logged in via GAI to reach this question
       wizard.store.present? && query_store.current_user.present?
-    end
-
-    def processed_trn
-      @processed_trn ||= trn || ""
     end
 
     def next_step
@@ -168,19 +161,6 @@ module Questionnaires
   private
 
     attr_reader :verified_trn
-
-    def validate_processed_trn
-      if FORBIDDEN_TRNS.include?(processed_trn)
-        errors.add(:trn, :not_real)
-      end
-      if processed_trn !~ /\A\d+\z/
-        errors.add(:trn, :invalid)
-      elsif processed_trn.length < 7
-        errors.add(:trn, :too_short, count: 7)
-      elsif processed_trn.length > 7
-        errors.add(:trn, :too_long, count: 7)
-      end
-    end
 
     def trn_to_store
       if trn_verified? && verified_trn.present?

--- a/app/forms/questionnaires/qualified_teacher_check.rb
+++ b/app/forms/questionnaires/qualified_teacher_check.rb
@@ -69,19 +69,6 @@ module Questionnaires
       wizard.store.present? && query_store.current_user.present?
     end
 
-    def validate_processed_trn
-      if FORBIDDEN_TRNS.include?(processed_trn)
-        errors.add(:trn, :not_real)
-      end
-      if processed_trn !~ /\A\d+\z/
-        errors.add(:trn, :invalid)
-      elsif processed_trn.length < 7
-        errors.add(:trn, :too_short, count: 7)
-      elsif processed_trn.length > 7
-        errors.add(:trn, :too_long, count: 7)
-      end
-    end
-
     def processed_trn
       @processed_trn ||= trn || ""
     end
@@ -181,6 +168,19 @@ module Questionnaires
   private
 
     attr_reader :verified_trn
+
+    def validate_processed_trn
+      if FORBIDDEN_TRNS.include?(processed_trn)
+        errors.add(:trn, :not_real)
+      end
+      if processed_trn !~ /\A\d+\z/
+        errors.add(:trn, :invalid)
+      elsif processed_trn.length < 7
+        errors.add(:trn, :too_short, count: 7)
+      elsif processed_trn.length > 7
+        errors.add(:trn, :too_long, count: 7)
+      end
+    end
 
     def trn_to_store
       if trn_verified? && verified_trn.present?

--- a/app/services/participants/change_trn.rb
+++ b/app/services/participants/change_trn.rb
@@ -2,8 +2,6 @@
 
 module Participants
   class ChangeTrn
-    FORBIDDEN_TRNS = %w[0000000].freeze
-
     include ActiveModel::Model
     include ActiveModel::Attributes
     include ActiveModel::Validations::Callbacks
@@ -13,9 +11,7 @@ module Participants
 
     before_validation :strip_trn_whitespace
 
-    validates :trn, presence: true, length: { is: 7 }
-    validates :trn, exclusion: FORBIDDEN_TRNS
-    validates :trn, format: { with: /\A\d+\z/ }
+    validates :trn, valid_trn: true
 
     def call
       return false if invalid?

--- a/app/services/participants/change_trn.rb
+++ b/app/services/participants/change_trn.rb
@@ -13,7 +13,7 @@ module Participants
 
     validates :trn, valid_trn: true
 
-    def call
+    def change_trn
       return false if invalid?
 
       user.update(trn:) # rubocop:disable Rails/SaveBang - return value is used by caller

--- a/app/services/participants/change_trn.rb
+++ b/app/services/participants/change_trn.rb
@@ -16,7 +16,7 @@ module Participants
     def change_trn
       return false if invalid?
 
-      user.update(trn:) # rubocop:disable Rails/SaveBang - return value is used by caller
+      user.update(trn:, trn_verified: true) # rubocop:disable Rails/SaveBang - return value is used by caller
     end
 
   private

--- a/app/services/participants/change_trn.rb
+++ b/app/services/participants/change_trn.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Participants
+  class ChangeTrn
+    FORBIDDEN_TRNS = %w[0000000].freeze
+
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+    include ActiveModel::Validations::Callbacks
+
+    attribute :user
+    attribute :trn
+
+    before_validation :strip_trn_whitespace
+
+    validates :trn, presence: true, length: { is: 7 }
+    validates :trn, exclusion: FORBIDDEN_TRNS
+    validates :trn, format: { with: /\A\d+\z/ }
+
+    def call
+      return false if invalid?
+
+      user.update(trn:) # rubocop:disable Rails/SaveBang - return value is used by caller
+    end
+
+  private
+
+    def strip_trn_whitespace
+      self.trn = trn&.gsub(" ", "")
+    end
+  end
+end

--- a/app/services/teacher_reference_number.rb
+++ b/app/services/teacher_reference_number.rb
@@ -4,7 +4,7 @@ class TeacherReferenceNumber
   MIN_UNPADDED_TRN_LENGTH = 5
   PADDED_TRN_LENGTH = 7
 
-  attr_reader :trn, :format_error
+  attr_reader :trn
 
   def initialize(trn)
     @trn = trn
@@ -15,21 +15,13 @@ class TeacherReferenceNumber
     @formatted_trn ||= extract_trn_value
   end
 
-  def valid?
-    formatted_trn.present?
-  end
-
 private
 
   def extract_trn_value
-    @format_error = :blank and return if trn.blank?
-
     # remove any characters that are not digits
     only_digits = trn.to_s.gsub(/[^\d]/, "")
 
-    @format_error = :invalid and return if only_digits.blank?
-    @format_error = :too_short and return if only_digits.length < MIN_UNPADDED_TRN_LENGTH
-    @format_error = :too_long and return if only_digits.length > PADDED_TRN_LENGTH
+    return if only_digits.length < MIN_UNPADDED_TRN_LENGTH || only_digits.length > PADDED_TRN_LENGTH
 
     only_digits.rjust(PADDED_TRN_LENGTH, "0")
   end

--- a/app/validators/valid_trn_validator.rb
+++ b/app/validators/valid_trn_validator.rb
@@ -10,7 +10,7 @@ class ValidTrnValidator < ActiveModel::EachValidator
     if value.blank?
       record.errors.add(attribute, :blank)
     elsif value !~ /\A\d+\z/
-      record.errors.add(attribute, :invalid)
+      record.errors.add(attribute, :invalid, message: I18n.t("errors.attributes.trn.invalid"))
     elsif value.length != 7
       record.errors.add(attribute, :wrong_length, count: 7)
     end

--- a/app/validators/valid_trn_validator.rb
+++ b/app/validators/valid_trn_validator.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class ValidTrnValidator < ActiveModel::EachValidator
+  FORBIDDEN_TRNS = %w[0000000].freeze
+
+  def validate_each(record, attribute, value)
+    if FORBIDDEN_TRNS.include?(value)
+      record.errors.add(attribute, :not_real)
+    end
+    if value.blank?
+      record.errors.add(attribute, :blank)
+    elsif value !~ /\A\d+\z/
+      record.errors.add(attribute, :invalid)
+    elsif value.length < 7
+      record.errors.add(attribute, :too_short, count: 7)
+    elsif value.length > 7
+      record.errors.add(attribute, :too_long, count: 7)
+    end
+  end
+end

--- a/app/validators/valid_trn_validator.rb
+++ b/app/validators/valid_trn_validator.rb
@@ -11,10 +11,8 @@ class ValidTrnValidator < ActiveModel::EachValidator
       record.errors.add(attribute, :blank)
     elsif value !~ /\A\d+\z/
       record.errors.add(attribute, :invalid)
-    elsif value.length < 7
-      record.errors.add(attribute, :too_short, count: 7)
-    elsif value.length > 7
-      record.errors.add(attribute, :too_long, count: 7)
+    elsif value.length != 7
+      record.errors.add(attribute, :wrong_length, count: 7)
     end
   end
 end

--- a/app/views/npq_separation/admin/users/change_trn/show.html.erb
+++ b/app/views/npq_separation/admin/users/change_trn/show.html.erb
@@ -1,0 +1,32 @@
+<%= govuk_back_link href: npq_separation_admin_user_path(@user) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      Change TRN
+    </h1>
+
+    <%=
+      govuk_summary_list do |sl|
+        sl.with_row do |row|
+          row.with_key(text: "Participant ID")
+          row.with_value(text: @user.ecf_id)
+        end
+        sl.with_row do |row|
+          row.with_key(text: "TRN")
+          row.with_value(text: @user.trn || "<em>- not set -</em>".html_safe)
+        end
+      end
+    %>
+
+    <%= form_for @change_trn,
+                 url: npq_separation_admin_users_change_trn_path(@user) do |f| %>
+      <%= f.govuk_text_field :trn, label: { text: 'New TRN' } %>
+
+      <div class="govuk-button-group">
+        <%= f.govuk_submit "Continue" %>
+        <%= govuk_link_to t("shared.cancel"), npq_separation_admin_user_path(@user) %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/npq_separation/admin/users/change_trn/show.html.erb
+++ b/app/views/npq_separation/admin/users/change_trn/show.html.erb
@@ -1,7 +1,7 @@
 <%= govuk_back_link href: npq_separation_admin_user_path(@user) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">
       Change TRN
     </h1>
@@ -21,7 +21,7 @@
 
     <%= form_for @change_trn,
                  url: npq_separation_admin_users_change_trn_path(@user) do |f| %>
-      <%= f.govuk_text_field :trn, label: { text: 'New TRN' } %>
+      <%= f.govuk_text_field :trn, label: { text: 'New TRN' }, width: 'one-quarter' %>
 
       <div class="govuk-button-group">
         <%= f.govuk_submit "Continue" %>

--- a/app/views/npq_separation/admin/users/change_trn/show.html.erb
+++ b/app/views/npq_separation/admin/users/change_trn/show.html.erb
@@ -14,11 +14,10 @@
         end
         sl.with_row do |row|
           row.with_key(text: "TRN")
-          row.with_value(text: @user.trn || "<em>- not set -</em>".html_safe)
+          row.with_value(text: @user.trn || tag.em("- not set -"))
         end
       end
     %>
-
     <%= form_for @change_trn,
                  url: npq_separation_admin_users_change_trn_path(@user) do |f| %>
       <%= f.govuk_text_field :trn, label: { text: 'New TRN' }, width: 'one-quarter' %>

--- a/app/views/npq_separation/admin/users/show.html.erb
+++ b/app/views/npq_separation/admin/users/show.html.erb
@@ -37,6 +37,7 @@
     sl.with_row do |row|
       row.with_key(text: "TRN")
       row.with_value(text: @user.trn)
+      row.with_action(text: "Change", href: npq_separation_admin_users_change_trn_path(@user))
     end
 
     sl.with_row do |row|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,7 +19,10 @@ en:
       taken: "ECF ID must be unique"
     attributes:
       trn:
-        not_real: You must enter a valid teacher reference number (TRN)
+        blank: TRN can't be blank
+        invalid: TRN must only contain numbers
+        not_real: You must enter a valid TRN
+        wrong_length: TRN is the wrong length (should be %{count} characters)
 
   application: &application
     blank: The entered '#/%{parameterized_attribute}' is missing from your request. Check details and try again.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -286,8 +286,7 @@ en:
           attributes:
             trn:
               blank: Teacher reference number cannot be blank
-              too_short: Teacher reference number is at least %{count} digits long
-              too_long: Teacher reference number is at most %{count} digits long
+              wrong_length: Teacher reference number is %{count} digits long
               invalid: Teacher reference number must only contain numbers
               not_real: You must enter a valid teacher reference number (TRN)
             full_name:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,6 +17,9 @@ en:
     ecf_id: &ecf_id
       blank: "Enter an ECF ID"
       taken: "ECF ID must be unique"
+    attributes:
+      trn:
+        not_real: You must enter a valid teacher reference number (TRN)
 
   application: &application
     blank: The entered '#/%{parameterized_attribute}' is missing from your request. Check details and try again.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -229,7 +229,13 @@ Rails.application.routes.draw do
 
       resources :schools, only: %i[index show]
       resources :courses, only: %i[index show]
-      resources :users, only: %i[index show]
+      resources :users, only: %i[index show] do
+        member do
+          namespace :users, path: nil do
+            resource :change_trn, controller: "change_trn", only: %i[show create]
+          end
+        end
+      end
 
       resources :participant_outcomes, only: %i[] do
         member { post :resend }

--- a/spec/features/npq_separation/admin/users_spec.rb
+++ b/spec/features/npq_separation/admin/users_spec.rb
@@ -99,5 +99,24 @@ RSpec.feature "User administration", type: :feature do
         end
       end
     end
+
+    scenario "changing a user's TRN" do
+      visit npq_separation_admin_user_path(user)
+      click_link "Change"
+
+      expect(page).to have_css("h1", text: "Change TRN")
+      within(first(".govuk-summary-list")) do |summary_list|
+        expect(summary_list).to have_summary_item("Participant ID", user.ecf_id)
+        expect(summary_list).to have_summary_item("TRN", user.trn)
+      end
+      fill_in("New TRN", with: "2345678")
+      click_on("Continue")
+
+      expect(page).to have_css("h1", text: "Participant")
+      within(first(".govuk-summary-list")) do |summary_list|
+        expect(summary_list).to have_summary_item("TRN", "2345678")
+      end
+      expect(user.reload.trn).to eq "2345678"
+    end
   end
 end

--- a/spec/features/npq_separation/admin/users_spec.rb
+++ b/spec/features/npq_separation/admin/users_spec.rb
@@ -109,6 +109,11 @@ RSpec.feature "User administration", type: :feature do
         expect(summary_list).to have_summary_item("Participant ID", user.ecf_id)
         expect(summary_list).to have_summary_item("TRN", user.trn)
       end
+
+      # blank TRN
+      click_on("Continue")
+      expect(page).to have_content "can't be blank"
+
       fill_in("New TRN", with: "2345678")
       click_on("Continue")
 

--- a/spec/lib/questionnaires/qualified_teacher_check_spec.rb
+++ b/spec/lib/questionnaires/qualified_teacher_check_spec.rb
@@ -135,13 +135,13 @@ RSpec.describe Questionnaires::QualifiedTeacherCheck, type: :model do
       it "denies trns over 7 characters" do
         subject.trn = "99123456"
         subject.valid?
-        expect(subject.errors[:trn]).to eq ["Teacher reference number is at most 7 digits long"]
+        expect(subject.errors[:trn]).to eq ["Teacher reference number is 7 digits long"]
       end
 
       it "denies trns under 7 characters" do
         subject.trn = "1234"
         subject.valid?
-        expect(subject.errors[:trn]).to eq ["Teacher reference number is at least 7 digits long"]
+        expect(subject.errors[:trn]).to eq ["Teacher reference number is 7 digits long"]
       end
 
       it "denies trns with other letters" do

--- a/spec/lib/questionnaires/qualified_teacher_check_spec.rb
+++ b/spec/lib/questionnaires/qualified_teacher_check_spec.rb
@@ -107,25 +107,29 @@ RSpec.describe Questionnaires::QualifiedTeacherCheck, type: :model do
     it { is_expected.to validate_presence_of(:date_of_birth) }
     it { is_expected.to validate_length_of(:national_insurance_number).is_at_most(9) }
 
-    describe "#trn" do
+    describe "TRN validations" do
       it "can only contain numbers" do
         subject.trn = "123456a"
         subject.valid?
         expect(subject.errors[:trn]).to eq ["Teacher reference number must only contain numbers"]
       end
-    end
 
-    describe "#processed_trn" do
-      it "returns an empty string for nil TRNs" do
+      it "doesn't permit nil TRN" do
         subject.trn = nil
-        expect(subject.processed_trn).to eql("")
+        subject.valid?
+        expect(subject.errors[:trn]).to eq ["Teacher reference number cannot be blank"]
+      end
+
+      it "doesn't permit empty TRN" do
+        subject.trn = ""
+        subject.valid?
+        expect(subject.errors[:trn]).to eq ["Teacher reference number cannot be blank"]
       end
 
       it "doesn't permit legacy style TRNs" do
         subject.trn = "RP99/12345"
         subject.valid?
         expect(subject.errors[:trn]).to eq ["Teacher reference number must only contain numbers"]
-        expect(subject.processed_trn).not_to eql("9912345")
       end
 
       it "denies trns over 7 characters" do

--- a/spec/lib/questionnaires/qualified_teacher_check_spec.rb
+++ b/spec/lib/questionnaires/qualified_teacher_check_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Questionnaires::QualifiedTeacherCheck, type: :model do
   end
 
   describe "validations" do
-    it { is_expected.to validate_presence_of(:trn) }
+    it { is_expected.to validate_presence_of(:trn).with_message("Teacher reference number cannot be blank") }
     it { is_expected.to validate_presence_of(:full_name) }
     it { is_expected.to validate_length_of(:full_name).is_at_most(128) }
     it { is_expected.to validate_presence_of(:date_of_birth) }
@@ -111,7 +111,7 @@ RSpec.describe Questionnaires::QualifiedTeacherCheck, type: :model do
       it "can only contain numbers" do
         subject.trn = "123456a"
         subject.valid?
-        expect(subject.errors[:trn]).to be_present
+        expect(subject.errors[:trn]).to eq ["Teacher reference number must only contain numbers"]
       end
     end
 
@@ -124,32 +124,32 @@ RSpec.describe Questionnaires::QualifiedTeacherCheck, type: :model do
       it "doesn't permit legacy style TRNs" do
         subject.trn = "RP99/12345"
         subject.valid?
-        expect(subject.errors[:trn]).to be_present
+        expect(subject.errors[:trn]).to eq ["Teacher reference number must only contain numbers"]
         expect(subject.processed_trn).not_to eql("9912345")
       end
 
       it "denies trns over 7 characters" do
         subject.trn = "99123456"
         subject.valid?
-        expect(subject.errors[:trn]).to be_present
+        expect(subject.errors[:trn]).to eq ["Teacher reference number is at most 7 digits long"]
       end
 
       it "denies trns under 7 characters" do
         subject.trn = "1234"
         subject.valid?
-        expect(subject.errors[:trn]).to be_present
+        expect(subject.errors[:trn]).to eq ["Teacher reference number is at least 7 digits long"]
       end
 
       it "denies trns with other letters" do
         subject.trn = "AA99/12345"
         subject.valid?
-        expect(subject.errors[:trn]).to be_present
+        expect(subject.errors[:trn]).to eq ["Teacher reference number must only contain numbers"]
       end
 
       it "denies fake trn 0000000" do
         subject.trn = "0000000"
         subject.valid?
-        expect(subject.errors[:trn]).to be_present
+        expect(subject.errors[:trn]).to eq ["You must enter a valid teacher reference number (TRN)"]
       end
     end
 

--- a/spec/services/dqt/record_check_spec.rb
+++ b/spec/services/dqt/record_check_spec.rb
@@ -5,10 +5,11 @@ require "rails_helper"
 RSpec.describe Dqt::RecordCheck do
   shared_context "with fake DQT response" do
     before do
-      allow(Dqt::V1::Teacher).to(receive(:find).with(trn:, birthdate: date_of_birth, nino:).and_return(fake_api_response || default_api_response))
+      allow(Dqt::V1::Teacher).to(receive(:find).with(trn: padded_trn, birthdate: date_of_birth, nino:).and_return(fake_api_response || default_api_response))
     end
   end
 
+  let(:padded_trn) { trn }
   let(:trn) { "1234567" }
   let(:nino) { "QQ123456A" }
   let(:date_of_birth) { 25.years.ago.to_date }
@@ -17,7 +18,7 @@ RSpec.describe Dqt::RecordCheck do
   let(:default_api_response) do
     {
       "state_name" => "Active",
-      "trn" => trn,
+      "trn" => padded_trn,
       "name" => full_name,
       "ni_number" => nino,
       "dob" => 25.years.ago.to_date,
@@ -48,6 +49,15 @@ RSpec.describe Dqt::RecordCheck do
   context "when active" do
     describe "matching on TRN" do
       context "when exact" do
+        include_context "with fake DQT response"
+
+        it("#trn_matches is true") { expect(subject.call.trn_matches).to be(true) }
+      end
+
+      context "when same after non-digits removed and padding added" do
+        let(:trn) { "123-45" }
+        let(:padded_trn) { "0012345" }
+
         include_context "with fake DQT response"
 
         it("#trn_matches is true") { expect(subject.call.trn_matches).to be(true) }

--- a/spec/services/dqt/record_check_spec.rb
+++ b/spec/services/dqt/record_check_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Dqt::RecordCheck do
 
   subject { described_class.new(**kwargs) }
 
-  context "when trn and national insurance number are blank" do
+  context "when TRN and national insurance number are blank" do
     let(:trn) { "" }
     let(:nino) { "" }
 
@@ -54,7 +54,7 @@ RSpec.describe Dqt::RecordCheck do
         it("#trn_matches is true") { expect(subject.call.trn_matches).to be(true) }
       end
 
-      context "when same after non-digits removed and padding added" do
+      context "when TRN same after non-digits removed and padding added" do
         let(:trn) { "123-45" }
         let(:padded_trn) { "0012345" }
 
@@ -222,7 +222,7 @@ RSpec.describe Dqt::RecordCheck do
         allow_any_instance_of(Dqt::RecordCheck).to receive(:check_record).and_call_original
       end
 
-      it "sets trn to 0000001 and calls check_record again" do
+      it "sets TRN to 0000001 and calls check_record again" do
         allow(Dqt::V1::Teacher).to(receive(:find).with(trn: "0000001", birthdate: date_of_birth, nino:).and_return(fake_api_response || default_api_response))
 
         expect(subject.send(:trn)).to eq(trn)

--- a/spec/services/participants/change_trn_spec.rb
+++ b/spec/services/participants/change_trn_spec.rb
@@ -11,23 +11,23 @@ RSpec.describe Participants::ChangeTrn, type: :model do
 
   describe "validations" do
     it "does not allow a blank TRN" do
-      expect(subject).to validate_presence_of(:trn).with_message(:blank).with_message("can't be blank")
+      expect(subject).to validate_presence_of(:trn).with_message(:blank).with_message("TRN can't be blank")
     end
 
     it "does not allow forbidden TRNs" do
-      expect(subject).not_to allow_value("0000000").for(:trn)
+      expect(subject).not_to allow_value("0000000").for(:trn).with_message("You must enter a valid TRN")
     end
 
     it "does not allow non-numeric characters" do
-      expect(subject).not_to allow_value("AA99/12345").for(:trn)
+      expect(subject).not_to allow_value("AA99/12345").for(:trn).with_message("TRN must only contain numbers")
     end
 
     it "does not allow less than 7 characters" do
-      expect(subject).not_to allow_value("1234").for(:trn)
+      expect(subject).not_to allow_value("1234").for(:trn).with_message("TRN is the wrong length (should be 7 characters)")
     end
 
     it "does not allow more than 7 characters" do
-      expect(subject).not_to allow_value("99123456").for(:trn)
+      expect(subject).not_to allow_value("99123456").for(:trn).with_message("TRN is the wrong length (should be 7 characters)")
     end
   end
 

--- a/spec/services/participants/change_trn_spec.rb
+++ b/spec/services/participants/change_trn_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Participants::ChangeTrn, type: :model do
   subject { described_class.new(trn: trn, user: user) }
 
-  let(:user) { create(:user, trn: original_trn) }
+  let(:user) { create(:user, :with_verified_trn, trn: original_trn) }
   let(:original_trn) { "1234567" }
   let(:trn) { "2345678" }
 
@@ -55,6 +55,14 @@ RSpec.describe Participants::ChangeTrn, type: :model do
 
       it "returns false" do
         expect(subject).to be false
+      end
+    end
+
+    context "when trn_verified is false" do
+      let(:user) { create(:user, trn: original_trn) }
+
+      it "updates trn_verified to true" do
+        expect { subject }.to change(user, :trn_verified).from(false).to(true)
       end
     end
   end

--- a/spec/services/participants/change_trn_spec.rb
+++ b/spec/services/participants/change_trn_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe Participants::ChangeTrn, type: :model do
     end
   end
 
-  describe "#call" do
-    subject { described_class.new(trn: trn, user: user).call }
+  describe "#change_trn" do
+    subject { described_class.new(trn: trn, user: user).change_trn }
 
     it "updates the user's TRN" do
       expect { subject }.to change(user, :trn).from(original_trn).to(trn)

--- a/spec/services/participants/change_trn_spec.rb
+++ b/spec/services/participants/change_trn_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Participants::ChangeTrn, type: :model do
+  subject { described_class.new(trn: trn, user: user) }
+
+  let(:user) { create(:user, trn: original_trn) }
+  let(:original_trn) { "1234567" }
+  let(:trn) { "2345678" }
+
+  describe "validations" do
+    it "does not allow a blank TRN" do
+      expect(subject).to validate_presence_of(:trn).with_message(:blank).with_message("can't be blank")
+    end
+
+    it "does not allow forbidden TRNs" do
+      expect(subject).not_to allow_value("0000000").for(:trn)
+    end
+
+    it "does not allow non-numeric characters" do
+      expect(subject).not_to allow_value("AA99/12345").for(:trn)
+    end
+
+    it "does not allow less than 7 characters" do
+      expect(subject).not_to allow_value("1234").for(:trn)
+    end
+
+    it "does not allow more than 7 characters" do
+      expect(subject).not_to allow_value("99123456").for(:trn)
+    end
+  end
+
+  describe "#call" do
+    subject { described_class.new(trn: trn, user: user).call }
+
+    it "updates the user's TRN" do
+      expect { subject }.to change(user, :trn).from(original_trn).to(trn)
+    end
+
+    context "when the TRN has whitespace" do
+      let(:trn) { "  2345  678  " }
+
+      it "strips whitespace" do
+        expect { subject }.to change(user, :trn).from(original_trn).to("2345678")
+      end
+    end
+
+    context "when the validations fail" do
+      let(:trn) { "" }
+
+      it "does not update the TRN" do
+        expect { subject }.not_to change(user, :trn)
+      end
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
+  end
+end

--- a/spec/services/teacher_reference_number_spec.rb
+++ b/spec/services/teacher_reference_number_spec.rb
@@ -3,55 +3,6 @@
 require "rails_helper"
 
 RSpec.describe TeacherReferenceNumber do
-  describe "valid?" do
-    context "when the original value contains the correct number of digits" do
-      it "returns true" do
-        expect(described_class.new("RP99/12345")).to be_valid
-        expect(described_class.new("12345")).to be_valid
-        expect(described_class.new("1234567")).to be_valid
-      end
-    end
-
-    context "when the original value is blank" do
-      subject(:trn) { described_class.new("") }
-
-      it "returns false" do
-        expect(trn).not_to be_valid
-      end
-
-      it "sets the format_error to :blank" do
-        trn.valid?
-        expect(trn.format_error).to eq(:blank)
-      end
-    end
-
-    context "when the original value contains fewer than 5 digits" do
-      subject(:trn) { described_class.new("R12WWS/ 2") }
-
-      it "returns false" do
-        expect(trn).not_to be_valid
-      end
-
-      it "sets the format_error to :too_short" do
-        trn.valid?
-        expect(trn.format_error).to eq(:too_short)
-      end
-    end
-
-    context "when the original value contains more than 7 digits" do
-      subject(:trn) { described_class.new("RP11/12345678") }
-
-      it "returns false" do
-        expect(trn).not_to be_valid
-      end
-
-      it "sets the format_error to :too_long" do
-        trn.valid?
-        expect(trn.format_error).to eq(:too_long)
-      end
-    end
-  end
-
   describe "#formatted_trn" do
     it "removes non-numeric characters" do
       expect(described_class.new("RP22/ 21 1 33").formatted_trn).to eq("2221133")
@@ -61,9 +12,21 @@ RSpec.describe TeacherReferenceNumber do
       expect(described_class.new("RP99/123").formatted_trn).to eq("0099123")
     end
 
-    context "when the original value is not valid" do
+    context "when the original value does not have enough digits" do
       it "returns nil" do
         expect(described_class.new("QWERTY123").formatted_trn).to be_nil
+      end
+    end
+
+    context "when the original value has too many digits" do
+      it "returns nil" do
+        expect(described_class.new("QWERTY123456789").formatted_trn).to be_nil
+      end
+    end
+
+    context "when the original value has no digits" do
+      it "returns nil" do
+        expect(described_class.new("QWERTY").formatted_trn).to be_nil
       end
     end
   end

--- a/spec/validators/valid_trn_validator_spec.rb
+++ b/spec/validators/valid_trn_validator_spec.rb
@@ -22,48 +22,48 @@ RSpec.describe ValidTrnValidator do
   it "can only contain numbers" do
     subject.trn = "123456a"
     subject.valid?
-    expect(subject.errors[:trn]).to eq ["is invalid"]
+    expect(subject.errors[:trn]).to eq ["TRN must only contain numbers"]
   end
 
   it "does not allow nil TRN" do
     subject.trn = nil
     subject.valid?
-    expect(subject.errors[:trn]).to eq ["can't be blank"]
+    expect(subject.errors[:trn]).to eq ["TRN can't be blank"]
   end
 
   it "does not allow empty TRN" do
     subject.trn = ""
     subject.valid?
-    expect(subject.errors[:trn]).to eq ["can't be blank"]
+    expect(subject.errors[:trn]).to eq ["TRN can't be blank"]
   end
 
   it "does not allow legacy style TRNs" do
     subject.trn = "RP99/12345"
     subject.valid?
-    expect(subject.errors[:trn]).to eq ["is invalid"]
+    expect(subject.errors[:trn]).to eq ["TRN must only contain numbers"]
   end
 
   it "does not allow TRNs over 7 characters" do
     subject.trn = "99123456"
     subject.valid?
-    expect(subject.errors[:trn]).to eq ["is the wrong length (should be 7 characters)"]
+    expect(subject.errors[:trn]).to eq ["TRN is the wrong length (should be 7 characters)"]
   end
 
   it "does not allow TRNs under 7 characters" do
     subject.trn = "1234"
     subject.valid?
-    expect(subject.errors[:trn]).to eq ["is the wrong length (should be 7 characters)"]
+    expect(subject.errors[:trn]).to eq ["TRN is the wrong length (should be 7 characters)"]
   end
 
   it "does not allow TRNs with other letters" do
     subject.trn = "AA99/12345"
     subject.valid?
-    expect(subject.errors[:trn]).to eq ["is invalid"]
+    expect(subject.errors[:trn]).to eq ["TRN must only contain numbers"]
   end
 
   it "does not allow fake TRN 0000000" do
     subject.trn = "0000000"
     subject.valid?
-    expect(subject.errors[:trn]).to eq ["You must enter a valid teacher reference number (TRN)"]
+    expect(subject.errors[:trn]).to eq ["You must enter a valid TRN"]
   end
 end

--- a/spec/validators/valid_trn_validator_spec.rb
+++ b/spec/validators/valid_trn_validator_spec.rb
@@ -46,13 +46,13 @@ RSpec.describe ValidTrnValidator do
   it "does not allow TRNs over 7 characters" do
     subject.trn = "99123456"
     subject.valid?
-    expect(subject.errors[:trn]).to eq ["is too long (maximum is 7 characters)"]
+    expect(subject.errors[:trn]).to eq ["is the wrong length (should be 7 characters)"]
   end
 
   it "does not allow TRNs under 7 characters" do
     subject.trn = "1234"
     subject.valid?
-    expect(subject.errors[:trn]).to eq ["is too short (minimum is 7 characters)"]
+    expect(subject.errors[:trn]).to eq ["is the wrong length (should be 7 characters)"]
   end
 
   it "does not allow TRNs with other letters" do

--- a/spec/validators/valid_trn_validator_spec.rb
+++ b/spec/validators/valid_trn_validator_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ValidTrnValidator do
+  before do
+    stub_const("TestModel", Class.new).class_eval do
+      include ActiveModel::Validations
+      attr_accessor :trn
+
+      validates :trn, valid_trn: true
+    end
+  end
+
+  subject { TestModel.new }
+
+  it "allows a valid TRN" do
+    subject.trn = "1234567"
+    expect(subject).to be_valid
+  end
+
+  it "can only contain numbers" do
+    subject.trn = "123456a"
+    subject.valid?
+    expect(subject.errors[:trn]).to eq ["is invalid"]
+  end
+
+  it "does not allow nil TRN" do
+    subject.trn = nil
+    subject.valid?
+    expect(subject.errors[:trn]).to eq ["can't be blank"]
+  end
+
+  it "does not allow empty TRN" do
+    subject.trn = ""
+    subject.valid?
+    expect(subject.errors[:trn]).to eq ["can't be blank"]
+  end
+
+  it "does not allow legacy style TRNs" do
+    subject.trn = "RP99/12345"
+    subject.valid?
+    expect(subject.errors[:trn]).to eq ["is invalid"]
+  end
+
+  it "does not allow TRNs over 7 characters" do
+    subject.trn = "99123456"
+    subject.valid?
+    expect(subject.errors[:trn]).to eq ["is too long (maximum is 7 characters)"]
+  end
+
+  it "does not allow TRNs under 7 characters" do
+    subject.trn = "1234"
+    subject.valid?
+    expect(subject.errors[:trn]).to eq ["is too short (minimum is 7 characters)"]
+  end
+
+  it "does not allow TRNs with other letters" do
+    subject.trn = "AA99/12345"
+    subject.valid?
+    expect(subject.errors[:trn]).to eq ["is invalid"]
+  end
+
+  it "does not allow fake TRN 0000000" do
+    subject.trn = "0000000"
+    subject.valid?
+    expect(subject.errors[:trn]).to eq ["You must enter a valid teacher reference number (TRN)"]
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2178

Allow admin users to change a participant's TRN

### Changes proposed in this pull request

- add ability to change TRN from separation admin participant page, including new `Participants::ChangeTrn` service
- add specs to cover existing TRN validation fully
- move common validation for TRN into new validator
- remove unused code from `TeacherReferenceNumber` service, to make it clear the validation there was never used
- change length validation from separate min and max to a single length check (this changes the error messages too)
- update `trn_verified` to true when the TRN is updated

### Screenshots

change link:
<img width="983" alt="Screenshot 2024-12-10 at 12 04 02" src="https://github.com/user-attachments/assets/612f16da-7239-4205-9de3-1c40c43a21ca">

error case:
<img width="737" alt="Screenshot 2024-12-10 at 12 24 26" src="https://github.com/user-attachments/assets/9b8724e5-31d7-452d-8e24-d1a34ff6ee7b">

