### PR TITLE
fix konduit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ define KONDUIT_CONNECT
 		(tail -f -n0 "$$tmp_file" & ) | grep -q "postgres://"; \
 		postgres_url=$$(grep -o 'postgres://[^ ]*' "$$tmp_file"); \
 		echo "$$postgres_url"; \
-		sed $(SED_INPLACE) -e "s|npq_registration_development|&\\n    url: \"$$postgres_url\"|g" config/database.yml; \
+		sed $(SED_INPLACE) -e "s|npq_registration_development|&\\n  url: \"$$postgres_url\"|g" config/database.yml; \
 	} & \
 	bin/konduit.sh -d
 endef


### PR DESCRIPTION
### Context

Using konduit (e.g. `make konduit-snapshot`) puts the database URL with the wrong indentation in our `config/database.yml`.

This is because the primary database was removed in https://github.com/DFE-Digital/npq-registration/pull/2055, the indentation changed, but the Makefile was not updated.

### Changes proposed in this pull request

Fix the indentation, so the URL is put in the right place.