### PR TITLE
Enable bullet in test+review and fix N+1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,9 +60,12 @@ gem "net-imap", "~> 0.5.1", require: false
 gem "net-pop", require: false
 gem "net-smtp", "~> 0.5.0", require: false
 
+group :development, :test, :review do
+  gem "bullet"
+end
+
 group :development, :test do
   gem "amazing_print"
-  gem "bullet"
   gem "byebug", platforms: %i[mri mingw x64_mingw]
   gem "capybara"
   gem "capybara-screenshot"

--- a/app/controllers/npq_separation/admin/lead_providers_controller.rb
+++ b/app/controllers/npq_separation/admin/lead_providers_controller.rb
@@ -5,6 +5,8 @@ class NpqSeparation::Admin::LeadProvidersController < NpqSeparation::AdminContro
 
   def show
     @lead_provider = LeadProviders::Find.new.find_by_id(params[:id])
-    @statements = Statements::Query.new(lead_provider: @lead_provider).statements
+    @statements = Statements::Query.new(lead_provider: @lead_provider)
+                                   .statements
+                                   .includes(:lead_provider)
   end
 end

--- a/config/environments/review.rb
+++ b/config/environments/review.rb
@@ -3,4 +3,11 @@ require Rails.root.join("config/environments/production")
 Rails.application.configure do
   config.ssl_options = { redirect: { exclude: ->(request) { request.path.include?("/healthcheck") } } }
   config.cache_store = :memory_store
+
+  config.after_initialize do
+    Bullet.enable                       = true
+    Bullet.bullet_logger                = true
+    Bullet.raise                        = true # Raise an error if n+1 query occurs
+    Bullet.unused_eager_loading_enable  = false # Disabled due to the way our queries are structured
+  end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -11,11 +11,6 @@ Rails.application.configure do
     Bullet.bullet_logger                = true
     Bullet.raise                        = true # Raise an error if n+1 query occurs
     Bullet.unused_eager_loading_enable  = false # Disabled due to the way our queries are structured
-    Bullet.stacktrace_excludes          = [
-      "app/controllers/api", # Ignore as request spec factories cause false positives (excluding controllers as we use shared examples so can't target spec/requests/api here), see: https://github.com/flyerhzm/bullet/issues/435
-      "spec/features/admin", # Ignore until they are fixed
-      "npq_separation/admin", # Ignore until they are fixed
-    ]
   end
 
   # Settings specified here will take precedence over those in config/application.rb.


### PR DESCRIPTION
### Context

Ticket: BAU

We want to know when our pages are not optimised automated testing (ie the `test` environment) and manual testing during production review (ie `review` environment) are our best options

### Changes proposed in this pull request

1. Remove 'ignores' from bullet in test environment
2. Enable bullet and make it hard fail in review environment
3. Fix an N+1 which was discovered as part of this