### PR TITLE
[CPDNPQ-2308] send email when eligible_for_funding changes from false to true

### DIFF
--- a/app/mailers/application_funding_eligibility_mailer.rb
+++ b/app/mailers/application_funding_eligibility_mailer.rb
@@ -1,0 +1,14 @@
+class ApplicationFundingEligibilityMailer < ApplicationMailer
+  ELIGIBLE_FOR_FUNDING_TEMPLATE = "87b6e2f6-e2ef-4354-9c3d-876099918507".freeze
+
+  def eligible_for_funding_mail(to:, full_name:, provider_name:, course_name:, ecf_id:)
+    template_mail(ELIGIBLE_FOR_FUNDING_TEMPLATE,
+                  to:,
+                  personalisation: {
+                    full_name:,
+                    provider_name:,
+                    course_name:,
+                    ecf_id:,
+                  })
+  end
+end

--- a/app/services/applications/change_funding_eligibility.rb
+++ b/app/services/applications/change_funding_eligibility.rb
@@ -29,7 +29,11 @@ module Applications
       funding_eligiblity_status_code =
         (eligible_for_funding ? :marked_funded_by_policy : :marked_ineligible_by_policy)
 
-      application.update!(eligible_for_funding:, funding_eligiblity_status_code:)
+      application.assign_attributes(eligible_for_funding: eligible_for_funding, funding_eligiblity_status_code: funding_eligiblity_status_code)
+      eligible_for_funding_change = application.changes["eligible_for_funding"]
+      application.save!.tap do
+        send_eligible_for_funding_email if eligible_for_funding_change == [false, true]
+      end
     end
 
   private
@@ -48,6 +52,16 @@ module Applications
 
     def declared_as_billable_or_changeable?
       application.declarations.billable_or_changeable.count.positive?
+    end
+
+    def send_eligible_for_funding_email
+      ApplicationFundingEligibilityMailer.eligible_for_funding_mail(
+        to: application.user.email,
+        full_name: application.user.full_name,
+        provider_name: application.lead_provider.name,
+        course_name: application.course.name,
+        ecf_id: application.ecf_id,
+      ).deliver_now
     end
   end
 end

--- a/spec/features/npq_separation/admin/applications_spec.rb
+++ b/spec/features/npq_separation/admin/applications_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Listing and viewing applications", type: :feature do
   include Helpers::AdminLogin
+  include Helpers::MailHelper
 
   let(:applications_per_page) { Pagy::DEFAULT[:limit] }
   let(:applications_in_order) { Application.order(created_at: :asc) }
@@ -304,6 +305,8 @@ RSpec.feature "Listing and viewing applications", type: :feature do
     expect(page).to have_css(".govuk-error-message", text: "Choose whether the Application is eligible for funding")
     choose "Yes", visible: :all
     click_button "Continue"
+
+    expect_mail_to_have_been_sent(to: application.user.email, template_id: ApplicationFundingEligibilityMailer::ELIGIBLE_FOR_FUNDING_TEMPLATE)
 
     expect(page).to have_css("h1", text: "Application for #{application.user.full_name}")
     within(".govuk-summary-list:nth-of-type(3)") do |summary_list|

--- a/spec/services/applications/change_funding_eligibility_spec.rb
+++ b/spec/services/applications/change_funding_eligibility_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe Applications::ChangeFundingEligibility, type: :model do
 
   let(:application) { create(:application, :accepted) }
 
+  before { allow(ApplicationFundingEligibilityMailer).to receive(:eligible_for_funding_mail).and_call_original }
+
   describe "validations" do
     it { is_expected.to validate_presence_of :application }
 
@@ -56,7 +58,7 @@ RSpec.describe Applications::ChangeFundingEligibility, type: :model do
 
     before { service.eligible_for_funding = true }
 
-    context "with valid update" do
+    context "with valid update from false to true" do
       it { is_expected.to be true }
 
       it "changes eligibility_for_funding" do
@@ -71,6 +73,57 @@ RSpec.describe Applications::ChangeFundingEligibility, type: :model do
           .to change { application.reload.funding_eligiblity_status_code }
                 .from(nil)
                 .to("marked_funded_by_policy")
+      end
+
+      it "sends an email" do
+        expect(ApplicationFundingEligibilityMailer).to receive(:eligible_for_funding_mail).with(
+          to: application.user.email,
+          full_name: application.user.full_name,
+          provider_name: application.lead_provider.name,
+          course_name: application.course.name,
+          ecf_id: application.ecf_id,
+        )
+        make_change
+      end
+    end
+
+    context "with valid update from true to false" do
+      let(:application) { create(:application, :pending, :eligible_for_funding) }
+
+      before { service.eligible_for_funding = false }
+
+      it { is_expected.to be true }
+
+      it "changes eligibility_for_funding" do
+        expect { make_change }
+          .to change { application.reload.eligible_for_funding }
+                .from(true)
+                .to(false)
+      end
+
+      it "sets funding_eligibility_status_code" do
+        expect { make_change }
+          .to change { application.reload.funding_eligiblity_status_code }
+                .from(nil)
+                .to("marked_ineligible_by_policy")
+      end
+
+      it "does not send an email" do
+        expect(ApplicationFundingEligibilityMailer).not_to receive(:eligible_for_funding_mail)
+        make_change
+      end
+    end
+
+    context "with a valid update from true to true" do
+      let(:application) { create(:application, :pending, :eligible_for_funding) }
+
+      before { service.eligible_for_funding = true }
+
+      it { is_expected.to be true }
+
+      it "does not send an email" do
+        expect(ApplicationFundingEligibilityMailer).not_to receive(:eligible_for_funding_mail)
+        make_change
       end
     end
 

--- a/spec/support/helpers/mail_helper.rb
+++ b/spec/support/helpers/mail_helper.rb
@@ -1,0 +1,7 @@
+module Helpers
+  module MailHelper
+    def expect_mail_to_have_been_sent(to:, template_id:)
+      expect(ActionMailer::Base.deliveries.count { |mail| mail.to == [to] && mail[:template_id].unparsed_value == template_id }).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2308

[Why are we making this change?]

### Changes proposed in this pull request

send email when application `eligible_for_funding` changes from `false` to `true`
don't send an email when it changes from `true` to `false`, or when it doesn't change.