### PR TITLE
[CPDNPQ-2463] ensure errors are JSON for API requests

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,6 +1,8 @@
 class ErrorsController < ApplicationController
   layout "application"
 
+  before_action :set_format
+
   def not_found
     respond_to do |format|
       format.html { render status: :not_found }
@@ -21,5 +23,11 @@ class ErrorsController < ApplicationController
       format.html { render status: :unprocessable_entity }
       format.json { render json: { error: "Unprocessable entity" }, status: :unprocessable_entity }
     end
+  end
+
+private
+
+  def set_format
+    request.format = :json if request.original_fullpath.start_with?("/api/")
   end
 end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -15,6 +15,7 @@ class ErrorsController < ApplicationController
     respond_to do |format|
       format.html { render status: :internal_server_error }
       format.json { render json: { error: "Internal server error" }, status: :internal_server_error }
+      format.all { render status: :internal_server_error, body: nil }
     end
   end
 
@@ -22,12 +23,13 @@ class ErrorsController < ApplicationController
     respond_to do |format|
       format.html { render status: :unprocessable_entity }
       format.json { render json: { error: "Unprocessable entity" }, status: :unprocessable_entity }
+      format.all { render status: :unprocessable_entity, body: nil }
     end
   end
 
 private
 
   def set_format
-    request.format = :json if request.original_fullpath.start_with?("/api/")
+    request.format = :json if request.original_fullpath.start_with?("/api/") && request.format.html?
   end
 end

--- a/spec/features/content_security_policy_spec.rb
+++ b/spec/features/content_security_policy_spec.rb
@@ -7,16 +7,7 @@ RSpec.feature "Happy journeys", type: :feature do
   end
 
   context "when showing error pages" do
-    before do
-      method = Rails.application.method(:env_config)
-      allow(Rails.application).to receive(:env_config).with(no_args) do
-        method.call.merge(
-          "action_dispatch.show_exceptions" => :all,
-          "action_dispatch.show_detailed_exceptions" => false,
-          "consider_all_requests_local" => false,
-        )
-      end
-    end
+    include_context "when errors are rendered"
 
     scenario "script-src nonce on not_found page", :no_js do
       visit "/thispagedoesnotexist"

--- a/spec/requests/api/errors_spec.rb
+++ b/spec/requests/api/errors_spec.rb
@@ -10,6 +10,15 @@ RSpec.describe "Error responses", type: :request do
       expect(response.body).to eq %({"error":"Resource not found"})
       expect(response.content_type).to match(/application\/json.*/)
     end
+
+    context "when the request is for a CSV" do
+      it "returns an plain text response" do
+        api_get "/api/v2/thisdoesnotexist.csv"
+        expect(response).to have_http_status(:not_found)
+        expect(response.body).to be_empty
+        expect(response.content_type).to match(/text\/plain.*/)
+      end
+    end
   end
 
   describe "internal server error" do
@@ -22,6 +31,37 @@ RSpec.describe "Error responses", type: :request do
       expect(response).to have_http_status(:internal_server_error)
       expect(response.body).to eq %({"error":"Internal server error"})
       expect(response.content_type).to match(/application\/json.*/)
+    end
+
+    context "when the request is for a CSV" do
+      it "returns an plain text response" do
+        api_get "/api/v2/npq-applications.csv"
+        expect(response).to have_http_status(:internal_server_error)
+        expect(response.body).to be_empty
+        expect(response.content_type).to match(/text\/plain.*/)
+      end
+    end
+  end
+
+  describe "unprocessable entity" do
+    before do
+      allow(Applications::Query).to receive(:new).and_raise(ActiveRecord::RecordInvalid)
+    end
+
+    it "returns a JSON error response" do
+      api_get "/api/v3/npq-applications"
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to eq %({"error":"Unprocessable entity"})
+      expect(response.content_type).to match(/application\/json.*/)
+    end
+
+    context "when the request is for a CSV" do
+      it "returns an plain text response" do
+        api_get "/api/v2/npq-applications.csv"
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).to be_empty
+        expect(response.content_type).to match(/text\/plain.*/)
+      end
     end
   end
 end

--- a/spec/requests/api/errors_spec.rb
+++ b/spec/requests/api/errors_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "Error responses", type: :request do
+  include_context "when errors are rendered"
+
+  describe "not found" do
+    it "returns a JSON error response" do
+      api_get "/api/v3/thisdoesnotexist"
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).to eq %({"error":"Resource not found"})
+      expect(response.content_type).to match(/application\/json.*/)
+    end
+  end
+
+  describe "internal server error" do
+    before do
+      allow(Applications::Query).to receive(:new).and_raise(StandardError)
+    end
+
+    it "returns a JSON error response" do
+      api_get "/api/v3/npq-applications"
+      expect(response).to have_http_status(:internal_server_error)
+      expect(response.body).to eq %({"error":"Internal server error"})
+      expect(response.content_type).to match(/application\/json.*/)
+    end
+  end
+end

--- a/spec/support/shared_contexts/render_errors.rb
+++ b/spec/support/shared_contexts/render_errors.rb
@@ -1,0 +1,12 @@
+RSpec.shared_context("when errors are rendered") do
+  before do
+    method = Rails.application.method(:env_config)
+    allow(Rails.application).to receive(:env_config).with(no_args) do
+      method.call.merge(
+        "action_dispatch.show_exceptions" => :all,
+        "action_dispatch.show_detailed_exceptions" => false,
+        "consider_all_requests_local" => false,
+      )
+    end
+  end
+end

--- a/spec/support/shared_examples/api_index_endpoint_support.rb
+++ b/spec/support/shared_examples/api_index_endpoint_support.rb
@@ -271,6 +271,7 @@ RSpec.shared_examples "an API index endpoint with filter by training_status" do
         api_get(path, params: { filter: { training_status: "not_valid_status" } })
 
         expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.content_type).to match(/application\/json.*/)
         expect(parsed_response.dig("errors", 0, "detail")).to include(%(The filter '#/training_status' must be ["active", "deferred", "withdrawn"]))
       end
     end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2463

The Not Found page always returned HTML

### Changes proposed in this pull request

We don't actually return formats based on the Content-Type header,
we always return JSON from API endpoints.

So now, the errors controller will check the request URL, and if it is API, it will return JSON.
Only the Not Found page was actually incorrectly returning HTML - the other responses were already correct (401, 422, 500).