### PR TITLE
[CPDNPQ-2335] enable sentry on staging and review environments

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Sentry.init do |config|
-  config.enabled_environments = %w[production sandbox]
+  config.enabled_environments = %w[production sandbox staging review]
   config.dsn = config.enabled_environments.include?(Rails.env) ? ENV["SENTRY_DSN"] : "disabled"
   config.breadcrumbs_logger = %i[active_support_logger http_logger]
   config.release = ENV["GIT_COMMIT_SHA"]


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2335

### Changes proposed in this pull request

enable sentry on staging and review environments.

we already have the environment variable `SENTRY_DSN` set for staging and review apps.

This PR needs to be merged before I can create the alert in sentry for staging (sentry needs at least one error from that environment for it to appear in the alert settings dropdown).