### PR TITLE
[CPDNPQ-2442] Default to running rails console from workers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,19 +174,23 @@ install-konduit: ## Install the konduit script, for accessing backend services
 
 aks-console: get-cluster-credentials
 	$(if $(PULL_REQUEST_NUMBER), $(eval export APP_ID=review-$(PULL_REQUEST_NUMBER)) , $(eval export APP_ID=$(CONFIG_LONG)))
-	kubectl -n ${NAMESPACE} exec -ti --tty deployment/npq-registration-${APP_ID}-web -- /bin/sh -c "cd /app && bundle exec rails c"
+	kubectl -n ${NAMESPACE} exec -ti --tty deployment/npq-registration-${APP_ID}-worker -- /bin/sh -c "cd /app && bundle exec rails c --sandbox"
+
+aks-rw-console: get-cluster-credentials
+	$(if $(PULL_REQUEST_NUMBER), $(eval export APP_ID=review-$(PULL_REQUEST_NUMBER)) , $(eval export APP_ID=$(CONFIG_LONG)))
+	kubectl -n ${NAMESPACE} exec -ti --tty deployment/npq-registration-${APP_ID}-worker -- /bin/sh -c "cd /app && bundle exec rails c"
 
 aks-runner: get-cluster-credentials
 	$(if $(PULL_REQUEST_NUMBER), $(eval export APP_ID=review-$(PULL_REQUEST_NUMBER)) , $(eval export APP_ID=$(CONFIG_LONG)))
-	kubectl -n ${NAMESPACE} exec -ti --tty deployment/npq-registration-${APP_ID}-web -- /bin/sh -c "cd /app && bundle exec rails runner \"$(code)\""
+	kubectl -n ${NAMESPACE} exec -ti --tty deployment/npq-registration-${APP_ID}-worker -- /bin/sh -c "cd /app && bundle exec rails runner \"$(code)\""
 
 aks-ssh: get-cluster-credentials
 	$(if $(PULL_REQUEST_NUMBER), $(eval export APP_ID=review-$(PULL_REQUEST_NUMBER)) , $(eval export APP_ID=$(CONFIG_LONG)))
-	kubectl -n ${NAMESPACE} exec -ti --tty deployment/npq-registration-${APP_ID}-web -- /bin/sh
-
-aks-worker-ssh: get-cluster-credentials
-	$(if $(PULL_REQUEST_NUMBER), $(eval export APP_ID=review-$(PULL_REQUEST_NUMBER)) , $(eval export APP_ID=$(CONFIG_LONG)))
 	kubectl -n ${NAMESPACE} exec -ti --tty deployment/npq-registration-${APP_ID}-worker -- /bin/sh
+
+aks-web-ssh: get-cluster-credentials
+	$(if $(PULL_REQUEST_NUMBER), $(eval export APP_ID=review-$(PULL_REQUEST_NUMBER)) , $(eval export APP_ID=$(CONFIG_LONG)))
+	kubectl -n ${NAMESPACE} exec -ti --tty deployment/npq-registration-${APP_ID}-web -- /bin/sh
 
 action-group-resources: set-azure-account # make env_aks action-group-resources ACTION_GROUP_EMAIL=notificationemail@domain.com . Must be run before setting enable_monitoring=true for each subscription
 	$(if $(ACTION_GROUP_EMAIL), , $(error Please specify a notification email for the action group))

--- a/docs/connecting-to-azure.md
+++ b/docs/connecting-to-azure.md
@@ -30,7 +30,7 @@ but you may need to re-authenticate every once in a while.
 
    You'll be asked to select development, test (used for review apps) or production.
 
-3. Install kubetctl:
+3. Install kubectl:
 
    ```shell
    brew install Azure/kubelogin/kubelogin
@@ -46,6 +46,7 @@ To get shell access on a review app for a given PR_NUMBER, run the following:
 ```shell
 make review aks-ssh PULL_REQUEST_NUMBER=[PR_NUMBER]
 ```
+
 From there, the rake task can be run
 
 To get shell access on production, run:
@@ -62,10 +63,22 @@ To get a rails console on a review app for a given PR_NUMBER, run the following:
 make review aks-console PULL_REQUEST_NUMBER=[PR_NUMBER]
 ```
 
-To get a rails console on production, run the following:
+By default a shell will safely run with `--sandbox` providing read only access. To run with read-write, run the following:
+
+```shell
+make review aks-rw-console PULL_REQUEST_NUMBER=[PR_NUMBER]
+```
+
+To get a read-only rails console on production, run the following:
 
 ```shell
 make ci production aks-console
+```
+
+Likewise, for a read-write console, run the following
+
+```shell
+make ci production aks-rw-console
 ```
 
 ### Copy a file


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2442

Currently the default `Makefile` commands will run consoles on the web nodes which can impact a running web request if the console usage triggers an out of memory scenario.

A secondary concern is the console command by default provides read-write and in production this will often only need to be read-only for investigation purposes

### Changes proposed in this pull request

1. Run all commands from worker nodes instead
2. Provide an alternative to ssh into a web node
3. Changed the default `aks-console` to use rails' `--sandbox` parameter
4. Added a new `aks-rw-console` command to run without the `--sandbox` parameter