### PR TITLE
[CPDNPQ-2625] remove lead provider Teacher Development Trust from all courses

### DIFF
--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -6,7 +6,7 @@ class LeadProvider < ApplicationRecord
     "LLSE" => "230e67c0-071a-4a48-9673-9d043d456281",
     "National Institute of Teaching" => "3ec607f2-7a3a-421f-9f1a-9aca8a634aeb",
     "School-Led Network" => "bc5e4e37-1d64-4149-a06b-ad10d3c55fd0",
-    "Teacher Development Trust" => "30fd937e-b93c-4f81-8fff-3c27544193f1",
+    "Teacher Development Trust" => "30fd937e-b93c-4f81-8fff-3c27544193f1", # no longer offers any NPQs
     "Teach First" => "a02ae582-f939-462f-90bc-cebf20fa8473",
     "UCL Institute of Education" => "ef687b3d-c1c0-4566-a295-16d6fa5d0fa7",
   }.freeze
@@ -17,7 +17,6 @@ class LeadProvider < ApplicationRecord
     "Church of England",
     "LLSE",
     "National Institute of Teaching",
-    "Teacher Development Trust",
     "Teach First",
     "UCL Institute of Education",
   ].freeze
@@ -34,7 +33,6 @@ class LeadProvider < ApplicationRecord
   EYL_LL_PROVIDERS = [
     "Ambition Institute",
     "National Institute of Teaching",
-    "Teacher Development Trust",
     "Teach First",
     "UCL Institute of Education",
   ].freeze

--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -1,12 +1,11 @@
 class LeadProvider < ApplicationRecord
-  ALL_PROVIDERS = {
+  ALL_ACTIVE_PROVIDERS = {
     "Ambition Institute" => "9e35e998-c63b-4136-89c4-e9e18ddde0ea",
     "Best Practice Network" => "57ba9e86-559f-4ff4-a6d2-4610c7259b67",
     "Church of England" => "79cb41ca-cb6d-405c-b52c-b6f7c752388d",
     "LLSE" => "230e67c0-071a-4a48-9673-9d043d456281",
     "National Institute of Teaching" => "3ec607f2-7a3a-421f-9f1a-9aca8a634aeb",
     "School-Led Network" => "bc5e4e37-1d64-4149-a06b-ad10d3c55fd0",
-    "Teacher Development Trust" => "30fd937e-b93c-4f81-8fff-3c27544193f1", # no longer offers any NPQs
     "Teach First" => "a02ae582-f939-462f-90bc-cebf20fa8473",
     "UCL Institute of Education" => "ef687b3d-c1c0-4566-a295-16d6fa5d0fa7",
   }.freeze
@@ -101,7 +100,7 @@ class LeadProvider < ApplicationRecord
 
     return all if course_specific_list.blank?
 
-    ecf_ids = ALL_PROVIDERS.slice(*course_specific_list).values.compact_blank
+    ecf_ids = ALL_ACTIVE_PROVIDERS.slice(*course_specific_list).values.compact_blank
     raise "Missing provider ECF_ID for available providers list" if ecf_ids.count != course_specific_list.count
 
     where(ecf_id: ecf_ids)

--- a/app/services/lead_providers/updater.rb
+++ b/app/services/lead_providers/updater.rb
@@ -8,7 +8,7 @@ module LeadProviders
 
     def call
       ActiveRecord::Base.transaction do
-        LeadProvider::ALL_PROVIDERS.each { |name, id| create_or_update_lead_provider(name, id) }
+        LeadProvider::ALL_ACTIVE_PROVIDERS.each { |name, id| create_or_update_lead_provider(name, id) }
       rescue StandardError => e
         Rails.logger.error("Encountered error #{e.message}. Rolling back all changes")
         raise ActiveRecord::Rollback

--- a/db/migrate/20221130142333_add_hint_to_lead_providers.rb
+++ b/db/migrate/20221130142333_add_hint_to_lead_providers.rb
@@ -2,7 +2,7 @@ class AddHintToLeadProviders < ActiveRecord::Migration[6.1]
   def up
     add_column :lead_providers, :hint, :string
 
-    school_led_network_lead_provider = LeadProvider.find_by(ecf_id: LeadProvider::ALL_PROVIDERS["School-Led Network"])
+    school_led_network_lead_provider = LeadProvider.find_by(ecf_id: LeadProvider::ALL_ACTIVE_PROVIDERS["School-Led Network"])
 
     school_led_network_lead_provider&.update!(
       hint: "You can only register with this provider if you already started your NPQ with them in October 2022.",

--- a/db/seeds/base/add_api_tokens.rb
+++ b/db/seeds/base/add_api_tokens.rb
@@ -4,7 +4,6 @@
   "Church of England" => "coe-token",
   "School-Led Network" => "school-led-token",
   "UCL Institute of Education" => "ucl-token",
-  "Teacher Development Trust" => "tdt-token",
   "Teach First" => "teach-first-token",
   "National Institute of Teaching" => "niot-token",
   "LLSE" => "llse-token",

--- a/lib/tasks/lead_providers.rake
+++ b/lib/tasks/lead_providers.rake
@@ -1,5 +1,5 @@
 namespace :lead_providers do
-  desc "Updates Lead Providers in DB to match LeadProvider::ALL_PROVIDERS"
+  desc "Updates Lead Providers in DB to match LeadProvider::ALL_ACTIVE_PROVIDERS"
   task update: :environment do |t|
     Rails.logger.info("Running #{t.name}")
 

--- a/spec/features/journeys/happy_paths/changing_npq_to_one_leadprovider_no_longer_supports_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_npq_to_one_leadprovider_no_longer_supports_spec.rb
@@ -134,7 +134,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/choose-your-provider", submit_form: true) do
       expect(page).to have_text("Select your provider")
       expect(page).not_to have_text("Best Practice Network")
-      page.choose("Teacher Development Trust", visible: :all)
+      page.choose("National Institute of Teaching", visible: :all)
     end
 
     expect_page_to_have(path: "/registration/share-provider", submit_form: true) do
@@ -148,7 +148,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
           "Course start" => "Before #{application_course_start_date}",
           "Course" => "Early years leadership",
           "Course funding" => "My workplace is covering the cost",
-          "Provider" => "Teacher Development Trust",
+          "Provider" => "National Institute of Teaching",
           "Work setting" => "Early years or childcare",
           "Workplace" => "open manchester school – street 1, manchester",
           "Early years setting" => public_kind_of_nursery,
@@ -198,7 +198,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "funding_eligiblity_status_code" => "not_entitled_ey_institution",
       "headteacher_status" => nil,
       "kind_of_nursery" => public_kind_of_nursery_key,
-      "lead_provider_id" => LeadProvider.find_by(name: "Teacher Development Trust").id,
+      "lead_provider_id" => LeadProvider.find_by(name: "National Institute of Teaching").id,
       "notes" => nil,
       "private_childcare_provider_id" => nil,
       "referred_by_return_to_teaching_adviser" => nil,
@@ -236,7 +236,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
         "institution_location" => "manchester",
         "institution_name" => js ? "" : "open",
         "kind_of_nursery" => public_kind_of_nursery_key,
-        "lead_provider_id" => LeadProvider.find_by(name: "Teacher Development Trust").id.to_s,
+        "lead_provider_id" => LeadProvider.find_by(name: "National Institute of Teaching").id.to_s,
         "submitted" => true,
         "targeted_delivery_funding_eligibility" => false,
         "teacher_catchment" => "england",

--- a/spec/forms/questionnaires/choose_your_provider_spec.rb
+++ b/spec/forms/questionnaires/choose_your_provider_spec.rb
@@ -96,7 +96,6 @@ RSpec.describe Questionnaires::ChooseYourProvider, type: :model do
           LeadProvider.where(name: [
             "Ambition Institute",
             "National Institute of Teaching",
-            "Teacher Development Trust",
             "Teach First",
             "UCL Institute of Education",
           ])
@@ -167,7 +166,6 @@ RSpec.describe Questionnaires::ChooseYourProvider, type: :model do
             "Church of England",
             "LLSE",
             "National Institute of Teaching",
-            "Teacher Development Trust",
             "Teach First",
             "UCL Institute of Education",
           ])
@@ -326,7 +324,6 @@ RSpec.describe Questionnaires::ChooseYourProvider, type: :model do
           LeadProvider.where(name: [
             "Ambition Institute",
             "National Institute of Teaching",
-            "Teacher Development Trust",
             "Teach First",
             "UCL Institute of Education",
           ])
@@ -369,7 +366,6 @@ RSpec.describe Questionnaires::ChooseYourProvider, type: :model do
             "Church of England",
             "LLSE",
             "National Institute of Teaching",
-            "Teacher Development Trust",
             "Teach First",
             "UCL Institute of Education",
           ])

--- a/spec/models/lead_provider_spec.rb
+++ b/spec/models/lead_provider_spec.rb
@@ -53,7 +53,6 @@ RSpec.describe LeadProvider do
           "Church of England",
           "LLSE",
           "National Institute of Teaching",
-          "Teacher Development Trust",
           "Teach First",
           "UCL Institute of Education",
         ])
@@ -70,7 +69,6 @@ RSpec.describe LeadProvider do
           "Church of England",
           "LLSE",
           "National Institute of Teaching",
-          "Teacher Development Trust",
           "Teach First",
           "UCL Institute of Education",
         ])
@@ -87,7 +85,6 @@ RSpec.describe LeadProvider do
           "Church of England",
           "LLSE",
           "National Institute of Teaching",
-          "Teacher Development Trust",
           "Teach First",
           "UCL Institute of Education",
         ])
@@ -104,7 +101,6 @@ RSpec.describe LeadProvider do
           "Church of England",
           "LLSE",
           "National Institute of Teaching",
-          "Teacher Development Trust",
           "Teach First",
           "UCL Institute of Education",
         ])
@@ -121,7 +117,6 @@ RSpec.describe LeadProvider do
           "Church of England",
           "LLSE",
           "National Institute of Teaching",
-          "Teacher Development Trust",
           "Teach First",
           "UCL Institute of Education",
         ])
@@ -153,7 +148,6 @@ RSpec.describe LeadProvider do
           "Church of England",
           "LLSE",
           "National Institute of Teaching",
-          "Teacher Development Trust",
           "Teach First",
           "UCL Institute of Education",
         ])
@@ -167,7 +161,6 @@ RSpec.describe LeadProvider do
         expect(subject).to eq([
           "Ambition Institute",
           "National Institute of Teaching",
-          "Teacher Development Trust",
           "Teach First",
           "UCL Institute of Education",
         ])
@@ -181,7 +174,6 @@ RSpec.describe LeadProvider do
         expect(subject).to eq([
           "Ambition Institute",
           "National Institute of Teaching",
-          "Teacher Development Trust",
           "Teach First",
           "UCL Institute of Education",
         ])


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2625

TDT have stopped offering NPQs

### Changes proposed in this pull request

remove Teacher Development Trust from all the provider course lists.
