### PR TITLE
sentry context needs to be a hash

### DIFF
--- a/app/controllers/omniauth_controller.rb
+++ b/app/controllers/omniauth_controller.rb
@@ -22,7 +22,7 @@ class OmniauthController < Devise::OmniauthCallbacksController
       # TODO: need a feature test for the error scenario:
       # - uid has already been taken
       user_id_with_clashing_email = User.find_by(email: provider_data.info.email)&.id
-      multibyte = (provider_data.info.email.chars.count != provider_data.info.email.bytes.count)
+      multibyte_email = (provider_data.info.email.chars.count != provider_data.info.email.bytes.count)
       send_error_to_sentry(
         "Could not persist user after omniauth callback",
         contexts: {
@@ -32,9 +32,11 @@ class OmniauthController < Devise::OmniauthCallbacksController
             uid: provider_data.uid,
             user_id_with_clashing_email:,
           },
-          "Persisted?" => @user.persisted?,
-          "Saved?" => user_saved,
-          "Multibyte email?" => multibyte,
+          "User" => {
+            persisted: @user.persisted?,
+            saved: user_saved,
+            multibyte_email:,
+          },
         },
       )
 


### PR DESCRIPTION
### Context

The last change to add additional info to the sentry error causes this error:
https://dfe-teacher-services.sentry.io/issues/6413570401/?project=5817541&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D%20omniauth_controller&referrer=issue-stream&sort=date&stream_index=0

### Changes proposed in this pull request

Change the additional information to be a hash

