### PR TITLE
[CPDNPQ-2455] show links to statements

### DIFF
--- a/app/controllers/npq_separation/admin/applications_controller.rb
+++ b/app/controllers/npq_separation/admin/applications_controller.rb
@@ -6,7 +6,7 @@ class NpqSeparation::Admin::ApplicationsController < NpqSeparation::AdminControl
   def show
     @application = applications_query.application(id: params[:id])
     @declarations = @application.declarations
-                                .includes(:lead_provider, :cohort, :participant_outcomes)
+                                .includes(:lead_provider, :cohort, :participant_outcomes, :statements)
                                 .order(created_at: :asc, id: :asc)
   end
 

--- a/app/views/npq_separation/admin/applications/show.html.erb
+++ b/app/views/npq_separation/admin/applications/show.html.erb
@@ -269,6 +269,15 @@
         row.with_key(text: "Updated at")
         row.with_value(text: declaration.updated_at.to_fs(:govuk_short))
       end
+
+      sl.with_row do |row|
+        row.with_key(text: "Statements")
+        row.with_value do
+          safe_join(declaration.statements.map do |statement|
+            tag.div govuk_link_to(statement_name(statement), npq_separation_admin_finance_statement_path(statement))
+          end)
+        end
+      end
     end)
 
     if declaration.participant_outcomes.any?

--- a/spec/features/npq_separation/admin/applications_spec.rb
+++ b/spec/features/npq_separation/admin/applications_spec.rb
@@ -113,13 +113,16 @@ RSpec.feature "Listing and viewing applications", type: :feature do
     application = Application.order(created_at: :asc).first
     started_declaration = create(:declaration, :from_ecf, application:)
     completed_declaration = create(:declaration, :completed, application:)
+    payable_statement = create(:statement, :payable)
+    payable_declaration = create(:declaration, :payable, application:, statement: payable_statement)
+    paid_statement = create(:statement, :paid, declaration: payable_declaration)
 
     click_link(application.ecf_id)
 
     expect(page).to have_css("h2", text: "Declarations")
 
     summary_cards = all(".govuk-summary-card")
-    expect(summary_cards).to have_attributes(length: 2)
+    expect(summary_cards).to have_attributes(length: 3)
 
     within(summary_cards[0]) do |summary_card|
       expect(summary_card).to have_css(".govuk-summary-card__title", text: "Started")
@@ -152,6 +155,24 @@ RSpec.feature "Listing and viewing applications", type: :feature do
         expect(summary_list).to have_summary_item("Updated at", completed_declaration.updated_at.to_fs(:govuk_short))
       end
     end
+
+    within(summary_cards[2]) do
+      within(find(".govuk-summary-list")) do |summary_list|
+        expect(summary_list).to have_summary_item(
+          "Statements",
+          "#{Date::MONTHNAMES[payable_statement.month]} #{payable_statement.year}" \
+          "\n" \
+          "#{Date::MONTHNAMES[paid_statement.month]} #{paid_statement.year}",
+        )
+      end
+    end
+
+    click_link("#{Date::MONTHNAMES[payable_statement.month]} #{payable_statement.year}")
+    expect(page).to have_current_path(npq_separation_admin_finance_statement_path(payable_statement))
+
+    visit(npq_separation_admin_application_path(application))
+    click_link("#{Date::MONTHNAMES[paid_statement.month]} #{paid_statement.year}")
+    expect(page).to have_current_path(npq_separation_admin_finance_statement_path(paid_statement))
   end
 
   scenario "viewing participant details" do


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2455

### Changes proposed in this pull request

show links to the statements linked to each declaration in the application show page

e.g.
<img width="929" alt="Screenshot 2025-01-15 at 16 08 20" src="https://github.com/user-attachments/assets/ec5f2258-a0ea-4b3c-b59b-b5077a2b2d17" />
