### PR TITLE
Admin console UI iterations

### DIFF
--- a/app/views/npq_separation/admin/applications/show.html.erb
+++ b/app/views/npq_separation/admin/applications/show.html.erb
@@ -14,7 +14,7 @@
 
     sl.with_row do |row|
       row.with_key(text: "User ID")
-      row.with_value(text: @application.user.id)
+      row.with_value(text: @application.user.ecf_id)
       row.with_action(text: "View Participant", href: npq_separation_admin_user_path(@application.user))
     end
 

--- a/app/views/npq_separation/admin/users/_application.html.erb
+++ b/app/views/npq_separation/admin/users/_application.html.erb
@@ -5,7 +5,7 @@
   govuk_summary_list(card: { title:, actions: }) do |sl|
     sl.with_row do |row|
       row.with_key(text: "Application ID")
-      row.with_value(text: application.id)
+      row.with_value(text: application.ecf_id)
     end
 
     sl.with_row do |row|

--- a/spec/features/npq_separation/admin/applications_spec.rb
+++ b/spec/features/npq_separation/admin/applications_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature "Listing and viewing applications", type: :feature do
 
     within(summary_lists[0]) do |summary_list|
       expect(summary_list).to have_summary_item("Application ID", application.ecf_id)
-      expect(summary_list).to have_summary_item("User ID", application.user.id)
+      expect(summary_list).to have_summary_item("User ID", application.user.ecf_id)
       expect(summary_list).to have_summary_item("Email", application.user.email)
       expect(summary_list).to have_summary_item("TRN", application.user.trn)
       expect(summary_list).to have_summary_item("TRN validated", "No")

--- a/spec/features/npq_separation/admin/users_spec.rb
+++ b/spec/features/npq_separation/admin/users_spec.rb
@@ -89,7 +89,7 @@ RSpec.feature "User administration", type: :feature do
       applications.each.with_index(1) do |application, index|
         within(".govuk-summary-card", text: "Application #{index}") do |summary_card|
           expect(summary_card).to have_link("View full application", href: npq_separation_admin_application_path(application))
-          expect(summary_card).to have_summary_item("Application ID", application.id)
+          expect(summary_card).to have_summary_item("Application ID", application.ecf_id)
           expect(summary_card).to have_summary_item("Lead Provider", application.lead_provider.name)
           expect(summary_card).to have_summary_item("Lead Provider Approval Status", application.lead_provider_approval_status)
           expect(summary_card).to have_summary_item("NPQ Course", application.course.name)


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2618

Context - the Support team/the API use UUIDs rather than IDs.

### Changes proposed in this pull request

- In the application summary card in the participant details page, change the Application ID from the NPQ ID to the UUID ECF ID.
- In the application details page, change the participant ID from the NPQ ID to the UUID ECF ID.

Acceptance criteria 3 in the ticket will be treated as a separate PR.
