### PR TITLE
[CPDNPQ-2632] ensure validate_schedule_exists is run before the cohort validation

### DIFF
--- a/app/services/declarations/create.rb
+++ b/app/services/declarations/create.rb
@@ -20,11 +20,13 @@ module Declarations
     validates :declaration_date, presence: true
     validates :declaration_type, presence: true
     validates :declaration_type, inclusion: { in: Declaration.declaration_types.values }
+
+    validate :validate_schedule_exists # this needs to come before the cohort validation
+
     validates :cohort, contract_for_cohort_and_course: true
 
     validate :output_fee_statement_available
     validate :validate_has_passed_field, if: :validate_has_passed?
-    validate :validate_schedule_exists
     validate :validates_billable_slot_available
     validate :declaration_date_not_in_the_future
 

--- a/app/services/declarations/create.rb
+++ b/app/services/declarations/create.rb
@@ -21,7 +21,7 @@ module Declarations
     validates :declaration_type, presence: true
     validates :declaration_type, inclusion: { in: Declaration.declaration_types.values }
 
-    validate :validate_schedule_exists # this needs to come before the cohort validation
+    validate :validate_schedule_exists, :validate_declaration_type_for_schedule # this needs to come before the cohort validation
 
     validates :cohort, contract_for_cohort_and_course: true
 
@@ -123,11 +123,18 @@ module Declarations
       end
     end
 
-    def validate_schedule_exists
+    def validate_declaration_type_for_schedule
       return if errors.any?
       return if schedule&.allowed_declaration_types&.include?(declaration_type)
 
       errors.add(:declaration_type, :mismatch_declaration_type_for_schedule)
+    end
+
+    def validate_schedule_exists
+      return if errors.any?
+      return if schedule
+
+      errors.add(:application, :application_schedule_missing)
     end
 
     def original_declaration

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,7 +52,6 @@ en:
     cohort_mismatch: The schedule cohort must match the application cohort
     invalid_for_course: Selected schedule is not valid for the course
 
-
   funded_place: &funded_place
     inclusion: Set '#/%{parameterized_attribute}' to true or false.
     not_eligible: "The participant is not eligible for funding, so '#/funded_place' cannot be set to true."
@@ -501,6 +500,8 @@ en:
             cohort:
               <<: *statement
               missing_contract_for_cohort_and_course: You cannot submit a declaration for this participant as you do not have a contract for the cohort and course. Contact the DfE for assistance.
+            application:
+              application_schedule_missing: The application is missing a schedule.
         participant_outcomes/create:
           attributes:
             base:

--- a/spec/services/declarations/create_spec.rb
+++ b/spec/services/declarations/create_spec.rb
@@ -277,7 +277,7 @@ RSpec.describe Declarations::Create, type: :model do
       let(:declaration_date) { Time.zone.now }
       let(:application) { create(:application, :eligible_for_funded_place, cohort:, course:, lead_provider:, schedule: nil) }
 
-      it { is_expected.to have_error(:declaration_type, :mismatch_declaration_type_for_schedule, "The property '#/declaration_type' does not exist for this schedule.") }
+      it { is_expected.to have_error(:application, :application_schedule_missing, "The application is missing a schedule.") }
     end
 
     context "when the declaration type does not exist for the schedule" do

--- a/spec/services/declarations/create_spec.rb
+++ b/spec/services/declarations/create_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Declarations::Create, type: :model do
-  let(:lead_provider) { LeadProvider.all.sample }
+  let(:lead_provider) { LeadProvider.first }
   let(:cohort) { create(:cohort, :current) }
   let(:course_group) { CourseGroup.find_by(name: "leadership") || create(:course_group, name: "leadership") }
   let(:course) { create(:course, :senior_leadership, course_group:) }
@@ -271,6 +271,20 @@ RSpec.describe Declarations::Create, type: :model do
       before { contract.update!(course: create(:course, :leading_literacy)) }
 
       it { is_expected.to have_error(:cohort, :missing_contract_for_cohort_and_course, "You cannot submit a declaration for this participant as you do not have a contract for the cohort and course. Contact the DfE for assistance.") }
+    end
+
+    context "when there is no schedule" do # bug CPDNPQ-2632
+      let(:declaration_date) { Time.zone.now }
+      let(:application) { create(:application, :eligible_for_funded_place, cohort:, course:, lead_provider:, schedule: nil) }
+
+      it { is_expected.to have_error(:declaration_type, :mismatch_declaration_type_for_schedule, "The property '#/declaration_type' does not exist for this schedule.") }
+    end
+
+    context "when the declaration type does not exist for the schedule" do
+      let(:schedule) { create(:schedule, :npq_specialist_autumn, course_group:, cohort:) }
+      let(:declaration_type) { "retained-2" }
+
+      it { is_expected.to have_error(:declaration_type, :mismatch_declaration_type_for_schedule, "The property '#/declaration_type' does not exist for this schedule.") }
     end
   end
 


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2632

### Changes proposed in this pull request

There was already a `validate_schedule_exists` validation, but it wasn't being run, because the cohort validation was raising an error first.

Just reordering the validations fixes this.

Also, it wasn't actually checking if the schedule exists, but rather if the declaration type was allowed - so I've split the validation into two separate validations.
