### PR TITLE
[CPDNPQ-2630] Don't fail auth if already logged in

### DIFF
--- a/app/controllers/omniauth_controller.rb
+++ b/app/controllers/omniauth_controller.rb
@@ -41,6 +41,8 @@ class OmniauthController < Devise::OmniauthCallbacksController
   end
 
   def failure
+    redirect_to after_sign_in_path_for(current_user) and return if logged_in_user.present?
+
     Rails.logger.info("[GAI][omniauth_failure] uid=#{try_to_extract_user_uid} error=#{try_to_extract_error_type}")
     send_error_to_sentry(
       "Omniauth login failure",


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2630

The remaining occurences of [RuntimeError: Omniauth login failure](https://dfe-teacher-services.sentry.io/discover/results/?field=title&field=release&field=environment&field=user.display&field=timestamp&name=RuntimeError%3A%20Omniauth%20login%20failure%20%28RuntimeError%29&project=5817541&query=issue%3ANPQ-REGISTRATION-MX&queryDataset=error-events&sort=-timestamp&statsPeriod=90d&yAxis=count%28%29) are ostensibly caused when the `state` token used by Omniauth to mitigate CSRF is not present in the user's session when they hit our Omniauth callback.

We don't have a user report with which to recreate this problem, but through investigation I've noticed that if you sign in, then travel back through browser history to the DfE ID service, then click through to return to the NPQ app, the scenario described above is triggered. This happens because the state token is deleted from the session when it is first compared to the OAuth callback payload, so subsequently hitting the callback again compares the payload token to `nil` which obviously fails. The same scenario may also potentially be triggered in certain configurations of multiple browser tabs.

In any case, if a user session is authenticated, we don't care if subsequent Omniauth callbacks fail during that session because we've already authenticated it, therefore we don't need them to sign in again, therefore there's no need to bounce them to an error message advising them to sign in again. So the change here is that if the CSRF check fails but there's already a logged in user, redirect them in the same way as a successful callback would. I expect this to resolve the exception, but we won't know for sure until we deploy.

n.b.
- we use `logged_in_user` because `current_user` can be a `NullUser`, which doesn't make sense here
- there's currently no test coverage of the omniauth controller, and providers are chasing on this issue, so I haven't included a controller spec in this PR — but once we've verified that this is the correct solution, we should certainly add a spec!