### PR TITLE
[CPDNPQ-2508] Change to always log users out at midnight

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,4 @@
 class ApplicationController < ActionController::Base
-  MAX_ADMIN_SESSION = 12.hours
-
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
   before_action :set_sentry_user
@@ -45,7 +43,7 @@ private
   def current_admin
     return unless session[:admin_id]
 
-    if session[:admin_sign_in_at].nil? || session[:admin_sign_in_at] < MAX_ADMIN_SESSION.ago
+    if session[:admin_sign_in_at].nil? || session[:admin_sign_in_at] < Time.zone.now.beginning_of_day
       reset_session
       nil
     else

--- a/spec/requests/npq_separation/admin_controller_spec.rb
+++ b/spec/requests/npq_separation/admin_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe NpqSeparation::AdminController, type: :request do
 
   context "when admin is logged in" do
     before do
-      travel_to 1.hour.ago do
+      travel_to Time.zone.now.beginning_of_day + 5.minutes do
         create :cohort, :current
 
         sign_in_as_admin
@@ -19,13 +19,15 @@ RSpec.describe NpqSeparation::AdminController, type: :request do
     end
 
     it "shows the admin landing page" do
-      expect(get(npq_separation_admin_path)).to eq(200)
+      travel_to Time.zone.now.end_of_day - 5.minutes do
+        expect(get(npq_separation_admin_path)).to eq(200)
+      end
     end
   end
 
-  context "when admin session has timed out" do
+  context "when admin session is from yesterday" do
     before do
-      travel_to 13.hours.ago do
+      travel_to Time.zone.now.beginning_of_day - 1.minute do
         create :cohort, :current
 
         sign_in_as_admin
@@ -33,7 +35,9 @@ RSpec.describe NpqSeparation::AdminController, type: :request do
     end
 
     it "redirects to the sign in page" do
-      expect(get(npq_separation_admin_path)).to redirect_to(sign_in_path)
+      travel_to Time.zone.now.beginning_of_day + 1.minute do
+        expect(get(npq_separation_admin_path)).to redirect_to(sign_in_path)
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2508](https://dfedigital.atlassian.net/browse/CPDNPQ-2508)

To ensure users do not get logged out in the middle of the day we are changing the logout time to always be midnight

### Changes proposed in this pull request

1. Change from logging out after 12 hours to logging out at midnight



[CPDNPQ-2508]: https://dfedigital.atlassian.net/browse/CPDNPQ-2508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ