### PR TITLE
[CPDNPQ-2368] stop invalid UUID reaching query object

### DIFF
--- a/app/services/declarations/query.rb
+++ b/app/services/declarations/query.rb
@@ -44,7 +44,7 @@ module Declarations
     def where_participant_ids_in(participant_ids)
       return if ignore?(filter: participant_ids)
 
-      scope.merge!(Declaration.where(user: { ecf_id: extract_conditions(participant_ids) }))
+      scope.merge!(Declaration.where(user: { ecf_id: extract_conditions(participant_ids, uuids: true) }))
     end
 
     def where_cohort_start_year_in(cohort_start_years)

--- a/app/services/queries/condition_formats.rb
+++ b/app/services/queries/condition_formats.rb
@@ -1,6 +1,6 @@
 module Queries
   module ConditionFormats
-    def extract_conditions(list, allowlist: nil)
+    def extract_conditions(list, allowlist: nil, uuids: false)
       conditions = case list
                    when String
                      list.split(",")
@@ -10,6 +10,8 @@ module Queries
                      list
                    end
 
+      conditions.select! { |uuid| uuid_valid?(uuid) } if uuids
+
       return conditions if allowlist.blank?
 
       case conditions
@@ -18,6 +20,12 @@ module Queries
       else
         conditions.in?(allowlist) ? conditions : nil
       end
+    end
+
+  private
+
+    def uuid_valid?(uuid)
+      uuid =~ /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
     end
   end
 end

--- a/docs/swagger.md
+++ b/docs/swagger.md
@@ -14,7 +14,7 @@ StatementsResponse: STATEMENTS_RESPONSE[version]
 
 ## Documenting
 
-When adding a new controller/endpoint, you need to ensure there is a corresponding spec file in the `spec/request/api/docs` directory. Ensure to set the correct API version in the `describe` metadata:
+When adding a new controller/endpoint, you need to ensure there is a corresponding spec file in the `spec/requests/api/docs` directory. Ensure to set the correct API version in the `describe` metadata:
 
 ```
 RSpec.describe "Statements endpoint", type: :request, openapi_spec: "v3/swagger.yaml" do

--- a/docs/swagger.md
+++ b/docs/swagger.md
@@ -14,7 +14,7 @@ StatementsResponse: STATEMENTS_RESPONSE[version]
 
 ## Documenting
 
-When adding a new controller/endpoint, you need to ensure there is a corresponding spec file in the `spec/api/docs` directory. Ensure to set the correct API version in the `describe` metadata:
+When adding a new controller/endpoint, you need to ensure there is a corresponding spec file in the `spec/request/api/docs` directory. Ensure to set the correct API version in the `describe` metadata:
 
 ```
 RSpec.describe "Statements endpoint", type: :request, openapi_spec: "v3/swagger.yaml" do

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "sass": "^1.82.0",
     "serialize-javascript": "^6.0.2",
     "svg-pan-zoom": "^3.6.2",
-    "swagger-ui-dist": "^5.18.3",
+    "swagger-ui-dist": "^5.19.0",
     "webpack": "^5.98.0",
     "webpack-cli": "^5.1.4"
   },

--- a/public/api/docs/v1/swagger.yaml
+++ b/public/api/docs/v1/swagger.yaml
@@ -949,7 +949,7 @@ components:
           type: integer
           description: The page number to paginate to in the collection. If no value
             is specified it defaults to the first page.
-          example: 3
+          example: 1
         per_page:
           type: integer
           description: The number items to display on a page. Defaults to 100. Maximum

--- a/public/api/docs/v1/swagger.yaml
+++ b/public/api/docs/v1/swagger.yaml
@@ -20,11 +20,13 @@ paths:
         required: false
         schema:
           "$ref": "#/components/schemas/ListApplicationsFilter"
+        style: deepObject
       - name: page
         in: query
         required: false
         schema:
           "$ref": "#/components/schemas/PaginationFilter"
+        style: deepObject
       responses:
         '200':
           description: A list of NPQ applications
@@ -374,11 +376,13 @@ paths:
         required: false
         schema:
           "$ref": "#/components/schemas/ListParticipantDeclarationsFilter"
+        style: deepObject
       - name: page
         in: query
         required: false
         schema:
           "$ref": "#/components/schemas/PaginationFilter"
+        style: deepObject
       responses:
         '200':
           description: A list of Participant declarations
@@ -538,11 +542,13 @@ paths:
         required: false
         schema:
           "$ref": "#/components/schemas/ListParticipantOutcomesFilter"
+        style: deepObject
       - name: page
         in: query
         required: false
         schema:
           "$ref": "#/components/schemas/PaginationFilter"
+        style: deepObject
       responses:
         '200':
           description: A list of NPQ Outcomes for all participants
@@ -569,6 +575,7 @@ paths:
         required: false
         schema:
           "$ref": "#/components/schemas/PaginationFilter"
+        style: deepObject
       - name: id
         in: path
         required: true
@@ -654,11 +661,13 @@ paths:
         required: false
         schema:
           "$ref": "#/components/schemas/ListParticipantsFilter"
+        style: deepObject
       - name: page
         in: query
         required: false
         schema:
           "$ref": "#/components/schemas/PaginationFilter"
+        style: deepObject
       responses:
         '200':
           description: A list of NPQ participants

--- a/public/api/docs/v2/swagger.yaml
+++ b/public/api/docs/v2/swagger.yaml
@@ -1037,7 +1037,7 @@ components:
           type: integer
           description: The page number to paginate to in the collection. If no value
             is specified it defaults to the first page.
-          example: 3
+          example: 1
         per_page:
           type: integer
           description: The number items to display on a page. Defaults to 100. Maximum

--- a/public/api/docs/v2/swagger.yaml
+++ b/public/api/docs/v2/swagger.yaml
@@ -20,11 +20,13 @@ paths:
         required: false
         schema:
           "$ref": "#/components/schemas/ListApplicationsFilter"
+        style: deepObject
       - name: page
         in: query
         required: false
         schema:
           "$ref": "#/components/schemas/PaginationFilter"
+        style: deepObject
       responses:
         '200':
           description: A list of NPQ applications
@@ -374,11 +376,13 @@ paths:
         required: false
         schema:
           "$ref": "#/components/schemas/ListParticipantDeclarationsFilter"
+        style: deepObject
       - name: page
         in: query
         required: false
         schema:
           "$ref": "#/components/schemas/PaginationFilter"
+        style: deepObject
       responses:
         '200':
           description: A list of Participant declarations
@@ -560,11 +564,13 @@ paths:
         required: false
         schema:
           "$ref": "#/components/schemas/ListParticipantOutcomesFilter"
+        style: deepObject
       - name: page
         in: query
         required: false
         schema:
           "$ref": "#/components/schemas/PaginationFilter"
+        style: deepObject
       responses:
         '200':
           description: A list of NPQ Outcomes for all participants
@@ -591,6 +597,7 @@ paths:
         required: false
         schema:
           "$ref": "#/components/schemas/PaginationFilter"
+        style: deepObject
       - name: id
         in: path
         required: true
@@ -676,11 +683,13 @@ paths:
         required: false
         schema:
           "$ref": "#/components/schemas/ListParticipantsFilter"
+        style: deepObject
       - name: page
         in: query
         required: false
         schema:
           "$ref": "#/components/schemas/PaginationFilter"
+        style: deepObject
       responses:
         '200':
           description: A list of NPQ participants

--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -1065,7 +1065,7 @@ components:
           type: integer
           description: The page number to paginate to in the collection. If no value
             is specified it defaults to the first page.
-          example: 3
+          example: 1
         per_page:
           type: integer
           description: The number items to display on a page. Defaults to 100. Maximum

--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -643,7 +643,6 @@ paths:
         required: true
         schema:
           "$ref": "#/components/schemas/IDAttribute"
-        style: deepObject
       responses:
         '200':
           description: A single NPQ participant
@@ -2253,11 +2252,12 @@ components:
               example: '2021-05-31T02:22:32.000Z'
     SortingOptions:
       description: Sort records being returned.
-      example:
+      enum:
       - created_at
       - "-created_at"
       - updated_at
       - "-updated_at"
+      example: created_at
     ParticipantDeclaration:
       description: The details of a participant declaration
       type: object

--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -20,11 +20,13 @@ paths:
         required: false
         schema:
           "$ref": "#/components/schemas/ListApplicationsFilter"
+        style: deepObject
       - name: page
         in: query
         required: false
         schema:
           "$ref": "#/components/schemas/PaginationFilter"
+        style: deepObject
       - name: sort
         in: query
         required: false
@@ -330,11 +332,13 @@ paths:
         required: false
         schema:
           "$ref": "#/components/schemas/ListParticipantDeclarationsFilter"
+        style: deepObject
       - name: page
         in: query
         required: false
         schema:
           "$ref": "#/components/schemas/PaginationFilter"
+        style: deepObject
       responses:
         '200':
           description: A list of Participant declarations
@@ -482,11 +486,13 @@ paths:
         required: false
         schema:
           "$ref": "#/components/schemas/ListParticipantOutcomesFilter"
+        style: deepObject
       - name: page
         in: query
         required: false
         schema:
           "$ref": "#/components/schemas/PaginationFilter"
+        style: deepObject
       responses:
         '200':
           description: A list of NPQ Outcomes for all participants
@@ -513,6 +519,7 @@ paths:
         required: false
         schema:
           "$ref": "#/components/schemas/PaginationFilter"
+        style: deepObject
       - name: id
         in: path
         required: true
@@ -598,11 +605,13 @@ paths:
         required: false
         schema:
           "$ref": "#/components/schemas/ListParticipantsFilter"
+        style: deepObject
       - name: page
         in: query
         required: false
         schema:
           "$ref": "#/components/schemas/PaginationFilter"
+        style: deepObject
       - name: sort
         in: query
         required: false
@@ -634,6 +643,7 @@ paths:
         required: true
         schema:
           "$ref": "#/components/schemas/IDAttribute"
+        style: deepObject
       responses:
         '200':
           description: A single NPQ participant
@@ -991,6 +1001,7 @@ paths:
         required: false
         schema:
           "$ref": "#/components/schemas/PaginationFilter"
+        style: deepObject
       responses:
         '200':
           description: A list of statements as part of which the DfE will make output

--- a/spec/requests/api/docs/v3/statements_spec.rb
+++ b/spec/requests/api/docs/v3/statements_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe "Statements endpoint", :exceptions_app, openapi_spec: "v3/swagger
                 required: false,
                 schema: {
                   "$ref": "#/components/schemas/PaginationFilter",
-                }
+                },
+                style: "deepObject"
 
       response "200", "A list of statements as part of which the DfE will make output payments for participants" do
         schema({ "$ref": "#/components/schemas/StatementsResponse" })

--- a/spec/services/applications/query_spec.rb
+++ b/spec/services/applications/query_spec.rb
@@ -221,6 +221,14 @@ RSpec.describe Applications::Query do
 
           expect(query.scope.to_sql).not_to include(condition_string)
         end
+
+        context "when the participant_id is not a valid UUID" do
+          it "does not include the particpant_id in the query" do
+            query = described_class.new(participant_ids: "not-a-uuid")
+
+            expect(query.scope.to_sql).not_to include("not-a-uuid")
+          end
+        end
       end
     end
 

--- a/spec/services/declarations/query_spec.rb
+++ b/spec/services/declarations/query_spec.rb
@@ -164,6 +164,14 @@ RSpec.describe Declarations::Query do
 
           expect(query.scope.to_sql).not_to include(condition_string)
         end
+
+        context "when the participant_id is not a valid UUID" do
+          it "does not include the particpant_id in the query" do
+            query = described_class.new(participant_ids: "not-a-uuid")
+
+            expect(query.scope.to_sql).not_to include("not-a-uuid")
+          end
+        end
       end
     end
   end

--- a/spec/services/queries/condition_formats_spec.rb
+++ b/spec/services/queries/condition_formats_spec.rb
@@ -47,5 +47,12 @@ RSpec.describe "Schools::Query" do
         expect(object.extract_conditions(123, allowlist: [123, 456])).to eq(123)
       end
     end
+
+    context "when uuid is true" do
+      it "returns only valid UUIDs" do
+        expect(object.extract_conditions(["123e4567-e89b-12d3-a456-426614174000", "not-a-uuid"], uuids: true))
+          .to eql(%w[123e4567-e89b-12d3-a456-426614174000])
+      end
+    end
   end
 end

--- a/spec/support/shared_examples/api_index_endpoint_documentation_support.rb
+++ b/spec/support/shared_examples/api_index_endpoint_documentation_support.rb
@@ -14,7 +14,8 @@ RSpec.shared_examples "an API index endpoint documentation", :exceptions_app do 
                   required: false,
                   schema: {
                     "$ref": filter_schema_ref,
-                  }
+                  },
+                  style: "deepObject"
       end
 
       parameter name: :page,
@@ -22,7 +23,8 @@ RSpec.shared_examples "an API index endpoint documentation", :exceptions_app do 
                 required: false,
                 schema: {
                   "$ref": "#/components/schemas/PaginationFilter",
-                }
+                },
+                style: "deepObject"
 
       if sortable
         parameter name: :sort,

--- a/spec/support/shared_examples/api_index_endpoint_support.rb
+++ b/spec/support/shared_examples/api_index_endpoint_support.rb
@@ -234,6 +234,13 @@ RSpec.shared_examples "an API index endpoint with filter by participant_id" do
       api_get(path, params: { filter: { participant_id: } })
     end
   end
+
+  context "when filtering with an invalid UUID" do
+    it do
+      api_get(path, params: { filter: { participant_id: "not-a-uuid" } })
+      expect(parsed_response["data"].size).to be_zero
+    end
+  end
 end
 
 RSpec.shared_examples "an API index endpoint with filter by training_status" do

--- a/spec/swagger_schemas/concerns/sorting.rb
+++ b/spec/swagger_schemas/concerns/sorting.rb
@@ -1,11 +1,12 @@
 SORTING_OPTIONS = {
   v3: {
     description: "Sort records being returned.",
-    example: [
+    enum: [
       "created_at",
       "-created_at",
       "updated_at",
       "-updated_at",
     ],
+    example: "created_at",
   },
 }.freeze

--- a/spec/swagger_schemas/filters/pagination.rb
+++ b/spec/swagger_schemas/filters/pagination.rb
@@ -5,7 +5,7 @@ PAGINATION_FILTER = {
     page: {
       type: :integer,
       description: "The page number to paginate to in the collection. If no value is specified it defaults to the first page.",
-      example: 3,
+      example: 1,
     },
     per_page: {
       type: :integer,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3019,10 +3019,10 @@ svg-pan-zoom@^3.6.2:
   resolved "https://registry.yarnpkg.com/svg-pan-zoom/-/svg-pan-zoom-3.6.2.tgz#be136506211b242627a234a9656f8128fcbbabed"
   integrity sha512-JwnvRWfVKw/Xzfe6jriFyfey/lWJLq4bUh2jwoR5ChWQuQoOH8FEh1l/bEp46iHHKHEJWIyFJETbazraxNWECg==
 
-swagger-ui-dist@^5.18.3:
-  version "5.18.3"
-  resolved "https://registry.yarnpkg.com/swagger-ui-dist/-/swagger-ui-dist-5.18.3.tgz#3ea990ed8b232f4c1e635e799d3da8f42c911486"
-  integrity sha512-G33HFW0iFNStfY2x6QXO2JYVMrFruc8AZRX0U/L71aA7WeWfX2E5Nm8E/tsipSZJeIZZbSjUDeynLK/wcuNWIw==
+swagger-ui-dist@^5.19.0:
+  version "5.19.0"
+  resolved "https://registry.yarnpkg.com/swagger-ui-dist/-/swagger-ui-dist-5.19.0.tgz#618057e1aaec97e016282eeee5c51ce6cf3da448"
+  integrity sha512-bSVZeYaqanMFeW5ZY3+EejFbsjkjazYxm1I7Lz3xayYz5XU3m2aUzvuPC0jI95WCQdduszHYV3ER4buQoy8DXA==
   dependencies:
     "@scarf/scarf" "=1.4.0"
 


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2368

Using an invalid UUID in the filter param for declarations, raises an error.
The other APIs cope with an invalid UUID fine (no error raised).

### Changes proposed in this pull request

I've added a `uuids` option to the `extract_conditions` method - which if true will remove invalid UUIDs from the conditions.

I don't think we need additional validation - especially because you can pass (for example) multiple participant_ids - so if only one is invalid, it is better to just return values for the IDs that _are_ valid, rather than raising an error for the one that is not valid.

Whilst investigating this, I noticed our 'try it out' feature on the swagger docs was not working, because the filter, page and sort parameters were not quite described correctly - I've fixed that in this PR.