### PR TITLE
[CPDNPQ-2511] add ecf_id to application_submitted_mail

### DIFF
--- a/app/jobs/send_application_submission_email_job.rb
+++ b/app/jobs/send_application_submission_email_job.rb
@@ -11,6 +11,7 @@ class SendApplicationSubmissionEmailJob < ApplicationJob
       provider_name: application.lead_provider.name,
       course_name: localise_sentence_embedded_course_name(application.course),
       amount: application.raw_application_data["funding_amount"],
+      ecf_id: application.ecf_id,
     ).deliver_now
   end
 end

--- a/app/mailers/application_submission_mailer.rb
+++ b/app/mailers/application_submission_mailer.rb
@@ -1,5 +1,5 @@
 class ApplicationSubmissionMailer < ApplicationMailer
-  def application_submitted_mail(_template_id, to:, full_name:, provider_name:, course_name:, amount:)
+  def application_submitted_mail(_template_id, to:, full_name:, provider_name:, course_name:, amount:, ecf_id:)
     template_mail("b8b53310-fa6f-4587-972a-f3f3c6e0892e",
                   to:,
                   personalisation: {
@@ -7,6 +7,7 @@ class ApplicationSubmissionMailer < ApplicationMailer
                     provider_name:,
                     course_name:,
                     amount:,
+                    ecf_id:,
                   })
   end
 end

--- a/spec/jobs/send_application_submission_email_job_spec.rb
+++ b/spec/jobs/send_application_submission_email_job_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe SendApplicationSubmissionEmailJob, type: :job do
         full_name: application.user.full_name,
         provider_name: application.lead_provider.name,
         course_name: "the Leading teaching NPQ",
+        ecf_id: application.ecf_id,
       )
 
       subject.perform_now


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2511

`ecf_id` is referenced in the gov.uk notify template, but is not set in the mailer.

### Changes proposed in this pull request

add `ecf_id` to `ApplicationSubmissionMailer#application_submitted_mail`