### PR TITLE
[CPDNPQ-2520] allow deadline_date and payment_date to be updated

### DIFF
--- a/app/models/financial_change_log.rb
+++ b/app/models/financial_change_log.rb
@@ -12,6 +12,7 @@
 # proper financial apps.
 class FinancialChangeLog < ApplicationRecord
   ONE_OFF_2326 = "OneOff 2326".freeze
+  ONE_OFF_2520 = "OneOff 2520".freeze
 
   validates :operation_description, presence: true, length: { minimum: 5 }
   validates :data_changes, presence: true

--- a/app/services/one_off/create_or_update_statements.rb
+++ b/app/services/one_off/create_or_update_statements.rb
@@ -38,6 +38,9 @@ module OneOff
             statement = statements.first
             if statement
               statement.output_fee = output_fee(row["output_fee"])
+              statement.deadline_date = row["deadline_date"]
+              statement.payment_date = row["payment_date"]
+
               if statement.changed?
                 FinancialChangeLog.log!(description: FinancialChangeLog::ONE_OFF_2326, data: { updated_statement_id: statement.id, changes: statement.changes })
                 statement.save!

--- a/app/services/one_off/create_or_update_statements.rb
+++ b/app/services/one_off/create_or_update_statements.rb
@@ -42,7 +42,7 @@ module OneOff
               statement.payment_date = row["payment_date"]
 
               if statement.changed?
-                FinancialChangeLog.log!(description: FinancialChangeLog::ONE_OFF_2326, data: { updated_statement_id: statement.id, changes: statement.changes })
+                FinancialChangeLog.log!(description: FinancialChangeLog::ONE_OFF_2520, data: { updated_statement_id: statement.id, changes: statement.changes })
                 statement.save!
               end
             else

--- a/spec/services/one_off/create_or_update_statements_spec.rb
+++ b/spec/services/one_off/create_or_update_statements_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe OneOff::CreateOrUpdateStatements do
         OneOff::CreateOrUpdateStatements.new.call(cohort_year:, csv_path:)
 
         log = FinancialChangeLog.first
-        expect(log.operation_description).to eq("OneOff 2326")
+        expect(log.operation_description).to eq("OneOff 2520")
         expect(log.data_changes).to eq(
           { "changes" => {
               "output_fee" => [true, false],


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2520

deadline date and payment date need to be updated on a couple of statements

### Changes proposed in this pull request

Update the `OneOff::CreateOrUpdateStatements` used by the `one_off:create_or_update_statements` rake task so that it updates the deadline date and payment date.
