### PR TITLE
Fix flakey test(s) due to statement factory dates

### DIFF
--- a/spec/factories/statements.rb
+++ b/spec/factories/statements.rb
@@ -11,9 +11,9 @@ FactoryBot.define do
     end
 
     month { Faker::Number.between(from: 1, to: 12) }
-    year { Faker::Number.between(from: 2021, to: 2024) }
-    deadline_date { Faker::Date.forward(days: 30) }
-    payment_date { Faker::Date.forward(days: 30) }
+    year { Faker::Number.between(from: 2022, to: 2024) }
+    deadline_date { Date.new(year, month, 1) - 6.days }
+    payment_date { Date.new(year, month, 25) }
     cohort { create(:cohort, :current) }
     lead_provider { declaration&.lead_provider || build(:lead_provider) }
     reconcile_amount { Faker::Number.decimal(l_digits: 3, r_digits: 2) }
@@ -22,7 +22,7 @@ FactoryBot.define do
     output_fee { true }
 
     trait(:next_output_fee) do
-      deadline_date { 1.day.from_now }
+      next_period
       output_fee { true }
     end
 


### PR DESCRIPTION
Recently merged #2086 introduced test flakiness e.g. https://github.com/DFE-Digital/npq-registration/actions/runs/12413145723/job/34654406802

This seems to be because of an assumption that `Statement#deadline_date` is correlated with the statement period, but in the factory this was being set as a random date within 30 days relative to the current date (not the statement)

This PR sets `deadline_date` and `payment_date` as -6 / +25 days respectively relative to the start of the statement month (which more closely represents how real statements work), which gets the failing test to pass with the same seed.

As a consequence of this, some other tests that did not follow monthly statement behaviour also need tweaking.