### PR TITLE
Handle symbol omniauth.error.type

### DIFF
--- a/app/controllers/omniauth_controller.rb
+++ b/app/controllers/omniauth_controller.rb
@@ -46,7 +46,7 @@ class OmniauthController < Devise::OmniauthCallbacksController
       "Omniauth login failure",
       contexts: {
         "Strategy" => { name: request.env["omniauth.error.strategy"].name },
-        "Error" => { "omniauth.error.type" => Base64.encode64(request.env["omniauth.error.type"]) },
+        "Error" => { "omniauth.error.type" => Base64.encode64(request.env["omniauth.error.type"].to_s) },
       },
     )
 


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2630

#2230 raises because apparently `omniauth.error.type` is a symbol. We need to convert it to a string in order to Base64-encode it.