### PR TITLE
fix childcare provider import doc

### DIFF
--- a/docs/acquiring_new_private_childcare_provider_data.md
+++ b/docs/acquiring_new_private_childcare_provider_data.md
@@ -3,7 +3,7 @@
 # Acquiring new Private Childcare Provider CSV data for import
 
 1. [Overview](#overview)
-1. [Acquiring the ODS files](#acquiring-the-ods-files)
+1. [Acquiring the CSV files](#acquiring-the-csv-files)
 1. [Extracting the data](#extracting-the-data)
 1. [Importing the data](../docs/importing_data.md#importing-private-childcare-provider-data)
 
@@ -28,5 +28,5 @@ Download from the above link the CSV files named:
 - delete the non-header rows from the files - the first line should be the CSV header
 
 As the exact structure of these files can differ year to year it is worth running these files through the import process locally to ensure the data is being imported correctly before committing the files to the repository. Any changes would mean that the [import rake task](../lib/tasks/private_childcare_providers.rake) would need to be updated to reflect the new structure, these changes would be made in the CSV row wrapper classes:
-- [Importers::ImportPrivateChildcareProviders::ChildcareProviderWrappedCSVRow](../app/services/importers/import_private_childcare_providers)
-- [Importers::ImportPrivateChildcareProviders::ChildminderAgencyWrappedCSVRow](../app/services/importers/import_private_childcare_providers)
+- [Importers::ImportPrivateChildcareProviders::ChildcareProviderWrappedCSVRow](../app/services/importers/import_private_childcare_providers.rb)
+- [Importers::ImportPrivateChildcareProviders::ChildminderAgencyWrappedCSVRow](../app/services/importers/import_private_childcare_providers.rb)

--- a/docs/importing_data.md
+++ b/docs/importing_data.md
@@ -28,12 +28,14 @@ If you need to update all schools you can do this by running the (Sync School Da
 
 See [Acquiring New Private Childcare Provider data](docs/acquiring_new_private_childcare_provider_data.md) for how to acquire new data.
 
+The import should be run on staging and production.
+
 ### Locally
 - Open a rails console and run the following
 - `bundle exec rake 'private_childcare_providers:import[lib/private_childcare_providers/2024-12-31/childcare_providers.csv,childcare_providers]'`
 - `bundle exec rake 'private_childcare_providers:import[lib/private_childcare_providers/2024-12-31/childminder_agencies.csv,childminder_agencies]'`
 
-### Production
+### Staging and Production
 There is no Github Action for this, the above rake tasks need to be called.
 
 ## Importing premium pupils data


### PR DESCRIPTION
### Context

In the `Acquiring new Private Childcare Provider CSV data for import` doc:
the link in the table of contents was wrong
also, the links to the importer classes didn't work.