### PR TITLE
CPDNPQ-2366 Improve migration robustness

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ gem "sprockets", "~> 4.2.0"
 gem "sprockets-rails", require: "sprockets/railtie"
 gem "state_machines-activerecord"
 gem "stimulus-rails"
+gem "strong_migrations"
 
 gem "net-imap", "~> 0.5.6", require: false
 gem "net-pop", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -673,6 +673,8 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.5)
+    strong_migrations (2.2.0)
+      activerecord (>= 7)
     swd (2.0.3)
       activesupport (>= 3)
       attr_required (>= 0.0.5)
@@ -815,6 +817,7 @@ DEPENDENCIES
   sprockets-rails
   state_machines-activerecord
   stimulus-rails
+  strong_migrations
   tzinfo-data
   web-console (>= 3.3.0)
   webmock (~> 3.25)

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,0 +1,26 @@
+# Mark existing migrations as safe
+StrongMigrations.start_after = 20250225102830 # rubocop:disable Style/NumericLiterals
+
+# Set timeouts for migrations
+# If you use PgBouncer in transaction mode, delete these lines and set timeouts on the database user
+StrongMigrations.lock_timeout = 10.seconds
+StrongMigrations.statement_timeout = 1.hour
+
+# Analyze tables after indexes are added
+# Outdated statistics can sometimes hurt performance
+StrongMigrations.auto_analyze = true
+
+# Set the version of the production database
+# so the right checks are run in development
+# StrongMigrations.target_version = 10
+
+# Add custom checks
+# StrongMigrations.add_check do |method, args|
+#   if method == :add_index && args[0].to_s == "users"
+#     stop! "No more indexes on the users table"
+#   end
+# end
+
+# Make some operations safe by default
+# See https://github.com/ankane/strong_migrations#safe-by-default
+# StrongMigrations.safe_by_default = true

--- a/db/seeds/base/add_applications.rb
+++ b/db/seeds/base/add_applications.rb
@@ -137,6 +137,8 @@ LeadProvider.find_each do |lead_provider|
   end
 end
 
+course = Course.find_by!(identifier: Course::IDENTIFIERS.first.to_sym)
+
 # Make sure some applications will appear in the In Review list
 [
   { employment_type: "hospital_school" },
@@ -147,5 +149,5 @@ end
   { employment_type: "other" },
   { referred_by_return_to_teaching_adviser: "yes" },
 ].each do |application_attrs|
-  FactoryBot.create(:application, **application_attrs)
+  FactoryBot.create(:application, **application_attrs.merge(course:))
 end

--- a/terraform/application/config/review.tfvars.json
+++ b/terraform/application/config/review.tfvars.json
@@ -4,6 +4,6 @@
     "environment": "review",
     "deploy_azure_backing_services": false,
     "enable_postgres_ssl" : false,
-    "command": ["/bin/sh", "-c", "RAILS_ENV=review bundle exec rails db:environment:set db:schema:load && bundle exec rake courses:update && bundle exec rails server -b 0.0.0.0"],
+    "command": ["/bin/sh", "-c", "RAILS_ENV=review bundle exec rails db:environment:set db:migrate && bundle exec rake courses:update && bundle exec rails server -b 0.0.0.0"],
     "enable_logit": true
 }


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2366](https://dfedigital.atlassian.net/browse/CPDNPQ-2366)

Migrations are one of the few ways to make a change to a site which cannot just be resolved by a revert, potentially resulting in down time. Improving our resilience to mistakes in migration files helps avoid unintended problems.

### Changes proposed in this pull request

1. Strong migrations gem has been added to protect against dangerous migrations
2. Review apps are changed to run through the migrations instead of just loading `db/schema` whilst this is slow it is more likely to catch problems and on an empty database only adds a few seconds to the deploy time so seems like a good trade-off.

[CPDNPQ-2366]: https://dfedigital.atlassian.net/browse/CPDNPQ-2366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ