### PR TITLE
Validate declaration_date only when its changed

### DIFF
--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -91,10 +91,8 @@ class Declaration < ApplicationRecord
     duplicate: "duplicate",
   }, _suffix: true
 
-  attr_accessor :skip_declaration_date_within_schedule_validation
-
   validates :declaration_date, :declaration_type, presence: true
-  validate :validate_declaration_date_within_schedule, if: -> { !skip_declaration_date_within_schedule_validation }
+  validate :validate_declaration_date_within_schedule
   validate :validate_declaration_date_not_in_the_future
   validates :ecf_id, uniqueness: { case_sensitive: false }
   validate :validate_max_statement_items_count
@@ -150,6 +148,7 @@ private
   def validate_declaration_date_within_schedule
     return unless application&.schedule
     return unless declaration_date
+    return if persisted? && !declaration_date_changed?
 
     if declaration_date < application.schedule.applies_from
       errors.add(:declaration_date, :declaration_before_schedule_start)

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -54,11 +54,7 @@ RSpec.describe Declaration, type: :model do
 
         let(:application) { create(:application, :accepted, user:, course:) }
 
-        subject do
-          d = build(:declaration, course:, user:, application:, declaration_date:)
-          d.save!(validate: false)
-          d
-        end
+        subject { build(:declaration, course:, user:, application:, declaration_date:).tap { |d| d.save!(validate: false) } }
 
         context "when declaration_date is not changed" do
           it { is_expected.to be_valid }

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -37,17 +37,42 @@ RSpec.describe Declaration, type: :model do
     end
 
     context "when declaration_date is before the schedule start" do
-      before { subject.declaration_date = subject.application.schedule.applies_from.prev_week }
+      let(:declaration_date) { application.schedule.applies_from.prev_week }
 
-      it "has a meaningful error" do
-        expect(subject).to be_invalid
-        expect(subject).to have_error(:declaration_date, :declaration_before_schedule_start, "Enter a '#/declaration_date' that's on or after the schedule start.")
+      context "when declaration is being created" do
+        before { subject.declaration_date = subject.application.schedule.applies_from.prev_week }
+
+        it "has a meaningful error" do
+          expect(subject).to be_invalid
+          expect(subject).to have_error(:declaration_date, :declaration_before_schedule_start, "Enter a '#/declaration_date' that's on or after the schedule start.")
+        end
       end
 
-      context "when `skip_declaration_date_within_schedule_validation` is set to true" do
-        before { subject.skip_declaration_date_within_schedule_validation = true }
+      context "when declaration already exists" do
+        let(:user) { create(:user) }
+        let(:course) { create(:course) }
 
-        it { is_expected.to be_valid }
+        let(:application) { create(:application, :accepted, user:, course:) }
+
+        subject do
+          d = build(:declaration, course:, user:, application:, declaration_date:)
+          d.save!(validate: false)
+          d
+        end
+
+        context "when declaration_date is not changed" do
+          it { is_expected.to be_valid }
+        end
+
+        context "when declaration_date is going to be changed" do
+          let(:declaration_date) { application.schedule.applies_from.next_week }
+          let(:new_declaration_date) { application.schedule.applies_from.prev_week }
+
+          it "is not valid" do
+            subject.declaration_date = new_declaration_date
+            expect(subject).not_to be_valid
+          end
+        end
       end
     end
 


### PR DESCRIPTION
`declaration_date` does not need to be validated when is not being changed.
https://dfedigital.atlassian.net/browse/CPDNPQ-2432