### PR TITLE
Document funnding/capping behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 1. [Migration Environment](docs/migration_environment.md)
 1. [Sending emails from application](docs/emails.md)
 1. [NPQ Contracts](docs/npq_contracts.md)
+1. [Funding](docs/funding.md)
 1. [Data Model](docs/data_model.md)
 
 ## Content Editors

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -119,14 +119,11 @@ class Course < ApplicationRecord
   end
 
   def rebranded_alternative_courses
-    case identifier
-    when NPQ_ADDITIONAL_SUPPORT_OFFER
-      [self, Course.find_by(identifier: NPQ_EARLY_HEADSHIP_COACHING_OFFER)]
-    when NPQ_EARLY_HEADSHIP_COACHING_OFFER
-      [self, Course.find_by(identifier: NPQ_ADDITIONAL_SUPPORT_OFFER)]
-    else
-      [self]
-    end
+    rebranded_identifiers = [NPQ_ADDITIONAL_SUPPORT_OFFER, NPQ_EARLY_HEADSHIP_COACHING_OFFER].freeze
+
+    return Course.where(identifier: rebranded_identifiers) if identifier.in?(rebranded_identifiers)
+
+    [self]
   end
 
   def npqs?

--- a/docs/funding.md
+++ b/docs/funding.md
@@ -1,0 +1,61 @@
+[< Back to Navigation](../README.md)
+
+# Funding
+
+## Funding eligibility during registration
+
+TODO: to be completed by NPQ reg team
+
+## Accepting an application
+
+When accepting an application we evaluate the `funded_place` attribute passed in the payload against the `funding_cap` of the cohort and `eligible_for_funding` status of the application:
+
+- The `funded_place` attribute in the accept application payload will be evaluated only for cohorts that have a `funding_cap`. 
+- The `funded_place` must be `true` or `false` if the cohort has a `funding_cap`.
+
+When accepting an application with a `funded_place`:
+
+- The `funded_place` can be `true` or `false` if the application is `eligible_for_funding`.
+- The `funded_place` can only be `false` if the application is not `eligible_for_funding`.
+
+## Changing the funded place of an application
+
+Lead providers can change the `funded_place` of an application via the API:
+
+- The application must be `accepted`.
+- The application must be `eligible_for_funding` if changing to `true`.
+- The cohort of the application must have a `funding_cap`.
+- If changing `funded_place` to `false` the application must have no `eligible`, `payable`, `paid` or `submitted` declarations.
+
+## Previously funded
+
+An application is considered `previously_funded` if:
+
+- Another application exists with an equivalent course (as determined by `rebranded_alternative_courses`).
+  - If the application course is not `npq-additional-support-offer` or `npq-early-headship-coaching-offer` it must be the same course.
+  - If the application course is `npq-additional-support-offer` or `npq-early-headship-coaching-offer` it can be an application with either of these two courses.
+- The other application is `accepted` and `eligible_for_funding`.
+- The `funded_place` of the application is either not set (`nil`, i.e. prior to 2024) or is `true`.
+
+## Application serialization/eligible for funding
+
+When an application is serialized we determine the `eligible_for_funding` state by inspecting the user eligibility and if the application has been `previously_funded`.
+
+An application is `eligible_for_funding` if:
+
+- They have no `previously_funded` applications.
+- They are `eligible_for_funding`.
+
+## Creating a declaration
+
+On creating a new declaration, it is marked as `eligible` if:
+
+- There are no `previously_funded` applications.
+- They are `eligible_for_funding` and `funded_place` is not set (`nil`, i.e. prior to 2024) or is `true`.
+
+## Pre-2024 funded place behaviour
+
+Prior to 2024 we only calculated eligibility for declarations using the `eligible_for_funding` attribute (there was no notion of `funded_place`). Similarly, we only checked only `eligible_for_funding` during the `previously_funded` method as well.
+
+See [ECF #4871](https://github.com/DFE-Digital/early-careers-framework/pull/4871) for how `funded_place` was originally introduced in ECF (and later replicated in NPQ reg) for more details.
+

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -56,26 +56,26 @@ RSpec.describe Course do
   end
 
   describe "#rebranded_alternative_courses" do
-    let(:course) { described_class.new(identifier:) }
+    let(:course) { create(:course, identifier:) }
 
-    subject { course.rebranded_alternative_courses }
+    subject { course.rebranded_alternative_courses.map(&:identifier) }
 
     context "when the identifier is npq-additional-support-offer" do
       let(:identifier) { "npq-additional-support-offer" }
 
-      it { is_expected.to contain_exactly(course, described_class.find_by(identifier: "npq-early-headship-coaching-offer")) }
+      it { is_expected.to contain_exactly(identifier, "npq-early-headship-coaching-offer") }
     end
 
     context "when the identifier is npq-early-headship-coaching-offer" do
       let(:identifier) { "npq-early-headship-coaching-offer" }
 
-      it { is_expected.to contain_exactly(course, described_class.find_by(identifier: "npq-additional-support-offer")) }
+      it { is_expected.to contain_exactly(identifier, "npq-additional-support-offer") }
     end
 
     context "when the identifier is not npq-additional-support-offer or npq-early-headship-coaching-offer" do
       let(:identifier) { "other" }
 
-      it { is_expected.to contain_exactly(course) }
+      it { is_expected.to contain_exactly(identifier) }
     end
   end
 


### PR DESCRIPTION
### Context

We want to document the behaviour around funding/capping as since we introduced `funded_place` there is a fair amount going on when dealing with applications, declarations and eligibility.

### Changes proposed in this pull request

- Document funding/capping behaviour

Add documenbtation for funding to detail how application funding, eligibility and capping behaviour works both pre and post 2024 when the `funded_place` attribute was added.

- Clean up rebranded_alternative_courses

I found the switch statement confusing and it makes the behaviour seem more complicated than it actually is.

If the course is a 'rebranded alternative' course return all possible courses otherwise just return the current course.

