### PR TITLE
[CPDNPQ-2441] Exclude healthchecks from logs

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -90,7 +90,12 @@ Rails.application.configure do
   if ENV["RAILS_LOG_TO_STDOUT"].present?
     $stdout.sync = true
     config.rails_semantic_logger.add_file_appender = false
-    config.semantic_logger.add_appender(io: $stdout, level: Rails.application.config.log_level, formatter: :json)
+    config.semantic_logger.add_appender(
+      io: $stdout,
+      level: Rails.application.config.log_level,
+      formatter: :json,
+      filter: ->(log) { log.name != "MonitoringController" },
+    )
   end
 
   # Do not dump schema after migrations.


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2441](https://dfedigital.atlassian.net/browse/CPDNPQ-2441)

Healthchecks are not useful log output but they do generate the majority of the log output in quiet times. 

### Changes proposed in this pull request

1. Don't log requests to the healthcheck endpoints



[CPDNPQ-2355]: https://dfedigital.atlassian.net/browse/CPDNPQ-2355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CPDNPQ-2441]: https://dfedigital.atlassian.net/browse/CPDNPQ-2441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ