### PR TITLE
[CPDNPQ-2730] Avoid checking dp_id for existing declarations

### DIFF
--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -206,6 +206,7 @@ private
   def delivery_partner_required
     return false unless Feature.declarations_require_delivery_partner?
     return false unless cohort
+    return false if persisted? && !delivery_partner_id_changed?
 
     cohort.start_year >= DELIVER_PARTNER_REQUIRED_FROM
   end

--- a/spec/factories/declarations.rb
+++ b/spec/factories/declarations.rb
@@ -68,5 +68,9 @@ FactoryBot.define do
     trait :voided do
       state { :voided }
     end
+
+    trait :with_delivery_partner do
+      delivery_partner { create(:delivery_partner, lead_provider:) }
+    end
   end
 end


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2730](https://dfedigital.atlassian.net/browse/CPDNPQ-2730)

Currently you cannot update the state on a declaration which was made without a delivery partner once the feature flag is enabled. 

### Changes proposed in this pull request

1. Only check the presence of the delivery_partner field if creating a new record or the field has actually been changed

[CPDNPQ-2730]: https://dfedigital.atlassian.net/browse/CPDNPQ-2730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ