### PR TITLE
[CPDNPQ-2448] Add delivery partners data model

### DIFF
--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -114,6 +114,9 @@ class Declaration < ApplicationRecord
 
   validate :delivery_partners_are_not_the_same, if: :delivery_partner
 
+  scope :for_delivery_partners,
+        ->(dp) { where(delivery_partner: dp).or(where(secondary_delivery_partner: dp)) }
+
   def billable_statement
     statement_items.find(&:billable?)&.statement
   end

--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -166,6 +166,10 @@ class Declaration < ApplicationRecord
     lead_provider.delivery_partners_for_cohort(cohort)
   end
 
+  def delivery_partners
+    [delivery_partner, secondary_delivery_partner].compact
+  end
+
 private
 
   def validate_declaration_date_within_schedule

--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -145,6 +145,12 @@ class Declaration < ApplicationRecord
       )
   end
 
+  def available_delivery_partners
+    return [] unless lead_provider && cohort
+
+    lead_provider.delivery_partners_for_cohort(cohort)
+  end
+
 private
 
   def validate_declaration_date_within_schedule

--- a/app/models/delivery_partner.rb
+++ b/app/models/delivery_partner.rb
@@ -1,0 +1,4 @@
+class DeliveryPartner < ApplicationRecord
+  validates :ecf_id, uniqueness: { case_sensitive: false }
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
+end

--- a/app/models/delivery_partner.rb
+++ b/app/models/delivery_partner.rb
@@ -5,4 +5,8 @@ class DeliveryPartner < ApplicationRecord
 
   validates :ecf_id, uniqueness: { case_sensitive: false }
   validates :name, presence: true, uniqueness: { case_sensitive: false }
+
+  def declarations
+    Declaration.for_delivery_partners(self)
+  end
 end

--- a/app/models/delivery_partner.rb
+++ b/app/models/delivery_partner.rb
@@ -1,4 +1,8 @@
 class DeliveryPartner < ApplicationRecord
+  has_many :delivery_partnerships
+  has_many :lead_providers, through: :delivery_partnerships
+  has_many :cohorts, through: :delivery_partnerships
+
   validates :ecf_id, uniqueness: { case_sensitive: false }
   validates :name, presence: true, uniqueness: { case_sensitive: false }
 end

--- a/app/models/delivery_partnership.rb
+++ b/app/models/delivery_partnership.rb
@@ -1,0 +1,10 @@
+class DeliveryPartnership < ApplicationRecord
+  belongs_to :delivery_partner
+  belongs_to :lead_provider
+  belongs_to :cohort
+
+  validates :delivery_partner_id, presence: true
+  validates :lead_provider_id, presence: true
+  validates :cohort_id, presence: true
+  validates :delivery_partner_id, uniqueness: { scope: %i[lead_provider_id cohort_id] }
+end

--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -87,6 +87,9 @@ class LeadProvider < ApplicationRecord
   has_many :applications
   has_many :statements
 
+  has_many :delivery_partnerships
+  has_many :delivery_partners, through: :delivery_partnerships
+
   validates :name, presence: true
   validates :ecf_id, uniqueness: { case_sensitive: false }, allow_nil: true
 

--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -95,10 +95,6 @@ class LeadProvider < ApplicationRecord
 
   scope :alphabetical, -> { order(name: :asc) }
 
-  def next_output_fee_statement(cohort)
-    statements.next_output_fee_statements.where(cohort:).first
-  end
-
   def self.for(course:)
     course_specific_list = COURSE_TO_PROVIDER_MAPPING[course.identifier]
 
@@ -108,5 +104,15 @@ class LeadProvider < ApplicationRecord
     raise "Missing provider ECF_ID for available providers list" if ecf_ids.count != course_specific_list.count
 
     where(ecf_id: ecf_ids)
+  end
+
+  def next_output_fee_statement(cohort)
+    statements.next_output_fee_statements.where(cohort:).first
+  end
+
+  def delivery_partners_for_cohort(cohort)
+    delivery_partners
+      .joins(:delivery_partnerships)
+      .where(delivery_partnerships: { cohort: })
   end
 end

--- a/app/services/feature.rb
+++ b/app/services/feature.rb
@@ -4,12 +4,10 @@ class Feature
   REGISTRATION_OPEN = "Registration open".freeze
   REGISTRATION_DISABLED = "Registration disabled".freeze
   CLOSED_REGISTRATION_ENABLED = "Closed registration enabled".freeze
-
   SENCO_ENABLED = "Senco enabled".freeze
-
   DFE_ANALYTICS_ENABLED = "DfE Analytics Enabled".freeze
-
   MAINTENANCE_BANNER = "Maintenance banner".freeze
+  DECLARATIONS_REQUIRE_DELIVERY_PARTNER = "Declarations require delivery partner".freeze
 
   # This constant 'registers' all the feature flags we are using. We must not use a feature flag that is
   # not included in this array. This approach will make tracking feature flags much easier.
@@ -19,6 +17,7 @@ class Feature
     SENCO_ENABLED,
     MAINTENANCE_BANNER,
     DFE_ANALYTICS_ENABLED,
+    DECLARATIONS_REQUIRE_DELIVERY_PARTNER,
   ].freeze
 
   class << self
@@ -66,6 +65,10 @@ class Feature
 
     def dfe_analytics_enabled?
       Flipper.enabled?(DFE_ANALYTICS_ENABLED)
+    end
+
+    def declarations_require_delivery_partner?
+      Flipper.enabled?(DECLARATIONS_REQUIRE_DELIVERY_PARTNER)
     end
   end
 end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -153,6 +153,13 @@ shared:
     - name
     - created_at
     - updated_at
+  :delivery_partnerships:
+    - id
+    - delivery_partner_id
+    - lead_provider_id
+    - cohort_id
+    - created_at
+    - updated_at
   :declarations:
     - id
     - ecf_id

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -147,6 +147,12 @@ shared:
     - created_at
     - updated_at
     - disabled_at
+  :delivery_partners:
+    - id
+    - ecf_id
+    - name
+    - created_at
+    - updated_at
   :declarations:
     - id
     - ecf_id

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -173,6 +173,8 @@ shared:
     - state_reason
     - created_at
     - updated_at
+    - delivery_partner_id
+    - secondary_delivery_partner_id
   :course_groups:
     - id
     - name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -583,6 +583,9 @@ en:
         npq_separation_ecf_api_disabled_html: |
           <p class="govuk-body">NPQ separation ECF API disabled</p>
           <p class="govuk-body">Hello</p>
+        declarations_require_delivery_partner_html: |
+          <p class="govuk-body">When this feature is turned on, submitting a declaration for the 2024 cohort onwards will require the delivery partner to be included</p>
+          <p class="govuk-body">When this feature is turned off, submitting a declaration does not require a delivery partner, but will still accept a declaration with a delivery partner</p>
     application_submissions:
       ecf_sync_request_log:
         sync_type:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -193,6 +193,9 @@ en:
               *declaration_type
             ecf_id:
               *ecf_id
+            secondary_delivery_partner:
+              duplicate_delivery_partner:
+                The secondary delivery partner cannot match the primary delivery partner
             statement_items:
               more_than_two_statement_items: There cannot be more than two items per declaration
         lead_provider:

--- a/db/migrate/20250210145412_create_delivery_partners.rb
+++ b/db/migrate/20250210145412_create_delivery_partners.rb
@@ -1,0 +1,12 @@
+class CreateDeliveryPartners < ActiveRecord::Migration[7.1]
+  def change
+    create_table :delivery_partners do |t|
+      t.uuid :ecf_id, null: false, default: "gen_random_uuid()"
+      t.string :name, null: false
+
+      t.timestamps
+    end
+    add_index :delivery_partners, :ecf_id, unique: true
+    add_index :delivery_partners, :name, unique: true
+  end
+end

--- a/db/migrate/20250210145412_create_delivery_partners.rb
+++ b/db/migrate/20250210145412_create_delivery_partners.rb
@@ -5,8 +5,19 @@ class CreateDeliveryPartners < ActiveRecord::Migration[7.1]
       t.string :name, null: false
 
       t.timestamps
+
+      t.index :ecf_id, unique: true
+      t.index :name, unique: true
     end
-    add_index :delivery_partners, :ecf_id, unique: true
-    add_index :delivery_partners, :name, unique: true
+
+    create_table :delivery_partnerships do |t|
+      t.references :delivery_partner, null: false, foreign_key: true
+      t.references :lead_provider, null: false, foreign_key: true
+      t.references :cohort, null: false, foreign_key: true
+
+      t.timestamps
+
+      t.index %i[delivery_partner_id lead_provider_id cohort_id], unique: true
+    end
   end
 end

--- a/db/migrate/20250210145412_create_delivery_partners.rb
+++ b/db/migrate/20250210145412_create_delivery_partners.rb
@@ -19,5 +19,11 @@ class CreateDeliveryPartners < ActiveRecord::Migration[7.1]
 
       t.index %i[delivery_partner_id lead_provider_id cohort_id], unique: true
     end
+
+    change_table :declarations do |t|
+      t.references :delivery_partner, foreign_key: true
+      t.references :secondary_delivery_partner,
+                   foreign_key: { to_table: :delivery_partners }
+    end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_06_140920) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_10_145412) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -270,6 +270,15 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_06_140920) do
     t.datetime "updated_at"
     t.string "cron"
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
+  end
+
+  create_table "delivery_partners", force: :cascade do |t|
+    t.uuid "ecf_id", default: -> { "gen_random_uuid()" }, null: false
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["ecf_id"], name: "index_delivery_partners_on_ecf_id", unique: true
+    t.index ["name"], name: "index_delivery_partners_on_name", unique: true
   end
 
   create_table "ecf_sync_request_logs", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -281,6 +281,18 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_10_145412) do
     t.index ["name"], name: "index_delivery_partners_on_name", unique: true
   end
 
+  create_table "delivery_partnerships", force: :cascade do |t|
+    t.bigint "delivery_partner_id", null: false
+    t.bigint "lead_provider_id", null: false
+    t.bigint "cohort_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["cohort_id"], name: "index_delivery_partnerships_on_cohort_id"
+    t.index ["delivery_partner_id", "lead_provider_id", "cohort_id"], name: "idx_on_delivery_partner_id_lead_provider_id_cohort__10d5da32cd", unique: true
+    t.index ["delivery_partner_id"], name: "index_delivery_partnerships_on_delivery_partner_id"
+    t.index ["lead_provider_id"], name: "index_delivery_partnerships_on_lead_provider_id"
+  end
+
   create_table "ecf_sync_request_logs", force: :cascade do |t|
     t.integer "syncable_id", null: false
     t.string "syncable_type", null: false
@@ -640,6 +652,9 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_10_145412) do
   add_foreign_key "declarations", "cohorts"
   add_foreign_key "declarations", "declarations", column: "superseded_by_id"
   add_foreign_key "declarations", "lead_providers"
+  add_foreign_key "delivery_partnerships", "cohorts"
+  add_foreign_key "delivery_partnerships", "delivery_partners"
+  add_foreign_key "delivery_partnerships", "lead_providers"
   add_foreign_key "participant_id_changes", "users"
   add_foreign_key "participant_outcome_api_requests", "participant_outcomes"
   add_foreign_key "participant_outcomes", "declarations"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -249,10 +249,14 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_10_145412) do
     t.enum "state_reason", enum_type: "declaration_state_reasons"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "delivery_partner_id"
+    t.bigint "secondary_delivery_partner_id"
     t.index ["application_id"], name: "index_declarations_on_application_id"
     t.index ["cohort_id"], name: "index_declarations_on_cohort_id"
+    t.index ["delivery_partner_id"], name: "index_declarations_on_delivery_partner_id"
     t.index ["ecf_id"], name: "index_declarations_on_ecf_id", unique: true
     t.index ["lead_provider_id"], name: "index_declarations_on_lead_provider_id"
+    t.index ["secondary_delivery_partner_id"], name: "index_declarations_on_secondary_delivery_partner_id"
     t.index ["superseded_by_id"], name: "index_declarations_on_superseded_by_id"
   end
 
@@ -651,6 +655,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_10_145412) do
   add_foreign_key "declarations", "applications"
   add_foreign_key "declarations", "cohorts"
   add_foreign_key "declarations", "declarations", column: "superseded_by_id"
+  add_foreign_key "declarations", "delivery_partners"
+  add_foreign_key "declarations", "delivery_partners", column: "secondary_delivery_partner_id"
   add_foreign_key "declarations", "lead_providers"
   add_foreign_key "delivery_partnerships", "cohorts"
   add_foreign_key "delivery_partnerships", "delivery_partners"

--- a/spec/factories/delivery_partners.rb
+++ b/spec/factories/delivery_partners.rb
@@ -1,6 +1,28 @@
 FactoryBot.define do
   factory :delivery_partner do
+    transient do
+      # either an array or a hash of cohort + array of lead providers
+      lead_providers { Array.wrap(lead_provider) }
+      lead_provider { nil }
+    end
+
     ecf_id { SecureRandom.uuid }
     sequence(:name) { |n| "Delivery Partner #{n}" }
+
+    after :create do |delivery_partner, evaluator|
+      partnerships = if evaluator.lead_providers.is_a?(Hash)
+                       evaluator.lead_providers
+                     elsif evaluator.lead_providers&.any?
+                       { Cohort.current => evaluator.lead_providers }
+                     else
+                       {}
+                     end
+
+      partnerships.each do |cohort, lead_providers|
+        Array.wrap(lead_providers).each do |lead_provider|
+          delivery_partner.delivery_partnerships.create! lead_provider:, cohort:
+        end
+      end
+    end
   end
 end

--- a/spec/factories/delivery_partners.rb
+++ b/spec/factories/delivery_partners.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :delivery_partner do
+    ecf_id { SecureRandom.uuid }
+    sequence(:name) { |n| "Delivery Partner #{n}" }
+  end
+end

--- a/spec/factories/delivery_partners.rb
+++ b/spec/factories/delivery_partners.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
       partnerships = if evaluator.lead_providers.is_a?(Hash)
                        evaluator.lead_providers
                      elsif evaluator.lead_providers&.any?
-                       { Cohort.current => evaluator.lead_providers }
+                       { create(:cohort, :current) => evaluator.lead_providers }
                      else
                        {}
                      end

--- a/spec/factories/delivery_partnerships.rb
+++ b/spec/factories/delivery_partnerships.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :delivery_partnership do
+    association(:delivery_partner)
+    association(:lead_provider)
+    cohort { create :cohort, :current }
+  end
+end

--- a/spec/factories/lead_providers.rb
+++ b/spec/factories/lead_providers.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
       partnerships = if evaluator.delivery_partners.is_a?(Hash)
                        evaluator.delivery_partners
                      elsif evaluator.delivery_partners&.any?
-                       { Cohort.current => evaluator.delivery_partners }
+                       { create(:cohort, :current) => evaluator.delivery_partners }
                      else
                        {}
                      end

--- a/spec/factories/lead_providers.rb
+++ b/spec/factories/lead_providers.rb
@@ -1,7 +1,28 @@
 FactoryBot.define do
   factory :lead_provider do
+    transient do
+      delivery_partner { nil }
+      delivery_partners { Array.wrap(delivery_partner) }
+    end
+
     name { Faker::Company.unique.name }
     ecf_id { SecureRandom.uuid }
     hint { Faker::Lorem.sentence }
+
+    after :create do |lead_provider, evaluator|
+      partnerships = if evaluator.delivery_partners.is_a?(Hash)
+                       evaluator.delivery_partners
+                     elsif evaluator.delivery_partners&.any?
+                       { Cohort.current => evaluator.delivery_partners }
+                     else
+                       {}
+                     end
+
+      partnerships.each do |cohort, delivery_partners|
+        Array.wrap(delivery_partners).each do |delivery_partner|
+          lead_provider.delivery_partnerships.create! delivery_partner:, cohort:
+        end
+      end
+    end
   end
 end

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe Declaration, type: :model do
     it { is_expected.to have_many(:participant_outcomes).dependent(:destroy) }
     it { is_expected.to have_many(:statement_items) }
     it { is_expected.to have_many(:statements).through(:statement_items) }
-    xit { is_expected.to have_many(:delivery_partners) }
+    it { is_expected.to belong_to(:delivery_partner).without_validating_presence }
+    it { is_expected.to belong_to(:secondary_delivery_partner).without_validating_presence }
 
     context "with delivery partners" do
       subject do
@@ -27,6 +28,13 @@ RSpec.describe Declaration, type: :model do
 
       it { is_expected.to have_attributes delivery_partner: primary_partner }
       it { is_expected.to have_attributes secondary_delivery_partner: secondary_partner }
+      it { is_expected.to have_attributes delivery_partners: [primary_partner, secondary_partner] }
+
+      context "without secondary partner" do
+        subject { create(:declaration, application:, delivery_partner: primary_partner) }
+
+        it { is_expected.to have_attributes delivery_partners: [primary_partner] }
+      end
     end
   end
 

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -635,6 +635,28 @@ RSpec.describe Declaration, type: :model do
 
       it { expect(described_class.with_course_identifier(course_identifier)).to contain_exactly(declaration) }
     end
+
+    describe ".for_delivery_partners" do
+      subject { Declaration.for_delivery_partners(delivery_partner) }
+
+      let(:delivery_partner) { create :delivery_partner }
+      let(:lead_provider) { create :lead_provider, delivery_partner: }
+      let(:declaration_as_primary) { create :declaration, lead_provider:, delivery_partner: }
+
+      it { is_expected.to include declaration_as_primary }
+
+      context "when declared as secondary partner" do
+        let(:another_partner) { create :delivery_partner, lead_provider: }
+
+        let :declaration_as_secondary do
+          create :declaration, lead_provider:,
+                               delivery_partner: another_partner,
+                               secondary_delivery_partner: delivery_partner
+        end
+
+        it { is_expected.to include declaration_as_secondary }
+      end
+    end
   end
 
   describe "#duplicate_declarations" do

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -614,4 +614,35 @@ RSpec.describe Declaration, type: :model do
       expect(Declaration.new).to be_versioned
     end
   end
+
+  describe "#available_delivery_partners" do
+    subject { declaration.available_delivery_partners }
+
+    let :lead_provider do
+      create :lead_provider, delivery_partners: {
+        twenty_three => twenty_three_partner,
+        create(:cohort, start_year: 2024) => twenty_four_partner,
+      }
+    end
+
+    let(:declaration) { build(:declaration, lead_provider:, cohort: twenty_three) }
+    let(:twenty_three) { create(:cohort, start_year: 2023) }
+    let(:twenty_three_partner) { create(:delivery_partner) }
+    let(:twenty_four_partner) { create(:delivery_partner) }
+
+    it { is_expected.to include twenty_three_partner }
+    it { is_expected.not_to include twenty_four_partner }
+
+    context "without delivery_partner" do
+      let(:lead_provider) { nil }
+
+      it { is_expected.to be_empty }
+    end
+
+    context "without cohort" do
+      let(:declaration) { build(:declaration, lead_provider:, cohort: nil) }
+
+      it { is_expected.to be_empty }
+    end
+  end
 end

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -88,8 +88,33 @@ RSpec.describe Declaration, type: :model do
           allow(Feature).to receive(:declarations_require_delivery_partner?).and_return(true)
         end
 
+        let(:declaration) { build(:declaration, cohort:) }
+        let(:cohort) { create(:cohort, start_year: cohort_start_year) }
+        let(:cohort_start_year) { described_class::DELIVER_PARTNER_REQUIRED_FROM }
+
         it { is_expected.to validate_presence_of(:delivery_partner) }
         it { is_expected.not_to validate_presence_of(:secondary_delivery_partner) }
+
+        context "with earlier cohort" do
+          let(:cohort_start_year) { described_class::DELIVER_PARTNER_REQUIRED_FROM - 1 }
+
+          it { is_expected.not_to validate_presence_of(:delivery_partner) }
+          it { is_expected.not_to validate_presence_of(:secondary_delivery_partner) }
+        end
+
+        context "with later cohort" do
+          let(:cohort_start_year) { described_class::DELIVER_PARTNER_REQUIRED_FROM + 1 }
+
+          it { is_expected.to validate_presence_of(:delivery_partner) }
+          it { is_expected.not_to validate_presence_of(:secondary_delivery_partner) }
+        end
+
+        context "without cohort set" do
+          let(:cohort) { nil }
+
+          it { is_expected.not_to validate_presence_of(:delivery_partner) }
+          it { is_expected.not_to validate_presence_of(:secondary_delivery_partner) }
+        end
       end
 
       context "when delivery_partner unchanged but removed from lead providers list" do

--- a/spec/models/delivery_partner_spec.rb
+++ b/spec/models/delivery_partner_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe DeliveryPartner, type: :model do
+  describe "attributes" do
+    subject { described_class.create(name: "new partner") }
+
+    let(:uuid_format) { /\A[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\z/ }
+
+    it { is_expected.to have_attributes ecf_id: uuid_format }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of :name }
+
+    describe "uniqueness" do
+      before { create :delivery_partner }
+
+      it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive }
+      it { is_expected.to validate_uniqueness_of(:name).case_insensitive }
+    end
+  end
+end

--- a/spec/models/delivery_partner_spec.rb
+++ b/spec/models/delivery_partner_spec.rb
@@ -25,4 +25,26 @@ RSpec.describe DeliveryPartner, type: :model do
       it { is_expected.to validate_uniqueness_of(:name).case_insensitive }
     end
   end
+
+  describe "#declarations" do
+    subject { delivery_partner.declarations }
+
+    let(:delivery_partner) { create :delivery_partner }
+    let(:lead_provider) { create :lead_provider, delivery_partner: }
+    let(:declaration_as_primary) { create :declaration, lead_provider:, delivery_partner: }
+
+    it { is_expected.to include declaration_as_primary }
+
+    context "when declared as secondary partner" do
+      let(:another_partner) { create :delivery_partner, lead_provider: }
+
+      let :declaration_as_secondary do
+        create :declaration, lead_provider:,
+                             delivery_partner: another_partner,
+                             secondary_delivery_partner: delivery_partner
+      end
+
+      it { is_expected.to include declaration_as_secondary }
+    end
+  end
 end

--- a/spec/models/delivery_partner_spec.rb
+++ b/spec/models/delivery_partner_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe DeliveryPartner, type: :model do
     it { is_expected.to have_attributes ecf_id: uuid_format }
   end
 
+  describe "relationships" do
+    it { is_expected.to have_many(:delivery_partnerships) }
+    it { is_expected.to have_many(:lead_providers).through(:delivery_partnerships) }
+    it { is_expected.to have_many(:cohorts).through(:delivery_partnerships) }
+  end
+
   describe "validations" do
     it { is_expected.to validate_presence_of :name }
 

--- a/spec/models/delivery_partnership_spec.rb
+++ b/spec/models/delivery_partnership_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe DeliveryPartnership, type: :model do
+  describe "relationships" do
+    it { is_expected.to belong_to :delivery_partner }
+    it { is_expected.to belong_to :lead_provider }
+    it { is_expected.to belong_to :cohort }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of :delivery_partner_id }
+    it { is_expected.to validate_presence_of :lead_provider_id }
+    it { is_expected.to validate_presence_of :cohort_id }
+
+    describe "uniqueness" do
+      subject { described_class.new }
+
+      before { create :delivery_partnership }
+
+      it "delivery partner must be unique for a given lead provider and cohort" do
+        expect(subject).to validate_uniqueness_of(:delivery_partner_id).scoped_to(%i[lead_provider_id cohort_id])
+      end
+    end
+  end
+end

--- a/spec/models/lead_provider_spec.rb
+++ b/spec/models/lead_provider_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe LeadProvider do
   describe "relationships" do
     it { is_expected.to have_many(:applications) }
     it { is_expected.to have_many(:statements) }
+    it { is_expected.to have_many(:delivery_partnerships) }
+    it { is_expected.to have_many(:delivery_partners).through(:delivery_partnerships) }
   end
 
   describe "validations" do

--- a/spec/models/lead_provider_spec.rb
+++ b/spec/models/lead_provider_spec.rb
@@ -13,31 +13,6 @@ RSpec.describe LeadProvider do
     it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique").allow_nil }
   end
 
-  describe "#next_output_fee_statement" do
-    let(:cohort) { create(:cohort, :current) }
-    let(:lead_provider) { next_output_fee_statement.lead_provider }
-    let(:next_output_fee_statement) { create(:statement, :next_output_fee, cohort:) }
-
-    before do
-      # Not output fee
-      create(:statement, output_fee: false, cohort:, lead_provider:, deadline_date: 1.hour.from_now)
-      # Paid
-      create(:statement, :paid, :next_output_fee, cohort:, lead_provider:, deadline_date: 2.hours.from_now)
-      # Payable
-      create(:statement, :payable, :next_output_fee, cohort:, lead_provider:, deadline_date: 3.hours.from_now)
-      # Deadline is later
-      create(:statement, output_fee: true, cohort:, lead_provider:, deadline_date: 2.days.from_now)
-      # Wrong cohort
-      create(:statement, output_fee: true, cohort: create(:cohort, start_year: cohort.start_year + 1), lead_provider:, deadline_date: 1.hour.from_now)
-      # In the past
-      create(:statement, output_fee: true, cohort:, lead_provider:, deadline_date: 1.day.ago)
-    end
-
-    subject { lead_provider.next_output_fee_statement(cohort) }
-
-    it { is_expected.to eq(next_output_fee_statement) }
-  end
-
   describe "#for" do
     subject { described_class.for(course:).map(&:name) }
 
@@ -198,5 +173,50 @@ RSpec.describe LeadProvider do
         ])
       end
     end
+  end
+
+  describe "#next_output_fee_statement" do
+    let(:cohort) { create(:cohort, :current) }
+    let(:lead_provider) { next_output_fee_statement.lead_provider }
+    let(:next_output_fee_statement) { create(:statement, :next_output_fee, cohort:) }
+
+    before do
+      # Not output fee
+      create(:statement, output_fee: false, cohort:, lead_provider:, deadline_date: 1.hour.from_now)
+      # Paid
+      create(:statement, :paid, :next_output_fee, cohort:, lead_provider:, deadline_date: 2.hours.from_now)
+      # Payable
+      create(:statement, :payable, :next_output_fee, cohort:, lead_provider:, deadline_date: 3.hours.from_now)
+      # Deadline is later
+      create(:statement, output_fee: true, cohort:, lead_provider:, deadline_date: 2.days.from_now)
+      # Wrong cohort
+      create(:statement, output_fee: true, cohort: create(:cohort, start_year: cohort.start_year + 1), lead_provider:, deadline_date: 1.hour.from_now)
+      # In the past
+      create(:statement, output_fee: true, cohort:, lead_provider:, deadline_date: 1.day.ago)
+    end
+
+    subject { lead_provider.next_output_fee_statement(cohort) }
+
+    it { is_expected.to eq(next_output_fee_statement) }
+  end
+
+  describe "#delivery_partners_for_cohort" do
+    subject { lead_provider.delivery_partners_for_cohort(twenty_three) }
+
+    let :lead_provider do
+      create :lead_provider, delivery_partners: {
+        twenty_three => twenty_three_partner,
+        create(:cohort, start_year: 2024) => twenty_four_partner,
+      }
+    end
+
+    let(:twenty_three) { create(:cohort, start_year: 2023) }
+    let(:twenty_three_partner) { create(:delivery_partner) }
+    let(:twenty_four_partner) { create(:delivery_partner) }
+    let(:unrelated_partner) { create(:delivery_partner) }
+
+    it { is_expected.to include twenty_three_partner }
+    it { is_expected.not_to include twenty_four_partner }
+    it { is_expected.not_to include unrelated_partner }
   end
 end

--- a/spec/services/feature_spec.rb
+++ b/spec/services/feature_spec.rb
@@ -98,4 +98,20 @@ RSpec.describe Feature do
       end
     end
   end
+
+  describe ".declarations_require_delivery_partner?" do
+    context "when disabled" do
+      it "returns false" do
+        expect(Feature).not_to be_declarations_require_delivery_partner
+      end
+    end
+
+    context "when enabled" do
+      before { Flipper.enable(Feature::DECLARATIONS_REQUIRE_DELIVERY_PARTNER) }
+
+      it "returns true" do
+        expect(Feature).to be_declarations_require_delivery_partner
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2448])(https://dfedigital.atlassian.net/browse/CPDNPQ-2448)

Add a data model for managing delivery partners

### Changes proposed in this pull request

1. Added DeliveryPartners model
2. Added DeliveryPartnership join model between LeadProviders, Cohorts, and DeliveryPartners
3. Added Primary and Secondary delivery partners to declarations

### Notes

Not quite finished yet - needs the checking for delivery_partner_id on Declaration to take account of whether is post 2024 cohort but sufficient for initial review now


[CPDNPQ-2448]: https://dfedigital.atlassian.net/browse/CPDNPQ-2448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ