### PR TITLE
[CPDNPQ-2605] Remove invalid EHCO provider options

### DIFF
--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -25,11 +25,9 @@ class LeadProvider < ApplicationRecord
   NPQH_EHCO_PROVIDERS = [
     "Ambition Institute",
     "Best Practice Network",
-    "Church of England",
     "National Institute of Teaching",
     "Teach First",
     "LLSE",
-    "Teacher Development Trust",
     "UCL Institute of Education",
   ].freeze
 

--- a/spec/forms/questionnaires/choose_your_provider_spec.rb
+++ b/spec/forms/questionnaires/choose_your_provider_spec.rb
@@ -388,11 +388,9 @@ RSpec.describe Questionnaires::ChooseYourProvider, type: :model do
           LeadProvider.where(name: [
             "Ambition Institute",
             "Best Practice Network",
-            "Church of England",
             "National Institute of Teaching",
             "Teach First",
             "LLSE",
-            "Teacher Development Trust",
             "UCL Institute of Education",
           ])
         end

--- a/spec/models/lead_provider_spec.rb
+++ b/spec/models/lead_provider_spec.rb
@@ -135,10 +135,8 @@ RSpec.describe LeadProvider do
         expect(subject).to eq([
           "Ambition Institute",
           "Best Practice Network",
-          "Church of England",
           "LLSE",
           "National Institute of Teaching",
-          "Teacher Development Trust",
           "Teach First",
           "UCL Institute of Education",
         ])


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2605

After choosing the EHCO NPQ, applicants are taken to a screen to specify their provider

The list of providers is hard-coded and hasn’t been updated to reflect a change in which providers offer this course

Ultimately these lists should not be hard-coded, but since the service is currently open, to solve this quickly we should remove invalid providers from this list