### PR TITLE
[CPDNPQ-2421] Prevent run-away cron jobs

### DIFF
--- a/app/jobs/crons/batch_send_latest_outcomes_job.rb
+++ b/app/jobs/crons/batch_send_latest_outcomes_job.rb
@@ -8,12 +8,10 @@ class Crons::BatchSendLatestOutcomesJob < CronJob
 
   sentry_monitor_check_ins slug: "batch-send-latest-outcomes"
 
-  discard_on StandardError do |_job, exception|
-    Sentry.capture_exception(exception)
-  end
-
   def perform(batch_size = DEFAULT_BATCH_SIZE)
-    outcomes.first(batch_size).each { |outcome| SendToQualifiedTeachersAPIJob.perform_later(participant_outcome_id: outcome.id) }
+    outcomes.first(batch_size).each do |outcome|
+      SendToQualifiedTeachersAPIJob.perform_now(participant_outcome_id: outcome.id)
+    end
   end
 
   def queue_name

--- a/app/jobs/crons/generate_dashboard_report_job.rb
+++ b/app/jobs/crons/generate_dashboard_report_job.rb
@@ -7,6 +7,7 @@ class Crons::GenerateDashboardReportJob < CronJob
   sentry_monitor_check_ins slug: "generate-dashboard"
 
   def perform
-    DashboardReportJob.perform_later
+    report = Report.find_or_initialize_by(identifier: "dashboard")
+    report.update!(data: ReportService.new.call)
   end
 end

--- a/app/jobs/crons/sweep_stale_sessions_job.rb
+++ b/app/jobs/crons/sweep_stale_sessions_job.rb
@@ -7,6 +7,8 @@ class Crons::SweepStaleSessionsJob < CronJob
   sentry_monitor_check_ins slug: "sweep-stale-sessions"
 
   def perform
-    SweepStaleSessionsJob.perform_later
+    ActiveRecord::SessionStore::Session
+      .where("updated_at < ?", 15.days.ago)
+      .delete_all
   end
 end

--- a/app/jobs/crons/update_schools_job.rb
+++ b/app/jobs/crons/update_schools_job.rb
@@ -7,6 +7,6 @@ class Crons::UpdateSchoolsJob < CronJob
   sentry_monitor_check_ins slug: "update-schools"
 
   def perform
-    ImportGiasSchoolsJob.perform_later
+    ImportGiasSchools.new.call
   end
 end

--- a/app/jobs/dashboard_report_job.rb
+++ b/app/jobs/dashboard_report_job.rb
@@ -1,8 +1,0 @@
-class DashboardReportJob < ApplicationJob
-  queue_as :default
-
-  def perform
-    report = Report.find_or_initialize_by(identifier: "dashboard")
-    report.update!(data: ReportService.new.call)
-  end
-end

--- a/app/jobs/sweep_stale_sessions_job.rb
+++ b/app/jobs/sweep_stale_sessions_job.rb
@@ -1,9 +1,0 @@
-class SweepStaleSessionsJob < ApplicationJob
-  queue_as :default
-
-  def perform
-    ActiveRecord::SessionStore::Session
-      .where("updated_at < ?", 15.days.ago)
-      .delete_all
-  end
-end

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -9,3 +9,18 @@ Delayed::Worker.queue_attributes = {
   low_priority: { priority: 10 },
   dfe_analytics: { priority: 0 },
 }
+
+# Non of our jobs should take longer than this and if they are they should be
+# broken up into multiple jobs
+Delayed::Worker.max_run_time = 30.minutes
+
+# The default of 25 is too high, instead we should retry less times and with
+# lower frequency
+Delayed::Worker.max_attempts = 8
+
+# Override backoff rate for retries
+ActiveJob::QueueAdapters::DelayedJobAdapter::JobWrapper.class_eval do
+  def reschedule_at(db_time_now, attempts, ...)
+    db_time_now + (attempts**6) + 5
+  end
+end

--- a/spec/jobs/crons/generate_dashboard_report_job_spec.rb
+++ b/spec/jobs/crons/generate_dashboard_report_job_spec.rb
@@ -1,6 +1,14 @@
 require "rails_helper"
 
-RSpec.describe DashboardReportJob do
+RSpec.describe Crons::GenerateDashboardReportJob do
+  describe "#schedule" do
+    it "enqueues job" do
+      expect {
+        described_class.schedule
+      }.to have_enqueued_job
+    end
+  end
+
   describe "#perform" do
     it "persists report record" do
       expect {

--- a/spec/jobs/crons/sweep_stale_sessions_job_spec.rb
+++ b/spec/jobs/crons/sweep_stale_sessions_job_spec.rb
@@ -1,6 +1,14 @@
 require "rails_helper"
 
-RSpec.describe SweepStaleSessionsJob do
+RSpec.describe Crons::SweepStaleSessionsJob do
+  describe "#schedule" do
+    it "enqueues job" do
+      expect {
+        described_class.schedule
+      }.to have_enqueued_job
+    end
+  end
+
   describe "#perform" do
     it "deletes stale sessions" do
       ActiveRecord::SessionStore::Session.create!(data: "world", session_id: "1", updated_at: 16.days.ago)

--- a/spec/jobs/crons/update_schools_job_spec.rb
+++ b/spec/jobs/crons/update_schools_job_spec.rb
@@ -1,6 +1,14 @@
 require "rails_helper"
 
-RSpec.describe ImportGiasSchoolsJob, type: :job do
+RSpec.describe Crons::UpdateSchoolsJob, type: :job do
+  describe "#schedule" do
+    it "enqueues job" do
+      expect {
+        described_class.schedule
+      }.to have_enqueued_job
+    end
+  end
+
   describe "#perform_later" do
     it "enqueues job" do
       expect {


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2421](https://dfedigital.atlassian.net/browse/CPDNPQ-2421)

It has been observed when cron jobs fail, eg API flakiness or bugs, the Jobs run away with themselves. Our sandbox environment is currently attempting to synchronise with GIAS every few minutes rather than once per day as scheduled.

This is caused by a combination of factors

1. Cron Jobs _should_ simply rescedule for the next point they are meant to run
2. Default retry behaviour is to allow for a job to run for 4 hours and retry 25 times - a theoretical max compute cost of 104 hours for every scheduled job!
3. Retry backoff is quite slow, this leads to failing jobs being processed sooner but at a cost of higher job retries if we want an adequate time window to address failing jobs
4. We are scheduling regular jobs (which retry 25 times) from cron jobs (which do not) - this means if a job runs hourly and is failing, after 24 hours we have 25 jobs scheduled, with 24 of them retrying with quite a slow backoff so jobs retrying every few minutes - rather than just keeping trying that job every hour.

### Changes proposed in this pull request

1. Replace use of `perform_later` in CronJobs with `perform_now` - if a cron job takes longer than max execution time, we don't want to be running another one concurrently anyway until its finished
2. Change the retry timings to backoff more agressive
3. Retry less times (8 not 25)

### Note

I've not addressed the analytics jobs using `perform_later` - I think these also need looking at and this issue is why we had so many jobs running on `sandbox` before xmas _but_ I need to understand the interaction of that code better since some of it is from other gems and this addresses the immediate issue with the GIAS job

[CPDNPQ-2421]: https://dfedigital.atlassian.net/browse/CPDNPQ-2421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ