### PR TITLE
Reverse sort direction - registrations in review - admin console

### DIFF
--- a/app/controllers/npq_separation/admin/applications/reviews_controller.rb
+++ b/app/controllers/npq_separation/admin/applications/reviews_controller.rb
@@ -10,7 +10,8 @@ module NpqSeparation
           applications = Application.includes(:private_childcare_provider, :school, :user)
                                     .merge(review_scope)
                                     .merge(filter_scope)
-                                    .merge(search_scope).order("applications.created_at DESC")
+                                    .merge(search_scope)
+                                    .order("applications.created_at DESC")
 
           @pagy, @applications = pagy(applications, limit: 9)
         end

--- a/app/controllers/npq_separation/admin/applications/reviews_controller.rb
+++ b/app/controllers/npq_separation/admin/applications/reviews_controller.rb
@@ -10,7 +10,7 @@ module NpqSeparation
           applications = Application.includes(:private_childcare_provider, :school, :user)
                                     .merge(review_scope)
                                     .merge(filter_scope)
-                                    .merge(search_scope)
+                                    .merge(search_scope).order("applications.created_at DESC")
 
           @pagy, @applications = pagy(applications, limit: 9)
         end

--- a/app/services/admin_service/applications_search.rb
+++ b/app/services/admin_service/applications_search.rb
@@ -22,6 +22,6 @@ class AdminService::ApplicationsSearch
 private
 
   def default_scope
-    Application.left_joins(:school).joins(:user).includes(:course, :lead_provider, :school, :user).order(id: :asc)
+    Application.left_joins(:school).joins(:user).includes(:course, :lead_provider, :school, :user)
   end
 end

--- a/db/seeds/base/add_applications.rb
+++ b/db/seeds/base/add_applications.rb
@@ -150,8 +150,6 @@ end
   FactoryBot.create(:application, **application_attrs)
 end
 
-i = 0
-Application.order("id DESC").each do |a|
+Application.order("id DESC").each do |a, i|
   a.update!(created_at: i.days.ago)
-  i += 1
 end

--- a/db/seeds/base/add_applications.rb
+++ b/db/seeds/base/add_applications.rb
@@ -150,6 +150,6 @@ end
   FactoryBot.create(:application, **application_attrs)
 end
 
-Application.order("id DESC").each do |a, i|
+Application.order("id DESC").each_with_index do |a, i|
   a.update!(created_at: i.days.ago)
 end

--- a/db/seeds/base/add_applications.rb
+++ b/db/seeds/base/add_applications.rb
@@ -149,3 +149,10 @@ end
 ].each do |application_attrs|
   FactoryBot.create(:application, **application_attrs)
 end
+
+i = 0
+Application.order("id DESC").each do |a|
+  a.update!(created_at: i.days.ago)
+  i += 1
+end
+puts "✅ Seed data created with unique timestamps!"

--- a/db/seeds/base/add_applications.rb
+++ b/db/seeds/base/add_applications.rb
@@ -155,4 +155,3 @@ Application.order("id DESC").each do |a|
   a.update!(created_at: i.days.ago)
   i += 1
 end
-puts "✅ Seed data created with unique timestamps!"

--- a/spec/features/npq_separation/admin/applications_in_review_spec.rb
+++ b/spec/features/npq_separation/admin/applications_in_review_spec.rb
@@ -7,14 +7,14 @@ RSpec.feature "Applications in review", type: :feature do
   let(:cohort_22) { create :cohort, start_year: 2022 }
 
   let!(:normal_application)                         { create(:application) }
-  let!(:application_for_hospital_school)            { create(:application, :accepted, employment_type: "hospital_school", employer_name: Faker::Company.name, cohort: cohort_21, referred_by_return_to_teaching_adviser: "yes") }
-  let!(:application_for_la_supply_teacher)          { create(:application, employment_type: "local_authority_supply_teacher", cohort: cohort_22, referred_by_return_to_teaching_adviser: "no") }
-  let!(:application_for_la_virtual_school)          { create(:application, employment_type: "local_authority_virtual_school") }
-  let!(:application_for_lead_mentor)                { create(:application, employment_type: "local_authority_virtual_school") }
-  let!(:application_for_young_offender_institution) { create(:application, employment_type: "young_offender_institution") }
-  let!(:application_for_other)                      { create(:application, employment_type: "other") }
-  let!(:application_for_rtta_yes)                   { create(:application, referred_by_return_to_teaching_adviser: "yes", school: nil, works_in_school: false) }
-  let!(:application_for_rtta_no)                    { create(:application, referred_by_return_to_teaching_adviser: "no") }
+  let!(:application_for_hospital_school)            { create(:application, :accepted, created_at: 10.days.ago, employment_type: "hospital_school", employer_name: Faker::Company.name, cohort: cohort_21, referred_by_return_to_teaching_adviser: "yes") }
+  let!(:application_for_la_supply_teacher)          { create(:application, created_at: 9.days.ago, employment_type: "local_authority_supply_teacher", cohort: cohort_22, referred_by_return_to_teaching_adviser: "no") }
+  let!(:application_for_la_virtual_school)          { create(:application, created_at: 8.days.ago, employment_type: "local_authority_virtual_school") }
+  let!(:application_for_lead_mentor)                { create(:application, created_at: 7.days.ago, employment_type: "local_authority_virtual_school") }
+  let!(:application_for_young_offender_institution) { create(:application, created_at: 6.days.ago, employment_type: "young_offender_institution") }
+  let!(:application_for_other)                      { create(:application, created_at: 5.days.ago, employment_type: "other") }
+  let!(:application_for_rtta_yes)                   { create(:application, created_at: 4.days.ago, referred_by_return_to_teaching_adviser: "yes", school: nil, works_in_school: false) }
+  let!(:application_for_rtta_no)                    { create(:application, created_at: 3.days.ago, referred_by_return_to_teaching_adviser: "no") }
 
   let(:serialized_application) { { application: 1 } }
 
@@ -212,5 +212,11 @@ RSpec.feature "Applications in review", type: :feature do
     within(".govuk-summary-list__row", text: "Notes") do
       expect(page).to have_text("Some notes")
     end
+  end
+
+  scenario "Applications should display in correct order" do
+    first_record = application_for_young_offender_institution.user.full_name
+    second_record = application_for_hospital_school.user.full_name
+    expect(page).to have_text(/#{first_record}.*#{second_record}/m)
   end
 end


### PR DESCRIPTION
Addresses task 3 on this ticket:

https://dfedigital.atlassian.net/browse/CPDNPQ-2618

In this PR:

- Reverse the sort order of applications on the 'Registrations in review' page in the admin console, so that the most recent application displays first.

- Edit the test data with unique timestamps, and add a new test scenario, so that the new order can be tested. 

New order displays most recent application first:

![Screenshot 2025-03-03 at 11 39 54](https://github.com/user-attachments/assets/0318fe8f-3bf6-4b66-a883-751b6609a9ee)



