### PR TITLE
show accessibility testing is working

### DIFF
--- a/public/wcag22aa.html
+++ b/public/wcag22aa.html
@@ -1,0 +1,11 @@
+<html>
+  <head>
+    <title>WCAG 2.2 AA test</title>
+  </head>
+  <body>
+    <main role="main">
+      <button id="target">+</button>
+      <button style="margin-left: -10px">Adjacent Target</button>
+    </main>
+  </body
+</html>

--- a/public/wcag2a.html
+++ b/public/wcag2a.html
@@ -1,0 +1,11 @@
+<html>
+  <head>
+    <title>WCAG 2.2 AA test</title>
+  </head>
+  <body>
+    <main role="main">
+      <h1></h1>
+      <img src="/apple-touch-icon.png"/>
+    </main>
+  </body
+</html>

--- a/spec/features/accessibility_testing_spec.rb
+++ b/spec/features/accessibility_testing_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.feature "Check accessibility testing works", type: :feature do
+  scenario "testing pages for wcag2a" do
+    visit "/wcag2a"
+
+    expect(page).not_to be_axe_clean.according_to :wcag2a # expecting failures for empty h1 and img with no alt text
+    expect(page).to be_axe_clean.according_to :wcag22aa
+  end
+
+  scenario "testing pages for wcag22aa" do
+    visit "/wcag22aa"
+
+    expect(page).not_to be_axe_clean.according_to :wcag2a # expecting failures for empty h1 and img with no alt text
+    expect(page).not_to be_axe_clean.according_to :wcag22aa # expecting failure for target-size
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -24,30 +24,20 @@ require "paper_trail/frameworks/rspec"
 require "dfe/analytics/testing"
 require "dfe/analytics/rspec/matchers"
 
-capybara_browser_options = {}.tap do |browser_opts|
-  version = Capybara::Selenium::Driver.load_selenium
-  options_key = Capybara::Selenium::Driver::CAPS_VERSION.satisfied_by?(version) ? :capabilities : :options
-  browser_options = ::Selenium::WebDriver::Chrome::Options.new.tap do |opts|
-    opts.add_argument("--headless")
-    opts.add_argument("--no-sandbox")
-    opts.add_argument("--disable-gpu")
-    opts.add_argument("--window-size=1920,1080")
-    # Workaround https://bugs.chromium.org/p/chromedriver/issues/detail?id=2650&q=load&sort=-id&colspec=ID%20Status%20Pri%20Owner%20Summary
-    opts.add_argument("--disable-site-isolation-trials")
-  end
-
-  browser_opts[:browser] = :chrome
-  browser_opts[options_key] = browser_options
-end
-
 Capybara.register_driver :headless_chrome do |app|
-  Capybara::Selenium::Driver.new(app, **capybara_browser_options)
-end
+  args = %w[disable-build-check disable-dev-shm-usage disable-gpu no-sandbox window-size=1400,1400 enable-features=NetworkService,NetworkServiceInProcess disable-features=VizDisplayCompositor disable-site-isolation-trials]
+  args << "headless" unless ENV["NOT_HEADLESS"]
 
-AxeCapybara.configure(:chrome) do |config|
-  # see below for a full list of configuration
-  # c.jslib_path = "next-version/axe.js"
-  config.page = Capybara::Selenium::Driver.new(nil, **capybara_browser_options)
+  http_client = Selenium::WebDriver::Remote::Http::Default.new
+  http_client.read_timeout = 120
+  http_client.open_timeout = 120
+
+  Capybara::Selenium::Driver.new(
+    app,
+    browser: :chrome,
+    options: Selenium::WebDriver::Options.chrome(args:),
+    http_client:,
+  )
 end
 
 Capybara.default_driver = :headless_chrome

--- a/spec/support/helpers/axe_helper.rb
+++ b/spec/support/helpers/axe_helper.rb
@@ -6,6 +6,7 @@ module AxeHelper
   define :be_accessible do
     match do |page|
       expect(page).to be_axe_clean.according_to :wcag22aa
+      # see https://dequeuniversity.com/rules/axe/4.10 for the one violiation possible (target-size)
     end
   end
 end


### PR DESCRIPTION
Our current accessibility testing is only checking for the one rule tagged [wcag22aa](https://github.com/dequelabs/axe-core/blob/master/doc/rule-descriptions.md#wcag-22-level-a--aa-rules), which is checking `target-size`.
Should we be testing for [wcag2a](https://github.com/dequelabs/axe-core/blob/master/doc/rule-descriptions.md#wcag-20-level-a--aa-rules) too?