### PR TITLE
[CPDNPQ-2449] Add admin UI for delivery partners

### DIFF
--- a/app/components/npq_separation/navigation_structures/admin_navigation_structure.rb
+++ b/app/components/npq_separation/navigation_structures/admin_navigation_structure.rb
@@ -68,6 +68,11 @@ module NpqSeparation
             prefix: "/npq-separation/admin/bulk_operations",
           ) => [],
           Node.new(
+            name: "Delivery partners",
+            href: npq_separation_admin_delivery_partners_path,
+            prefix: "/npq-separation/admin/delivery-partners",
+          ) => [],
+          Node.new(
             name: "Settings",
             href: "#",
             prefix: "/npq-separation/admin/settings",

--- a/app/controllers/npq_separation/admin/delivery_partners_controller.rb
+++ b/app/controllers/npq_separation/admin/delivery_partners_controller.rb
@@ -1,0 +1,42 @@
+class NpqSeparation::Admin::DeliveryPartnersController < NpqSeparation::AdminController
+  def index
+    scope = DeliveryPartner.all.order(name: :asc)
+    @pagy, @delivery_partners = pagy(scope, limit: 10)
+  end
+
+  def new
+    @delivery_partner = DeliveryPartner.new
+  end
+
+  def create
+    @delivery_partner = DeliveryPartner.new(delivery_partners_params)
+
+    if @delivery_partner.save
+      flash[:success] = "Delivery partner created"
+      redirect_to action: :index
+    else
+      render :new
+    end
+  end
+
+  def edit
+    @delivery_partner = DeliveryPartner.find(params[:id])
+  end
+
+  def update
+    @delivery_partner = DeliveryPartner.find(params[:id])
+
+    if @delivery_partner.update(delivery_partners_params)
+      flash[:success] = "Delivery partner updated"
+      redirect_to action: :index
+    else
+      render :edit
+    end
+  end
+
+private
+
+  def delivery_partners_params
+    params.require(:delivery_partner).permit(:name)
+  end
+end

--- a/app/views/npq_separation/admin/delivery_partners/_form.html.erb
+++ b/app/views/npq_separation/admin/delivery_partners/_form.html.erb
@@ -1,0 +1,15 @@
+<%= form_with model: [:npq_separation, :admin, @delivery_partner] do |form| %>
+  <%=
+    form.govuk_text_field :name,
+                          width: 'two-thirds',
+                          label: {
+                            text: "Enter delivery partner name",
+                            size: "m",
+                          }
+  %>
+
+  <div class="govuk-button-group">
+    <%= form.govuk_submit 'Save' %>
+    <%= govuk_link_to 'Cancel', npq_separation_admin_delivery_partners_path %>
+  </div>
+<% end %>

--- a/app/views/npq_separation/admin/delivery_partners/edit.html.erb
+++ b/app/views/npq_separation/admin/delivery_partners/edit.html.erb
@@ -1,0 +1,14 @@
+<%= govuk_back_link href: npq_separation_admin_delivery_partners_path %>
+
+<h1 class="govuk-heading-l govuk-!-margin-top-6">Update delivery partner name</h1>
+
+<%=
+  govuk_summary_list do |summary_list|
+    summary_list.with_row do |row|
+      row.with_key { 'Delivery partner' }
+      row.with_value { @delivery_partner.name }
+    end
+  end
+%>
+
+<%= render 'form' %>

--- a/app/views/npq_separation/admin/delivery_partners/index.html.erb
+++ b/app/views/npq_separation/admin/delivery_partners/index.html.erb
@@ -1,0 +1,25 @@
+<h1 class="govuk-heading-l">Delivery partners</h1>
+
+<%= govuk_button_link_to "Add a delivery partner", new_npq_separation_admin_delivery_partner_path %>
+
+<%=
+  govuk_table do |table|
+    table.with_head do |header|
+      header.with_row do |row|
+        row.with_cell(text: "Delivery partner")
+        row.with_cell(text: "Actions")
+      end
+    end
+
+    table.with_body do |body|
+      @delivery_partners.each do |delivery_partner|
+        body.with_row do |row|
+          row.with_cell(text: delivery_partner.name)
+          row.with_cell(text: govuk_link_to("Update", edit_npq_separation_admin_delivery_partner_path(delivery_partner)))
+        end
+      end
+    end
+  end
+%>
+
+<%= govuk_pagination(pagy: @pagy) %>

--- a/app/views/npq_separation/admin/delivery_partners/new.html.erb
+++ b/app/views/npq_separation/admin/delivery_partners/new.html.erb
@@ -1,0 +1,5 @@
+<%= govuk_back_link href: npq_separation_admin_delivery_partners_path %>
+
+<h1 class="govuk-heading-l govuk-!-margin-top-6">Add a delivery partner</h1>
+
+<%= render 'form' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -245,6 +245,8 @@ Rails.application.routes.draw do
         resources :statements, only: %i[new create show]
       end
 
+      resources :delivery_partners, path: "delivery-partners", except: %i[show destroy]
+
       resources :schools, only: %i[index show]
       resources :courses, only: %i[index show]
       resources :users, only: %i[index show] do

--- a/spec/components/npq_separation/navigation_structures/admin_navigation_structure_spec.rb
+++ b/spec/components/npq_separation/navigation_structures/admin_navigation_structure_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe NpqSeparation::NavigationStructures::AdminNavigationStructure, ty
       "Schools" => "/npq-separation/admin/schools",
       "Lead providers" => "/npq-separation/admin/lead-providers",
       "Bulk operations" => "/npq-separation/admin/bulk-operations",
+      "Delivery partners" => "/npq-separation/admin/delivery-partners",
       "Settings" => "#",
     }.each_with_index do |(name, href), i|
       it "#{name} with href #{href} is at position #{i + 1}" do

--- a/spec/features/npq_separation/admin/delivery_partners_spec.rb
+++ b/spec/features/npq_separation/admin/delivery_partners_spec.rb
@@ -1,0 +1,112 @@
+require "rails_helper"
+
+RSpec.feature "NPQ Separation Admin Delivery Partners", type: :feature do
+  include Helpers::AdminLogin
+
+  let(:admin) { create(:admin) }
+
+  context "when not logged in" do
+    scenario "delivery partners interface is inaccessible" do
+      visit npq_separation_admin_delivery_partners_path
+      expect(page).to have_current_path(sign_in_path)
+    end
+  end
+
+  context "when logged in as admin" do
+    before { sign_in_as_admin }
+
+    scenario "when logged in as admin, it displays the list of delivery partners" do
+      delivery_partners = create_list(:delivery_partner, 11).sort_by(&:name)
+
+      visit npq_separation_admin_delivery_partners_path
+
+      expect(page).to have_content("Delivery partners")
+
+      # Test delivery partner pagination
+      delivery_partners[0..9].each do |delivery_partner|
+        expect(page).to have_content(delivery_partner.name)
+        expect(page).to have_link("Update", href: edit_npq_separation_admin_delivery_partner_path(delivery_partner))
+      end
+
+      page.find("[rel=next]").click
+
+      delivery_partners[10..].each do |delivery_partner|
+        expect(page).to have_content(delivery_partner.name)
+      end
+    end
+
+    scenario "when logged in as admin, it allows creating a new delivery partner" do
+      visit npq_separation_admin_delivery_partners_path
+      click_link "Add a delivery partner"
+
+      expect(page).to have_content("Add a delivery partner")
+
+      expect {
+        fill_in "Enter delivery partner name", with: "New Test Partner"
+        click_button "Save"
+      }.to change(DeliveryPartner, :count).by(1)
+
+      expect(page).to have_content("Delivery partners")
+      expect(page).to have_content("Delivery partner created")
+      expect(page).to have_content("New Test Partner")
+    end
+
+    scenario "when creating a delivery partner with invalid data, it shows validation errors" do
+      visit npq_separation_admin_delivery_partners_path
+      click_link "Add a delivery partner"
+
+      fill_in "Enter delivery partner name", with: ""
+      click_button "Save"
+
+      expect(page).to have_content("Add a delivery partner")
+      expect(page).to have_content("can't be blank")
+    end
+
+    scenario "when logged in as admin, it allows updating an existing delivery partner" do
+      create(:delivery_partner, name: "Original Partner Name")
+
+      visit npq_separation_admin_delivery_partners_path
+      click_link "Update"
+
+      expect(page).to have_content("Update delivery partner name")
+      expect(page).to have_content("Original Partner Name")
+
+      fill_in "Enter delivery partner name", with: "Updated Partner Name"
+      click_button "Save"
+
+      expect(page).to have_content("Delivery partners")
+      expect(page).to have_content("Delivery partner updated")
+      expect(page).to have_content("Updated Partner Name")
+      expect(page).not_to have_content("Original Partner Name")
+    end
+
+    scenario "when updating a delivery partner with invalid data, it shows validation errors" do
+      create(:delivery_partner, name: "Original Partner Name")
+
+      visit npq_separation_admin_delivery_partners_path
+      click_link "Update"
+
+      fill_in "Enter delivery partner name", with: ""
+      click_button "Save"
+
+      expect(page).to have_content("Update delivery partner name")
+      expect(page).to have_content("can't be blank")
+    end
+
+    scenario "cancel button on new form redirects back to index page" do
+      visit new_npq_separation_admin_delivery_partner_path
+
+      click_link "Cancel"
+      expect(page).to have_current_path(npq_separation_admin_delivery_partners_path)
+    end
+
+    scenario "cancel button on edit form redirects back to index page" do
+      delivery_partner = create(:delivery_partner)
+
+      visit edit_npq_separation_admin_delivery_partner_path(delivery_partner)
+
+      click_link "Cancel"
+      expect(page).to have_current_path(npq_separation_admin_delivery_partners_path)
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2698

Based on mockups in the ticket. n.b. the MoJ pagination component has the total number of records, but GOV.UK pagination doesn't — I could add if it's critical.

I also added the edit screen based on related ticket 2698 because it wasn't in this one, hopefully that's correct.