### PR TITLE
[CPDNPQ-2397] Switched to using ubuntu-24.04 in CI

### DIFF
--- a/.github/workflows/backup_production_database.yml
+++ b/.github/workflows/backup_production_database.yml
@@ -32,7 +32,7 @@ env:
 jobs:
   backup:
     name: Backup database
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment:
       name: ${{ inputs.environment || 'production' }}
     env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,13 +24,13 @@ jobs:
   all-checks-passed:
     name: All checks passed
     needs: [rspec]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - run: "echo 'Linting and tests passed, this branch is ready to be merged'"
 
   docker:
     name: Build and push Docker image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.actor != 'dependabot[bot]' && github.event_name != 'merge_group'
     outputs:
       docker-image: ${{ steps.build-docker-image.outputs.image }}
@@ -49,7 +49,7 @@ jobs:
     concurrency: deploy_review_${{ github.event.pull_request.number }}
     if: github.actor != 'dependabot[bot]' && github.event_name == 'pull_request'
     needs: [docker]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment:
       name: review
     steps:
@@ -74,7 +74,7 @@ jobs:
   deploy-staging:
     name: Deploy staging
     needs: [docker, all-checks-passed]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.ref == 'refs/heads/main'
     environment:
       name: staging
@@ -95,7 +95,7 @@ jobs:
   deploy-sandbox:
     name: Deploy sandbox
     needs: [deploy-staging]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.ref == 'refs/heads/main'
     environment:
       name: sandbox
@@ -114,7 +114,7 @@ jobs:
   deploy-production:
     name: Deploy production
     needs: [deploy-staging]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.ref == 'refs/heads/main'
     environment:
       name: production

--- a/.github/workflows/destroy_review_app.yml
+++ b/.github/workflows/destroy_review_app.yml
@@ -10,7 +10,7 @@ jobs:
     name: Delete Review App ${{ github.event.pull_request.number }}
     concurrency: deploy_review_${{ github.event.pull_request.number }}
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: review
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lead_provider_openapi_check.yml
+++ b/.github/workflows/lead_provider_openapi_check.yml
@@ -18,7 +18,7 @@ jobs:
   rspec:
     name: Check OpenAPI schema
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     env:
       RAILS_ENV: test

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   set-maintenance-mode:
     name: Set maintenance mode
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: ${{ inputs.environment }}
 
     steps:

--- a/.github/workflows/restore_azure_database.yml
+++ b/.github/workflows/restore_azure_database.yml
@@ -32,7 +32,7 @@ jobs:
   restore:
     name: Restore AKS Database
     if: ${{ inputs.environment != 'production' || (inputs.environment == 'production' && github.event.inputs.confirm-production == 'true' ) }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: ${{ inputs.environment }}
     concurrency: deploy_${{ inputs.environment }}
 

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -24,7 +24,7 @@ jobs:
     name: "Lint ruby"
     env:
       GOVUK_NOTIFY_API_KEY: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -53,7 +53,7 @@ jobs:
     name: "Lint SCSS"
     env:
       GOVUK_NOTIFY_API_KEY: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -74,7 +74,7 @@ jobs:
   rspec:
     name: Run Rspec
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     env:
       RAILS_ENV: test
@@ -161,7 +161,7 @@ jobs:
 
   sonar-scanner:
     name: Sonar Scanner
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [ rspec, ruby_linting ]
     if: github.ref != 'refs/heads/main' && github.actor != 'dependabot[bot]'
     environment:


### PR DESCRIPTION


### Context

Ticket: [CPDNPQ-2397](https://dfedigital.atlassian.net/browse/CPDNPQ-2397)

We are getting warnings in GitHub actions because we use `ubuntu-latest` for our runners and this is going to change the image it corresponds to to 24.04 soon

### Changes proposed in this pull request

1. Explicitly use `ubuntu-24.04` to verify that our pipelines work with 24.04 and optionally merge to silence warnings


[CPDNPQ-2397]: https://dfedigital.atlassian.net/browse/CPDNPQ-2397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ