### PR TITLE
[CPDNPQ-2357] Make staging auth operate like production

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -62,7 +62,7 @@ module ApplicationHelper
   end
 
   def show_otp_code_in_ui(current_env, admin)
-    return unless current_env.in?(%w[development review staging])
+    return unless current_env.in?(%w[development review])
 
     tag.p("OTP code: #{admin.otp_hash}")
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe ApplicationHelper, type: :helper do
 
     {
       "development" => otp_snippet,
-      "staging" => otp_snippet,
       "review" => otp_snippet,
+      "staging" => nil,
       "sandbox" => nil,
       "production" => nil,
     }.each do |environment, expected_result|


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2357](https://dfedigital.atlassian.net/browse/CPDNPQ-2357)

We want the user to need to go via the email to login

### Changes proposed in this pull request

1. Prevent showing the OTP code on staging


[CPDNPQ-2357]: https://dfedigital.atlassian.net/browse/CPDNPQ-2357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ