### PR TITLE
Remove whenever gem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,4 +76,4 @@ ENV PORT=8080
 
 EXPOSE ${PORT}
 
-CMD bundle exec rake db:migrate && bundle exec whenever --update-crontab && bundle exec rails s -p ${PORT} --binding=0.0.0.0
+CMD bundle exec rake db:migrate && bundle exec rails s -p ${PORT} --binding=0.0.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,6 @@ gem "sprockets", "~> 4.2.0"
 gem "sprockets-rails", require: "sprockets/railtie"
 gem "state_machines-activerecord"
 gem "stimulus-rails"
-gem "whenever"
 
 gem "net-imap", "~> 0.5.1", require: false
 gem "net-pop", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,7 +143,6 @@ GEM
       launchy
     cgi (0.3.6)
     choice (0.2.0)
-    chronic (0.10.2)
     coderay (1.1.3)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
@@ -674,8 +673,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    whenever (1.0.0)
-      chronic (>= 0.6.3)
     with_model (2.1.7)
       activerecord (>= 6.0)
     xpath (3.2.0)
@@ -774,7 +771,6 @@ DEPENDENCIES
   tzinfo-data
   web-console (>= 3.3.0)
   webmock (~> 3.24)
-  whenever
   with_model (~> 2.1, >= 2.1.7)
 
 RUBY VERSION


### PR DESCRIPTION
### Context

Ticket: N/A

There was only one job being scheduled via `whenever` gem, which got removed as it was linked to ECF.
The other jobs use `delayed_cron_job` instead.

### Changes proposed in this pull request

Remove whenever gem.