### PR TITLE
Don't require CSRF token for omniauth failure

### DIFF
--- a/app/controllers/omniauth_controller.rb
+++ b/app/controllers/omniauth_controller.rb
@@ -46,7 +46,7 @@ class OmniauthController < Devise::OmniauthCallbacksController
       "Omniauth login failure",
       contexts: {
         "Strategy" => { name: request.env["omniauth.error.strategy"].name },
-        "Error" => { "omniauth.error.type" => request.env["omniauth.error.type"] },
+        "Error" => { "omniauth.error.type" => Base64.encode64(request.env["omniauth.error.type"]) },
       },
     )
 
@@ -99,10 +99,10 @@ private
   rescue StandardError
     "unknown-provider-uid"
   end
-end
 
-def try_to_extract_error_type
-  request.env["omniauth.error.type"]
-rescue StandardError
-  "unknown-error-type"
+  def try_to_extract_error_type
+    request.env["omniauth.error.type"]
+  rescue StandardError
+    "unknown-error-type"
+  end
 end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2630

We're seeing [`Omniauth login failure (RuntimeError)` exceptions](https://dfe-teacher-services.sentry.io/discover/results/?field=title&field=release&field=environment&field=user.display&field=timestamp&name=RuntimeError:%20Omniauth%20login%20failure%20(RuntimeError)&project=5817541&query=issue:NPQ-REGISTRATION-MX&queryDataset=error-events&sort=-timestamp&statsPeriod=90d&yAxis=count()), but currently according to the logs, the exception itself is superseded by Rails' rejection of the (presumably missing) CSRF token

By skipping the CSRF validation, we should now see the actual omniauth error

While we're at it, we're also taking a shot at avoiding Sentry scrubbing the error message by Base64-encoding the value on the off chance that the value is triggering the scrubbing behaviour