### PR TITLE
[CPDNPQ-2433] fix ImportGiasSchools

### DIFF
--- a/app/services/import_gias_schools.rb
+++ b/app/services/import_gias_schools.rb
@@ -17,6 +17,8 @@ class ImportGiasSchools
         school.update!(attributes_from_row(row))
       end
     end
+  rescue CSV::MalformedCSVError => e
+    raise e, e.message + ", line: #{csv_file.gets}"
   ensure
     csv_file.close
     csv_file.unlink

--- a/app/services/import_gias_schools.rb
+++ b/app/services/import_gias_schools.rb
@@ -11,7 +11,7 @@ class ImportGiasSchools
         s.assign_attributes(attributes_from_row(row))
       end
 
-      if refresh_all?
+      if refresh_all? || school.last_changed_date.nil?
         school.update!(attributes_from_row(row))
       elsif row["LastChangedDate"].present? && (school.last_changed_date < row["LastChangedDate"])
         school.update!(attributes_from_row(row))

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     sequence(:urn) { rand(100_000..999_999).to_s }
     sequence(:ukprn) { rand(10_000_000..99_999_999).to_s }
     establishment_status_code { %w[1 3 4].sample }
+    last_changed_date { Date.new(2010, 1, 1) }
 
     trait :funding_eligible_establishment_type_code do
       establishment_type_code do

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :school do
-    sequence(:name) { Faker::Educator.primary_school }
+    sequence(:name) { |n| Faker::Educator.primary_school + " #{n}" }
     sequence(:urn) { rand(100_000..999_999).to_s }
     sequence(:ukprn) { rand(10_000_000..99_999_999).to_s }
     establishment_status_code { %w[1 3 4].sample }

--- a/spec/fixtures/files/invalid_csv_header.csv
+++ b/spec/fixtures/files/invalid_csv_header.csv
@@ -1,0 +1,2 @@
+"header one", "
+data, data


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2433
If the `ImportGiasSchools` is run on a local development environment, it will fail because 766 out of 1766 of the seeded schools have null `last_changed_date`.
This change to the factory that is used by the seeds fixes that, so it is more like production.
For sandbox and staging, there are a number of seeded schools with null `last_changed_date` - for this the `ImportGiasSchools` will now cope with that.

### Changes proposed in this pull request

Set the `last_changed_date` to 1/1/2010 for all schools created using a factory.
Cope with a null `last_changed_date` in `ImportGiasSchools`

⚠️ do not merge until CPDNPQ-2421 is merged ⚠️ 
