### PR TITLE
[CPDNPQ-2480] Admin console - change lead provider

### DIFF
--- a/app/controllers/npq_separation/admin/applications/change_lead_provider_controller.rb
+++ b/app/controllers/npq_separation/admin/applications/change_lead_provider_controller.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module NpqSeparation
+  module Admin
+    module Applications
+      class ChangeLeadProviderController < NpqSeparation::AdminController
+        before_action :set_application, :set_change_lead_provider
+
+        def create
+          @change_lead_provider.assign_attributes(lead_provider_params)
+
+          if @change_lead_provider.change_lead_provider
+            redirect_to npq_separation_admin_application_path(@application)
+          else
+            render :show, status: :unprocessable_entity
+          end
+        end
+
+      private
+
+        def set_application
+          @application = Application.find(params[:id])
+        end
+
+        def set_change_lead_provider
+          @change_lead_provider =
+            ::Applications::ChangeLeadProvider.new(application: @application)
+        end
+
+        def lead_provider_params
+          params.fetch(:applications_change_lead_provider, {}).permit(:lead_provider_id)
+        end
+      end
+    end
+  end
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -47,6 +47,9 @@ class Course < ApplicationRecord
     npq-headship
   ].freeze
 
+  # Two courses do not have short codes:
+  # - npq-early-headship-coaching-offer
+  # - npq-additional-support-offer
   SHORT_CODES = {
     "npq-leading-teaching" => "NPQLT",
     "npq-leading-behaviour-culture" => "NPQLBC",

--- a/app/services/applications/change_lead_provider.rb
+++ b/app/services/applications/change_lead_provider.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Applications
+  class ChangeLeadProvider
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+    include ActiveModel::Validations::Callbacks
+
+    attribute :application
+    attribute :lead_provider_id, :integer
+
+    validates :application, presence: true
+    validates :lead_provider_id, presence: { message: "Choose a lead provider" }
+    validate :different_lead_provider, if: :application
+
+    def change_lead_provider
+      return false if invalid?
+
+      application.update!(lead_provider: lead_provider)
+    end
+
+    def lead_provider_options
+      current_cohort_lead_providers_offering_the_same_course = LeadProvider.for(course: application.course).pluck(:id)
+      LeadProvider.where.not(id: application.lead_provider.id).pluck(:id, :name).map do |id, name|
+        unless current_cohort_lead_providers_offering_the_same_course.include?(id)
+          description = "This lead provider is not offering #{application.course.short_code} for the latest cohort"
+        end
+        OpenStruct.new(id:, name:, description:)
+      end
+    end
+
+  private
+
+    def lead_provider
+      @lead_provider ||= LeadProvider.find(lead_provider_id)
+    end
+
+    def different_lead_provider
+      errors.add(:lead_provider_id, :inclusion) if lead_provider_id == application.lead_provider.id
+    end
+  end
+end

--- a/app/services/applications/change_lead_provider.rb
+++ b/app/services/applications/change_lead_provider.rb
@@ -23,7 +23,7 @@ module Applications
       current_cohort_lead_providers_offering_the_same_course = LeadProvider.for(course: application.course).pluck(:id)
       LeadProvider.where.not(id: application.lead_provider.id).pluck(:id, :name).map do |id, name|
         unless current_cohort_lead_providers_offering_the_same_course.include?(id)
-          description = "This lead provider is not offering #{application.course.short_code} for the latest cohort"
+          description = "This lead provider is not offering #{application.course.identifier} for the latest cohort"
         end
         OpenStruct.new(id:, name:, description:)
       end

--- a/app/views/npq_separation/admin/applications/change_lead_provider/show.html.erb
+++ b/app/views/npq_separation/admin/applications/change_lead_provider/show.html.erb
@@ -15,7 +15,11 @@
         <%= @application.lead_provider.name %>
       </p>
     </div>
+  </div>
+</div>
 
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
     <%= form_for @change_lead_provider,
                  url: npq_separation_admin_applications_change_lead_provider_path(@application) do |f| %>
       <%= f.govuk_error_summary %>

--- a/app/views/npq_separation/admin/applications/change_lead_provider/show.html.erb
+++ b/app/views/npq_separation/admin/applications/change_lead_provider/show.html.erb
@@ -1,0 +1,35 @@
+<%= govuk_back_link href: npq_separation_admin_application_path(@application) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      Transfer lead provider
+    </h1>
+
+    <%= govuk_warning_text(text: "Before continuing with this transfer, make sure the provider has submitted their declarations for this application") %>
+
+    <div class="govuk-inset-text">
+      <p class="govuk-body">
+        <strong>Lead Provider</strong>
+        <br/>
+        <%= @application.lead_provider.name %>
+      </p>
+    </div>
+
+    <%= form_for @change_lead_provider,
+                 url: npq_separation_admin_applications_change_lead_provider_path(@application) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_collection_radio_buttons :lead_provider_id,
+                                           f.object.lead_provider_options,
+                                           :id,
+                                           :name,
+                                           :description,
+                                           legend: { tag: 'h1', size: 'm' } %>
+      <div class="govuk-button-group">
+        <%= f.govuk_submit t("shared.continue") %>
+        <%= govuk_link_to t("shared.cancel"), npq_separation_admin_application_path(@application) %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/npq_separation/admin/applications/show.html.erb
+++ b/app/views/npq_separation/admin/applications/show.html.erb
@@ -52,6 +52,7 @@
     sl.with_row do |row|
       row.with_key(text: "Lead provider name")
       row.with_value(text: @application.lead_provider.name)
+      row.with_action(text: "Transfer", href: npq_separation_admin_applications_change_lead_provider_path(@application))
     end
 
     sl.with_row do |row|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -825,6 +825,8 @@ en:
         training_status: Choose a different training status
       applications_change_funding_eligibility:
         eligible_for_funding: Is eligible for funding?
+      applications_change_lead_provider:
+        lead_provider_id: Choose a different lead provider
       registration_wizard:
         can_share_choices: "Sharing your NPQ information"
         ehco_headteacher: "Are you a headteacher?"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -234,6 +234,7 @@ Rails.application.routes.draw do
             resource :revert_to_pending, controller: "revert_to_pending", only: %i[new create]
             resource :change_training_status, only: %i[new create]
             resource :change_funding_eligibility, only: %i[new create]
+            resource :change_lead_provider, controller: "change_lead_provider", only: %i[show create]
             resource :notes, only: %i[edit update]
           end
         end

--- a/spec/features/npq_separation/admin/applications_spec.rb
+++ b/spec/features/npq_separation/admin/applications_spec.rb
@@ -247,11 +247,13 @@ RSpec.feature "Listing and viewing applications", type: :feature do
     application_details = page.find("h2", text: "Application details", exact_text: true)
                               .sibling(".govuk-summary-list:first-of-type")
 
-    within(application_details) do |summary_list|
-      expect(summary_list).to have_summary_item("Training status", "active")
-      expect(summary_list).to have_link("Change")
+    within(application_details) do
+      within(".govuk-summary-list__row:nth-of-type(8)") do |summary_list_row|
+        expect(summary_list_row).to have_summary_item("Training status", "active")
+        expect(summary_list_row).to have_link("Change")
 
-      click_link("Change")
+        click_link("Change")
+      end
     end
 
     expect(page).to have_css("h1", text: "Change training status")
@@ -266,11 +268,13 @@ RSpec.feature "Listing and viewing applications", type: :feature do
     application_details = page.find("h2", text: "Application details", exact_text: true)
                               .sibling(".govuk-summary-list:first-of-type")
 
-    within(application_details) do |summary_list|
-      expect(summary_list).to have_summary_item("Training status", "deferred")
-      expect(summary_list).to have_link("Change")
+    within(application_details) do
+      within(".govuk-summary-list__row:nth-of-type(8)") do |summary_list_row|
+        expect(summary_list_row).to have_summary_item("Training status", "deferred")
+        expect(summary_list_row).to have_link("Change")
 
-      click_link("Change")
+        click_link("Change")
+      end
     end
 
     expect(page).to have_css("h1", text: "Change training status")
@@ -283,6 +287,38 @@ RSpec.feature "Listing and viewing applications", type: :feature do
 
     within(application_details) do |summary_list|
       expect(summary_list).to have_summary_item("Training status", "active")
+    end
+  end
+
+  scenario "changing lead provider" do
+    application = create(:application)
+
+    visit npq_separation_admin_application_path(application)
+
+    application_details = page.find("h2", text: "Application details", exact_text: true)
+                              .sibling(".govuk-summary-list:first-of-type")
+
+    within(application_details) do
+      within(".govuk-summary-list__row:nth-of-type(9)") do |summary_list_row|
+        expect(summary_list_row).to have_summary_item("Lead provider name", application.lead_provider.name)
+
+        click_link("Transfer")
+      end
+    end
+
+    expect(page).to have_css("h1", text: "Transfer lead provider")
+
+    click_button "Continue"
+    expect(page).to have_css(".govuk-error-message", text: "Choose a lead provider")
+
+    choose "Best Practice Network", visible: :all
+    click_button "Continue"
+
+    application_details = page.find("h2", text: "Application details", exact_text: true)
+                              .sibling(".govuk-summary-list:first-of-type")
+
+    within(application_details) do |summary_list|
+      expect(summary_list).to have_summary_item("Lead provider name", "Best Practice Network")
     end
   end
 

--- a/spec/services/applications/change_lead_provider_spec.rb
+++ b/spec/services/applications/change_lead_provider_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Applications::ChangeLeadProvider, type: :model do
+  subject(:service) { described_class.new(application:, lead_provider_id:) }
+
+  let(:application) { create(:application) }
+  let(:lead_provider_id) { LeadProvider.for(course: application.course).last.id }
+
+  describe "validation" do
+    it { is_expected.to validate_presence_of :application }
+    it { is_expected.to validate_presence_of(:lead_provider_id).with_message "Choose a lead provider" }
+
+    context "when lead_provider_id is not different to the current lead provider" do
+      let(:lead_provider_id) { application.lead_provider.id }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context "when the lead_provider_id is different" do
+      let(:lead_provider_id) { LeadProvider.for(course: application.course).last.id }
+
+      it { is_expected.to be_valid }
+    end
+  end
+
+  describe "#change_lead_provider" do
+    subject { service.change_lead_provider }
+
+    context "when lead_provider_id is not different to the current lead provider" do
+      let(:lead_provider_id) { application.lead_provider.id }
+
+      it { is_expected.to be false }
+    end
+
+    context "when lead_provider_id is different to the current lead provider" do
+      it "changes the lead provider" do
+        expect { subject }.to change(application, :lead_provider_id).to(lead_provider_id)
+      end
+
+      it { is_expected.to be true }
+    end
+  end
+
+  describe "#lead_provider_options" do
+    it "includes all lead providers except the current lead provider" do
+      expect(service.lead_provider_options).to match_array(
+        LeadProvider.where.not(id: application.lead_provider.id).map { |lp| an_object_having_attributes(id: lp.id, name: lp.name) },
+      )
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2480

### Changes proposed in this pull request
* a new link next to the Lead Provider name: 'Transfer'
* a page showing all Lead Providers
* validation to ensure a LP is selected

I've used a `show` page instead of a `new` page - our admin pages seem to mostly use `new`.
Advantages of using 'show' instead of 'new'
* the URL is better I think: `/admin/applications/:id/change_lead_provider`
* the controller doesn't need an empty `def new; end` method
* if using 'new', and there's an error on the page, then user ends up on the show page anyway, which if they reload, causes an error. Using 'show' avoids this.

example page:
<img width="1123" alt="Screenshot 2025-02-14 at 13 54 54" src="https://github.com/user-attachments/assets/2c76cf9a-abe0-4407-8c9a-df2c6a90185a" />

