### PR TITLE
CPDNPQ-2461 fix schedule calculations

### DIFF
--- a/app/services/course_groups/leadership.rb
+++ b/app/services/course_groups/leadership.rb
@@ -12,6 +12,8 @@ module CourseGroups
     def schedule
       if autumn_schedule_2022?(schedule_date)
         schedules.find_by!(cohort:, identifier: "npq-leadership-autumn")
+      elsif autumn_schedule_2024?(schedule_date)
+        schedules.find_by!(cohort:, identifier: "npq-leadership-autumn")
       elsif spring_schedule?(schedule_date)
         schedules.find_by!(cohort:, identifier: "npq-leadership-spring")
       elsif autumn_schedule?(schedule_date)
@@ -25,6 +27,11 @@ module CourseGroups
     def autumn_schedule_2022?(date)
       # Between: Jun 1 to Dec 25
       (Date.new(2022, 6, 1)..Date.new(2022, 12, 25)).include?(date)
+    end
+
+    def autumn_schedule_2024?(date)
+      # Between: Jun 28 to Feb 10
+      (Date.new(2024, 6, 28)..Date.new(2025, 2, 10)).include?(date)
     end
 
     def spring_schedule?(date)

--- a/app/services/course_groups/specialist.rb
+++ b/app/services/course_groups/specialist.rb
@@ -12,6 +12,8 @@ module CourseGroups
     def schedule
       if autumn_schedule_2022?(schedule_date)
         schedules.find_by!(cohort:, identifier: "npq-specialist-autumn")
+      elsif autumn_schedule_2024?(schedule_date)
+        schedules.find_by!(cohort:, identifier: "npq-specialist-autumn")
       elsif spring_schedule?(schedule_date)
         schedules.find_by!(cohort:, identifier: "npq-specialist-spring")
       elsif autumn_schedule?(schedule_date)
@@ -25,6 +27,11 @@ module CourseGroups
     def autumn_schedule_2022?(date)
       # Between: Jun 1 to Dec 25
       (Date.new(2022, 6, 1)..Date.new(2022, 12, 25)).include?(date)
+    end
+
+    def autumn_schedule_2024?(date)
+      # Between: Jun 28 to Feb 10
+      (Date.new(2024, 6, 28)..Date.new(2025, 2, 10)).include?(date)
     end
 
     def spring_schedule?(date)

--- a/spec/services/course_groups/leadership_spec.rb
+++ b/spec/services/course_groups/leadership_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe CourseGroups::Leadership do
       end
     end
 
-    context "when date is between December of cohort start year and April of 2026" do
+    context "when date is between December and April of cohort start year" do
       let(:cohort) { create(:cohort, start_year: 2025) }
 
       it "returns Spring schedule" do

--- a/spec/services/course_groups/leadership_spec.rb
+++ b/spec/services/course_groups/leadership_spec.rb
@@ -19,7 +19,9 @@ RSpec.describe CourseGroups::Leadership do
       end
     end
 
-    context "when date is between December of cohort start year and April of the next year" do
+    context "when date is between December of cohort start year and April of 2026" do
+      let(:cohort) { create(:cohort, start_year: 2025) }
+
       it "returns Spring schedule" do
         travel_to Date.new(cohort.start_year, 12, 26) do
           expect(subject.schedule).to eq(spring_schedule)
@@ -42,6 +44,16 @@ RSpec.describe CourseGroups::Leadership do
         end
       end
     end
+
+    context "when date is spring 2025" do
+      let(:cohort) { create(:cohort, start_year: 2024) }
+
+      it "returns Autumn schedule" do
+        travel_to Date.new(2025, 1, 13) do
+          expect(subject.schedule).to eq(autumn_schedule)
+        end
+      end
+    end
   end
 
   describe "#autumn_schedule_2022?" do
@@ -56,6 +68,20 @@ RSpec.describe CourseGroups::Leadership do
         (("#{year}-12-26".to_date)..("#{year + 1}-05-31".to_date)).each do |date|
           expect(subject.autumn_schedule_2022?(date)).to be(false)
         end
+      end
+    end
+  end
+
+  describe "#autumn_schedule_2024?" do
+    it "returns true when date between Jun 28 2024 to Feb 10 2025" do
+      (("2024-06-28".to_date)..("2025-02-10".to_date)).each do |date|
+        expect(subject.autumn_schedule_2024?(date)).to be(true)
+      end
+    end
+
+    it "returns false when before Jun 28 2024" do
+      (("2022-01-01".to_date)..("2024-06-27".to_date)).each do |date|
+        expect(subject.autumn_schedule_2024?(date)).to be(false)
       end
     end
   end

--- a/spec/services/course_groups/specialist_spec.rb
+++ b/spec/services/course_groups/specialist_spec.rb
@@ -19,7 +19,9 @@ RSpec.describe CourseGroups::Specialist do
       end
     end
 
-    context "when date is between December of cohort start year and April of the next year" do
+    context "when date is between December of cohort start year and April of 2026" do
+      let(:cohort) { create(:cohort, start_year: 2025) }
+
       it "returns Spring schedule" do
         travel_to Date.new(cohort.start_year, 12, 26) do
           expect(subject.schedule).to eq(spring_schedule)
@@ -42,6 +44,16 @@ RSpec.describe CourseGroups::Specialist do
         end
       end
     end
+
+    context "when date is spring 2025" do
+      let(:cohort) { create(:cohort, start_year: 2024) }
+
+      it "returns Autumn schedule" do
+        travel_to Date.new(2025, 1, 13) do
+          expect(subject.schedule).to eq(autumn_schedule)
+        end
+      end
+    end
   end
 
   describe "#autumn_schedule_2022?" do
@@ -56,6 +68,26 @@ RSpec.describe CourseGroups::Specialist do
         (("#{year}-12-26".to_date)..("#{year + 1}-05-31".to_date)).each do |date|
           expect(subject.autumn_schedule_2022?(date)).to be(false)
         end
+      end
+    end
+  end
+
+  describe "#autumn_schedule_2024?" do
+    it "returns true when date between Jun 28 2024 to Feb 10 2025" do
+      (("2024-06-28".to_date)..("2025-02-10".to_date)).each do |date|
+        expect(subject.autumn_schedule_2024?(date)).to be(true)
+      end
+    end
+
+    it "returns false when before Jun 28 2024" do
+      (("2022-01-01".to_date)..("2024-06-27".to_date)).each do |date|
+        expect(subject.autumn_schedule_2024?(date)).to be(false)
+      end
+    end
+
+    it "returns false when after Feb 10 2025" do
+      (("2025-02-11".to_date)..(Date.current.end_of_year)).each do |date|
+        expect(subject.autumn_schedule_2024?(date)).to be(false)
       end
     end
   end


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2461](https://dfedigital.atlassian.net/browse/CPDNPQ-2461)

Currently lead providers are unable to accept applications because our schedule calculation does not return any schedule for today for Leadership and Specialist courses

### Changes proposed in this pull request

1. The `CourseGroup::Leadership` calculator is updated to special case the extended autumn 2024 schedule
2. The `CourseGroup::Specialist` calculator is updated to special case the extended autumn 2024 schedule



[CPDNPQ-2461]: https://dfedigital.atlassian.net/browse/CPDNPQ-2461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ