### PR TITLE
CPDNPQ-2361 Handle invalid session steps

### DIFF
--- a/app/controllers/session_wizard_controller.rb
+++ b/app/controllers/session_wizard_controller.rb
@@ -1,15 +1,13 @@
 class SessionWizardController < ApplicationController
   def show
-    @wizard = SessionWizard.new(current_step: params[:step].underscore,
-                                store:,
-                                session:)
+    @wizard = SessionWizard.new(current_step: session_step, store:, session:)
     @form = @wizard.form
 
     render @wizard.current_step
   end
 
   def update
-    @wizard = SessionWizard.new(current_step: params[:step].underscore,
+    @wizard = SessionWizard.new(current_step: session_step,
                                 store:,
                                 params: wizard_params,
                                 session:)
@@ -39,6 +37,11 @@ private
   end
 
   def wizard_params
-    params.fetch(:session_wizard, {}).permit(SessionWizard.permitted_params_for_step(params[:step].underscore))
+    params.fetch(:session_wizard, {})
+          .permit(SessionWizard.permitted_params_for_step(session_step))
+  end
+
+  def session_step
+    params[:step].underscore
   end
 end

--- a/app/models/session_wizard.rb
+++ b/app/models/session_wizard.rb
@@ -1,6 +1,8 @@
 class SessionWizard
   include ActiveModel::Model
 
+  STEPS = %i[sign_in sign_in_code].freeze
+
   class InvalidStep < StandardError; end
 
   attr_reader :current_step, :params, :store, :session
@@ -13,6 +15,8 @@ class SessionWizard
   end
 
   def self.permitted_params_for_step(step)
+    return [] unless STEPS.include?(step.to_sym)
+
     "Questionnaires::#{step.to_s.camelcase}".constantize.permitted_params
   end
 
@@ -63,9 +67,6 @@ private
   end
 
   def steps
-    %i[
-      sign_in
-      sign_in_code
-    ]
+    STEPS
   end
 end

--- a/config/initializers/exceptions.rb
+++ b/config/initializers/exceptions.rb
@@ -1,0 +1,3 @@
+ActionDispatch::ExceptionWrapper.rescue_responses.merge!(
+  "SessionWizard::InvalidStep" => :not_found,
+)

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -12,6 +12,10 @@ Sentry.init do |config|
     filter.filter(event.to_hash)
   end
 
+  config.excluded_exceptions += %w[
+    SessionWizard::InvalidStep
+  ]
+
   config.traces_sampler = lambda do |sampling_context|
     transaction_context = sampling_context[:transaction_context]
     op = transaction_context[:op]

--- a/spec/controllers/session_wizard_controller_spec.rb
+++ b/spec/controllers/session_wizard_controller_spec.rb
@@ -1,6 +1,24 @@
 require "rails_helper"
 
 RSpec.describe SessionWizardController do
+  describe "show" do
+    context "with valid step" do
+      before { get :show, params: { step: "sign-in" } }
+
+      it "renders the page" do
+        expect(response).to have_http_status :success
+      end
+    end
+
+    context "with invalid step" do
+      it "raises InvalidStep exception" do
+        expect {
+          get :show, params: { step: "login" }
+        }.to raise_exception SessionWizard::InvalidStep
+      end
+    end
+  end
+
   describe "#update" do
     context "when signing in successfully" do
       let(:admin) { FactoryBot.create(:admin, otp_hash: "123456", otp_expires_at: 15.minutes.from_now) }
@@ -18,6 +36,14 @@ RSpec.describe SessionWizardController do
         patch :update, params: { step: "sign-in-code", session_wizard: { code: "123456" } }
 
         expect(controller).to have_received(:reset_session)
+      end
+    end
+
+    context "with invalid step" do
+      it "raises InvalidStep exception" do
+        expect {
+          patch :update, params: { step: "login" }
+        }.to raise_exception SessionWizard::InvalidStep
       end
     end
   end


### PR DESCRIPTION
### Context

Ticket: [2361](https://dfedigital.atlassian.net/browse/CPDNPQ-2361)

Visits to invalid URLs under `/session` path trigger an error instead of a 404. Whilst harmless this is creating noise for us in the errors channel and risks distracting from 'real' errors. The fix is a trivial change

### Changes proposed in this pull request

1. Rescue the invalid step and treat it as a page not found