### PR TITLE
[CPDNPQ-2437] Fix course calculator allowed_declaration_types

### DIFF
--- a/app/services/statements/course_calculator.rb
+++ b/app/services/statements/course_calculator.rb
@@ -65,7 +65,10 @@ module Statements
     end
 
     def allowed_declaration_types
-      course.schedule_for(cohort:).allowed_declaration_types.sort_by { Schedule::DECLARATION_TYPES.index(_1) }
+      Schedule.where(cohort:, course_group: course.course_group)
+              .flat_map(&:allowed_declaration_types)
+              .uniq
+              .sort_by { Schedule::DECLARATION_TYPES.index(_1) }
     end
 
     def declaration_count_for_declaration_type(declaration_type)

--- a/spec/services/statements/course_calculator_spec.rb
+++ b/spec/services/statements/course_calculator_spec.rb
@@ -329,6 +329,20 @@ RSpec.describe Statements::CourseCalculator do
     end
   end
 
+  describe "#allowed_declaration_types" do
+    let(:course_group) { course.course_group }
+
+    before do
+      course_group.schedules.destroy_all
+      create(:schedule, course_group:, cohort:, allowed_declaration_types: %w[started retained-1])
+      create(:schedule, course_group:, cohort:, allowed_declaration_types: %w[retained-1 completed])
+    end
+
+    it "is derived from schedules" do
+      expect(subject.allowed_declaration_types).to eql(%w[started retained-1 completed])
+    end
+  end
+
   describe "#output_payment" do
     it "is a hash" do
       expect(subject.output_payment).to be_a(Hash)


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2437

Viewing some statements in the admin console was broken because we need to know the `allowed_declaration_types` for each course in order to count declarations

`allowed_declaration_types` comes from the course's schedule. Previously we were looking for an individual schedule according to today's date, which is wrong because a statement refers to a past point in time (i.e. has no relation to today's date), and also a statement may include declarations across multiple schedules.

Although in theory all schedules for a course in a particular cohort should have the same `allowed_declaration_types`, in any case it is safer and simpler to aggregate the allowed declarations for all of the schedules for the course/cohort, which is what this PR does.

Confirmed locally that this resolves the original issue, i.e. the previously unviewable statements are now loading as expected via snapshot database.