### PR TITLE
[CPDNPQ-2394] Don't allow duplicate statements

### DIFF
--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -20,11 +20,18 @@ class Statement < ApplicationRecord
               only_integer: true,
               message: "Month must be a number between 1 and 12",
             }
+
   validates :year,
             numericality: {
               in: 2020..2050,
               only_integer: true,
               message: "Year must be a 4 digit number",
+            }
+
+  validates :lead_provider_id,
+            uniqueness: {
+              scope: %i[cohort_id year month],
+              message: "A statement for this lead provider, cohort, year and month already exists",
             }
 
   validates :ecf_id, uniqueness: { case_sensitive: false }

--- a/db/migrate/20241212170751_add_unique_index_to_statements.rb
+++ b/db/migrate/20241212170751_add_unique_index_to_statements.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToStatements < ActiveRecord::Migration[7.1]
+  def change
+    add_index :statements, %i[lead_provider_id cohort_id year month], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_12_09_112415) do
+ActiveRecord::Schema[7.1].define(version: 2024_12_12_170751) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -501,6 +501,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_09_112415) do
     t.uuid "ecf_id", default: -> { "gen_random_uuid()" }, null: false
     t.index ["cohort_id"], name: "index_statements_on_cohort_id"
     t.index ["ecf_id"], name: "index_statements_on_ecf_id", unique: true
+    t.index ["lead_provider_id", "cohort_id", "year", "month"], name: "idx_on_lead_provider_id_cohort_id_year_month_2dece26c47", unique: true
     t.index ["lead_provider_id"], name: "index_statements_on_lead_provider_id"
   end
 

--- a/spec/factories/statements.rb
+++ b/spec/factories/statements.rb
@@ -26,6 +26,18 @@ FactoryBot.define do
       output_fee { true }
     end
 
+    trait(:next_period) do
+      transient do
+        latest_statement do
+          existing = Statement.where(cohort:, lead_provider:).order(year: :desc, month: :desc)
+          existing.first || OpenStruct.new(year: cohort.start_year, month: 1)
+        end
+      end
+
+      month { latest_statement.month == 12 ? 1 : latest_statement.month + 1 }
+      year { latest_statement.month == 12 ? latest_statement.year + 1 : latest_statement.year }
+    end
+
     trait(:paid) do
       state { "paid" }
       marked_as_paid_at { 1.week.ago }

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Statement, type: :model do
     it { is_expected.to allow_value(%w[true false]).for(:output_fee).with_message("Output fee must be true or false") }
     it { is_expected.not_to allow_value(nil).for(:output_fee).with_message("Choose yes or no for output fee") }
     it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique") }
+    it { is_expected.to validate_uniqueness_of(:lead_provider_id).scoped_to(:cohort_id, :year, :month).with_message("A statement for this lead provider, cohort, year and month already exists") }
 
     describe "State validation" do
       context "when setting invalid state" do

--- a/spec/requests/api/v3/statements_spec.rb
+++ b/spec/requests/api/v3/statements_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Statements endpoint", type: "request" do
     let(:resource_id_key) { :ecf_id }
 
     def create_resource(**attrs)
-      create(:statement, **attrs)
+      create(:statement, :next_period, **attrs)
     end
 
     it_behaves_like "an API index endpoint with pagination"

--- a/spec/services/assurance_reports/query_spec.rb
+++ b/spec/services/assurance_reports/query_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe AssuranceReports::Query do
   end
 
   let :other_statement do
-    create(:statement, lead_provider:, deadline_date: statement.deadline_date + 1.day)
+    create(:statement, :next_period, lead_provider:, deadline_date: statement.deadline_date + 1.day)
   end
 
   let :other_declaration do


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2394

It’s currently possible to create more than one statement per lead provider / cohort / year / month

This is incorrect, there should be a maximum of one statement per lead provider / cohort / year / month

This currently affects seed data; although #2079  will correct the seeds to no longer create duplicate statements, it should be technically impossible to do so in any circumstances

#### 1: Check that no production data violates this

In a production console just now:

```
irb(main):001> Statement.find_each.map { [_1.cohort_id, _1.lead_provider_id, _1.year, _1.month] }.tally.values.all?(1)
=> true
```

I think this means we're all good, unless there are any other checks I haven't considered?

#### 2: Introduce necessary model validation and database constraint(s) to make this impossible in future

See Pull Request — one unique index, one `uniqueness` validation 🔒 