### PR TITLE
[CPDNPQ-2645] Rake task to correct unverified users

### DIFF
--- a/lib/tasks/one_off/backfill_trn_verified_status.rake
+++ b/lib/tasks/one_off/backfill_trn_verified_status.rake
@@ -1,0 +1,64 @@
+namespace :one_off do
+  desc "Reset the TRN Verified status for users incorrectly marked as unverified"
+  task :backfill_trn_verified_status, %i[dry_run] => :environment do |_task, args|
+    logger = Rails.env.test? ? Rails.logger : Logger.new($stdout)
+    dry_run = args[:dry_run] != "false"
+    issue_introduced = Date.parse("2024-10-03").at_beginning_of_day
+
+    User.transaction do
+      # Find potential affected users
+      user_ids = User.where(trn_verified: false,
+                            trn_auto_verified: true,
+                            updated_at: issue_introduced..)
+                     .limit(4000)
+                     .pluck(:id)
+
+      corrected_user_ids = []
+      batch_counter = 0
+
+      logger.info "Identified #{user_ids.length} potential users to correct"
+      logger.info "DRY RUN: will roll back at end" if dry_run
+
+      # work in batches because each user may have tens of versions
+      user_ids.each_slice(200) do |batch|
+        logger.info("Processing #{batch.length + 200 * batch_counter} / #{user_ids.length}")
+        batch_counter += 1
+
+        users = User.where(id: batch).includes(:versions).to_a
+
+        users.each do |user|
+          # Identify if user had problem with problem
+          next unless user.versions.any? do |version|
+            version.created_at > issue_introduced &&
+              !version.object_changes.nil? &&
+              version.object_changes["trn_verified"] == [true, false] &&
+              version.object_changes["trn_lookup_status"] == ["Found", nil]
+          end
+
+          trn_got_changed = user.versions.any? do |version|
+            version.created_at > issue_introduced &&
+              !version.object_changes.nil? &&
+              version.object_changes.key?("trn") &&
+              version.object_changes["trn"][0] # changed from non-nil value
+          end
+
+          if trn_got_changed
+            logger.info "Skipping User #{user.id} - TRN got changed at some point"
+            next
+          end
+
+          # Code to update user
+          user.update!(trn_verified: true, trn_lookup_status: "Found")
+          corrected_user_ids << user.id
+        end
+      end
+
+      logger.info "Finished, updated #{corrected_user_ids.length}"
+
+      if dry_run
+        logger.info "DRY RUN: rolling back"
+        raise ActiveRecord::Rollback
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/one_off/backfill_trn_verified_status_spec.rb
+++ b/spec/lib/tasks/one_off/backfill_trn_verified_status_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+RSpec.describe "one_off:backfill_trn_verified_status", :versioning do
+  subject :run_task do
+    Rake::Task["one_off:backfill_trn_verified_status"].invoke(dry_run)
+  end
+
+  after { Rake::Task["one_off:backfill_trn_verified_status"].reenable }
+
+  let(:user) { create(:user, trn: nil, trn_verified: false) }
+  let(:dry_run) { "false" }
+
+  context "with users who were incorrectly marked unverified" do
+    before do
+      user.trn = "1029384"
+      user.trn_verified = true
+      user.trn_auto_verified = true
+      user.trn_lookup_status = "Found"
+      user.save!
+
+      user.update!(trn_verified: false, trn_lookup_status: nil)
+    end
+
+    it "updates trn_verified" do
+      expect { run_task }.to change { user.reload.trn_verified }.from(false).to(true)
+    end
+
+    it "updates trn_lookup_status" do
+      expect { run_task }.to change { user.reload.trn_lookup_status }.from(nil).to("Found")
+    end
+
+    context "when performing a dry run" do
+      let(:dry_run) { "" }
+
+      it "does not update trn_verified" do
+        expect { run_task }.not_to(change { user.reload.trn_verified })
+      end
+
+      it "does not update trn_lookup_status" do
+        expect { run_task }.not_to(change { user.reload.trn_lookup_status })
+      end
+    end
+  end
+
+  context "with users who were never verified" do
+    before { user.update!(trn: "1029384") }
+
+    it "does not update trn_verified" do
+      expect { run_task }.not_to(change { user.reload.trn_verified })
+    end
+
+    it "does not update trn_lookup_status" do
+      expect { run_task }.not_to(change { user.reload.trn_lookup_status })
+    end
+  end
+
+  context "with users whose TRN was also changed" do
+    before do
+      user.trn = "1029384"
+      user.trn_verified = true
+      user.trn_auto_verified = true
+      user.trn_lookup_status = "Found"
+      user.save!
+
+      user.update!(trn: "2121212", trn_verified: false, trn_lookup_status: nil)
+    end
+
+    it "does not update trn_verified" do
+      expect { run_task }.not_to(change { user.reload.trn_verified })
+    end
+
+    it "does not update trn_lookup_status" do
+      expect { run_task }.not_to(change { user.reload.trn_lookup_status })
+    end
+  end
+end

--- a/spec/lib/tasks/one_off/backfill_trn_verified_status_spec.rb
+++ b/spec/lib/tasks/one_off/backfill_trn_verified_status_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "one_off:backfill_trn_verified_status", :versioning do
       user.trn_lookup_status = "Found"
       user.save!
 
-      user.update!(trn_verified: false, trn_lookup_status: nil)
+      user.update!(trn_verified: false, trn_lookup_status: nil, updated_from_tra_at: Time.zone.now)
     end
 
     it "updates trn_verified" do
@@ -43,7 +43,7 @@ RSpec.describe "one_off:backfill_trn_verified_status", :versioning do
   end
 
   context "with users who were never verified" do
-    before { user.update!(trn: "1029384") }
+    before { user.update!(trn: "1029384", updated_from_tra_at: Time.zone.now) }
 
     it "does not update trn_verified" do
       expect { run_task }.not_to(change { user.reload.trn_verified })
@@ -62,7 +62,12 @@ RSpec.describe "one_off:backfill_trn_verified_status", :versioning do
       user.trn_lookup_status = "Found"
       user.save!
 
-      user.update!(trn: "2121212", trn_verified: false, trn_lookup_status: nil)
+      user.update!(
+        trn: "2121212",
+        trn_verified: false,
+        trn_lookup_status: nil,
+        updated_from_tra_at: Time.zone.now,
+      )
     end
 
     it "does not update trn_verified" do
@@ -70,6 +75,26 @@ RSpec.describe "one_off:backfill_trn_verified_status", :versioning do
     end
 
     it "does not update trn_lookup_status" do
+      expect { run_task }.not_to(change { user.reload.trn_lookup_status })
+    end
+  end
+
+  context "with users whose trn_verified status changed but they've never had lookup_status set" do
+    before do
+      user.trn = "1029384"
+      user.trn_verified = true
+      user.trn_auto_verified = true
+      user.trn_lookup_status = nil
+      user.save!
+
+      user.update!(trn_verified: false, trn_lookup_status: nil, updated_from_tra_at: Time.zone.now)
+    end
+
+    it "updates trn_verified" do
+      expect { run_task }.to change { user.reload.trn_verified }.from(false).to(true)
+    end
+
+    it "leaves trn_lookup_status as nil" do
       expect { run_task }.not_to(change { user.reload.trn_lookup_status })
     end
   end


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2645](https://dfedigital.atlassian.net/browse/CPDNPQ-2645)

We have a subset of users who have incorrectly have their TRN flagged as unverified. This happened because when the user logs in via DfE Identity, their `trn_verified` field and `trn_lookup_status` are always updated according to whether DfE Identity holds a TRN for the user.

Their TRN is _not_ updated if DfE Identity does not hold a TRN for the user.

This leads to a situation where users who have gone down the DQT path are left with their TRN set, but having had that marked as verified, any subsequent login will mark it back as unverified.

This provides a script to identify these users and correct their `trn_verified` status

### Changes proposed in this pull request

1. It finds users who have `trn_auto_verified` set to `true` (so they went down the DQT check process) but `trn_verified` set to false. This is a pattern we have identified for users who've been impacted by this issue. The 'login' code never updates the `trn_auto_verified` field but the DQT check does so this is an approximate identifier for the users impacted.
2. It checks the users version history looking for evidence `trn_verified` was updated from `true` to `false`
4. It checks that the user did not have their TRN changed which would be a legitimate reason to mark their TRN unverified
5. If all checks are passed then the users `trn_validated` field is updated
6. It also attempts to use the earliest value for `trn_lookup_status` from the versions which changed `trn_verified` to false - we use this version because once its gone to nil, it will remain nil. Its not just set to `Found` because it was nil on some users previously before they were marked as unverified

[CPDNPQ-2645]: https://dfedigital.atlassian.net/browse/CPDNPQ-2645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ