### PR TITLE
[CPDNPQ-2692] extend autumn 2024 schedule to 6/6/25

### DIFF
--- a/app/services/course_groups/leadership.rb
+++ b/app/services/course_groups/leadership.rb
@@ -25,24 +25,24 @@ module CourseGroups
     end
 
     def autumn_schedule_2022?(date)
-      # Between: Jun 1 to Dec 25
+      # Between: 1st Jun 2022 and 25th Dec 2022
       (Date.new(2022, 6, 1)..Date.new(2022, 12, 25)).include?(date)
     end
 
     def autumn_schedule_2024?(date)
-      # Between: Jun 28 to Feb 10
-      (Date.new(2024, 6, 28)..Date.new(2025, 2, 10)).include?(date)
+      # Between: 28th June 2024 and 6th June 2025
+      (Date.new(2024, 6, 28)..Date.new(2025, 6, 6)).include?(date)
     end
 
     def spring_schedule?(date)
-      # Between: Jan 1 to Apr 2
-      # Or between: Dec 26 to Dec 31
+      # Between: 1st Jan and 2nd Apr
+      # Or between: 26th Dec and 31st Dec
       (Date.new(date.year, 1, 1)..Date.new(date.year, 4, 2)).include?(date) ||
         (Date.new(date.year, 12, 26)..Date.new(date.year, 12, 31)).include?(date)
     end
 
     def autumn_schedule?(date)
-      # Between: Apr 3 to Dec 25
+      # Between: 3rd Apr and 25th Dec
       (Date.new(date.year, 4, 3)..Date.new(date.year, 12, 25)).include?(date)
     end
   end

--- a/app/services/course_groups/specialist.rb
+++ b/app/services/course_groups/specialist.rb
@@ -25,24 +25,24 @@ module CourseGroups
     end
 
     def autumn_schedule_2022?(date)
-      # Between: Jun 1 to Dec 25
+      # Between: 1st Jun 2022 and 25th Dec 2022
       (Date.new(2022, 6, 1)..Date.new(2022, 12, 25)).include?(date)
     end
 
     def autumn_schedule_2024?(date)
-      # Between: Jun 28 to Feb 10
-      (Date.new(2024, 6, 28)..Date.new(2025, 2, 10)).include?(date)
+      # Between: 28th June 2024 and 6th June 2025
+      (Date.new(2024, 6, 28)..Date.new(2025, 6, 6)).include?(date)
     end
 
     def spring_schedule?(date)
-      # Between: Jan 1 to Apr 2
-      # Or between: Dec 26 to Dec 31
+      # Between: 1st Jan and 2nd Apr
+      # Or between: 26th Dec and 31st Dec
       (Date.new(date.year, 1, 1)..Date.new(date.year, 4, 2)).include?(date) ||
         (Date.new(date.year, 12, 26)..Date.new(date.year, 12, 31)).include?(date)
     end
 
     def autumn_schedule?(date)
-      # Between: Apr 3 to Dec 25
+      # Between: 3rd Apr and 25th Dec
       (Date.new(date.year, 4, 3)..Date.new(date.year, 12, 25)).include?(date)
     end
   end

--- a/spec/services/course_groups/leadership_spec.rb
+++ b/spec/services/course_groups/leadership_spec.rb
@@ -11,59 +11,51 @@ RSpec.describe CourseGroups::Leadership do
     let!(:autumn_schedule) { create(:schedule, :npq_leadership_autumn, course_group:, cohort:) }
     let!(:spring_schedule) { create(:schedule, :npq_leadership_spring, course_group:, cohort:) }
 
+    subject(:schedule) { described_class.new(course_group:, cohort:, schedule_date:).schedule }
+
     context "when date is between June and December of cohort start year" do
-      it "returns Autumn schedule" do
-        travel_to Date.new(cohort.start_year, 6, 1) do
-          expect(subject.schedule).to eq(autumn_schedule)
-        end
-      end
+      before { travel_to Date.new(cohort.start_year, 6, 1) }
+
+      it { is_expected.to eq(autumn_schedule) }
     end
 
-    context "when date is between December and April of cohort start year" do
+    context "when date is between December of cohort start year and April of the following year" do
       let(:cohort) { create(:cohort, start_year: 2025) }
 
-      it "returns Spring schedule" do
-        travel_to Date.new(cohort.start_year, 12, 26) do
-          expect(subject.schedule).to eq(spring_schedule)
-        end
-      end
+      before { travel_to Date.new(cohort.start_year, 12, 26) }
+
+      it { is_expected.to eq(spring_schedule) }
     end
 
     context "when date is between April and December of the next year" do
-      it "returns Autumn schedule" do
-        travel_to Date.new(cohort.start_year + 1, 4, 3) do
-          expect(subject.schedule).to eq(autumn_schedule)
-        end
-      end
+      before { travel_to Date.new(cohort.start_year + 1, 4, 3) }
+
+      it { is_expected.to eq(autumn_schedule) }
     end
 
     context "when date is between December of next year and April in 2 years" do
-      it "returns Spring schedule" do
-        travel_to Date.new(cohort.start_year + 1, 12, 26) do
-          expect(subject.schedule).to eq(spring_schedule)
-        end
-      end
+      before { travel_to Date.new(cohort.start_year + 1, 12, 26) }
+
+      it { is_expected.to eq(spring_schedule) }
     end
 
     context "when date is spring 2025" do
       let(:cohort) { create(:cohort, start_year: 2024) }
 
-      it "returns Autumn schedule" do
-        travel_to Date.new(2025, 1, 13) do
-          expect(subject.schedule).to eq(autumn_schedule)
-        end
-      end
+      before { travel_to Date.new(2025, 1, 13) }
+
+      it { is_expected.to eq(autumn_schedule) }
     end
   end
 
   describe "#autumn_schedule_2022?" do
-    it "returns true when date between Jun 1 to Dec 25 in 2022" do
+    it "returns true when date between 1st Jun 2022 and 25th Dec 2022" do
       (("2022-06-1".to_date)..("2022-12-25".to_date)).each do |date|
         expect(subject.autumn_schedule_2022?(date)).to be(true)
       end
     end
 
-    it "returns false when date between Dec 26 to May 31" do
+    it "returns false when date between 26th Dec and 31st May" do
       (2022..Date.current.year).each do |year|
         (("#{year}-12-26".to_date)..("#{year + 1}-05-31".to_date)).each do |date|
           expect(subject.autumn_schedule_2022?(date)).to be(false)
@@ -73,21 +65,27 @@ RSpec.describe CourseGroups::Leadership do
   end
 
   describe "#autumn_schedule_2024?" do
-    it "returns true when date between Jun 28 2024 to Feb 10 2025" do
-      (("2024-06-28".to_date)..("2025-02-10".to_date)).each do |date|
+    it "returns true when date between 28th Jun 2024 and 6th June 2025" do
+      (("2024-06-28".to_date)..("2025-06-06".to_date)).each do |date|
         expect(subject.autumn_schedule_2024?(date)).to be(true)
       end
     end
 
-    it "returns false when before Jun 28 2024" do
+    it "returns false when before 28th Jun 2024" do
       (("2022-01-01".to_date)..("2024-06-27".to_date)).each do |date|
+        expect(subject.autumn_schedule_2024?(date)).to be(false)
+      end
+    end
+
+    it "returns false when after 6th June 2025" do
+      (("2025-06-07".to_date)..(Date.current.end_of_year)).each do |date|
         expect(subject.autumn_schedule_2024?(date)).to be(false)
       end
     end
   end
 
   describe "#spring_schedule?" do
-    it "returns true when date between Dec 26 to Apr 2" do
+    it "returns true when date between 26th Dec and 2nd Apr" do
       (2.years.ago.year..Date.current.year).each do |year|
         (("#{year}-12-26".to_date)..("#{year + 1}-04-2".to_date)).each do |date|
           expect(subject.spring_schedule?(date)).to be(true)
@@ -95,7 +93,7 @@ RSpec.describe CourseGroups::Leadership do
       end
     end
 
-    it "returns false when date between Apr 3 to Dec 25" do
+    it "returns false when date between 3rd Apr and 25th Dec" do
       (2.years.ago.year..Date.current.year).each do |year|
         (("#{year}-04-3".to_date)..("#{year}-12-25".to_date)).each do |date|
           expect(subject.spring_schedule?(date)).to be(false)
@@ -105,7 +103,7 @@ RSpec.describe CourseGroups::Leadership do
   end
 
   describe "#autumn_schedule?" do
-    it "returns true when date between Apr 3 to Dec 25" do
+    it "returns true when date between 3rd Apr and 25th Dec" do
       (2.years.ago.year..Date.current.year).each do |year|
         (("#{year}-04-3".to_date)..("#{year}-12-25".to_date)).each do |date|
           expect(subject.autumn_schedule?(date)).to be(true)
@@ -113,7 +111,7 @@ RSpec.describe CourseGroups::Leadership do
       end
     end
 
-    it "returns false when date between Dec 26 to Apr 2" do
+    it "returns false when date between 26th Dec and 2nd Apr" do
       (2.years.ago.year..Date.current.year).each do |year|
         (("#{year}-12-26".to_date)..("#{year + 1}-04-2".to_date)).each do |date|
           expect(subject.autumn_schedule?(date)).to be(false)

--- a/spec/services/course_groups/specialist_spec.rb
+++ b/spec/services/course_groups/specialist_spec.rb
@@ -11,59 +11,51 @@ RSpec.describe CourseGroups::Specialist do
     let!(:autumn_schedule) { create(:schedule, :npq_specialist_autumn, course_group:, cohort:) }
     let!(:spring_schedule) { create(:schedule, :npq_specialist_spring, course_group:, cohort:) }
 
+    subject(:schedule) { described_class.new(course_group:, cohort:, schedule_date:).schedule }
+
     context "when date is between June and December of cohort start year" do
-      it "returns Autumn schedule" do
-        travel_to Date.new(cohort.start_year, 6, 1) do
-          expect(subject.schedule).to eq(autumn_schedule)
-        end
-      end
+      before { travel_to Date.new(cohort.start_year, 6, 1) }
+
+      it { is_expected.to eq(autumn_schedule) }
     end
 
-    context "when date is between December of cohort start year and April of 2026" do
+    context "when date is between December of cohort start year and April of the following year" do
       let(:cohort) { create(:cohort, start_year: 2025) }
 
-      it "returns Spring schedule" do
-        travel_to Date.new(cohort.start_year, 12, 26) do
-          expect(subject.schedule).to eq(spring_schedule)
-        end
-      end
+      before { travel_to Date.new(cohort.start_year, 12, 26) }
+
+      it { is_expected.to eq(spring_schedule) }
     end
 
     context "when date is between April and December of the next year" do
-      it "returns Autumn schedule" do
-        travel_to Date.new(cohort.start_year + 1, 4, 3) do
-          expect(subject.schedule).to eq(autumn_schedule)
-        end
-      end
+      before { travel_to Date.new(cohort.start_year + 1, 4, 3) }
+
+      it { is_expected.to eq(autumn_schedule) }
     end
 
     context "when date is between December of next year and April in 2 years" do
-      it "returns Spring schedule" do
-        travel_to Date.new(cohort.start_year + 1, 12, 26) do
-          expect(subject.schedule).to eq(spring_schedule)
-        end
-      end
+      before { travel_to Date.new(cohort.start_year + 1, 12, 26) }
+
+      it { is_expected.to eq(spring_schedule) }
     end
 
     context "when date is spring 2025" do
       let(:cohort) { create(:cohort, start_year: 2024) }
 
-      it "returns Autumn schedule" do
-        travel_to Date.new(2025, 1, 13) do
-          expect(subject.schedule).to eq(autumn_schedule)
-        end
-      end
+      before { travel_to Date.new(2025, 1, 13) }
+
+      it { is_expected.to eq(autumn_schedule) }
     end
   end
 
   describe "#autumn_schedule_2022?" do
-    it "returns true when date between Jun 1 to Dec 25 in 2022" do
+    it "returns true when date between 1st Jun 2022 and 25th Dec 2022" do
       (("2022-06-1".to_date)..("2022-12-25".to_date)).each do |date|
         expect(subject.autumn_schedule_2022?(date)).to be(true)
       end
     end
 
-    it "returns false when date between Dec 26 to May 31" do
+    it "returns false when date between 26th Dec and 31st May" do
       (2022..Date.current.year).each do |year|
         (("#{year}-12-26".to_date)..("#{year + 1}-05-31".to_date)).each do |date|
           expect(subject.autumn_schedule_2022?(date)).to be(false)
@@ -73,27 +65,27 @@ RSpec.describe CourseGroups::Specialist do
   end
 
   describe "#autumn_schedule_2024?" do
-    it "returns true when date between Jun 28 2024 to Feb 10 2025" do
-      (("2024-06-28".to_date)..("2025-02-10".to_date)).each do |date|
+    it "returns true when date between 28th Jun 2024 and 6th Jun 2025" do
+      (("2024-06-28".to_date)..("2025-06-06".to_date)).each do |date|
         expect(subject.autumn_schedule_2024?(date)).to be(true)
       end
     end
 
-    it "returns false when before Jun 28 2024" do
+    it "returns false when before 28th Jun 2024" do
       (("2022-01-01".to_date)..("2024-06-27".to_date)).each do |date|
         expect(subject.autumn_schedule_2024?(date)).to be(false)
       end
     end
 
-    it "returns false when after Feb 10 2025" do
-      (("2025-02-11".to_date)..(Date.current.end_of_year)).each do |date|
+    it "returns false when after 6th June 2025" do
+      (("2025-06-07".to_date)..(Date.current.end_of_year)).each do |date|
         expect(subject.autumn_schedule_2024?(date)).to be(false)
       end
     end
   end
 
   describe "#spring_schedule?" do
-    it "returns true when date between Dec 26 to Apr 2" do
+    it "returns true when date between 26th Dec and 2nd Apr" do
       (2.years.ago.year..Date.current.year).each do |year|
         (("#{year}-12-26".to_date)..("#{year + 1}-04-2".to_date)).each do |date|
           expect(subject.spring_schedule?(date)).to be(true)
@@ -101,7 +93,7 @@ RSpec.describe CourseGroups::Specialist do
       end
     end
 
-    it "returns false when date between Apr 3 to Dec 25" do
+    it "returns false when date between 3rd Apr and 25th Dec" do
       (2.years.ago.year..Date.current.year).each do |year|
         (("#{year}-04-3".to_date)..("#{year}-12-25".to_date)).each do |date|
           expect(subject.spring_schedule?(date)).to be(false)
@@ -111,7 +103,7 @@ RSpec.describe CourseGroups::Specialist do
   end
 
   describe "#autumn_schedule?" do
-    it "returns true when date between Apr 3 to Dec 25" do
+    it "returns true when date between 3rd Apr and 25th Dec" do
       (2.years.ago.year..Date.current.year).each do |year|
         (("#{year}-04-3".to_date)..("#{year}-12-25".to_date)).each do |date|
           expect(subject.autumn_schedule?(date)).to be(true)
@@ -119,7 +111,7 @@ RSpec.describe CourseGroups::Specialist do
       end
     end
 
-    it "returns false when date between Dec 26 to Apr 2" do
+    it "returns false when date between 26th Dec and 2nd Apr" do
       (2.years.ago.year..Date.current.year).each do |year|
         (("#{year}-12-26".to_date)..("#{year + 1}-04-2".to_date)).each do |date|
           expect(subject.autumn_schedule?(date)).to be(false)


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2692

we need the autumn 2024 schedule to be until 6/6/25 to allow providers to accept late registration Autumn 2024 applications.

### Changes proposed in this pull request

autumn 2024 schedule now ends 6/6/25
