### PR TITLE
[CPDNPQ-2490] show Application ID on registration success page

### DIFF
--- a/app/views/accounts/user_registrations/show.html.erb
+++ b/app/views/accounts/user_registrations/show.html.erb
@@ -25,6 +25,9 @@
 <% else %>
   <h1 class="govuk-heading-xl"><%= I18n.t("accounts.show.title") %></h1>
 <% end %>
+
+<p class="govuk-body"><strong>Application ID:</strong> <%= @application.ecf_id %></p>
+
 <%= render "accounts/course_details", application: @application %>
 <%= render "accounts/funding_details", application: @application %>
 <%= render "accounts/personal_details", application: @application %>

--- a/spec/support/helpers/journey_assertion_helper.rb
+++ b/spec/support/helpers/journey_assertion_helper.rb
@@ -34,6 +34,7 @@ module Helpers
     def expect_applicant_reached_end_of_journey(total_number_of_created_applications: 1)
       expect_page_to_have(path: "/accounts/user_registrations/#{latest_application.id}?success=true", submit_form: false) do
         expect(page).to have_text("Registration successfully submitted")
+        expect(page).to have_text("Application ID: #{latest_application.ecf_id}")
         expect(page).to have_link("Register for another NPQ", href: /\/registration\/provider_check/)
       end
 


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2490

### Changes proposed in this pull request

Added _Application ID_ on the registration success page:
<img width="1072" alt="Screenshot 2025-01-27 at 15 37 42" src="https://github.com/user-attachments/assets/d7e478de-3b1a-4db2-8aee-6704d69d229b" />

