### PR TITLE
[CPDNPQ-2534] Missing employment type & info for certain edge cases

### DIFF
--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -152,20 +152,11 @@ class RegistrationWizard
       end
     end
 
-    if (works_in_another_setting? && inside_catchment?) || lead_mentor_for_accredited_itt_provider?
+    if employment_type_matters?
       array << Answer.new("Employment type", t("employment_type"), :your_employment)
-
-      if lead_mentor_for_accredited_itt_provider?
-        array << Answer.new("ITT provider", itt_provider, :itt_provider)
-      end
-
-      unless lead_mentor_for_accredited_itt_provider? || employment_type_hospital_school? || young_offender_institution? || employment_type_other?
-        array << Answer.new("Role", store["employment_role"], :your_role)
-      end
-
-      unless lead_mentor_for_accredited_itt_provider? || employment_type_other?
-        array << Answer.new("Employer", store["employer_name"], :your_employer)
-      end
+      array << Answer.new("ITT provider", itt_provider, :itt_provider) if lead_mentor_for_accredited_itt_provider?
+      array << Answer.new("Role", store["employment_role"], :your_role) if employment_role_matters?
+      array << Answer.new("Employer", store["employer_name"], :your_employer) if employer_name_matters?
     end
 
     array << Answer.new("Course", I18n.t(course.identifier, scope: "course.name"), :choose_your_npq)
@@ -215,11 +206,11 @@ class RegistrationWizard
 
 private
 
-  delegate :ineligible_institution_type?,
-           to: :funding_eligibility_calculator
-
   delegate :approved_itt_provider?,
            :course,
+           :employment_type_matters?,
+           :employment_role_matters?,
+           :employer_name_matters?,
            :employment_type_hospital_school?,
            :employment_type_other?,
            :formatted_date_of_birth,

--- a/app/services/handle_submission_for_store.rb
+++ b/app/services/handle_submission_for_store.rb
@@ -61,13 +61,11 @@ private
     @query_store ||= RegistrationQueryStore.new(store:)
   end
 
-  delegate :inside_catchment?, to: :query_store
-
-  def store_employer_data?
-    return false if eligible_for_funding?
-
-    (ineligible_institution_type? && inside_catchment?) || referred_by_return_to_teaching_adviser?
-  end
+  delegate :employment_type_matters?,
+           :employment_role_matters?,
+           :employer_name_matters?,
+           :inside_catchment?,
+           to: :query_store
 
   def referred_by_return_to_teaching_adviser?
     store["referred_by_return_to_teaching_adviser"] == "yes"
@@ -90,15 +88,15 @@ private
   end
 
   def employer_name
-    store["employer_name"].presence if store_employer_data?
+    store["employer_name"].presence if employer_name_matters?
   end
 
   def employment_role
-    store["employment_role"].presence if store_employer_data?
+    store["employment_role"].presence if employment_role_matters?
   end
 
   def employment_type
-    store["employment_type"].presence if store_employer_data? || lead_mentor?
+    store["employment_type"].presence if employment_type_matters?
   end
 
   def institution_from_store

--- a/app/services/registration_query_store.rb
+++ b/app/services/registration_query_store.rb
@@ -165,4 +165,21 @@ class RegistrationQueryStore
   def childminder?
     store["kind_of_nursery"] == "childminder"
   end
+
+  def employment_type_matters?
+    (works_in_another_setting? && inside_catchment?) || lead_mentor_for_accredited_itt_provider?
+  end
+
+  def employment_role_matters?
+    return false unless employment_type_matters?
+
+    !(lead_mentor_for_accredited_itt_provider? || employment_type_hospital_school? || young_offender_institution? || employment_type_other?)
+  end
+
+  def employer_name_matters?
+    return true if referred_by_return_to_teaching_adviser?
+    return false unless employment_type_matters?
+
+    !(lead_mentor_for_accredited_itt_provider? || employment_type_other?)
+  end
 end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2534

Aligns the behaviour of the three employment fields between the "check answers" screen and the saved application attributes.

Includes refactoring of RegistrationWizard to make it a bit easier to understand – I've left these commits unsquashed to ease review.