### PR TITLE
[CPDNPQ-2639] Use GitHub bundler caching to speed up CI

### DIFF
--- a/.github/workflows/build_flow_visualisation.yml
+++ b/.github/workflows/build_flow_visualisation.yml
@@ -17,11 +17,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.3.4
-
-      - name: Install gems
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
+          bundler-cache: true
 
       - name: Install yarn
         run: npm install yarn -g

--- a/.github/workflows/lead_provider_openapi_check.yml
+++ b/.github/workflows/lead_provider_openapi_check.yml
@@ -48,16 +48,12 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ inputs.ruby-version }}
+          bundler-cache: true
 
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-version }}
-
-      - name: Install gems
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
 
       - name: Install yarn
         run: npm install yarn -g

--- a/.github/workflows/refresh_knapsack_manifest.yml
+++ b/.github/workflows/refresh_knapsack_manifest.yml
@@ -38,16 +38,12 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ inputs.ruby-version }}
+          bundler-cache: true
 
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
           node-version: "20.15.1"
-
-      - name: Install gems
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
 
       - name: Install yarn
         run: npm install yarn -g

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -34,9 +34,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ inputs.ruby-version }}
-
-      - name: Install dependencies
-        run: bundle install
+          bundler-cache: true
 
       - name: Lint Ruby
         run: bundle exec rubocop --format json --out=out/rubocop-result.json
@@ -63,9 +61,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ inputs.ruby-version }}
-
-      - name: Install dependencies
-        run: bundle install
+          bundler-cache: true
 
       - name: Lint SCSS
         run: |-
@@ -110,16 +106,12 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ inputs.ruby-version }}
+          bundler-cache: true
 
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-version }}
-
-      - name: Install gems
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
 
       - name: Install yarn
         run: npm install yarn -g
@@ -174,11 +166,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ inputs.ruby-version }}
-
-      - name: Install gems
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
+          bundler-cache: true
 
       - name: Setup sonarqube
         uses: warchant/setup-sonar-scanner@v8


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2639](https://dfedigital.atlassian.net/browse/CPDNPQ-2639)

We currently spend over 5 minutes just installing dependencies during the cycle of 'open a PR', 'get approval', 'merge checks', 'merge', 'deploy'

This can be sped up with caching and github actions has support for this built already, we just need to turn it on

### Changes proposed in this pull request

1. Use the `ruby/setup-ruby` GitHub actions caching feature
2. Avoid re-installing gems already installed by the `setup-ruby` step