### PR TITLE
[CPDNPQ-2501] Remove Cohort/Schedule#editable?

### DIFF
--- a/app/controllers/npq_separation/admin/cohorts_controller.rb
+++ b/app/controllers/npq_separation/admin/cohorts_controller.rb
@@ -1,7 +1,6 @@
 class NpqSeparation::Admin::CohortsController < NpqSeparation::AdminController
   before_action :ensure_super_admin, except: %i[index show]
   before_action :cohort, only: %i[show edit update destroy]
-  before_action :ensure_editable, only: %i[edit update destroy]
 
   def index
     @pagy, @cohorts = pagy(Cohort.all.order(start_year: :desc))
@@ -62,13 +61,6 @@ private
     unless current_admin.super_admin?
       flash[:error] = "You must be a super admin to change cohorts"
       redirect_to action: :index
-    end
-  end
-
-  def ensure_editable
-    unless @cohort.editable?
-      flash[:error] = "This cohort is not editable"
-      redirect_to npq_separation_admin_cohort_path(@cohort)
     end
   end
 end

--- a/app/controllers/npq_separation/admin/schedules_controller.rb
+++ b/app/controllers/npq_separation/admin/schedules_controller.rb
@@ -1,7 +1,6 @@
 class NpqSeparation::Admin::SchedulesController < NpqSeparation::AdminController
   before_action :ensure_super_admin, except: :show
   before_action :schedule, only: %i[show edit update destroy]
-  before_action :ensure_editable, only: %i[edit update destroy]
 
   def show; end
 
@@ -62,13 +61,6 @@ private
     unless current_admin.super_admin?
       flash[:error] = "You must be a super admin to change schedules"
       redirect_to npq_separation_admin_cohort_path(cohort)
-    end
-  end
-
-  def ensure_editable
-    unless @schedule.editable?
-      flash[:error] = "This schedule is not editable"
-      redirect_to npq_separation_admin_cohort_schedule_path(cohort, @schedule)
     end
   end
 end

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -31,8 +31,4 @@ class Cohort < ApplicationRecord
 
     errors.add(:registration_start_date, "year must match the start year") if registration_start_date.year != start_year
   end
-
-  def editable?
-    registration_start_date.future? && statements.none? && declarations.none?
-  end
 end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -17,8 +17,6 @@ class Schedule < ApplicationRecord
   belongs_to :cohort
   has_many :courses, through: :course_group
 
-  delegate :editable?, to: :cohort
-
   normalizes :allowed_declaration_types, with: ->(value) { value.reject(&:blank?) }
 
   validates :name, presence: true

--- a/app/views/npq_separation/admin/cohorts/show.html.erb
+++ b/app/views/npq_separation/admin/cohorts/show.html.erb
@@ -19,11 +19,9 @@
   end
 %>
 
-<% if current_admin.super_admin? && @cohort.editable? %>
+<% if current_admin.super_admin? %>
   <%= govuk_button_link_to('Edit cohort details', edit_npq_separation_admin_cohort_path(@cohort)) %>
   <%= govuk_button_link_to('Delete cohort', npq_separation_admin_cohort_path(@cohort), method: :delete, warning: true) %>
-<% end %>
-<% if current_admin.super_admin? %>
   <%= govuk_button_link_to('Create statements', new_npq_separation_admin_cohort_statement_path(@cohort), secondary: true) %>
 <% end %>
 
@@ -31,7 +29,7 @@
 
 <h2 class="govuk-heading-m">Schedules</h1>
 
-<% if current_admin.super_admin? && @cohort.editable? %>
+<% if current_admin.super_admin? %>
   <%= govuk_button_link_to('New schedule', new_npq_separation_admin_cohort_schedule_path(@cohort)) %>
 <% end %>
 

--- a/app/views/npq_separation/admin/schedules/show.html.erb
+++ b/app/views/npq_separation/admin/schedules/show.html.erb
@@ -41,7 +41,7 @@
   end
 %>
 
-<% if current_admin.super_admin? && @schedule.editable? %>
+<% if current_admin.super_admin? %>
   <%= govuk_button_link_to 'Edit schedule details', edit_npq_separation_admin_cohort_schedule_path(@schedule.cohort, @schedule) %>
   <%= govuk_button_link_to 'Delete schedule', npq_separation_admin_cohort_schedule_path(@schedule.cohort, @schedule), method: :delete, warning: true %>
 <% end %>

--- a/spec/features/npq_separation/admin/cohorts_spec.rb
+++ b/spec/features/npq_separation/admin/cohorts_spec.rb
@@ -63,54 +63,32 @@ RSpec.feature "Managing cohorts", :ecf_api_disabled, type: :feature do
       expect(cohort.registration_start_date).to eq(Date.new(2029, 3, 2))
     end
 
-    context "with an editable cohort" do
-      before do
-        allow_any_instance_of(Cohort).to receive(:editable?).and_return(true)
-      end
+    scenario "editing" do
+      cohort.update! funding_cap: false
 
-      scenario "editing" do
-        cohort.update! funding_cap: false
+      navigate_to_cohort
+      click_on edit_button_text
 
-        navigate_to_cohort
-        click_on edit_button_text
+      fill_in "Start year", with: "2025"
+      check "Funding cap", visible: :all
+      fill_in "Day", with: "6"
+      fill_in "Month", with: "5"
+      fill_in "Year", with: "2025"
 
-        fill_in "Start year", with: "2025"
-        check "Funding cap", visible: :all
-        fill_in "Day", with: "6"
-        fill_in "Month", with: "5"
-        fill_in "Year", with: "2025"
+      expect { click_on "Update cohort" }.not_to(change(Cohort, :count))
+      expect(page).to have_text("Cohort updated")
 
-        expect { click_on "Update cohort" }.not_to(change(Cohort, :count))
-        expect(page).to have_text("Cohort updated")
-
-        cohort.reload
-        expect(cohort.start_year).to be(2025)
-        expect(cohort.funding_cap).to be(true)
-        expect(cohort.registration_start_date.to_date).to eq(Date.new(2025, 5, 6))
-      end
-
-      scenario "deletion" do
-        navigate_to_cohort
-        click_on delete_button_text
-
-        expect { click_on "Confirm" }.to change(Cohort, :count).by(-1)
-      end
+      cohort.reload
+      expect(cohort.start_year).to be(2025)
+      expect(cohort.funding_cap).to be(true)
+      expect(cohort.registration_start_date.to_date).to eq(Date.new(2025, 5, 6))
     end
 
-    context "with a non-editable cohort" do
-      before do
-        allow_any_instance_of(Cohort).to receive(:editable?).and_return(false)
-      end
+    scenario "deletion" do
+      navigate_to_cohort
+      click_on delete_button_text
 
-      scenario "cannot edit" do
-        navigate_to_cohort
-        expect(page).not_to have_link(edit_button_text)
-      end
-
-      scenario "cannot delete" do
-        navigate_to_cohort
-        expect(page).not_to have_link(delete_button_text)
-      end
+      expect { click_on "Confirm" }.to change(Cohort, :count).by(-1)
     end
   end
 

--- a/spec/features/npq_separation/admin/schedules_spec.rb
+++ b/spec/features/npq_separation/admin/schedules_spec.rb
@@ -56,63 +56,36 @@ RSpec.feature "Managing schedules", :ecf_api_disabled, type: :feature do
       admin.update! super_admin: true
     end
 
-    context "when the cohort is editable" do
-      before do
-        allow_any_instance_of(Cohort).to receive(:editable?).and_return(true)
-      end
+    scenario "creation" do
+      visit_cohort
+      click_on new_button_text
 
-      scenario "creation" do
-        visit_cohort
-        click_on new_button_text
+      fill_in_schedule_form(course_group)
 
-        fill_in_schedule_form(course_group)
+      expect { click_on "Create schedule" }.to change(Schedule, :count).by(1)
 
-        expect { click_on "Create schedule" }.to change(Schedule, :count).by(1)
-
-        schedule = Schedule.order(created_at: :desc).first
-        expect(page).to have_text("Schedule created")
-        expect_filled_in_schedule_attributes(schedule, course_group)
-      end
-
-      scenario "editing" do
-        navigate_to_schedule
-        click_on edit_button_text
-        fill_in_schedule_form(course_group)
-
-        expect { click_on "Update schedule" }.not_to(change(Schedule, :count))
-
-        schedule.reload
-        expect(page).to have_text("Schedule updated")
-        expect_filled_in_schedule_attributes(schedule, course_group)
-      end
-
-      scenario "deletion" do
-        navigate_to_schedule
-
-        click_on delete_button_text
-        expect { click_on "Confirm" }.to change(Schedule, :count).by(-1)
-      end
+      schedule = Schedule.order(created_at: :desc).first
+      expect(page).to have_text("Schedule created")
+      expect_filled_in_schedule_attributes(schedule, course_group)
     end
 
-    context "when the cohort is not editable" do
-      before do
-        allow_any_instance_of(Cohort).to receive(:editable?).and_return(false)
-      end
+    scenario "editing" do
+      navigate_to_schedule
+      click_on edit_button_text
+      fill_in_schedule_form(course_group)
 
-      scenario "cannot create" do
-        visit_cohort
-        expect(page).not_to have_link(new_button_text)
-      end
+      expect { click_on "Update schedule" }.not_to(change(Schedule, :count))
 
-      scenario "cannot edit" do
-        navigate_to_schedule
-        expect(page).not_to have_link(edit_button_text)
-      end
+      schedule.reload
+      expect(page).to have_text("Schedule updated")
+      expect_filled_in_schedule_attributes(schedule, course_group)
+    end
 
-      scenario "cannot delete" do
-        navigate_to_schedule
-        expect(page).not_to have_link(delete_button_text)
-      end
+    scenario "deletion" do
+      navigate_to_schedule
+
+      click_on delete_button_text
+      expect { click_on "Confirm" }.to change(Schedule, :count).by(-1)
     end
   end
 

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -74,32 +74,4 @@ RSpec.describe Cohort, type: :model do
       end
     end
   end
-
-  describe "#editable?" do
-    subject { cohort.editable? }
-
-    context "when conditions are met" do
-      before { cohort.update! start_year: 2029, registration_start_date: Date.new(2029, 12, 31) }
-
-      it { is_expected.to be true }
-    end
-
-    context "when the cohort has declarations" do
-      before { create(:declaration, cohort:) }
-
-      it { is_expected.to be false }
-    end
-
-    context "when the cohort has statements" do
-      before { create(:statement, cohort:) }
-
-      it { is_expected.to be false }
-    end
-
-    context "when registration_start_date is not in the future" do
-      before { cohort.update! start_year: Time.zone.today.year, registration_start_date: Date.yesterday }
-
-      it { is_expected.to be false }
-    end
-  end
 end

--- a/spec/models/schedule_spec.rb
+++ b/spec/models/schedule_spec.rb
@@ -18,20 +18,4 @@ RSpec.describe Schedule, type: :model do
     it { is_expected.to belong_to(:course_group) }
     it { is_expected.to belong_to(:cohort) }
   end
-
-  describe "#editable?" do
-    subject { schedule.editable? }
-
-    context "when cohort#editable? is true" do
-      before { allow(schedule.cohort).to receive(:editable?).and_return(true) }
-
-      it { is_expected.to be true }
-    end
-
-    context "when cohort#editable? is false" do
-      before { allow(schedule.cohort).to receive(:editable?).and_return(false) }
-
-      it { is_expected.to be false }
-    end
-  end
 end

--- a/spec/requests/npq_separation/admin/cohorts_controller_spec.rb
+++ b/spec/requests/npq_separation/admin/cohorts_controller_spec.rb
@@ -46,81 +46,41 @@ RSpec.describe NpqSeparation::Admin::CohortsController, :ecf_api_disabled, type:
       it { is_expected.to have_http_status :unprocessable_entity }
     end
 
-    context "with editable cohort" do
-      before { allow_any_instance_of(Cohort).to receive(:editable?).and_return(true) }
+    describe "#edit" do
+      before { get edit_npq_separation_admin_cohort_path(cohort) }
 
-      describe "#edit" do
-        before { get edit_npq_separation_admin_cohort_path(cohort) }
+      it { is_expected.to have_http_status :success }
+    end
 
-        it { is_expected.to have_http_status :success }
-      end
+    describe "#update" do
+      before { patch npq_separation_admin_cohort_path(cohort), params: valid_params }
 
-      describe "#update" do
-        before { patch npq_separation_admin_cohort_path(cohort), params: valid_params }
+      it { is_expected.to redirect_to npq_separation_admin_cohort_path(cohort) }
 
-        it { is_expected.to redirect_to npq_separation_admin_cohort_path(cohort) }
-
-        it "flashes success" do
-          expect(flash[:success]).to match(/Cohort updated/i)
-        end
-      end
-
-      describe "#update with invalid params" do
-        before { patch npq_separation_admin_cohort_path(cohort), params: invalid_params }
-
-        it { is_expected.to have_http_status :unprocessable_entity }
-      end
-
-      describe "#destroy" do
-        before { delete npq_separation_admin_cohort_path(cohort) }
-
-        it { is_expected.to have_http_status :success }
-      end
-
-      describe "#destroy with confirm" do
-        before { delete npq_separation_admin_cohort_path(cohort), params: { confirm: "1" } }
-
-        it { is_expected.to redirect_to npq_separation_admin_cohorts_path }
-
-        it "flashes success" do
-          expect(flash[:success]).to match(/Cohort deleted/i)
-        end
+      it "flashes success" do
+        expect(flash[:success]).to match(/Cohort updated/i)
       end
     end
 
-    context "with non-editable cohort" do
-      before { allow_any_instance_of(Cohort).to receive(:editable?).and_return(false) }
+    describe "#update with invalid params" do
+      before { patch npq_separation_admin_cohort_path(cohort), params: invalid_params }
 
-      shared_examples "cannot be changed" do
-        it { is_expected.to redirect_to npq_separation_admin_cohort_path(cohort) }
+      it { is_expected.to have_http_status :unprocessable_entity }
+    end
 
-        it "flashes the correct error" do
-          expect(flash[:error]).to match(/This cohort is not editable/i)
-        end
-      end
+    describe "#destroy" do
+      before { delete npq_separation_admin_cohort_path(cohort) }
 
-      describe "#edit" do
-        before { get edit_npq_separation_admin_cohort_path(cohort) }
+      it { is_expected.to have_http_status :success }
+    end
 
-        it_behaves_like "cannot be changed"
-      end
+    describe "#destroy with confirm" do
+      before { delete npq_separation_admin_cohort_path(cohort), params: { confirm: "1" } }
 
-      describe "#update" do
-        before { patch npq_separation_admin_cohort_path(cohort), params: valid_params }
+      it { is_expected.to redirect_to npq_separation_admin_cohorts_path }
 
-        it_behaves_like "cannot be changed"
-      end
-
-      describe "#destroy" do
-        before { delete npq_separation_admin_cohort_path(cohort) }
-
-        it_behaves_like "cannot be changed"
-      end
-
-      describe "#destroy with confirm" do
-        before { delete npq_separation_admin_cohort_path(cohort), params: { confirm: "1" } }
-
-        it_behaves_like "cannot be changed"
+      it "flashes success" do
+        expect(flash[:success]).to match(/Cohort deleted/i)
       end
     end
   end

--- a/spec/requests/npq_separation/admin/schedules_controller_spec.rb
+++ b/spec/requests/npq_separation/admin/schedules_controller_spec.rb
@@ -42,81 +42,41 @@ RSpec.describe NpqSeparation::Admin::SchedulesController, :ecf_api_disabled, typ
       it { is_expected.to have_http_status :unprocessable_entity }
     end
 
-    context "with editable cohort" do
-      before { allow_any_instance_of(Cohort).to receive(:editable?).and_return(true) }
+    describe "#edit" do
+      before { get edit_npq_separation_admin_cohort_schedule_path(cohort, schedule) }
 
-      describe "#edit" do
-        before { get edit_npq_separation_admin_cohort_schedule_path(cohort, schedule) }
+      it { is_expected.to have_http_status :success }
+    end
 
-        it { is_expected.to have_http_status :success }
-      end
+    describe "#update" do
+      before { patch npq_separation_admin_cohort_schedule_path(cohort, schedule), params: valid_params }
 
-      describe "#update" do
-        before { patch npq_separation_admin_cohort_schedule_path(cohort, schedule), params: valid_params }
+      it { is_expected.to redirect_to npq_separation_admin_cohort_path(cohort) }
 
-        it { is_expected.to redirect_to npq_separation_admin_cohort_path(cohort) }
-
-        it "flashes success" do
-          expect(flash[:success]).to match(/Schedule updated/i)
-        end
-      end
-
-      describe "#update with invalid params" do
-        before { patch npq_separation_admin_cohort_schedule_path(cohort, schedule), params: invalid_params }
-
-        it { is_expected.to have_http_status :unprocessable_entity }
-      end
-
-      describe "#destroy" do
-        before { delete npq_separation_admin_cohort_schedule_path(cohort, schedule) }
-
-        it { is_expected.to have_http_status :success }
-      end
-
-      describe "#destroy with confirm" do
-        before { delete npq_separation_admin_cohort_schedule_path(cohort, schedule), params: { confirm: "1" } }
-
-        it { is_expected.to redirect_to npq_separation_admin_cohort_path(cohort) }
-
-        it "flashes success" do
-          expect(flash[:success]).to match(/Schedule deleted/i)
-        end
+      it "flashes success" do
+        expect(flash[:success]).to match(/Schedule updated/i)
       end
     end
 
-    context "with non-editable cohort" do
-      before { allow_any_instance_of(Cohort).to receive(:editable?).and_return(false) }
+    describe "#update with invalid params" do
+      before { patch npq_separation_admin_cohort_schedule_path(cohort, schedule), params: invalid_params }
 
-      shared_examples "cannot be changed" do
-        it { is_expected.to redirect_to npq_separation_admin_cohort_schedule_path(cohort, schedule) }
+      it { is_expected.to have_http_status :unprocessable_entity }
+    end
 
-        it "flashes the correct error" do
-          expect(flash[:error]).to match(/This schedule is not editable/i)
-        end
-      end
+    describe "#destroy" do
+      before { delete npq_separation_admin_cohort_schedule_path(cohort, schedule) }
 
-      describe "#edit" do
-        before { get edit_npq_separation_admin_cohort_schedule_path(cohort, schedule) }
+      it { is_expected.to have_http_status :success }
+    end
 
-        it_behaves_like "cannot be changed"
-      end
+    describe "#destroy with confirm" do
+      before { delete npq_separation_admin_cohort_schedule_path(cohort, schedule), params: { confirm: "1" } }
 
-      describe "#update" do
-        before { patch npq_separation_admin_cohort_schedule_path(cohort, schedule), params: valid_params }
+      it { is_expected.to redirect_to npq_separation_admin_cohort_path(cohort) }
 
-        it_behaves_like "cannot be changed"
-      end
-
-      describe "#destroy" do
-        before { delete npq_separation_admin_cohort_schedule_path(cohort, schedule) }
-
-        it_behaves_like "cannot be changed"
-      end
-
-      describe "#destroy with confirm" do
-        before { delete npq_separation_admin_cohort_schedule_path(cohort, schedule), params: { confirm: "1" } }
-
-        it_behaves_like "cannot be changed"
+      it "flashes success" do
+        expect(flash[:success]).to match(/Schedule deleted/i)
       end
     end
   end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2501

In the admin console, editing a cohort or schedule that has started is not currently possible.

In practice, this turns out to be over-restrictive and we do need to edit cohorts or schedules that have started, so this PR removes the restrictions (except for the requirement to be a Super Admin).