### PR TITLE
[CPDNPQ-2602] remove link to non-existent step

### DIFF
--- a/app/views/registration_wizard/shared/_additional_info.html.erb
+++ b/app/views/registration_wizard/shared/_additional_info.html.erb
@@ -4,10 +4,8 @@
   <ul class="govuk-list govuk-list--bullet">
     <li>use your previous name to register with the service</li>
     <li>use your previous name to register, and then change it on the Teaching Regulation Agency records at a later date</li>
-    <li><%= govuk_link_to "change your name on the Teaching Regulation Agency records", registration_wizard_show_path(step: "change-dqt") %> first and then return to register for an NPQ</li>
+    <li><%= govuk_link_to "change your name on your DfE Identity Teaching record", identity_link_uri(request.original_url) %> first and then return to register for an NPQ</li>
   </ul>
 
   <p>It will take a minimum of 5 days to update your Teaching Regulation Agency records.</p>
-
-  <p>If you are unsure whether you have updated your name, you can <%= govuk_link_to "request a reminder", registration_wizard_show_path(step: "not-sure-updated-name") %>.</p>
 <% end %>

--- a/spec/requests/rate_limiting_spec.rb
+++ b/spec/requests/rate_limiting_spec.rb
@@ -3,10 +3,15 @@
 require "rails_helper"
 
 RSpec.describe "Rate limiting" do
+  include Helpers::JourneyHelper
+
   let(:ip) { "1.2.3.4" }
   let(:other_ip) { "9.8.7.6" }
 
-  before { set_request_ip(ip) }
+  before do
+    set_request_ip(ip)
+    stub_env_variables_for_gai
+  end
 
   [
     "/api/guidance",


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2602

we show a link to a `change-dqt` step, which does not exist

### Changes proposed in this pull request

Change link to point to Dfe Identity - where they can change their name.
Also, remove the last paragraph, which has a link to a non-existent `not-sure-updated-name` step.