### PR TITLE
[BAU] - allow for failed login attempts

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -44,7 +44,7 @@ class Rack::Attack
   end
 
   # Throttle protected routes by IP (5rpm)
-  throttle("protected routes (hitting external services)", limit: 5, period: 1.minute) do |request|
+  throttle("protected routes (hitting external services)", limit: 10, period: 2.minutes) do |request|
     request.ip if protected_path?(request)
   end
 


### PR DESCRIPTION
### Context

Ticket: BAU

Currently with a limit of 5 attempts in 1 minute its not possible to mistype an OTP code and then login on the second attempt.

### Changes proposed in this pull request

1. Change form 5 page loads under `/session` in 1 minute to 10 page loads in 2 minutes

This should allow for a real user to retry with rate limiting still taking effect at the same point