### PR TITLE
[CPDNPQ-2645] Stop unverifying users

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -26,6 +26,7 @@ FactoryBot.define do
 
     trait :with_verified_trn do
       trn_verified { true }
+      trn_lookup_status { "Found" }
     end
 
     trait :with_application do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -198,12 +198,14 @@ RSpec.describe User do
           email_verified: true,
           name: "Example User",
           trn:,
+          trn_lookup_status:,
         ),
       )
     end
 
     let(:feature_flag_id) { 1 }
     let(:trn) { "1234567" }
+    let(:trn_lookup_status) { "Found" }
     let(:user_scopes) { %i[with_verified_trn] }
 
     shared_examples "a TRN updater" do |method_name|
@@ -221,11 +223,14 @@ RSpec.describe User do
           described_class.public_send(method_name, provider_data, feature_flag_id:)
 
           expect(user.trn).to eq "1234567"
+          expect(user.trn_verified).to be true
+          expect(user.trn_lookup_status).to eq "Found"
         end
       end
 
       context "when TRA provides a nil TRN" do
         let(:trn) { nil }
+        let(:trn_lookup_status) { "Failed" }
 
         it "update the user details" do
           described_class.public_send(method_name, provider_data, feature_flag_id:)
@@ -240,6 +245,8 @@ RSpec.describe User do
           described_class.public_send(method_name, provider_data, feature_flag_id:)
 
           expect(user.trn).to eq original_attrs["trn"]
+          expect(user.trn_verified).to eq original_attrs["trn_verified"]
+          expect(user.trn_lookup_status).to eq original_attrs["trn_lookup_status"]
         end
       end
     end


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2645](https://dfedigital.atlassian.net/browse/CPDNPQ-2645)

There was a prior change to avoid updating a users TRN on login if their TRN was blank in DfE Identity (#1782). Unfortunately it is still resetting the users trn_verified status back to unverified.

### Changes proposed in this pull request

1. Refactored specs to allow extension
2. Changed User to only set `trn`+`trn_verified`+`trn_lookup_status` if the user is has TRN information in DfE Identity

[CPDNPQ-2645]: https://dfedigital.atlassian.net/browse/CPDNPQ-2645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ