### PR TITLE
[CPDNPQ-2647] do not use archived users when logging in

### DIFF
--- a/app/services/users/archiver.rb
+++ b/app/services/users/archiver.rb
@@ -17,5 +17,9 @@ module Users
       user.provider = nil
       user.save!
     end
+
+    def set_uid_to_nil!
+      user.update!(uid: nil)
+    end
   end
 end

--- a/spec/services/users/archiver_spec.rb
+++ b/spec/services/users/archiver_spec.rb
@@ -34,4 +34,14 @@ RSpec.describe Users::Archiver do
       end
     end
   end
+
+  describe ".set_uid_to_nil!" do
+    let(:user) { create(:user, :archived, :with_get_an_identity_id) }
+
+    it "sets uid to nil" do
+      subject.set_uid_to_nil!
+
+      expect(user.uid).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2647

When logging in, users that have been archived are being found and used (because they have a UID that matches the one of the user logging in)

### Changes proposed in this pull request

* do not use an archived user
* before saving the new user using the DfE Identity data, blank the UID of the clashing archived user - there is a uniqueness constraint on UID that will fail otherwise.
