### PR TITLE
[CPDNPQ-2638] cope with expired/non-existent session on qualified_teacher_check step

### DIFF
--- a/app/forms/questionnaires/course_start_date.rb
+++ b/app/forms/questionnaires/course_start_date.rb
@@ -42,7 +42,7 @@ module Questionnaires
     end
 
     def requirements_met?
-      query_store.current_user.present?
+      query_store.current_user&.actual_user?
     end
 
     def next_step

--- a/app/forms/questionnaires/dqt_mismatch.rb
+++ b/app/forms/questionnaires/dqt_mismatch.rb
@@ -4,6 +4,10 @@ module Questionnaires
       :qualified_teacher_check
     end
 
+    def requirements_met?
+      query_store.current_user&.actual_user?
+    end
+
     def next_step
       return :check_answers if changing_answer?
 

--- a/app/forms/questionnaires/qualified_teacher_check.rb
+++ b/app/forms/questionnaires/qualified_teacher_check.rb
@@ -141,17 +141,19 @@ module Questionnaires
       wizard.store["verified_trn"] = verified_trn
       wizard.store["active_alert"] = active_alert?
 
-      query_store.current_user.update!(
-        trn: trn_to_store,
-        full_name:,
-        date_of_birth:,
-        national_insurance_number: ni_number_to_store,
-        trn_verified: trn_verified?,
-        trn_lookup_status:,
-        trn_auto_verified: !!trn_auto_verified?,
-        active_alert: active_alert?,
-      )
-      wizard.store["trn_set_via_fallback_verification_question"] = true
+      if query_store.current_user.actual_user?
+        query_store.current_user.update!(
+          trn: trn_to_store,
+          full_name:,
+          date_of_birth:,
+          national_insurance_number: ni_number_to_store,
+          trn_verified: trn_verified?,
+          trn_lookup_status:,
+          trn_auto_verified: !!trn_auto_verified?,
+          active_alert: active_alert?,
+        )
+        wizard.store["trn_set_via_fallback_verification_question"] = true
+      end
     end
 
     def ni_number_required?

--- a/spec/features/journeys/sad_paths/session_expires_before_qualified_teacher_check_spec.rb
+++ b/spec/features/journeys/sad_paths/session_expires_before_qualified_teacher_check_spec.rb
@@ -1,0 +1,86 @@
+require "rails_helper"
+
+RSpec.feature "Sad journeys", :with_default_schedules, type: :feature do
+  include Helpers::JourneyAssertionHelper
+  include Helpers::JourneyStepHelper
+  include ApplicationHelper
+
+  include_context "Stub Get An Identity Omniauth Responses"
+
+  let(:user_trn) { "" }
+  let(:manually_entered_trn) { "3651763" }
+
+  scenario "session expires before qualified teacher check - no DQT mismatch", :no_js do
+    stub_participant_validation_request(trn: manually_entered_trn, response: { trn: manually_entered_trn, date_of_birth: "1980-12-13" })
+
+    navigate_to_page(path: "/", submit_form: false, axe_check: false) do
+      expect(page).to have_text("Before you start")
+      page.click_button("Start now")
+    end
+
+    expect(page).not_to have_content("Before you start")
+
+    expect_page_to_have(path: "/registration/teacher-reference-number", submit_form: true) do
+      page.choose("No, I need to request one", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/dont-have-teacher-reference-number", submit_form: false) do
+      expect(page).to have_text("Get a teacher reference number (TRN) before registering for an NPQ")
+
+      page.click_link("Back")
+    end
+
+    expect_page_to_have(path: "/registration/teacher-reference-number", submit_form: true) do
+      page.choose("Yes", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/qualified-teacher-check", submit_form: true) do
+      travel_to 3.weeks.from_now # expire the session by going to when the session would have expired
+      page.fill_in "Teacher reference number (TRN)", with: manually_entered_trn
+      page.fill_in "Full name", with: "Jane Smith"
+      page.fill_in "Day", with: "13"
+      page.fill_in "Month", with: "12"
+      page.fill_in "Year", with: "1980"
+      page.fill_in "National Insurance number", with: "AB123456C"
+    end
+
+    expect(page).to have_current_path("/")
+  end
+
+  scenario "session expires before qualified teacher check - DQT mismatch", :no_js do
+    stub_inactive_participant_validation_request(trn: manually_entered_trn)
+
+    navigate_to_page(path: "/", submit_form: false, axe_check: false) do
+      expect(page).to have_text("Before you start")
+      page.click_button("Start now")
+    end
+
+    expect(page).not_to have_content("Before you start")
+
+    expect_page_to_have(path: "/registration/teacher-reference-number", submit_form: true) do
+      page.choose("No, I need to request one", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/dont-have-teacher-reference-number", submit_form: false) do
+      expect(page).to have_text("Get a teacher reference number (TRN) before registering for an NPQ")
+
+      page.click_link("Back")
+    end
+
+    expect_page_to_have(path: "/registration/teacher-reference-number", submit_form: true) do
+      page.choose("Yes", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/qualified-teacher-check", submit_form: true) do
+      travel_to 3.weeks.from_now # expire the session by going to when the session would have expired
+      page.fill_in "Teacher reference number (TRN)", with: manually_entered_trn
+      page.fill_in "Full name", with: "Jane Smith"
+      page.fill_in "Day", with: "13"
+      page.fill_in "Month", with: "12"
+      page.fill_in "Year", with: "1980"
+      page.fill_in "National Insurance number", with: "AB123456C"
+    end
+
+    expect(page).to have_current_path("/")
+  end
+end

--- a/spec/forms/questionnaires/qualified_teacher_check_spec.rb
+++ b/spec/forms/questionnaires/qualified_teacher_check_spec.rb
@@ -561,5 +561,7 @@ RSpec.describe Questionnaires::QualifiedTeacherCheck, type: :model do
         end
       end
     end
+
+    it_behaves_like "coping with an expired or non-existent session"
   end
 end

--- a/spec/support/api_responses.rb
+++ b/spec/support/api_responses.rb
@@ -8,3 +8,7 @@ def dqt_response_body(trn: "1234567", date_of_birth: "1960-12-13", active_alert:
     "state_name": "Active",
   }.to_json
 end
+
+def dqt_inactive_response_body
+  {}.to_json
+end

--- a/spec/support/helpers/journey_helper.rb
+++ b/spec/support/helpers/journey_helper.rb
@@ -36,5 +36,18 @@ module Helpers
         )
         .to_return(status: 200, body: dqt_response_body(**response), headers: {})
     end
+
+    def stub_inactive_participant_validation_request(trn: "1234567", date_of_birth: "1980-12-13", nino: "AB123456C")
+      stub_request(:get, "https://dqt-api.example.com/v1/teachers/#{trn}?birthdate=#{date_of_birth}&nino=#{nino}")
+        .with(
+          headers: {
+            "Accept" => "*/*",
+            "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+            "Authorization" => "Bearer test-apikey",
+            "User-Agent" => "Ruby",
+          },
+        )
+        .to_return(status: 200, body: dqt_inactive_response_body, headers: {})
+    end
   end
 end

--- a/spec/support/shared_examples/forms_questionnaires_support.rb
+++ b/spec/support/shared_examples/forms_questionnaires_support.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.shared_examples "coping with an expired or non-existent session" do
+  context "when the session has expired or does not exist" do
+    let(:current_user) { NullUser.new }
+
+    it "does not raise an error" do
+      expect { subject.after_save }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2638

If the user's session expires, or does not exist, and the page they have in their browser is the qualfied_teacher_check page - then submitting this form causes an error.

### Changes proposed in this pull request

The `after_save` on this step, and also the `next_step` on the next step (course_start_date) rely on having a current_user.
In the expired/non-existent session scenario, that user is a `NullUser`.
The fix is:
* cope with NullUser in the qualfied_teacher_check step
* check if the user is is not a NullUser before the `dqt_mismatch` and `course_start_date` steps (either of which could follow the qualfied_teacher_check step) , and redirect them to the start of the journey if it is a NullUser