### PR TITLE
[CPDNPQ-2317] change validation and do not destroy declarations

### DIFF
--- a/app/services/applications/revert_to_pending.rb
+++ b/app/services/applications/revert_to_pending.rb
@@ -1,6 +1,6 @@
 module Applications
   class RevertToPending
-    REMOVEABLE_DECLARATION_STATES = %w[submitted voided ineligible].freeze
+    REVERTABLE_DECLARATION_STATES = %w[voided ineligible awaiting_clawback clawed_back].freeze
 
     include ActiveModel::Model
     include ActiveModel::Attributes
@@ -20,7 +20,6 @@ module Applications
 
       Application.transaction do
         application.application_states.destroy_all
-        application.declarations.destroy_all
         application.funded_place = nil
         application.pending_lead_provider_approval_status!
 
@@ -31,7 +30,7 @@ module Applications
   private
 
     def application_has_no_unremoveable_declarations
-      if application.declarations.where.not(state: REMOVEABLE_DECLARATION_STATES).any?
+      if application.declarations.where.not(state: REVERTABLE_DECLARATION_STATES).any?
         errors.add :base, :pending_unremoveable_declarations
       end
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -264,7 +264,7 @@ en:
             lead_provider_approval_status:
               inclusion: Current lead provider approval status is not Accepted
             base:
-              pending_unremoveable_declarations: There are already declarations for this participant on this course, please ask provider to void and/or clawback any declarations they have made before attempting to reset the application.
+              pending_unremoveable_declarations: There are already declarations for this participant on this course, please ask the provider to void any declarations they have made before attempting to revert the application.
         questionnaires/teacher_reference_number:
           attributes:
             trn_knowledge:

--- a/spec/services/bulk_operation/bulk_change_applications_to_pending_spec.rb
+++ b/spec/services/bulk_operation/bulk_change_applications_to_pending_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe BulkOperation::BulkChangeApplicationsToPending do
       it_behaves_like "changes to pending", "rejected"
     end
 
-    %i[submitted voided ineligible].each do |state|
+    Applications::RevertToPending::REVERTABLE_DECLARATION_STATES.each do |state|
       context "when the application has #{state} declarations" do
         let(:declaration) { create(:declaration, state) }
 
@@ -75,7 +75,7 @@ RSpec.describe BulkOperation::BulkChangeApplicationsToPending do
       it { expect(run[application_ecf_id]).to eq("Not found") }
     end
 
-    Declaration.states.keys.excluding("submitted", "voided", "ineligible").each do |state|
+    Declaration.states.keys.excluding(Applications::RevertToPending::REVERTABLE_DECLARATION_STATES).each do |state|
       context "when the application has #{state} declarations" do
         let(:declaration) { create(:declaration, state) }
         let(:application) { declaration.application }


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2317

When there are voided statement items and a voided declaration, it is currently not possible to revert an application to pending.
It raises an error in the admin console:
```
ActiveRecord::InvalidForeignKey in NpqSeparation::Admin::Applications::RevertToPendingController#create`
PG::ForeignKeyViolation: ERROR: update or delete on table "declarations" violates foreign key constraint "fk_rails_19a5cbebb5" on table "statement_items"
DETAIL: Key (id)=(1278) is still referenced from table "statement_items".
```

### Changes proposed in this pull request
* Change the validation, so that only applications with declaration in revertable states(`voided`, `ineligible`, `awaiting_clawback`, `clawed_back`) can be reverted to pending
* Do not delete any declarations
* If there are declarations with states `submitted`, `eligible`, `payable` or `paid` - an error will be shown. 
* Previously declarations that were in state `submitted` were allowed - but this has been removed - the provider will have to void those declarations first if they want the application reverted to pending.

The error you get if the state of the declarations are not revertable is:
<img width="939" alt="Screenshot 2025-01-22 at 13 16 32" src="https://github.com/user-attachments/assets/2985b314-6b42-4b32-93f7-20512d2ca932" />
