### PR TITLE
[BAU] Fix flaky specs

### DIFF
--- a/app/controllers/admin/unsynced_applications_controller.rb
+++ b/app/controllers/admin/unsynced_applications_controller.rb
@@ -8,6 +8,6 @@ class Admin::UnsyncedApplicationsController < AdminController
 private
 
   def scope
-    Application.unsynced.joins(:user).eager_load(:user, :course, :lead_provider).order(created_at: :desc)
+    Application.unsynced.joins(:user).eager_load(:user, :course, :lead_provider).order(created_at: :desc, id: :desc)
   end
 end

--- a/app/controllers/admin/unsynced_users_controller.rb
+++ b/app/controllers/admin/unsynced_users_controller.rb
@@ -8,6 +8,6 @@ class Admin::UnsyncedUsersController < AdminController
 private
 
   def scope
-    User.unsynced.joins(:applications).distinct.order(created_at: :desc)
+    User.unsynced.joins(:applications).distinct.order(created_at: :desc, id: :desc)
   end
 end

--- a/app/controllers/admin/webhook_messages_controller.rb
+++ b/app/controllers/admin/webhook_messages_controller.rb
@@ -12,6 +12,6 @@ class Admin::WebhookMessagesController < AdminController
 private
 
   def scope
-    GetAnIdentity::WebhookMessage.all.order(created_at: :desc)
+    GetAnIdentity::WebhookMessage.all.order(created_at: :desc, id: :desc)
   end
 end

--- a/app/controllers/npq_separation/admin/bulk_operations/reject_applications_controller.rb
+++ b/app/controllers/npq_separation/admin/bulk_operations/reject_applications_controller.rb
@@ -30,7 +30,7 @@ module NpqSeparation::Admin::BulkOperations
   private
 
     def set_bulk_operations
-      @bulk_operations = BulkOperation::RejectApplications.all.includes([file_attachment: :blob]).order(:created_at)
+      @bulk_operations = BulkOperation::RejectApplications.all.includes([file_attachment: :blob]).order(:created_at, :id)
     end
 
     def set_bulk_operation

--- a/app/controllers/npq_separation/admin/bulk_operations/revert_applications_to_pending_controller.rb
+++ b/app/controllers/npq_separation/admin/bulk_operations/revert_applications_to_pending_controller.rb
@@ -30,7 +30,7 @@ module NpqSeparation::Admin::BulkOperations
   private
 
     def set_bulk_operations
-      @bulk_operations = BulkOperation::RevertApplicationsToPending.all.includes([file_attachment: :blob]).order(:created_at)
+      @bulk_operations = BulkOperation::RevertApplicationsToPending.all.includes([file_attachment: :blob]).order(:created_at, :id)
     end
 
     def set_bulk_operation

--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -28,7 +28,7 @@ class Declaration < ApplicationRecord
   scope :with_lead_provider, ->(lead_provider) { where(lead_provider:) }
   scope :completed, -> { where(declaration_type: "completed") }
   scope :with_course_identifier, ->(course_identifier) { joins(application: :course).where(course: { identifier: course_identifier }) }
-  scope :latest_first, -> { order(created_at: :desc) }
+  scope :latest_first, -> { order(created_at: :desc, id: :desc) }
   scope :eligible_for_outcomes, lambda { |lead_provider, course_identifier|
     completed
     .with_lead_provider(lead_provider)

--- a/app/models/participant_outcome.rb
+++ b/app/models/participant_outcome.rb
@@ -19,7 +19,7 @@ class ParticipantOutcome < ApplicationRecord
 
   class << self
     def latest
-      order(created_at: :desc).first
+      order(created_at: :desc, id: :desc).first
     end
 
     def to_send_to_qualified_teachers_api

--- a/app/services/declarations/create.rb
+++ b/app/services/declarations/create.rb
@@ -138,7 +138,7 @@ module Declarations
     end
 
     def original_declaration
-      @original_declaration ||= declaration.duplicate_declarations.order(created_at: :asc).first
+      @original_declaration ||= declaration.duplicate_declarations.order(created_at: :asc, id: :asc).first
     end
 
     def validates_billable_slot_available

--- a/app/services/declarations/query.rb
+++ b/app/services/declarations/query.rb
@@ -16,7 +16,7 @@ module Declarations
     end
 
     def declarations
-      scope.order(created_at: :asc)
+      scope.order(created_at: :asc, id: :asc)
     end
 
     def declaration(id: nil, ecf_id: nil)

--- a/app/services/participant_outcomes/query.rb
+++ b/app/services/participant_outcomes/query.rb
@@ -14,7 +14,7 @@ module ParticipantOutcomes
     end
 
     def participant_outcomes
-      scope.order(:created_at)
+      scope.order(:created_at, :id)
     end
 
   private

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -13,8 +13,8 @@
 <% end %>
 
 <% if Time.zone.now > Time.zone.local(2024, 4, 2) %>
-  <% active_applications = current_user.applications.active_applications.includes(:course, :lead_provider).order(created_at: :desc) %>
-  <% expired_applications = current_user.applications.expired_applications.includes(:course, :lead_provider).order(created_at: :desc) %>
+  <% active_applications = current_user.applications.active_applications.includes(:course, :lead_provider).order(created_at: :desc, id: :desc) %>
+  <% expired_applications = current_user.applications.expired_applications.includes(:course, :lead_provider).order(created_at: :desc, id: :desc) %>
 
   <% active_applications.each do |application| %>
     <%= render "active_application_table", application: application %>
@@ -28,7 +28,7 @@
     <% end %>
   <% end %>
 <% else %>
-  <% active_applications = current_user.applications.order(created_at: :desc) %>
+  <% active_applications = current_user.applications.order(created_at: :desc, id: :desc) %>
 
   <% active_applications.each do |application| %>
     <%= render "active_application_table", application: application %>

--- a/app/views/admin/application_submissions/_ecf_sync_request_log.html.erb
+++ b/app/views/admin/application_submissions/_ecf_sync_request_log.html.erb
@@ -20,7 +20,7 @@
       </tr>
     <% end %>
 
-    <% logs.order(created_at: :desc).each do |log| %>
+    <% logs.order(created_at: :desc, id: :desc).each do |log| %>
       <tr class="govuk-table__row" id="log-row-<%= log.id %>">
         <td class="govuk-table__cell"><%= t(".sync_type.#{log.sync_type}") %></td>
         <td class="govuk-table__cell"><%= log.created_at.to_formatted_s(:govuk_short) %></td>

--- a/app/views/admin/closed_registration_users/index.html.erb
+++ b/app/views/admin/closed_registration_users/index.html.erb
@@ -37,7 +37,7 @@
           </td>
           <td class="govuk-table__cell">
             <% if service_user.present? %>
-              <%= service_user.applications.order(created_at: "desc").first&.created_at&.strftime("%-d %b %Y") || "-" %>
+              <%= service_user.applications.order(created_at: :desc, id: :desc).first&.created_at&.strftime("%-d %b %Y") || "-" %>
             <% else %>
               –
             <% end %>

--- a/spec/features/npq_separation/admin/applications_spec.rb
+++ b/spec/features/npq_separation/admin/applications_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Listing and viewing applications", type: :feature do
   include Helpers::MailHelper
 
   let(:applications_per_page) { Pagy::DEFAULT[:limit] }
-  let(:applications_in_order) { Application.order(created_at: :asc) }
+  let(:applications_in_order) { Application.order(created_at: :asc, id: :asc) }
 
   before do
     create_list(:application, applications_per_page + 1)
@@ -110,7 +110,7 @@ RSpec.feature "Listing and viewing applications", type: :feature do
   scenario "viewing application details with declarations" do
     visit(npq_separation_admin_applications_path)
 
-    application = Application.order(created_at: :asc).first
+    application = Application.order(created_at: :asc, id: :asc).first
     started_declaration = create(:declaration, :from_ecf, application:)
     completed_declaration = create(:declaration, :completed, application:)
     payable_statement = create(:statement, :payable)

--- a/spec/features/npq_separation/admin/cohorts_spec.rb
+++ b/spec/features/npq_separation/admin/cohorts_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature "Managing cohorts", :ecf_api_disabled, type: :feature do
 
       expect { click_on "Create cohort" }.to change(Cohort, :count).by(1)
 
-      cohort = Cohort.order(created_at: :desc).first
+      cohort = Cohort.order(created_at: :desc, id: :desc).first
       expect(cohort.start_year).to be(2029)
       expect(cohort.funding_cap).to be(true)
       expect(cohort.registration_start_date).to eq(Date.new(2029, 3, 2))

--- a/spec/features/npq_separation/admin/schedules_spec.rb
+++ b/spec/features/npq_separation/admin/schedules_spec.rb
@@ -64,7 +64,7 @@ RSpec.feature "Managing schedules", :ecf_api_disabled, type: :feature do
 
       expect { click_on "Create schedule" }.to change(Schedule, :count).by(1)
 
-      schedule = Schedule.order(created_at: :desc).first
+      schedule = Schedule.order(created_at: :desc, id: :desc).first
       expect(page).to have_text("Schedule created")
       expect_filled_in_schedule_attributes(schedule, course_group)
     end

--- a/spec/models/api_token_spec.rb
+++ b/spec/models/api_token_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe APIToken, type: :model do
 
       expect(
         APIToken.find_by_unhashed_token(unhashed_token, scope:),
-      ).to eql(APIToken.order(:created_at).last)
+      ).to eql(APIToken.order(:created_at, :id).last)
     end
 
     context "when a lead provider is not specified" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -101,10 +101,10 @@ RSpec.describe User do
 
   describe ".latest_participant_outcome" do
     let(:user) { create(:user) }
-    let(:lead_provider) { participant_outcome.lead_provider }
-    let(:course_identifier) { participant_outcome.course.identifier }
-    let(:participant_outcome) { create(:participant_outcome, user:) }
-    let(:course) { participant_outcome.course }
+    let(:lead_provider) { create(:lead_provider) }
+    let(:course_identifier) { ParticipantOutcomes::Create::PERMITTED_COURSES.first }
+    let(:participant_outcome) { create(:participant_outcome, user:, course:, lead_provider:) }
+    let(:course) { Course.find_by!(identifier: course_identifier) }
 
     subject { user.latest_participant_outcome(lead_provider, course_identifier) }
 
@@ -127,6 +127,8 @@ RSpec.describe User do
           create(:participant_outcome, user:, course:, lead_provider:).declaration.update!(state:)
         end
       end
+
+      participant_outcome
     end
 
     it { is_expected.to eq(participant_outcome) }

--- a/spec/support/helpers/journey_helper.rb
+++ b/spec/support/helpers/journey_helper.rb
@@ -1,7 +1,7 @@
 module Helpers
   module JourneyHelper
     def latest_application
-      Application.order(created_at: :asc).last
+      Application.order(created_at: :asc, id: :asc).last
     end
 
     def latest_application_user


### PR DESCRIPTION
### Context

Ticket: BAU

Various specs occasionally fail - this doesn't relate to seeds. I found a seed which I can replicate the ParticipantOutcomes failure about 1 in 20 runs of `rspec spec/models`. Eventually I tracked it to the combination of our use of `travel_to` in speeds and seed data combined with ordering on the created at timestamp.  `travel_to` ignores microseconds (see [rails issue](https://github.com/rails/rails/issues/40602)), which means multiple records are likely to be created in the same second in a test run and its random as to which order they are returned in. If this doesn't match the spec's expectation then the spec will occassionally fail.

I cannot change the behaviour of `travel_to` so I've instead added predictability to our `order` clauses - including `id` in addition to `created_at`. In the scenario where there are not multiple records in the same second this will have no impact _but_ when there are (almost certainly only tests) it will lead to consistency.

### Changes proposed in this pull request

1. Updated various `order` clauses throughout the codebase to also use `id` for ordering when there are 2 records with the same `created_at` timestamp.
2. Fixed a spec which started consistently failing once I'd tweaked the `order` clauses. 

