### PR TITLE
fix failing spec

### DIFF
--- a/spec/services/participants/change_schedule_spec.rb
+++ b/spec/services/participants/change_schedule_spec.rb
@@ -289,7 +289,7 @@ RSpec.describe Participants::ChangeSchedule, type: :model do
       end
 
       context "when using fallback_cohort" do
-        let(:cohort) { create(:cohort, start_year: (Date.current.year + 5)) }
+        let(:cohort) { create(:cohort, start_year: (Date.current.year + 1)) }
 
         context "when application has schedule" do
           before do


### PR DESCRIPTION
### Context

spec failing because it's now 2025

### Changes proposed in this pull request

change cohort in spec to `Date.current.year + 1` because it still uses the fallback_cohort.
