### PR TITLE
[CPDNPQ-2453] set delivery partners on declarations

### DIFF
--- a/app/controllers/api/v3/declarations_controller.rb
+++ b/app/controllers/api/v3/declarations_controller.rb
@@ -50,7 +50,13 @@ module API
         params
           .require(:data)
           .require(:attributes)
-          .permit(:participant_id, :declaration_type, :declaration_date, :course_identifier, :has_passed)
+          .permit(:participant_id,
+                  :declaration_type,
+                  :declaration_date,
+                  :course_identifier,
+                  :has_passed,
+                  :delivery_partner_id,
+                  :secondary_delivery_partner_id)
           .merge(
             lead_provider: current_lead_provider,
           )

--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -103,13 +103,13 @@ class Declaration < ApplicationRecord
   validates :ecf_id, uniqueness: { case_sensitive: false }
   validate :validate_max_statement_items_count
 
-  validates :delivery_partner, presence: true, if: :delivery_partner_required
-  validates :delivery_partner, inclusion: { in: :available_delivery_partners },
-                               if: -> { delivery_partner && delivery_partner_changed? }
+  validates :delivery_partner_id, presence: true, if: :delivery_partner_required
+  validates :delivery_partner_id, inclusion: { in: :available_delivery_partner_ids },
+                                  if: -> { delivery_partner && delivery_partner_changed? }
 
-  validates :secondary_delivery_partner, absence: true, unless: :delivery_partner
-  validates :secondary_delivery_partner,
-            inclusion: { in: :available_delivery_partners },
+  validates :secondary_delivery_partner_id, absence: true, unless: :delivery_partner
+  validates :secondary_delivery_partner_id,
+            inclusion: { in: :available_delivery_partner_ids },
             if: -> { secondary_delivery_partner && secondary_delivery_partner_changed? }
 
   validate :delivery_partners_are_not_the_same, if: :delivery_partner
@@ -165,10 +165,10 @@ class Declaration < ApplicationRecord
       )
   end
 
-  def available_delivery_partners
+  def available_delivery_partner_ids
     return [] unless lead_provider && cohort
 
-    lead_provider.delivery_partners_for_cohort(cohort)
+    lead_provider.delivery_partners_for_cohort(cohort).map(&:id)
   end
 
   def delivery_partners
@@ -199,7 +199,7 @@ private
 
   def delivery_partners_are_not_the_same
     if delivery_partner == secondary_delivery_partner
-      errors.add :secondary_delivery_partner, :duplicate_delivery_partner
+      errors.add :secondary_delivery_partner_id, :duplicate_delivery_partner
     end
   end
 

--- a/app/services/declarations/create.rb
+++ b/app/services/declarations/create.rb
@@ -30,7 +30,7 @@ module Declarations
     validate :output_fee_statement_available
     validate :validate_has_passed_field, if: :validate_has_passed?
     validate :validates_billable_slot_available
-    validate :declaration_date_not_in_the_future
+    validate :declaration_valid
 
     attr_reader :raw_declaration_date, :declaration
 
@@ -167,10 +167,6 @@ module Declarations
       errors.add(:base, :declaration_already_exists)
     end
 
-    def declaration_date_not_in_the_future
-      errors.add(:declaration_date, :future_declaration_date) if declaration_date&.future?
-    end
-
     def validate_has_passed_field
       self.has_passed = has_passed.to_s
 
@@ -205,6 +201,13 @@ module Declarations
       else
         raise ArgumentError, I18n.t(:cannot_create_completed_declaration)
       end
+    end
+
+    def declaration_valid
+      return if errors.any?
+
+      declaration = Declaration.new(declaration_parameters_for_create)
+      errors.merge!(declaration.errors) unless declaration.valid?
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -193,9 +193,13 @@ en:
               *declaration_type
             ecf_id:
               *ecf_id
-            secondary_delivery_partner:
-              duplicate_delivery_partner:
-                The secondary delivery partner cannot match the primary delivery partner
+            delivery_partner_id:
+              inclusion: The entered '#/delivery_partner_id' is not from your list of confirmed Delivery Partners for the Cohort
+              blank: The property '#/delivery_partner_id' must be present
+            secondary_delivery_partner_id:
+              inclusion: The entered '#/secondary_delivery_partner_id' is not from your list of confirmed Delivery Partners for the Cohort
+              present: The property '#/secondary_delivery_partner_id' cannot be specified without the property '#/delivery_partner_id'
+              duplicate_delivery_partner: The property '#/secondary_delivery_partner_id' cannot have the same value as the property '#/delivery_partner_id'
             statement_items:
               more_than_two_statement_items: There cannot be more than two items per declaration
         lead_provider:

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -61,26 +61,26 @@ RSpec.describe Declaration, type: :model do
         }
       end
 
-      it { is_expected.not_to validate_presence_of(:delivery_partner) }
-      it { is_expected.not_to validate_presence_of(:secondary_delivery_partner) }
+      it { is_expected.not_to validate_presence_of(:delivery_partner_id) }
+      it { is_expected.not_to validate_presence_of(:secondary_delivery_partner_id) }
 
       it "allows delivery_partner who is on the available partners list" do
-        expect(declaration).to allow_value(delivery_partner).for(:delivery_partner)
+        expect(declaration).to allow_value(delivery_partner.id).for(:delivery_partner_id)
       end
 
       it "rejects delivery_partner who is on not on the available partners list" do
-        expect(declaration).not_to allow_value(old_cohort_partner).for(:delivery_partner)
+        expect(declaration).not_to allow_value(old_cohort_partner.id).for(:delivery_partner_id)
       end
 
       it "allows secondary_delivery_partner who is on the available partners list" do
         declaration.delivery_partner = delivery_partner
 
-        expect(declaration).to allow_value(second_partner).for(:secondary_delivery_partner)
+        expect(declaration).to allow_value(second_partner.id).for(:secondary_delivery_partner_id)
       end
 
       it "rejects secondary_delivery_partner who is on not on the available partners list" do
         expect(declaration)
-          .not_to allow_value(old_cohort_partner).for(:secondary_delivery_partner)
+          .not_to allow_value(old_cohort_partner.id).for(:secondary_delivery_partner_id)
       end
 
       context "with feature_flag enabled" do
@@ -92,28 +92,28 @@ RSpec.describe Declaration, type: :model do
         let(:cohort) { create(:cohort, start_year: cohort_start_year) }
         let(:cohort_start_year) { described_class::DELIVER_PARTNER_REQUIRED_FROM }
 
-        it { is_expected.to validate_presence_of(:delivery_partner) }
-        it { is_expected.not_to validate_presence_of(:secondary_delivery_partner) }
+        it { is_expected.to validate_presence_of(:delivery_partner_id) }
+        it { is_expected.not_to validate_presence_of(:secondary_delivery_partner_id) }
 
         context "with earlier cohort" do
           let(:cohort_start_year) { described_class::DELIVER_PARTNER_REQUIRED_FROM - 1 }
 
-          it { is_expected.not_to validate_presence_of(:delivery_partner) }
-          it { is_expected.not_to validate_presence_of(:secondary_delivery_partner) }
+          it { is_expected.not_to validate_presence_of(:delivery_partner_id) }
+          it { is_expected.not_to validate_presence_of(:secondary_delivery_partner_id) }
         end
 
         context "with later cohort" do
           let(:cohort_start_year) { described_class::DELIVER_PARTNER_REQUIRED_FROM + 1 }
 
-          it { is_expected.to validate_presence_of(:delivery_partner) }
-          it { is_expected.not_to validate_presence_of(:secondary_delivery_partner) }
+          it { is_expected.to validate_presence_of(:delivery_partner_id) }
+          it { is_expected.not_to validate_presence_of(:secondary_delivery_partner_id) }
         end
 
         context "without cohort set" do
           let(:cohort) { nil }
 
-          it { is_expected.not_to validate_presence_of(:delivery_partner) }
-          it { is_expected.not_to validate_presence_of(:secondary_delivery_partner) }
+          it { is_expected.not_to validate_presence_of(:delivery_partner_id) }
+          it { is_expected.not_to validate_presence_of(:secondary_delivery_partner_id) }
         end
       end
 
@@ -132,7 +132,7 @@ RSpec.describe Declaration, type: :model do
           declaration.delivery_partner = old_cohort_partner
         end
 
-        it { expect(declaration.tap(&:valid?).errors).to include :delivery_partner }
+        it { expect(declaration.tap(&:valid?).errors).to include :delivery_partner_id }
       end
 
       context "when secondary_delivery_partner unchanged but removed from lead providers list" do
@@ -152,7 +152,7 @@ RSpec.describe Declaration, type: :model do
           declaration.secondary_delivery_partner = old_cohort_partner
         end
 
-        it { expect(declaration.tap(&:valid?).errors).to include :secondary_delivery_partner }
+        it { expect(declaration.tap(&:valid?).errors).to include :secondary_delivery_partner_id }
       end
 
       context "when delivery_partner is blank but secondary_delivery_partner is not" do
@@ -161,13 +161,13 @@ RSpec.describe Declaration, type: :model do
           declaration.valid?
         end
 
-        it { expect(declaration.errors).to include :secondary_delivery_partner }
+        it { expect(declaration.errors).to include :secondary_delivery_partner_id }
       end
 
       context "when delivery_partner and secondary_delivery partner are the same" do
         before { declaration.delivery_partner = delivery_partner }
 
-        it { is_expected.not_to allow_value(delivery_partner).for(:secondary_delivery_partner) }
+        it { is_expected.not_to allow_value(delivery_partner.id).for(:secondary_delivery_partner_id) }
       end
     end
 
@@ -789,8 +789,8 @@ RSpec.describe Declaration, type: :model do
     end
   end
 
-  describe "#available_delivery_partners" do
-    subject(:available_delivery_partners) { declaration.available_delivery_partners }
+  describe "#available_delivery_partner_ids" do
+    subject(:available_delivery_partner_ids) { declaration.available_delivery_partner_ids }
 
     let :lead_provider do
       create :lead_provider, delivery_partners: {
@@ -804,8 +804,8 @@ RSpec.describe Declaration, type: :model do
     let(:twenty_three_partner) { create(:delivery_partner) }
     let(:twenty_four_partner) { create(:delivery_partner) }
 
-    it { is_expected.to include twenty_three_partner }
-    it { is_expected.not_to include twenty_four_partner }
+    it { is_expected.to include twenty_three_partner.id }
+    it { is_expected.not_to include twenty_four_partner.id }
 
     context "without delivery_partner" do
       let(:lead_provider) { nil }
@@ -821,7 +821,7 @@ RSpec.describe Declaration, type: :model do
       it { is_expected.to be_empty }
 
       it "avoids querying the database" do
-        available_delivery_partners
+        available_delivery_partner_ids
 
         expect(lead_provider).not_to have_received(:delivery_partners_for_cohort)
       end

--- a/spec/requests/api/v3/declarations_spec.rb
+++ b/spec/requests/api/v3/declarations_spec.rb
@@ -68,6 +68,8 @@ RSpec.describe "Declaration endpoints", type: :request do
     let(:declaration_date) { (schedule.applies_from + 1.day).rfc3339 }
     let(:course_identifier) { course.identifier }
     let(:has_passed) { true }
+    let(:delivery_partner_id) { create(:delivery_partner, lead_providers: { cohort => lead_provider }).ecf_id }
+    let(:secondary_delivery_partner_id) { create(:delivery_partner, lead_providers: { cohort => lead_provider }).ecf_id }
     let(:attributes) do
       {
         participant_id:,
@@ -75,6 +77,8 @@ RSpec.describe "Declaration endpoints", type: :request do
         declaration_date:,
         course_identifier:,
         has_passed:,
+        delivery_partner_id:,
+        secondary_delivery_partner_id:,
       }
     end
     let(:service_args) { { lead_provider: }.merge!(attributes) }

--- a/spec/services/declarations/create_spec.rb
+++ b/spec/services/declarations/create_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe Declarations::Create, type: :model do
   let(:declaration_date) { schedule.applies_from + 1.hour }
   let(:course_identifier) { course.identifier }
   let(:has_passed) { true }
+  let!(:delivery_partner_id) { create(:delivery_partner, lead_providers: { cohort => lead_provider }).ecf_id }
+  let!(:secondary_delivery_partner_id) { create(:delivery_partner, lead_providers: { cohort => lead_provider }).ecf_id }
   let(:params) do
     {
       lead_provider:,
@@ -23,6 +25,8 @@ RSpec.describe Declarations::Create, type: :model do
       declaration_date: declaration_date.rfc3339,
       course_identifier:,
       has_passed:,
+      delivery_partner_id:,
+      secondary_delivery_partner_id:,
     }
   end
   let(:statement) { create(:statement, cohort:, lead_provider:) }
@@ -305,6 +309,8 @@ RSpec.describe Declarations::Create, type: :model do
       expect(declaration.course_identifier).to eq(course_identifier)
       expect(declaration.lead_provider).to eq(lead_provider)
       expect(declaration.cohort).to eq(cohort)
+      expect(declaration.delivery_partner.ecf_id).to eq(delivery_partner_id)
+      expect(declaration.secondary_delivery_partner.ecf_id).to eq(secondary_delivery_partner_id)
     end
 
     context "when declaration is `submitted`" do

--- a/spec/support/matchers/error_matcher.rb
+++ b/spec/support/matchers/error_matcher.rb
@@ -7,4 +7,10 @@ RSpec::Matchers.define :have_error do |attribute, type, message, context|
       error.attribute == attribute && error_type_match && error_message_match
     end
   end
+
+  failure_message do |actual|
+    actual.errors.map { |error|
+      "expected error on :#{attribute} with type :#{type} and message \"#{message}\", but got :#{error.attribute} with type :#{error.type} and message \"#{error.message}\""
+    }.join(" and ")
+  end
 end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2453

Allow `delivery_partner_id` and `secondary_delivery_partner_id` to be specified when creating a declaration.

### Changes proposed in this pull request

Call the validations for delivery partners from the `Declaration` model directly.
Update the validation error messages on the Declaration model, so they are public-facing API error messages.
Allow two new attributes: `delivery_partner_id`, `secondary_delivery_partner_id`.
