### PR TITLE
CPDNPQ-2725 Check requirements are met for step

### DIFF
--- a/app/controllers/registration_wizard_controller.rb
+++ b/app/controllers/registration_wizard_controller.rb
@@ -20,6 +20,9 @@ class RegistrationWizardController < ApplicationController
   def update
     @form.flag_as_changing_answer if params[:changing_answer] == "1"
 
+    return redirect_to registration_wizard_show_path(@wizard.next_step_path) if @wizard.skip_step?
+    return redirect_to root_path unless @form.requirements_met?
+
     if @form.valid?
       if @form.redirect_to_change_path?
         redirect_to registration_wizard_show_change_path(@wizard.next_step_path)

--- a/spec/controllers/registration_wizard_controller_spec.rb
+++ b/spec/controllers/registration_wizard_controller_spec.rb
@@ -1,11 +1,21 @@
 require "rails_helper"
 
 RSpec.describe RegistrationWizardController do
+  subject { response }
+
+  before { session[:user_id] = create(:user).id }
+
+  describe "#show" do
+    before { get :show, params: { step: "course-start-date" } }
+
+    it { is_expected.to have_http_status :success }
+  end
+
   describe "#update" do
     context "when agreeing to terms" do
       it "persists data to session" do
-        patch :update, params: { step: "share-provider", registration_wizard: { can_share_choices: "1" } }
-        expect(session["registration_store"]["can_share_choices"]).to eql("1")
+        patch :update, params: { step: "course-start-date", registration_wizard: { course_start_date: "yes" } }
+        expect(session["registration_store"]["course_start_date"]).to eql("yes")
       end
     end
   end


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2725](https://dfedigital.atlassian.net/browse/CPDNPQ-2725)

Currently form submission isn't checking that the user should be allow to submit data for the step they are on, this seems incorrect since there are checks to ensure a user isn't hopping into the middle of a journey.

This changes the `#update` action to check the steps `#requirements_met?` method the same as for the `#show` endpoint

### Changes proposed in this pull request

1. Check `Step#requirements_met?` and bounce the user back to the start if they're not met in the middle

[CPDNPQ-2725]: https://dfedigital.atlassian.net/browse/CPDNPQ-2725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ