### PR TITLE
Course start updates

### DIFF
--- a/app/forms/questionnaires/course_start_date.rb
+++ b/app/forms/questionnaires/course_start_date.rb
@@ -7,7 +7,7 @@ module Questionnaires
       end
 
       def question_text
-        "Do you want to start a course in spring 2025?"
+        "Do you want to start a course in #{application_course_start_date}?"
       end
     end
 

--- a/app/forms/questionnaires/course_start_date.rb
+++ b/app/forms/questionnaires/course_start_date.rb
@@ -7,7 +7,7 @@ module Questionnaires
       end
 
       def question_text
-        "Do you want to start a course before #{application_course_start_date}?"
+        "Do you want to start a course in spring 2025?"
       end
     end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -51,7 +51,7 @@ module ApplicationHelper
   end
 
   def application_course_start_date
-    "Spring 2025"
+    "spring 2025"
   end
 
   def show_otp_code_in_ui(current_env, admin)

--- a/app/views/accounts/_course_details.html.erb
+++ b/app/views/accounts/_course_details.html.erb
@@ -72,7 +72,7 @@
             Course start
           </dt>
           <dd class="govuk-summary-list__value">
-            Before <%= application_course_start_date %>
+            <%= application_course_start_date.titleize %>
             <% if application.eligible_for_funding %>
               <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= I18n.t("course_start_details.eligible_for_funding", date: application_course_start_date) %></p>
             <% else %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -749,8 +749,8 @@ en:
   provider_details:
     expired_status_when_service_is_closed: "Your registration has expired but you can register again later for courses starting in October 2024. You'll receive an email when registrations open. This is usually around June."
   course_start_details:
-    eligible_for_funding: "If your provider does not confirm you've started the course before %{date}, your registration will expire. You can register again later, but your funding may change."
-    not_eligible_for_funding: "If your provider does not confirm you've started the course before %{date}, your registration will expire. You can register again later."
+    eligible_for_funding: "If your provider does not confirm you’ve started the course by %{date}, your registration will expire. You can register again later, but your funding may change."
+    not_eligible_for_funding: "If your provider does not confirm you’ve started the course by %{date}, your registration will expire. You can register again later."
 
   statements:
     payment_authorisations:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -861,9 +861,9 @@ en:
         choose_your_npq_html: "To register for an NPQ and the <a href=\"https://professional-development-for-teachers-leaders.education.gov.uk/early-headship-coaching-offer\" class=\"govuk-link\">Early headship coaching offer</a>, submit 2 separate registrations."
         maths_eligibility_teaching_for_mastery_html_one: "You need to be able to demonstrate that you have an understanding of mastery approaches to teaching maths."
         maths_eligibility_teaching_for_mastery_two_html: "You can demonstrate this if you’ve taken at least one year of the <a href=\"https://www.gov.uk/guidance/join-the-maths-teaching-for-mastery-programme\" class=\"govuk-link\">primary maths Teaching for Mastery programme</a>."
-        course_start_date_one: "NPQ start dates are usually every April and October."
-        course_start_date_two: "Early headship coaching offer start dates vary by provider and are throughout the year."
-        course_start_date_three: "Registrations are currently open for courses starting before %{date}."
+        course_start_date_one: "NPQs usually start every spring and autumn."
+        course_start_date_two: "The early headship coaching offer starts at different times throughout the year depending on the provider."
+        course_start_date_three: "Registrations are currently open for courses starting in spring 2025."
         maths_understanding_of_approach_html: "Your provider will ask you for details."
         work_setting_options:
           a_school_html: "Includes:<ul><li>local authority maintained schools (some may provide hospital education, for example pupil referral units, alternative provision or special schools)</li><li>secure children’s homes and secure training centres</li></ul>"

--- a/spec/features/course_start_date_spec.rb
+++ b/spec/features/course_start_date_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "Happy journeys", type: :feature do
       expect(page).not_to have_content("Before you start")
 
       expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-        expect(page).to have_text("NPQs usually start every spring and autumn.")
+        expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
         expect(page).to have_text("Do you want to start a course in spring 2025?")
       end
     end
@@ -43,7 +43,7 @@ RSpec.feature "Happy journeys", type: :feature do
       expect(page).not_to have_content("Before you start")
 
       expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-        expect(page).to have_text("NPQs usually start every spring and autumn.")
+        expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
         expect(page).to have_text("Do you want to start a course in spring 2025?")
       end
     end

--- a/spec/features/course_start_date_spec.rb
+++ b/spec/features/course_start_date_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "Happy journeys", type: :feature do
       expect(page).not_to have_content("Before you start")
 
       expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-        expect(page).to have_text("NPQs usually start every spring and autumn.")
+        expect(page).to have_text("NPQs usually start every spring and autumn")
         expect(page).to have_text("Do you want to start a course in spring 2025?")
       end
     end

--- a/spec/features/course_start_date_spec.rb
+++ b/spec/features/course_start_date_spec.rb
@@ -19,8 +19,8 @@ RSpec.feature "Happy journeys", type: :feature do
       expect(page).not_to have_content("Before you start")
 
       expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-        expect(page).to have_text("NPQ start dates are usually every April and October.")
-        expect(page).to have_text("Do you want to start a course before Spring 2025?")
+        expect(page).to have_text("NPQs usually start every spring and autumn.")
+        expect(page).to have_text("Do you want to start a course in spring 2025?")
       end
     end
   end
@@ -43,8 +43,8 @@ RSpec.feature "Happy journeys", type: :feature do
       expect(page).not_to have_content("Before you start")
 
       expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-        expect(page).to have_text("NPQ start dates are usually every April and October.")
-        expect(page).to have_text("Do you want to start a course before Spring 2025?")
+        expect(page).to have_text("NPQs usually start every spring and autumn.")
+        expect(page).to have_text("Do you want to start a course in spring 2025?")
       end
     end
   end

--- a/spec/features/course_start_date_spec.rb
+++ b/spec/features/course_start_date_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "Happy journeys", type: :feature do
       expect(page).not_to have_content("Before you start")
 
       expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-        expect(page).to have_text("NPQs usually start every spring and autumn")
+        expect(page).to have_text("NPQs usually start every spring and autumn.")
         expect(page).to have_text("Do you want to start a course in spring 2025?")
       end
     end

--- a/spec/features/journeys/happy_paths/able_to_receive_targeted_delivery_funding_spec.rb
+++ b/spec/features/journeys/happy_paths/able_to_receive_targeted_delivery_funding_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQ start dates are usually every April and October.")
+      expect(page).to have_text("NPQs usually start every spring and autumn.")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/able_to_receive_targeted_delivery_funding_spec.rb
+++ b/spec/features/journeys/happy_paths/able_to_receive_targeted_delivery_funding_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQs usually start every spring and autumn.")
+      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQs usually start every spring and autumn.")
+      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQ start dates are usually every April and October.")
+      expect(page).to have_text("NPQs usually start every spring and autumn.")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQs usually start every spring and autumn.")
+      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQ start dates are usually every April and October.")
+      expect(page).to have_text("NPQs usually start every spring and autumn.")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQs usually start every spring and autumn.")
+      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQ start dates are usually every April and October.")
+      expect(page).to have_text("NPQs usually start every spring and autumn.")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/changing_from_outside_of_catchment_area_to_inside_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_from_outside_of_catchment_area_to_inside_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQs usually start every spring and autumn.")
+      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/changing_from_outside_of_catchment_area_to_inside_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_from_outside_of_catchment_area_to_inside_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQ start dates are usually every April and October.")
+      expect(page).to have_text("NPQs usually start every spring and autumn.")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/changing_npq_to_one_leadprovider_no_longer_supports_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_npq_to_one_leadprovider_no_longer_supports_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQ start dates are usually every April and October.")
+      expect(page).to have_text("NPQs usually start every spring and autumn.")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/changing_npq_to_one_leadprovider_no_longer_supports_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_npq_to_one_leadprovider_no_longer_supports_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQs usually start every spring and autumn.")
+      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/funded_ehco_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/funded_ehco_registration_journey_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQ start dates are usually every April and October.")
+      expect(page).to have_text("NPQs usually start every spring and autumn.")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/funded_ehco_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/funded_ehco_registration_journey_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQs usually start every spring and autumn.")
+      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/international_teacher_npqh_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/international_teacher_npqh_journey_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQs usually start every spring and autumn.")
+      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/international_teacher_npqh_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/international_teacher_npqh_journey_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQ start dates are usually every April and October.")
+      expect(page).to have_text("NPQs usually start every spring and autumn.")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/other_funded_ehco_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/other_funded_ehco_registration_journey_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQ start dates are usually every April and October.")
+      expect(page).to have_text("NPQs usually start every spring and autumn.")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/other_funded_ehco_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/other_funded_ehco_registration_journey_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQs usually start every spring and autumn.")
+      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/previously_received_targeted_delivery_funding_spec.rb
+++ b/spec/features/journeys/happy_paths/previously_received_targeted_delivery_funding_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQ start dates are usually every April and October.")
+      expect(page).to have_text("NPQs usually start every spring and autumn.")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/previously_received_targeted_delivery_funding_spec.rb
+++ b/spec/features/journeys/happy_paths/previously_received_targeted_delivery_funding_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQs usually start every spring and autumn.")
+      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/via_using_old_name_and_not_headship_spec.rb
+++ b/spec/features/journeys/happy_paths/via_using_old_name_and_not_headship_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQs usually start every spring and autumn.")
+      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/via_using_old_name_and_not_headship_spec.rb
+++ b/spec/features/journeys/happy_paths/via_using_old_name_and_not_headship_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQ start dates are usually every April and October.")
+      expect(page).to have_text("NPQs usually start every spring and autumn.")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/via_using_same_name_spec.rb
+++ b/spec/features/journeys/happy_paths/via_using_same_name_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQs usually start every spring and autumn.")
+      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/via_using_same_name_spec.rb
+++ b/spec/features/journeys/happy_paths/via_using_same_name_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQ start dates are usually every April and October.")
+      expect(page).to have_text("NPQs usually start every spring and autumn.")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/when_choose_lead_mentor_course_spec.rb
+++ b/spec/features/journeys/happy_paths/when_choose_lead_mentor_course_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQs usually start every spring and autumn.")
+      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/when_choose_lead_mentor_course_spec.rb
+++ b/spec/features/journeys/happy_paths/when_choose_lead_mentor_course_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQ start dates are usually every April and October.")
+      expect(page).to have_text("NPQs usually start every spring and autumn.")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/when_choose_maths_course_spec.rb
+++ b/spec/features/journeys/happy_paths/when_choose_maths_course_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQ start dates are usually every April and October.")
+      expect(page).to have_text("NPQs usually start every spring and autumn.")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/when_choose_maths_course_spec.rb
+++ b/spec/features/journeys/happy_paths/when_choose_maths_course_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQs usually start every spring and autumn.")
+      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/when_get_an_identity_returns_no_trn_spec.rb
+++ b/spec/features/journeys/happy_paths/when_get_an_identity_returns_no_trn_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     end
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQ start dates are usually every April and October.")
+      expect(page).to have_text("NPQs usually start every spring and autumn.")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/when_get_an_identity_returns_no_trn_spec.rb
+++ b/spec/features/journeys/happy_paths/when_get_an_identity_returns_no_trn_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     end
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQs usually start every spring and autumn.")
+      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/when_outside_of_catchment_area_crown_dependencies_spec.rb
+++ b/spec/features/journeys/happy_paths/when_outside_of_catchment_area_crown_dependencies_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQs usually start every spring and autumn.")
+      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/when_outside_of_catchment_area_crown_dependencies_spec.rb
+++ b/spec/features/journeys/happy_paths/when_outside_of_catchment_area_crown_dependencies_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQ start dates are usually every April and October.")
+      expect(page).to have_text("NPQs usually start every spring and autumn.")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/when_outside_of_catchment_area_spec.rb
+++ b/spec/features/journeys/happy_paths/when_outside_of_catchment_area_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQs usually start every spring and autumn.")
+      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/when_outside_of_catchment_area_spec.rb
+++ b/spec/features/journeys/happy_paths/when_outside_of_catchment_area_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQ start dates are usually every April and October.")
+      expect(page).to have_text("NPQs usually start every spring and autumn.")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/when_referred_by_return_to_teaching_adviser_spec.rb
+++ b/spec/features/journeys/happy_paths/when_referred_by_return_to_teaching_adviser_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQs usually start every spring and autumn.")
+      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/when_referred_by_return_to_teaching_adviser_spec.rb
+++ b/spec/features/journeys/happy_paths/when_referred_by_return_to_teaching_adviser_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQ start dates are usually every April and October.")
+      expect(page).to have_text("NPQs usually start every spring and autumn.")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/when_working_at_an_eligible_primary_school_spec.rb
+++ b/spec/features/journeys/happy_paths/when_working_at_an_eligible_primary_school_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQs usually start every spring and autumn.")
+      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/when_working_at_an_eligible_primary_school_spec.rb
+++ b/spec/features/journeys/happy_paths/when_working_at_an_eligible_primary_school_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQ start dates are usually every April and October.")
+      expect(page).to have_text("NPQs usually start every spring and autumn.")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/when_working_in_other_spec.rb
+++ b/spec/features/journeys/happy_paths/when_working_in_other_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQs usually start every spring and autumn.")
+      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/when_working_in_other_spec.rb
+++ b/spec/features/journeys/happy_paths/when_working_in_other_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQ start dates are usually every April and October.")
+      expect(page).to have_text("NPQs usually start every spring and autumn.")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/while_not_currently_working_at_school_spec.rb
+++ b/spec/features/journeys/happy_paths/while_not_currently_working_at_school_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature "Happy journeys",
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQs usually start every spring and autumn.")
+      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/while_not_currently_working_at_school_spec.rb
+++ b/spec/features/journeys/happy_paths/while_not_currently_working_at_school_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature "Happy journeys",
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQ start dates are usually every April and October.")
+      expect(page).to have_text("NPQs usually start every spring and autumn.")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/while_working_at_private_childcare_provider_but_not_a_nursery_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_at_private_childcare_provider_but_not_a_nursery_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQs usually start every spring and autumn.")
+      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/while_working_at_private_childcare_provider_but_not_a_nursery_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_at_private_childcare_provider_but_not_a_nursery_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQ start dates are usually every April and October.")
+      expect(page).to have_text("NPQs usually start every spring and autumn.")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/while_working_at_private_nursery_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_at_private_nursery_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQs usually start every spring and autumn.")
+      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/while_working_at_private_nursery_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_at_private_nursery_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQ start dates are usually every April and October.")
+      expect(page).to have_text("NPQs usually start every spring and autumn.")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/while_working_at_public_nursery_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_at_public_nursery_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQs usually start every spring and autumn.")
+      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/while_working_at_public_nursery_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_at_public_nursery_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQ start dates are usually every April and October.")
+      expect(page).to have_text("NPQs usually start every spring and autumn.")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/while_working_in_neither_a_school_nor_childcare_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_in_neither_a_school_nor_childcare_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQs usually start every spring and autumn.")
+      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/happy_paths/while_working_in_neither_a_school_nor_childcare_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_in_neither_a_school_nor_childcare_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQ start dates are usually every April and October.")
+      expect(page).to have_text("NPQs usually start every spring and autumn.")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/sad_paths/applying_for_ehco_but_not_new_headteacher_spec.rb
+++ b/spec/features/journeys/sad_paths/applying_for_ehco_but_not_new_headteacher_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQ start dates are usually every April and October.")
+      expect(page).to have_text("NPQs usually start every spring and autumn.")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/sad_paths/applying_for_ehco_but_not_new_headteacher_spec.rb
+++ b/spec/features/journeys/sad_paths/applying_for_ehco_but_not_new_headteacher_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQs usually start every spring and autumn.")
+      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/sad_paths/lead_mentor_journey_with_incorrect_course_spec.rb
+++ b/spec/features/journeys/sad_paths/lead_mentor_journey_with_incorrect_course_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQs usually start every spring and autumn.")
+      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/sad_paths/lead_mentor_journey_with_incorrect_course_spec.rb
+++ b/spec/features/journeys/sad_paths/lead_mentor_journey_with_incorrect_course_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQ start dates are usually every April and October.")
+      expect(page).to have_text("NPQs usually start every spring and autumn.")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/sad_paths/not_chosen_dqt_or_provider_spec.rb
+++ b/spec/features/journeys/sad_paths/not_chosen_dqt_or_provider_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQ start dates are usually every April and October.")
+      expect(page).to have_text("NPQs usually start every spring and autumn.")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/sad_paths/not_chosen_dqt_or_provider_spec.rb
+++ b/spec/features/journeys/sad_paths/not_chosen_dqt_or_provider_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQs usually start every spring and autumn.")
+      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/sad_paths/school_not_in_england_spec.rb
+++ b/spec/features/journeys/sad_paths/school_not_in_england_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQ start dates are usually every April and October.")
+      expect(page).to have_text("NPQs usually start every spring and autumn.")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/sad_paths/school_not_in_england_spec.rb
+++ b/spec/features/journeys/sad_paths/school_not_in_england_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQs usually start every spring and autumn.")
+      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/sad_paths/works_in_childcare_but_not_in_england_spec.rb
+++ b/spec/features/journeys/sad_paths/works_in_childcare_but_not_in_england_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQ start dates are usually every April and October.")
+      expect(page).to have_text("NPQs usually start every spring and autumn.")
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/journeys/sad_paths/works_in_childcare_but_not_in_england_spec.rb
+++ b/spec/features/journeys/sad_paths/works_in_childcare_but_not_in_england_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("NPQs usually start every spring and autumn.")
+      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
       page.choose("Yes", visible: :all)
     end
 

--- a/spec/features/service_closed_spec.rb
+++ b/spec/features/service_closed_spec.rb
@@ -74,7 +74,7 @@ RSpec.feature "Service is closed", type: :feature do
       click_on("Start now")
 
       expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-        expect(page).to have_text("NPQs usually start every spring and autumn.")
+        expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
       end
     end
 
@@ -98,7 +98,7 @@ RSpec.feature "Service is closed", type: :feature do
       click_on("Start now")
 
       expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-        expect(page).to have_text("NPQs usually start every spring and autumn.")
+        expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
       end
 
       visit "/admin"

--- a/spec/features/service_closed_spec.rb
+++ b/spec/features/service_closed_spec.rb
@@ -74,7 +74,7 @@ RSpec.feature "Service is closed", type: :feature do
       click_on("Start now")
 
       expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-        expect(page).to have_text("NPQ start dates are usually every April and October.")
+        expect(page).to have_text("NPQs usually start every spring and autumn.")
       end
     end
 
@@ -98,7 +98,7 @@ RSpec.feature "Service is closed", type: :feature do
       click_on("Start now")
 
       expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-        expect(page).to have_text("NPQ start dates are usually every April and October.")
+        expect(page).to have_text("NPQs usually start every spring and autumn.")
       end
 
       visit "/admin"


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2646

### Changes proposed in this pull request

| Change number              | Before | After |
| :---------------- | :------: | :----: |
| 1       |   ![Screenshot 2025-02-19 at 12 06 04](https://github.com/user-attachments/assets/7e2c3099-fe40-472a-a4c9-98a94f3c08e0)   | ![Screenshot 2025-02-19 at 12 05 26](https://github.com/user-attachments/assets/134843d9-c55d-4610-8804-3cbc26184d43) |
| 2           |   ![Screenshot 2025-02-19 at 14 24 48](https://github.com/user-attachments/assets/07be7c58-e5da-4741-9376-8dea2dae3037)  | ![Screenshot 2025-02-19 at 14 23 29](https://github.com/user-attachments/assets/15ddb468-7469-4684-881c-38f3b73459be) |

Change number 2 was not in the scope of [the ticket](https://dfedigital.atlassian.net/browse/CPDNPQ-2646). I made the change because change number 1 introduced inconsistency. Needs content design review to standardise and define the approach. (I think the previous wording - 'before' - was to do with the fact that the early headship coaching offer can start at any time of the year.)

