### PR TITLE
[CPDNPQ-2395] improve participants API load times

### DIFF
--- a/app/controllers/concerns/api/pagination.rb
+++ b/app/controllers/concerns/api/pagination.rb
@@ -10,7 +10,7 @@ module API
   private
 
     def paginate(scope)
-      _pagy, paginated_records = pagy(scope, limit: per_page, page:)
+      _pagy, paginated_records = pagy_countless(scope, limit: per_page, page:)
 
       paginated_records
     end

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,3 +1,4 @@
+require "pagy/extras/countless"
 require "pagy/extras/overflow"
 
 Pagy::DEFAULT[:size] = [1, 1, 1, 1]

--- a/db/migrate/20250103111630_add_indexes.rb
+++ b/db/migrate/20250103111630_add_indexes.rb
@@ -1,5 +1,6 @@
 class AddIndexes < ActiveRecord::Migration[7.1]
   def change
     add_index :applications, %i[lead_provider_approval_status lead_provider_id]
+    add_index :users, :created_at
   end
 end

--- a/db/migrate/20250103111630_add_indexes.rb
+++ b/db/migrate/20250103111630_add_indexes.rb
@@ -1,0 +1,5 @@
+class AddIndexes < ActiveRecord::Migration[7.1]
+  def change
+    add_index :applications, %i[lead_provider_approval_status lead_provider_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_12_18_101840) do
+ActiveRecord::Schema[7.1].define(version: 2025_01_03_111630) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -119,6 +119,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_18_101840) do
     t.index ["course_id"], name: "index_applications_on_course_id"
     t.index ["ecf_id"], name: "index_applications_on_ecf_id", unique: true
     t.index ["itt_provider_id"], name: "index_applications_on_itt_provider_id"
+    t.index ["lead_provider_approval_status", "lead_provider_id"], name: "idx_on_lead_provider_approval_status_lead_provider__299e5bac06"
     t.index ["lead_provider_id"], name: "index_applications_on_lead_provider_id"
     t.index ["private_childcare_provider_id"], name: "index_applications_on_private_childcare_provider_id"
     t.index ["schedule_id"], name: "index_applications_on_schedule_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -538,6 +538,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_03_111630) do
     t.string "archived_email"
     t.datetime "archived_at"
     t.datetime "significantly_updated_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.index ["created_at"], name: "index_users_on_created_at"
     t.index ["ecf_id"], name: "index_users_on_ecf_id", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["provider"], name: "index_users_on_provider"


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2395

requests to `/api/v3/participants/npq?page_size=3000&updated_since=2020-01-01` are too slow (~800ms)

### Changes proposed in this pull request

* switch to [pagy_countless](https://ddnexus.github.io/pagy/docs/extras/countless/) (saves 200-300ms)
* add index to applications lead_provider_approval_status (saves ~100ms)
* add index to users created_at (saves ~200ms)

Tested using a production data dump, using lead provider _Ambition Institute_, which has ~46,000 users.

before optimisation: page load ~800ms
after optimisation: page load ~150ms
