### PR TITLE
BAU - Fix flaky statements factory

### DIFF
--- a/spec/factories/statements.rb
+++ b/spec/factories/statements.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :statement do
     transient do
       declaration {}
+      sequence(:months_from_start_of_2021) { |n| (n - 1) % 48 }
     end
 
     after(:create) do |statement, evaluator|
@@ -10,8 +11,8 @@ FactoryBot.define do
       end
     end
 
-    month { Faker::Number.between(from: 1, to: 12) }
-    year { Faker::Number.between(from: 2021, to: 2024) }
+    month { months_from_start_of_2021 % 12 + 1 }
+    year { 2021 + months_from_start_of_2021 / 12 }
     deadline_date { Faker::Date.forward(days: 30) }
     payment_date { Faker::Date.forward(days: 30) }
     cohort { create(:cohort, :current) }


### PR DESCRIPTION
### Context

Ticket: BAU

We are getting regular failures from flaky specs when trying to deploy out to production

The origin of this is we no longer allow duplicate statements, and due to randomness in the statement period combined with a pool of only 48 possible periods, occasionally a spec which generates 2 statements will generate 2 for the same period.

### Changes proposed in this pull request

1. Iterate the periods instead within the pool of 48