### PR TITLE
[CPDNPQ-2727] pick schedule correctly for 2025 and 2024 cohorts

### DIFF
--- a/app/services/course_groups/leadership.rb
+++ b/app/services/course_groups/leadership.rb
@@ -10,10 +10,12 @@ module CourseGroups
     delegate :schedules, to: :course_group
 
     def schedule
-      if autumn_schedule_2022?(schedule_date)
-        schedules.find_by!(cohort:, identifier: "npq-leadership-autumn")
-      elsif autumn_schedule_2024?(schedule_date)
-        schedules.find_by!(cohort:, identifier: "npq-leadership-autumn")
+      if autumn_schedule_2024?(schedule_date)
+        if cohort.start_year == 2025
+          schedules.find_by!(cohort:, identifier: "npq-leadership-spring")
+        elsif cohort.start_year == 2024
+          schedules.find_by!(cohort:, identifier: "npq-leadership-autumn")
+        end
       elsif spring_schedule?(schedule_date)
         schedules.find_by!(cohort:, identifier: "npq-leadership-spring")
       elsif autumn_schedule?(schedule_date)
@@ -22,11 +24,6 @@ module CourseGroups
         # Default
         schedules.find_by!(cohort:, identifier: "npq-leadership-spring")
       end
-    end
-
-    def autumn_schedule_2022?(date)
-      # Between: 1st Jun 2022 and 25th Dec 2022
-      (Date.new(2022, 6, 1)..Date.new(2022, 12, 25)).include?(date)
     end
 
     def autumn_schedule_2024?(date)

--- a/app/services/course_groups/specialist.rb
+++ b/app/services/course_groups/specialist.rb
@@ -10,10 +10,12 @@ module CourseGroups
     delegate :schedules, to: :course_group
 
     def schedule
-      if autumn_schedule_2022?(schedule_date)
-        schedules.find_by!(cohort:, identifier: "npq-specialist-autumn")
-      elsif autumn_schedule_2024?(schedule_date)
-        schedules.find_by!(cohort:, identifier: "npq-specialist-autumn")
+      if autumn_schedule_2024?(schedule_date)
+        if cohort.start_year == 2025
+          schedules.find_by!(cohort:, identifier: "npq-specialist-spring")
+        elsif cohort.start_year == 2024
+          schedules.find_by!(cohort:, identifier: "npq-specialist-autumn")
+        end
       elsif spring_schedule?(schedule_date)
         schedules.find_by!(cohort:, identifier: "npq-specialist-spring")
       elsif autumn_schedule?(schedule_date)
@@ -22,11 +24,6 @@ module CourseGroups
         # Default
         schedules.find_by!(cohort:, identifier: "npq-specialist-spring")
       end
-    end
-
-    def autumn_schedule_2022?(date)
-      # Between: 1st Jun 2022 and 25th Dec 2022
-      (Date.new(2022, 6, 1)..Date.new(2022, 12, 25)).include?(date)
     end
 
     def autumn_schedule_2024?(date)

--- a/spec/services/course_groups/leadership_spec.rb
+++ b/spec/services/course_groups/leadership_spec.rb
@@ -4,65 +4,13 @@ RSpec.describe CourseGroups::Leadership do
   let(:cohort) { create(:cohort, :current) }
   let(:schedule_date) { Date.current }
   let(:course_group) { CourseGroup.find_by(name: "leadership") || create(:course_group, name: "leadership") }
+  let(:course_group_name) { "leadership" }
+  let(:spring_schedule_identifier) { "npq_leadership_spring" }
+  let(:autumn_schedule_identifier) { "npq_leadership_autumn" }
 
   subject { described_class.new(course_group:, cohort:, schedule_date:) }
 
-  describe "#schedule" do
-    let!(:autumn_schedule) { create(:schedule, :npq_leadership_autumn, course_group:, cohort:) }
-    let!(:spring_schedule) { create(:schedule, :npq_leadership_spring, course_group:, cohort:) }
-
-    subject(:schedule) { described_class.new(course_group:, cohort:, schedule_date:).schedule }
-
-    context "when date is between June and December of cohort start year" do
-      before { travel_to Date.new(cohort.start_year, 6, 1) }
-
-      it { is_expected.to eq(autumn_schedule) }
-    end
-
-    context "when date is between December of cohort start year and April of the following year" do
-      let(:cohort) { create(:cohort, start_year: 2025) }
-
-      before { travel_to Date.new(cohort.start_year, 12, 26) }
-
-      it { is_expected.to eq(spring_schedule) }
-    end
-
-    context "when date is between April and December of the next year" do
-      before { travel_to Date.new(cohort.start_year + 1, 4, 3) }
-
-      it { is_expected.to eq(autumn_schedule) }
-    end
-
-    context "when date is between December of next year and April in 2 years" do
-      before { travel_to Date.new(cohort.start_year + 1, 12, 26) }
-
-      it { is_expected.to eq(spring_schedule) }
-    end
-
-    context "when date is spring 2025" do
-      let(:cohort) { create(:cohort, start_year: 2024) }
-
-      before { travel_to Date.new(2025, 1, 13) }
-
-      it { is_expected.to eq(autumn_schedule) }
-    end
-  end
-
-  describe "#autumn_schedule_2022?" do
-    it "returns true when date between 1st Jun 2022 and 25th Dec 2022" do
-      (("2022-06-1".to_date)..("2022-12-25".to_date)).each do |date|
-        expect(subject.autumn_schedule_2022?(date)).to be(true)
-      end
-    end
-
-    it "returns false when date between 26th Dec and 31st May" do
-      (2022..Date.current.year).each do |year|
-        (("#{year}-12-26".to_date)..("#{year + 1}-05-31".to_date)).each do |date|
-          expect(subject.autumn_schedule_2022?(date)).to be(false)
-        end
-      end
-    end
-  end
+  it_behaves_like "leadership and specialist #schedule"
 
   describe "#autumn_schedule_2024?" do
     it "returns true when date between 28th Jun 2024 and 6th June 2025" do

--- a/spec/services/course_groups/specialist_spec.rb
+++ b/spec/services/course_groups/specialist_spec.rb
@@ -3,66 +3,14 @@ require "rails_helper"
 RSpec.describe CourseGroups::Specialist do
   let(:cohort) { create(:cohort, :current) }
   let(:schedule_date) { Date.current }
-  let(:course_group) { CourseGroup.find_by(name: "specialist") || create(:course_group, name: "specialist") }
+  let(:course_group) { CourseGroup.find_by(name: "specialist") }
+  let(:course_group_name) { "specialist" }
+  let(:spring_schedule_identifier) { "npq_specialist_spring" }
+  let(:autumn_schedule_identifier) { "npq_specialist_autumn" }
 
   subject { described_class.new(course_group:, cohort:, schedule_date:) }
 
-  describe "#schedule" do
-    let!(:autumn_schedule) { create(:schedule, :npq_specialist_autumn, course_group:, cohort:) }
-    let!(:spring_schedule) { create(:schedule, :npq_specialist_spring, course_group:, cohort:) }
-
-    subject(:schedule) { described_class.new(course_group:, cohort:, schedule_date:).schedule }
-
-    context "when date is between June and December of cohort start year" do
-      before { travel_to Date.new(cohort.start_year, 6, 1) }
-
-      it { is_expected.to eq(autumn_schedule) }
-    end
-
-    context "when date is between December of cohort start year and April of the following year" do
-      let(:cohort) { create(:cohort, start_year: 2025) }
-
-      before { travel_to Date.new(cohort.start_year, 12, 26) }
-
-      it { is_expected.to eq(spring_schedule) }
-    end
-
-    context "when date is between April and December of the next year" do
-      before { travel_to Date.new(cohort.start_year + 1, 4, 3) }
-
-      it { is_expected.to eq(autumn_schedule) }
-    end
-
-    context "when date is between December of next year and April in 2 years" do
-      before { travel_to Date.new(cohort.start_year + 1, 12, 26) }
-
-      it { is_expected.to eq(spring_schedule) }
-    end
-
-    context "when date is spring 2025" do
-      let(:cohort) { create(:cohort, start_year: 2024) }
-
-      before { travel_to Date.new(2025, 1, 13) }
-
-      it { is_expected.to eq(autumn_schedule) }
-    end
-  end
-
-  describe "#autumn_schedule_2022?" do
-    it "returns true when date between 1st Jun 2022 and 25th Dec 2022" do
-      (("2022-06-1".to_date)..("2022-12-25".to_date)).each do |date|
-        expect(subject.autumn_schedule_2022?(date)).to be(true)
-      end
-    end
-
-    it "returns false when date between 26th Dec and 31st May" do
-      (2022..Date.current.year).each do |year|
-        (("#{year}-12-26".to_date)..("#{year + 1}-05-31".to_date)).each do |date|
-          expect(subject.autumn_schedule_2022?(date)).to be(false)
-        end
-      end
-    end
-  end
+  it_behaves_like "leadership and specialist #schedule"
 
   describe "#autumn_schedule_2024?" do
     it "returns true when date between 28th Jun 2024 and 6th Jun 2025" do

--- a/spec/support/shared_examples/course_group_schedule_support.rb
+++ b/spec/support/shared_examples/course_group_schedule_support.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.shared_examples "leadership and specialist #schedule" do
+  let(:course_group) { CourseGroup.find_by(name: course_group_name) }
+
+  subject { described_class.new(course_group:, cohort:, schedule_date: date).schedule }
+
+  before { travel_to(date) }
+
+  context "when the course is only in the spring schedule (like the 2025 cohort)" do
+    let!(:spring_schedule) { create(:schedule, spring_schedule_identifier, course_group:, cohort:) }
+    let(:cohort) { create(:cohort, start_year: 2025) }
+
+    context "when date is between 28th June 2024 and 6th June 2025" do
+      let(:date) { Date.new(2025, 6, 1) }
+
+      it { is_expected.to eq(spring_schedule) }
+    end
+  end
+
+  context "when the course is only in the autumn schedule (like the 2024 cohort)" do
+    let!(:autumn_schedule) { create(:schedule, autumn_schedule_identifier, course_group:, cohort:) }
+    let(:cohort) { create(:cohort, start_year: 2024) }
+
+    context "when date is between 28th June 2024 and 6th June 2025" do
+      let(:date) { Date.new(2025, 6, 1) }
+
+      it { is_expected.to eq(autumn_schedule) }
+    end
+  end
+
+  context "when course is in both autumn and spring schedules (like 2021-2023 cohorts)" do
+    let!(:spring_schedule) { create(:schedule, spring_schedule_identifier, course_group:, cohort:) }
+    let!(:autumn_schedule) { create(:schedule, autumn_schedule_identifier, course_group:, cohort:) }
+    let(:cohort) { create(:cohort, start_year: 2023) }
+
+    context "when date is between 1st January and 2nd April" do
+      let(:date) { Date.new(2023, 4, 2) }
+
+      it { is_expected.to eq(spring_schedule) }
+    end
+
+    context "when date is between 26th December and 31st December" do
+      let(:date) { Date.new(2023, 12, 31) }
+
+      it { is_expected.to eq(spring_schedule) }
+    end
+
+    context "when date is between 3rd April and 25th December" do
+      let(:date) { Date.new(2023, 12, 25) }
+
+      it { is_expected.to eq(autumn_schedule) }
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2727

Providers are unable to accept applications when they don't specify `schedule_identifier`.
Most accepts do not specify `schedule_identifier`.

Right now - there are 2 schedules that could be used for the current cohort - the autumn 2024 schedule (which was updated to end on 6th June in CPDNPQ-2692), or the spring 2025 schedule.
We're seeing errors, because we currently try and pick the autumn 2024 schedule, even for courses that are only in the spring 2025 schedule.

For the 2025 and 2024 cohorts, courses are only ever in one of these schedules - never in both.
For previous cohorts, courses are in both schedules.

### Changes proposed in this pull request
For the 2025 cohort, use the spring 2025 schedule, for the 2024 cohort, use the autumn 2024 schedule.
For applications being accepted in the 2021-2023 cohorts - the previous date ranges will still be respected when picking the autumn or spring schedules.

Also `course_group.schedule_for` is only ever called with `schedule_date: Date.current` - so the method `autumn_schedule_2022?` would never get called - so I removed it.
