### PR TITLE
Allow for slow file downloads in CI

### DIFF
--- a/spec/features/npq_separation/admin/creating_statements_spec.rb
+++ b/spec/features/npq_separation/admin/creating_statements_spec.rb
@@ -70,14 +70,24 @@ RSpec.feature "Creating statements", type: :feature do
 
       find("summary", text: "Example statements CSV").click
       click_on "Download empty statements template"
-      sleep 0.1
-      csv = CSV.read("#{Capybara.save_path}/statements.csv")
+
+      csv_file = "#{Capybara.save_path}/statements.csv"
+      1.upto(50) do
+        sleep 0.1
+        break if File.exist?(csv_file)
+      end
+      csv = CSV.read(csv_file)
       expect(csv.count).to eq(1)
 
       find("summary", text: "Example contracts CSV").click
       click_on "Download empty contracts template"
-      sleep 0.1
-      csv = CSV.read("#{Capybara.save_path}/contracts.csv")
+
+      csv_file = "#{Capybara.save_path}/contracts.csv"
+      1.upto(50) do
+        sleep 0.1
+        break if File.exist?(csv_file)
+      end
+      csv = CSV.read(csv_file)
       expect(csv.count).to eq(1)
     end
   end


### PR DESCRIPTION
### Context

Ticket: BAU

Specs are consistently failing on `main`, they were not earlier today - I think this is because we're only allowing 0.1 seconds to download the file and CI is more heavily loaded later in the day.

### Changes proposed in this pull request

1. I cannot see an obvious way of blocking on the download, so instead I'm just checking in a loop for up to 5 seconds for the file to download

