### PR TITLE
Fix schedule spec failures due to date changes

### DIFF
--- a/spec/components/npq_separation/admin/course_payment_overview_component_spec.rb
+++ b/spec/components/npq_separation/admin/course_payment_overview_component_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe NpqSeparation::Admin::CoursePaymentOverviewComponent, type: :comp
 
   before do
     create :schedule, :npq_leadership_autumn
+    create :schedule, :npq_leadership_spring
 
     create_list(:declaration, 2, :eligible, declaration_type: "started", course:, statement:)
     create_list(:declaration, 3, :eligible, declaration_type: "retained-1", course:, statement:)

--- a/spec/features/npq_separation/admin/finance/statement_spec.rb
+++ b/spec/features/npq_separation/admin/finance/statement_spec.rb
@@ -18,7 +18,9 @@ RSpec.feature "Statement", type: :feature do
 
   before do
     create(:schedule, :npq_leadership_autumn)
+    create(:schedule, :npq_leadership_spring)
     create(:schedule, :npq_specialist_autumn)
+    create(:schedule, :npq_specialist_spring)
 
     sign_in_as(create(:admin))
   end

--- a/spec/models/lead_provider_spec.rb
+++ b/spec/models/lead_provider_spec.rb
@@ -14,21 +14,21 @@ RSpec.describe LeadProvider do
   describe "#next_output_fee_statement" do
     let(:cohort) { create(:cohort, :current) }
     let(:lead_provider) { next_output_fee_statement.lead_provider }
-    let(:next_output_fee_statement) { create(:statement, :next_output_fee, cohort:) }
+    let(:next_output_fee_statement) { create(:statement, :next_output_fee, cohort:, month: 7) }
 
     before do
       # Not output fee
-      create(:statement, output_fee: false, cohort:, lead_provider:, deadline_date: 1.hour.from_now)
+      create(:statement, output_fee: false, cohort:, lead_provider:, deadline_date: 1.hour.from_now, month: 1)
       # Paid
-      create(:statement, :paid, :next_output_fee, cohort:, lead_provider:, deadline_date: 2.hours.from_now)
+      create(:statement, :paid, :next_output_fee, cohort:, lead_provider:, deadline_date: 2.hours.from_now, month: 2)
       # Payable
-      create(:statement, :payable, :next_output_fee, cohort:, lead_provider:, deadline_date: 3.hours.from_now)
+      create(:statement, :payable, :next_output_fee, cohort:, lead_provider:, deadline_date: 3.hours.from_now, month: 3)
       # Deadline is later
-      create(:statement, output_fee: true, cohort:, lead_provider:, deadline_date: 2.days.from_now)
+      create(:statement, output_fee: true, cohort:, lead_provider:, deadline_date: 2.days.from_now, month: 4)
       # Wrong cohort
-      create(:statement, output_fee: true, cohort: create(:cohort, start_year: cohort.start_year + 1), lead_provider:, deadline_date: 1.hour.from_now)
+      create(:statement, output_fee: true, cohort: create(:cohort, start_year: cohort.start_year + 1), lead_provider:, deadline_date: 1.hour.from_now, month: 5)
       # In the past
-      create(:statement, output_fee: true, cohort:, lead_provider:, deadline_date: 1.day.ago)
+      create(:statement, output_fee: true, cohort:, lead_provider:, deadline_date: 1.day.ago, month: 6)
     end
 
     subject { lead_provider.next_output_fee_statement(cohort) }

--- a/spec/requests/api/docs/v1/applications_spec.rb
+++ b/spec/requests/api/docs/v1/applications_spec.rb
@@ -1,13 +1,11 @@
 require "rails_helper"
 require "swagger_helper"
 
-RSpec.describe "NPQ Applications endpoint", openapi_spec: "v1/swagger.yaml", type: :request do
+RSpec.describe "NPQ Applications endpoint", :with_default_schedules, openapi_spec: "v1/swagger.yaml", type: :request do
   include_context "with authorization for api doc request"
 
   let(:course_group) { CourseGroup.find_by(name: "leadership") || create(:course_group, name: "leadership") }
   let(:course) { create(:course, :senior_leadership, course_group:) }
-  let(:schedule) { create(:schedule, :npq_leadership_autumn, course_group:, cohort:) }
-  let(:schedule) { create(:schedule, :npq_leadership_spring, course_group:, cohort:) }
   let(:cohort) { create(:cohort, :current, funding_cap: true) }
   let!(:application) do
     create(
@@ -15,7 +13,6 @@ RSpec.describe "NPQ Applications endpoint", openapi_spec: "v1/swagger.yaml", typ
       course:,
       lead_provider:,
       cohort:,
-      schedule:,
     )
   end
 

--- a/spec/requests/api/docs/v1/applications_spec.rb
+++ b/spec/requests/api/docs/v1/applications_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "NPQ Applications endpoint", openapi_spec: "v1/swagger.yaml", typ
   let(:course_group) { CourseGroup.find_by(name: "leadership") || create(:course_group, name: "leadership") }
   let(:course) { create(:course, :senior_leadership, course_group:) }
   let(:schedule) { create(:schedule, :npq_leadership_autumn, course_group:, cohort:) }
+  let(:schedule) { create(:schedule, :npq_leadership_spring, course_group:, cohort:) }
   let(:cohort) { create(:cohort, :current, funding_cap: true) }
   let!(:application) do
     create(

--- a/spec/requests/api/docs/v2/applications_spec.rb
+++ b/spec/requests/api/docs/v2/applications_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "NPQ Applications endpoint", openapi_spec: "v2/swagger.yaml", typ
   let(:course_group) { CourseGroup.find_by(name: "leadership") || create(:course_group, name: "leadership") }
   let(:course) { create(:course, :senior_leadership, course_group:) }
   let(:schedule) { create(:schedule, :npq_leadership_autumn, course_group:, cohort:) }
+  let(:schedule) { create(:schedule, :npq_leadership_spring, course_group:, cohort:) }
   let(:cohort) { create(:cohort, :current, funding_cap: true) }
   let!(:application) do
     create(

--- a/spec/requests/api/docs/v2/applications_spec.rb
+++ b/spec/requests/api/docs/v2/applications_spec.rb
@@ -1,13 +1,11 @@
 require "rails_helper"
 require "swagger_helper"
 
-RSpec.describe "NPQ Applications endpoint", openapi_spec: "v2/swagger.yaml", type: :request do
+RSpec.describe "NPQ Applications endpoint", :with_default_schedules, openapi_spec: "v2/swagger.yaml", type: :request do
   include_context "with authorization for api doc request"
 
   let(:course_group) { CourseGroup.find_by(name: "leadership") || create(:course_group, name: "leadership") }
   let(:course) { create(:course, :senior_leadership, course_group:) }
-  let(:schedule) { create(:schedule, :npq_leadership_autumn, course_group:, cohort:) }
-  let(:schedule) { create(:schedule, :npq_leadership_spring, course_group:, cohort:) }
   let(:cohort) { create(:cohort, :current, funding_cap: true) }
   let!(:application) do
     create(
@@ -15,7 +13,6 @@ RSpec.describe "NPQ Applications endpoint", openapi_spec: "v2/swagger.yaml", typ
       course:,
       lead_provider:,
       cohort:,
-      schedule:,
     )
   end
 

--- a/spec/requests/api/docs/v3/applications_spec.rb
+++ b/spec/requests/api/docs/v3/applications_spec.rb
@@ -1,21 +1,18 @@
 require "rails_helper"
 require "swagger_helper"
 
-RSpec.describe "NPQ Applications endpoint", openapi_spec: "v3/swagger.yaml", type: :request do
+RSpec.describe "NPQ Applications endpoint", :with_default_schedules, openapi_spec: "v3/swagger.yaml", type: :request do
   include_context "with authorization for api doc request"
 
   let(:course_group) { CourseGroup.find_by(name: "leadership") || create(:course_group, name: "leadership") }
   let(:course) { create(:course, :senior_leadership, course_group:) }
   let(:cohort) { create(:cohort, :current, funding_cap: true) }
-  let(:schedule) { create(:schedule, :npq_leadership_autumn, course_group:, cohort:) }
-  let(:schedule) { create(:schedule, :npq_leadership_spring, course_group:, cohort:) }
   let(:application) do
     create(
       :application,
       course:,
       lead_provider:,
       cohort:,
-      schedule:,
     )
   end
 
@@ -82,7 +79,7 @@ RSpec.describe "NPQ Applications endpoint", openapi_spec: "v3/swagger.yaml", typ
                     "The NPQ application after changing the funded place",
                     "#/components/schemas/ApplicationResponse",
                     "#/components/schemas/ApplicationChangeFundedPlaceRequest" do
-      let(:application) { create(:application, :eligible_for_funded_place, lead_provider:, schedule:, cohort:, course:) }
+      let(:application) { create(:application, :eligible_for_funded_place, lead_provider:, cohort:, course:) }
       let(:resource) { application }
       let(:type) { "npq-application-change-funded-place" }
       let(:attributes) { { funded_place: true } }

--- a/spec/requests/api/docs/v3/applications_spec.rb
+++ b/spec/requests/api/docs/v3/applications_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "NPQ Applications endpoint", openapi_spec: "v3/swagger.yaml", typ
   let(:course) { create(:course, :senior_leadership, course_group:) }
   let(:cohort) { create(:cohort, :current, funding_cap: true) }
   let(:schedule) { create(:schedule, :npq_leadership_autumn, course_group:, cohort:) }
+  let(:schedule) { create(:schedule, :npq_leadership_spring, course_group:, cohort:) }
   let(:application) do
     create(
       :application,

--- a/spec/services/valid_test_data_generators/statements_populater_spec.rb
+++ b/spec/services/valid_test_data_generators/statements_populater_spec.rb
@@ -47,9 +47,11 @@ RSpec.describe ValidTestDataGenerators::StatementsPopulater do
       end
 
       it "creates unpaid statements" do
-        expect {
-          subject.populate
-        }.to(change { Statement.unpaid.count })
+        travel_to(Date.new(cohort.start_year, 12, 26)) do
+          expect {
+            subject.populate
+          }.to(change { Statement.unpaid.count })
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-000

After the 25th of December we have failing specs due to schedules

### Changes proposed in this pull request

After certain dates the schedules change for courses. Create both courses to avoid failures at certain times in the year.

I avoided the `with_default_schedules` setup as it does not amend dates to stop declaration failures which is needed in those specs.

For the valid test data, there is a date in the service itself we have to travel to, travel to it in the specs.

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
