### PR TITLE
[CPDNPQ-2517] void ineligible statement_items when voiding a declaration

### DIFF
--- a/app/models/statement_item.rb
+++ b/app/models/statement_item.rb
@@ -38,7 +38,7 @@ class StatementItem < ApplicationRecord
     end
 
     event :mark_voided do
-      transition %i[eligible payable] => :voided
+      transition %i[eligible ineligible payable] => :voided
     end
 
     event :mark_awaiting_clawback do

--- a/app/services/declarations/void.rb
+++ b/app/services/declarations/void.rb
@@ -39,7 +39,7 @@ module Declarations
 
     def void_declaration
       declaration.mark_voided!
-      declaration.statement_items.with_state(:eligible, :payable).first&.mark_voided!
+      declaration.statement_items.with_state(:eligible, :ineligible, :payable).first&.mark_voided!
     end
 
     def declaration_not_already_voided

--- a/docs/state_machines.md
+++ b/docs/state_machines.md
@@ -35,6 +35,7 @@ stateDiagram-v2
     paid --> awaiting_clawback: mark_awaiting_clawback
     awaiting_clawback --> clawed_back: mark_clawed_back
     eligible --> ineligible: mark_ineligible
+    ineligible --> voided: mark_voided
 ```
 
 ## Declaration

--- a/spec/models/statement_item_spec.rb
+++ b/spec/models/statement_item_spec.rb
@@ -128,6 +128,17 @@ RSpec.describe StatementItem, type: :model do
                 .to("voided")
         end
       end
+
+      context "when from ineligible" do
+        let(:statement_item) { create(:statement_item, :ineligible) }
+
+        it "transitions state to voided" do
+          expect { statement_item.mark_voided! }
+          .to change { statement_item.reload.state }
+                .from("ineligible")
+                .to("voided")
+        end
+      end
     end
 
     describe ".mark_awaiting_clawback" do

--- a/spec/services/declarations/void_spec.rb
+++ b/spec/services/declarations/void_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Declarations::Void, type: :model do
 
         it { expect { void }.to change { declaration.reload.state }.from(declaration_state).to("voided") }
 
-        %w[eligible payable].each do |statement_item_state|
+        %w[eligible ineligible payable].each do |statement_item_state|
           context "when the declaration has a #{statement_item_state} statement item" do
             let(:statement_item) { create(:statement_item, declaration:, state: statement_item_state) }
 


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2517

### Changes proposed in this pull request

void ineligible statement_items when voiding a declaration - previously only eligible and payable statement_items were voided.