### PR TITLE
[CPDNPQ-2451] delivery partner API index and show

### DIFF
--- a/app/controllers/api/v3/delivery_partners_controller.rb
+++ b/app/controllers/api/v3/delivery_partners_controller.rb
@@ -1,0 +1,45 @@
+module API
+  module V3
+    class DeliveryPartnersController < BaseController
+      include Pagination
+
+      def index
+        conditions = { cohort_start_year:, sort: }
+        delivery_partners = query(conditions:).delivery_partners
+
+        render json: to_json(paginate(delivery_partners))
+      end
+
+      def show
+        render json: to_json(delivery_partner)
+      end
+
+    private
+
+      def query(conditions: {})
+        conditions.merge!(lead_provider: current_lead_provider)
+        DeliveryPartners::Query.new(**conditions.compact)
+      end
+
+      def delivery_partner
+        query.delivery_partner(ecf_id: delivery_partner_params[:ecf_id])
+      end
+
+      def cohort_start_year
+        delivery_partner_params.dig(:filter, :cohort)
+      end
+
+      def delivery_partner_params
+        params.permit(:ecf_id, :sort, filter: %i[cohort])
+      end
+
+      def sort
+        delivery_partner_params[:sort]
+      end
+
+      def to_json(obj)
+        DeliveryPartnerSerializer.render(obj, view: :v3, root: "data", lead_provider: current_lead_provider)
+      end
+    end
+  end
+end

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -2,6 +2,7 @@ class Cohort < ApplicationRecord
   has_many :declarations, dependent: :restrict_with_exception
   has_many :schedules, dependent: :destroy
   has_many :statements, dependent: :restrict_with_exception
+  has_many :delivery_partnerships
 
   validates :start_year,
             presence: true,

--- a/app/models/delivery_partner.rb
+++ b/app/models/delivery_partner.rb
@@ -9,4 +9,8 @@ class DeliveryPartner < ApplicationRecord
   def declarations
     Declaration.for_delivery_partners(self)
   end
+
+  def cohorts_for_lead_provider(lead_provider)
+    delivery_partnerships.select { |delivery_partnership| delivery_partnership.lead_provider_id == lead_provider.id }.map(&:cohort)
+  end
 end

--- a/app/serializers/api/delivery_partner_serializer.rb
+++ b/app/serializers/api/delivery_partner_serializer.rb
@@ -1,0 +1,23 @@
+module API
+  class DeliveryPartnerSerializer < Blueprinter::Base
+    identifier :ecf_id, name: :id
+    field(:type) { "delivery-partner" }
+
+    class AttributesSerializer < Blueprinter::Base
+      exclude :id
+
+      view :v3 do
+        field(:name)
+        field(:cohort) { |object, options| object.cohorts_for_lead_provider(options[:lead_provider]).map(&:start_year) }
+        field(:created_at)
+        field(:updated_at)
+      end
+    end
+
+    view :v3 do
+      association :attributes, blueprint: AttributesSerializer, view: :v3 do |delivery_partner|
+        delivery_partner
+      end
+    end
+  end
+end

--- a/app/services/delivery_partners/query.rb
+++ b/app/services/delivery_partners/query.rb
@@ -1,0 +1,48 @@
+module DeliveryPartners
+  class Query
+    include API::Concerns::Orderable
+    include Queries::ConditionFormats
+    include API::Concerns::FilterIgnorable
+
+    attr_reader :scope, :sort
+
+    def initialize(lead_provider:, cohort_start_year: :ignore, sort: nil)
+      @scope = all_delivery_partners
+      @sort = sort
+
+      where_lead_provider_is(lead_provider)
+      where_cohort_start_year(cohort_start_year)
+    end
+
+    def delivery_partners
+      scope.order(order_by)
+    end
+
+    def delivery_partner(id: nil, ecf_id: nil)
+      return scope.find_by!(ecf_id:) if ecf_id.present?
+      return scope.find(id) if id.present?
+
+      fail(ArgumentError, "id or ecf_id needed")
+    end
+
+  private
+
+    def where_lead_provider_is(lead_provider)
+      scope.merge!(DeliveryPartner.where(delivery_partnerships: { lead_provider: lead_provider }))
+    end
+
+    def where_cohort_start_year(cohort_start_year)
+      return if ignore?(filter: cohort_start_year)
+
+      scope.merge!(DeliveryPartner.where(delivery_partnerships: { cohorts: { start_year: cohort_start_year } }))
+    end
+
+    def order_by
+      sort_order(sort:, model: DeliveryPartner, default: { name: :asc })
+    end
+
+    def all_delivery_partners
+      DeliveryPartner.distinct.joins(delivery_partnerships: %i[cohort lead_provider]).includes(delivery_partnerships: %i[cohort])
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -208,6 +208,8 @@ Rails.application.routes.draw do
       end
 
       resources :statements, only: %i[index show], param: :ecf_id
+
+      resources :delivery_partners, path: "delivery-partners", only: %i[index show], param: :ecf_id
     end
 
     namespace :teacher_record_service, path: "teacher-record-service", defaults: { format: :json } do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -39,6 +39,7 @@ ApplicationRecord.descendants.each(&:reset_column_information)
   "add_declarations.rb",
   "add_api_tokens.rb",
   "process_statements.rb",
+  "add_delivery_partners.rb",
 ].each do |seed_file|
   Rails.logger.info("seeding #{seed_file}")
   ApplicationRecord.transaction do

--- a/db/seeds/base/add_delivery_partners.rb
+++ b/db/seeds/base/add_delivery_partners.rb
@@ -1,0 +1,13 @@
+# first lead provider will have 100 delivery partners - useful for showing what production volume will get up to
+100.times do
+  FactoryBot.create(:delivery_partner, lead_providers: Cohort.all.index_with { LeadProvider.first })
+end
+
+# other lead providers will have 10 delivery partners, each with a random sample of 3 cohorts
+LeadProvider.excluding(LeadProvider.first).find_each do |lead_provider|
+  DeliveryPartner.limit(10).find_each do |delivery_partner|
+    Cohort.all.sample(3).each do |cohort|
+      FactoryBot.create(:delivery_partnership, delivery_partner: delivery_partner, lead_provider: lead_provider, cohort: cohort)
+    end
+  end
+end

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -5,6 +5,13 @@ RSpec.describe Cohort, type: :model do
 
   subject { cohort }
 
+  describe "relationships" do
+    it { is_expected.to have_many(:declarations).dependent(:restrict_with_exception) }
+    it { is_expected.to have_many(:schedules).dependent(:destroy) }
+    it { is_expected.to have_many(:statements).dependent(:restrict_with_exception) }
+    it { is_expected.to have_many(:delivery_partnerships) }
+  end
+
   describe "validations" do
     it { is_expected.to validate_presence_of(:registration_start_date) }
     it { is_expected.to allow_value(%w[true false]).for(:funding_cap).with_message("Choose true or false for funding cap") }

--- a/spec/models/delivery_partner_spec.rb
+++ b/spec/models/delivery_partner_spec.rb
@@ -47,4 +47,20 @@ RSpec.describe DeliveryPartner, type: :model do
       it { is_expected.to include declaration_as_secondary }
     end
   end
+
+  describe "#cohorts_for_lead_provider" do
+    subject { delivery_partner.cohorts_for_lead_provider(lead_provider) }
+
+    let(:delivery_partner) { create :delivery_partner, lead_providers: { cohort => lead_provider, other_cohort => other_lead_provider } }
+    let(:lead_provider) { create :lead_provider }
+    let(:other_lead_provider) { create :lead_provider }
+    let(:cohort) { create :cohort }
+    let(:other_cohort) { create :cohort }
+
+    before do
+      create :delivery_partner, lead_providers: { cohort => lead_provider, other_cohort => other_lead_provider }
+    end
+
+    it { is_expected.to eq [cohort] }
+  end
 end

--- a/spec/requests/api/v3/delivery_partners_spec.rb
+++ b/spec/requests/api/v3/delivery_partners_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.describe "Delivery Partner endpoints", type: :request do
+  let(:current_lead_provider) { create(:lead_provider) }
+  let(:query) { DeliveryPartners::Query }
+  let(:serializer) { API::DeliveryPartnerSerializer }
+  let(:serializer_version) { :v3 }
+  let(:serializer_lead_provider) { current_lead_provider }
+
+  describe "GET /api/v3/delivery_partners/:id" do
+    let(:resource) { create(:delivery_partner, lead_provider: current_lead_provider) }
+    let(:resource_id) { resource.ecf_id }
+
+    def path(id = nil)
+      api_v3_delivery_partner_path(id)
+    end
+
+    it_behaves_like "an API show endpoint"
+  end
+
+  describe "GET /api/v3/delivery_partners" do
+    let(:path) { api_v3_delivery_partners_path }
+    let(:resource_id_key) { :ecf_id }
+
+    def create_resource(**attrs)
+      create(:delivery_partner, **attrs)
+    end
+
+    it_behaves_like "an API index endpoint"
+    it_behaves_like "an API index endpoint with pagination"
+    it_behaves_like "an API index endpoint with sorting"
+
+    context "when filtering by cohort" do
+      let(:cohort_2023) { create(:cohort, start_year: 2023) }
+      let(:cohort_2024) { create(:cohort, start_year: 2024) }
+      let!(:delivery_partner_2023) { create(:delivery_partner, lead_providers: { cohort_2023 => current_lead_provider }) }
+
+      before { create(:delivery_partner, lead_providers: { cohort_2024 => current_lead_provider }) }
+
+      it "returns delivery partners for the specified cohort" do
+        api_get(path, params: { filter: { cohort: "2023" } })
+
+        expect(parsed_response["data"].size).to eq(1)
+        expect(parsed_response["data"].first["id"]).to eq(delivery_partner_2023.ecf_id)
+      end
+
+      it "calls the correct query" do
+        expect(query).to receive(:new).with(a_hash_including(lead_provider: current_lead_provider, cohort_start_year: "2023")).and_call_original
+
+        api_get(path, params: { filter: { cohort: "2023" } })
+      end
+    end
+  end
+end

--- a/spec/serializers/api/delivery_partner_serializer_spec.rb
+++ b/spec/serializers/api/delivery_partner_serializer_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe API::DeliveryPartnerSerializer, type: :serializer do
+  let(:current_lead_provider) { LeadProvider.first }
+  let(:other_lead_provider) { LeadProvider.last }
+  let(:delivery_partner) do
+    create(:delivery_partner,
+           lead_providers: {
+             cohort_21 => current_lead_provider,
+             cohort_22 => current_lead_provider,
+             cohort_23 => other_lead_provider,
+           })
+  end
+  let(:cohort_21) { create :cohort, start_year: 2021 }
+  let(:cohort_22) { create :cohort, start_year: 2022 }
+  let(:cohort_23) { create :cohort, start_year: 2023 }
+
+  subject(:response) { JSON.parse(described_class.render(delivery_partner)) }
+
+  describe "core attributes" do
+    it "serializes the `id`" do
+      expect(response["id"]).to eq(delivery_partner.ecf_id)
+    end
+
+    it "serializes the `type`" do
+      response = JSON.parse(described_class.render(delivery_partner))
+
+      expect(response["type"]).to eq("delivery-partner")
+    end
+  end
+
+  context "when serializing the v3 view" do
+    describe "nested attributes" do
+      subject(:attributes) { JSON.parse(described_class.render(delivery_partner, view: :v3, lead_provider: current_lead_provider))["attributes"] }
+
+      it "serializes the `name`" do
+        expect(attributes["name"]).to eq(delivery_partner.name)
+      end
+
+      it "serializes the cohorts" do
+        expect(attributes["cohort"]).to eq([cohort_21.start_year, cohort_22.start_year])
+      end
+
+      it "serializes the `created_at`" do
+        expect(attributes["created_at"]).to eq(delivery_partner.created_at.rfc3339)
+      end
+
+      it "serializes the `updated_at`" do
+        expect(attributes["updated_at"]).to eq(delivery_partner.updated_at.rfc3339)
+      end
+    end
+  end
+end

--- a/spec/services/applications/query_spec.rb
+++ b/spec/services/applications/query_spec.rb
@@ -449,7 +449,8 @@ RSpec.describe Applications::Query do
       other_application = create(:application, lead_provider: other_lead_provider)
 
       query = described_class.new(lead_provider:)
-      expect { query.application(id: other_application.ecf_id) }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { query.application(ecf_id: other_application.ecf_id) }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { query.application(id: other_application.id) }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 end

--- a/spec/services/delivery_partners/query_spec.rb
+++ b/spec/services/delivery_partners/query_spec.rb
@@ -1,0 +1,99 @@
+require "rails_helper"
+
+RSpec.describe DeliveryPartners::Query do
+  let(:lead_provider_1) { LeadProvider.first }
+  let(:lead_provider_2) { LeadProvider.last }
+  let(:cohort_21) { create :cohort, start_year: 2021 }
+  let(:cohort_22) { create :cohort, start_year: 2022 }
+  let(:cohort_23) { create :cohort, start_year: 2023 }
+  let(:sort) { nil }
+
+  subject(:query) { described_class.new(lead_provider: lead_provider_1, sort: sort) }
+
+  describe "#delivery_partners" do
+    let!(:delivery_partner_1) { create :delivery_partner, name: "z", lead_providers: { cohort_21 => lead_provider_1 }, created_at: 2.minutes.ago }
+    let!(:delivery_partner_2) { create :delivery_partner, name: "a", lead_providers: { cohort_21 => lead_provider_1, cohort_22 => lead_provider_1 }, created_at: 1.minute.ago }
+    let!(:delivery_partner_other_lead_provider) { create :delivery_partner, lead_providers: { cohort_21 => lead_provider_2 }, created_at: 1.minute.ago }
+    let!(:delivery_partner_an_hour_ago) { create :delivery_partner, name: "c", lead_providers: { cohort_23 => lead_provider_1 }, created_at: 1.hour.ago }
+
+    it "returns delivery partners for the specified lead provider, ordered by name" do
+      expect(query.delivery_partners).to eq([delivery_partner_2, delivery_partner_an_hour_ago, delivery_partner_1])
+    end
+
+    context "when sorting" do
+      context "when sort is +created_at" do
+        let(:sort) { "+created_at" }
+
+        it "orders by created_at in ascending order" do
+          expect(query.delivery_partners).to eq([delivery_partner_an_hour_ago, delivery_partner_1, delivery_partner_2])
+        end
+      end
+
+      context "when sort is -created_at" do
+        let(:sort) { "-created_at" }
+
+        it "orders by created_at in descending order" do
+          expect(query.delivery_partners).to eq([delivery_partner_2, delivery_partner_1, delivery_partner_an_hour_ago])
+        end
+      end
+    end
+
+    context "when filtering by lead_provider" do
+      subject(:query) { described_class.new lead_provider: lead_provider_2 }
+
+      it "returns delivery partners for the specified lead_provider" do
+        expect(query.delivery_partners).to eq([delivery_partner_other_lead_provider])
+      end
+    end
+
+    context "when filtering by cohort" do
+      subject(:query) { described_class.new lead_provider: lead_provider_1, cohort_start_year: cohort_22.start_year }
+
+      it "returns delivery partners for the specified cohort" do
+        expect(query.delivery_partners).to eq([delivery_partner_2])
+      end
+    end
+  end
+
+  describe "#delivery_partner" do
+    let!(:delivery_partner) do
+      create(:delivery_partner,
+             lead_providers: {
+               cohort_21 => lead_provider_1,
+               cohort_22 => lead_provider_1,
+               cohort_23 => lead_provider_2,
+             })
+    end
+
+    it "raises an error if no `id` or `ecf_id` is provided" do
+      expect { query.delivery_partner }.to raise_error(ArgumentError).with_message("id or ecf_id needed")
+    end
+
+    it "returns the delivery_partner using the `id`" do
+      expect(query.delivery_partner(id: delivery_partner.id)).to eq(delivery_partner)
+    end
+
+    it "returns the delivery_partner using the `ecf_id`" do
+      expect(query.delivery_partner(ecf_id: delivery_partner.ecf_id)).to eq(delivery_partner)
+    end
+
+    it "raises an error if the delivery_partner does not exist" do
+      expect { query.delivery_partner(id: "XXX123") }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    context "when a `lead_provider` is specified" do
+      let!(:other_delivery_partner) { create(:delivery_partner, lead_providers: { cohort_23 => lead_provider_2 }) }
+
+      subject(:query) { described_class.new(lead_provider: lead_provider_1) }
+
+      it "returns the delivery_partner if the lead_provider is in the filtered query" do
+        expect(query.delivery_partner(id: delivery_partner.id)).to eq(delivery_partner)
+      end
+
+      it "raises an error if the delivery_partner is not in the filtered query" do
+        expect { query.delivery_partner(ecf_id: other_delivery_partner.ecf_id) }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { query.delivery_partner(id: other_delivery_partner.id) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2451

### Changes proposed in this pull request
* controller
* delivery partners service
* query object
* serializer
* `DeliveryPartner#cohorts_for_lead_provider` method
* index API supports filtering by cohort and sorting

### Notes
When querying for delivery partners, the query is joining two `has_many through:` tables.
Rails makes 2 SQL queries - one for the delivery partners, and one for the cohorts.
I couldn't figure out a way to make that a single query - so the serializer calls `DeliveryPartner#cohorts_for_lead_provider`