### PR TITLE
[2158] Staging and sandbox front door domains

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ domains-infra-plan: domains domains-infra-init
 domains-infra-apply: domains domains-infra-init
 	terraform -chdir=terraform/domains/infrastructure apply -var-file config/zones.tfvars.json ${AUTO_APPROVE}
 
-domains-init: domains-composed-variables domains set-azure-account
+domains-init: domains domains-composed-variables set-azure-account
 	rm -rf terraform/domains/environment_domains/vendor/modules/domains
 	git -c advice.detachedHead=false clone --depth=1 --single-branch --branch ${TERRAFORM_MODULES_TAG} https://github.com/DFE-Digital/terraform-modules.git terraform/domains/environment_domains/vendor/modules/domains
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-TERRAFILE_VERSION=0.8
 ARM_TEMPLATE_TAG=1.1.6
 RG_TAGS={"Product" : "Register for National Professional Qualifications (NPQ)"}
 REGION=UK South

--- a/terraform/domains/environment_domains/config/production.tfvars.json
+++ b/terraform/domains/environment_domains/config/production.tfvars.json
@@ -10,13 +10,7 @@
         "/packs/*"
       ],
       "environment_short": "pd",
-      "origin_hostname": "npq-registration-production-web.teacherservices.cloud",
-      "cnames": {
-        "_14c49b3a20d4ad049e0708795e1f8ca4": {
-          "target": "_9156bba248c12a46b784f7312750bd29.gwpjclltnz.acm-validations.aws.",
-          "ttl": 86400
-        }
-      }
+      "origin_hostname": "npq-registration-production-web.teacherservices.cloud"
     }
   }
 }

--- a/terraform/domains/environment_domains/config/production_Terrafile
+++ b/terraform/domains/environment_domains/config/production_Terrafile
@@ -1,3 +1,0 @@
-domains:
-    source:  "https://github.com/DFE-Digital/terraform-modules"
-    version: "stable"

--- a/terraform/domains/environment_domains/config/sandbox.tfvars.json
+++ b/terraform/domains/environment_domains/config/sandbox.tfvars.json
@@ -1,0 +1,16 @@
+{
+  "hosted_zone": {
+    "register-national-professional-qualifications.education.gov.uk": {
+      "front_door_name": "s189p01-cpdnpqdomains-fd",
+      "resource_group_name": "s189p01-cpdnpqdomains-rg",
+      "domains": [
+        "t"
+      ],
+      "cached_paths": [
+        "/packs/*"
+      ],
+      "environment_short": "sb",
+      "origin_hostname": "npq-registration-sandbox-web.teacherservices.cloud"
+    }
+  }
+}

--- a/terraform/domains/environment_domains/config/staging.tfvars.json
+++ b/terraform/domains/environment_domains/config/staging.tfvars.json
@@ -1,0 +1,16 @@
+{
+  "hosted_zone": {
+    "register-national-professional-qualifications.education.gov.uk": {
+      "front_door_name": "s189p01-cpdnpqdomains-fd",
+      "resource_group_name": "s189p01-cpdnpqdomains-rg",
+      "domains": [
+        "x"
+      ],
+      "cached_paths": [
+        "/packs/*"
+      ],
+      "environment_short": "st",
+      "origin_hostname": "npq-registration-staging-web.test.teacherservices.cloud"
+    }
+  }
+}

--- a/terraform/domains/environment_domains/main.tf
+++ b/terraform/domains/environment_domains/main.tf
@@ -11,9 +11,3 @@ module "domains" {
   null_host_header    = try(each.value.null_host_header, false)
   cached_paths        = try(each.value.cached_paths, [])
 }
-
-# Takes values from hosted_zone.domain_name.cnames (or txt_records, a-records). Use for domains which are not associated with front door.
-module "dns_records" {
-  source      = "./vendor/modules/domains//dns/records"
-  hosted_zone = var.hosted_zone
-}

--- a/terraform/domains/infrastructure/config/zones_Terrafile
+++ b/terraform/domains/infrastructure/config/zones_Terrafile
@@ -1,3 +1,0 @@
-domains:
-    source:  "https://github.com/DFE-Digital/terraform-modules"
-    version: "testing"


### PR DESCRIPTION
### Context

Ticket: https://trello.com/c/5jCq2a3p

Add front door environments for pen testers and external users

Depends on https://github.com/DFE-Digital/terraform-modules/pull/139

### Changes proposed in this pull request
- Configure staging and sandbox environment
- Delete references to terrafile
- Delete old records

### Review
Domains are ready:
- https://x.register-national-professional-qualifications.education.gov.uk/
- https://t.register-national-professional-qualifications.education.gov.uk/

### Before merging
- Wait for https://github.com/DFE-Digital/terraform-modules/pull/139 to be relase to stable (check with infra)
- Remove TEMP commit