### PR TITLE
[CPDNPQ-2546] Separate out the wizard session steps

### DIFF
--- a/app/forms/session_wizard_steps/base.rb
+++ b/app/forms/session_wizard_steps/base.rb
@@ -1,0 +1,30 @@
+module SessionWizardSteps
+  class Base
+    include ActiveModel::Model
+    include ActiveModel::Validations::Callbacks
+
+    attr_accessor :wizard
+
+    def before_render
+      reset_store! if wizard.store["submitted"]
+    end
+
+    def after_save; end
+
+    def after_render; end
+
+    def attributes
+      self.class.permitted_params.index_with do |key|
+        public_send(key)
+      end
+    end
+
+    def reset_store!
+      wizard.store.clear
+    end
+
+    def query_store
+      wizard.query_store
+    end
+  end
+end

--- a/app/forms/session_wizard_steps/sign_in.rb
+++ b/app/forms/session_wizard_steps/sign_in.rb
@@ -1,4 +1,4 @@
-module Questionnaires
+module SessionWizardSteps
   class SignIn < Base
     attr_reader :email
 

--- a/app/forms/session_wizard_steps/sign_in_code.rb
+++ b/app/forms/session_wizard_steps/sign_in_code.rb
@@ -1,4 +1,4 @@
-module Questionnaires
+module SessionWizardSteps
   class SignInCode < Base
     attr_accessor :code
 

--- a/app/models/session_wizard.rb
+++ b/app/models/session_wizard.rb
@@ -17,7 +17,7 @@ class SessionWizard
   def self.permitted_params_for_step(step)
     return [] unless STEPS.include?(step.to_sym)
 
-    "Questionnaires::#{step.to_s.camelcase}".constantize.permitted_params
+    "SessionWizardSteps::#{step.to_s.camelcase}".constantize.permitted_params
   end
 
   def form
@@ -57,7 +57,7 @@ private
   end
 
   def form_class
-    @form_class ||= "Questionnaires::#{current_step.to_s.camelcase}".constantize
+    @form_class ||= "SessionWizardSteps::#{current_step.to_s.camelcase}".constantize
   end
 
   def set_current_step(step)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -332,15 +332,6 @@ en:
             lead_provider_id:
               blank: Choose a provider
               invalid: Choose a valid provider
-        questionnaires/sign_in:
-          attributes:
-            email:
-              blank: Email can’t be blank
-        questionnaires/sign_in_code:
-          attributes:
-            code:
-              blank: Code can’t be blank
-              incorrect: Code is not correct. Please try again
         questionnaires/choose_childcare_provider:
           attributes:
             institution_name:
@@ -427,6 +418,15 @@ en:
               blank: Enter the date you became a SENCO
               in_future: The date you became a SENCO must be in the past
               invalid: The date you became a SENCO must be a real date
+        session_wizard_steps/sign_in:
+          attributes:
+            email:
+              blank: Email can’t be blank
+        session_wizard_steps/sign_in_code:
+          attributes:
+            code:
+              blank: Code can’t be blank
+              incorrect: Code is not correct. Please try again
         participants/resume:
           attributes:
             course_identifier:

--- a/spec/forms/session_wizard_steps/sign_in_code_spec.rb
+++ b/spec/forms/session_wizard_steps/sign_in_code_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Questionnaires::SignInCode, type: :model do
+RSpec.describe SessionWizardSteps::SignInCode, type: :model do
   subject do
     described_class.new(code:)
   end

--- a/spec/forms/session_wizard_steps/sign_in_spec.rb
+++ b/spec/forms/session_wizard_steps/sign_in_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Questionnaires::SignIn, type: :model do
+RSpec.describe SessionWizardSteps::SignIn, type: :model do
   describe "validations" do
     it { is_expected.to validate_presence_of(:email) }
   end


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2546](https://dfedigital.atlassian.net/browse/CPDNPQ-2546)

This is a separate wizard, UI components are separate and having them grouped together is confusing

### Changes proposed in this pull request

1. Separate out the SessionWizard steps

[CPDNPQ-2546]: https://dfedigital.atlassian.net/browse/CPDNPQ-2546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ