### PR TITLE
[CPDNPQ-2369] validate declaration_type at both model and service layer

### DIFF
--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -80,12 +80,12 @@ class Declaration < ApplicationRecord
     end
   end
 
-  enum declaration_type: {
+  enum :declaration_type, {
     started: "started",
     "retained-1": "retained-1",
     "retained-2": "retained-2",
     completed: "completed",
-  }, _suffix: true
+  }, suffix: true, validate: true
 
   enum state_reason: {
     duplicate: "duplicate",

--- a/app/services/declarations/create.rb
+++ b/app/services/declarations/create.rb
@@ -19,6 +19,7 @@ module Declarations
     validates :declaration_date, declaration_date: true
     validates :declaration_date, presence: true
     validates :declaration_type, presence: true
+    validates :declaration_type, inclusion: { in: Declaration.declaration_types.values }
     validates :cohort, contract_for_cohort_and_course: true
 
     validate :output_fee_statement_available

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -76,6 +76,7 @@ en:
   declaration_type: &declaration_type
     blank: "Enter a '#/%{parameterized_attribute}'."
     mismatch_declaration_type_for_schedule: "The property '#/%{parameterized_attribute}' does not exist for this schedule."
+    inclusion: The entered '#/%{parameterized_attribute}' is not recognised.
 
   has_passed: &has_passed
     invalid: "Enter 'true' or 'false' in the '#/%{parameterized_attribute}' field to indicate whether this participant has passed or failed their course."

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Declaration, type: :model do
 
   describe "validations" do
     it { is_expected.to validate_presence_of(:declaration_type) }
+    it { is_expected.to validate_inclusion_of(:declaration_type).in_array(described_class.declaration_types.values) }
     it { is_expected.to validate_presence_of(:declaration_date) }
     it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique") }
 

--- a/spec/services/declarations/create_spec.rb
+++ b/spec/services/declarations/create_spec.rb
@@ -347,5 +347,20 @@ RSpec.describe Declarations::Create, type: :model do
         expect(declaration.superseded_by).to eq(original_declaration)
       end
     end
+
+    context "when the declaration_type is not valid" do
+      subject(:service) { described_class.new(**params) }
+
+      let(:declaration_type) { "started-1" }
+
+      it "returns false" do
+        expect(service.create_declaration).to be false
+      end
+
+      it "has an error" do
+        service.create_declaration
+        expect(service).to have_error(:declaration_type, :inclusion, "The entered '#/declaration_type' is not recognised.")
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2369

Creating a declaration via the API with an invalid `declaration_type` causes a 500 error

### Changes proposed in this pull request

The issue is that a query that uses an invalid `declaration_type` will raise the error:
 `ActiveRecord::StatementInvalid: PG::InvalidTextRepresentation: ERROR:  invalid input value for enum declaration_types`.
This is happening in `Declarations::Create#existing_declaration` which is used in the `output_fee_statement_available` validation.

Rather than catching the `ActiveRecord::StatementInvalid` error, I think it's cleaner to just add an inclusion validation on the `Declarations::Create` service.

The validation added to the Declaration model won't be used in this scenario, but I've added it for thoroughness.