### PR TITLE
[CPDNPQ-2731] Allow overseas declarations

### DIFF
--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -105,13 +105,17 @@ class Declaration < ApplicationRecord
   validate :validate_max_statement_items_count
 
   validates :delivery_partner_id, presence: true, if: :delivery_partner_required
-  validates :delivery_partner_id, absence: true, unless: :application_inside_catchment?
+  validates :delivery_partner_id, absence: { message: :overseas },
+                                  unless: :application_inside_catchment?
   validates :delivery_partner_id, inclusion: { in: :available_delivery_partner_ids },
                                   if: -> { delivery_partner && delivery_partner_changed? }
 
+  validates :secondary_delivery_partner_id, absence: true, unless: :delivery_partner
+
   validates :secondary_delivery_partner_id,
-            absence: true,
-            unless: -> { delivery_partner_id && application_inside_catchment? }
+            absence: { message: :overseas },
+            if: -> { delivery_partner_id && !application_inside_catchment? }
+
   validates :secondary_delivery_partner_id,
             inclusion: { in: :available_delivery_partner_ids },
             if: -> { secondary_delivery_partner && secondary_delivery_partner_changed? }

--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -19,6 +19,7 @@ class Declaration < ApplicationRecord
   has_many :statements, through: :statement_items
 
   delegate :course, :user, to: :application
+  delegate :inside_catchment?, to: :application, prefix: true, allow_nil: true
   delegate :identifier, to: :course, prefix: true
   delegate :name, to: :lead_provider, prefix: true
 
@@ -104,10 +105,13 @@ class Declaration < ApplicationRecord
   validate :validate_max_statement_items_count
 
   validates :delivery_partner_id, presence: true, if: :delivery_partner_required
+  validates :delivery_partner_id, absence: true, unless: :application_inside_catchment?
   validates :delivery_partner_id, inclusion: { in: :available_delivery_partner_ids },
                                   if: -> { delivery_partner && delivery_partner_changed? }
 
-  validates :secondary_delivery_partner_id, absence: true, unless: :delivery_partner
+  validates :secondary_delivery_partner_id,
+            absence: true,
+            unless: -> { delivery_partner_id && application_inside_catchment? }
   validates :secondary_delivery_partner_id,
             inclusion: { in: :available_delivery_partner_ids },
             if: -> { secondary_delivery_partner && secondary_delivery_partner_changed? }
@@ -206,6 +210,7 @@ private
   def delivery_partner_required
     return false unless Feature.declarations_require_delivery_partner?
     return false unless cohort
+    return false unless application_inside_catchment?
     return false if persisted? && !delivery_partner_id_changed?
 
     cohort.start_year >= DELIVER_PARTNER_REQUIRED_FROM

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -196,9 +196,11 @@ en:
             delivery_partner_id:
               inclusion: The entered '#/delivery_partner_id' is not from your list of confirmed Delivery Partners for the Cohort
               blank: The property '#/delivery_partner_id' must be present
+              overseas: The property '#/delivery_partner_id' cannot be specified for Applications from outside of England'
             secondary_delivery_partner_id:
               inclusion: The entered '#/secondary_delivery_partner_id' is not from your list of confirmed Delivery Partners for the Cohort
               present: The property '#/secondary_delivery_partner_id' cannot be specified without the property '#/delivery_partner_id'
+              overseas: The property '#/secondary_delivery_partner_id' cannot be specified for Applications from outside of England'
               duplicate_delivery_partner: The property '#/secondary_delivery_partner_id' cannot have the same value as the property '#/delivery_partner_id'
             statement_items:
               more_than_two_statement_items: There cannot be more than two items per declaration

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -94,6 +94,8 @@ RSpec.describe Declaration, type: :model do
 
         it { is_expected.to validate_presence_of(:delivery_partner_id) }
         it { is_expected.not_to validate_presence_of(:secondary_delivery_partner_id) }
+        it { is_expected.not_to validate_absence_of(:delivery_partner_id) }
+        it { is_expected.to validate_absence_of(:secondary_delivery_partner_id) }
 
         context "with earlier cohort" do
           let(:cohort_start_year) { described_class::DELIVER_PARTNER_REQUIRED_FROM - 1 }
@@ -124,6 +126,31 @@ RSpec.describe Declaration, type: :model do
           end
 
           it { is_expected.to be_eligible_state }
+        end
+
+        context "with application from another country" do
+          let(:declaration) { build(:declaration, cohort:, application:) }
+
+          let :application do
+            create(:application, teacher_catchment: nil,
+                                 teacher_catchment_country: "Italy",
+                                 teacher_catchment_iso_country_code: "ITA")
+          end
+
+          it { is_expected.not_to validate_presence_of(:delivery_partner) }
+          it { is_expected.not_to validate_presence_of(:secondary_delivery_partner) }
+          it { is_expected.to validate_absence_of(:delivery_partner_id) }
+          it { is_expected.to validate_absence_of(:secondary_delivery_partner_id) }
+        end
+
+        context "with application from a non-english home nation" do
+          let(:declaration) { build(:declaration, cohort:, application:) }
+          let(:application) { build(:application, teacher_catchment: "wales") }
+
+          it { is_expected.not_to validate_presence_of(:delivery_partner) }
+          it { is_expected.not_to validate_presence_of(:secondary_delivery_partner) }
+          it { is_expected.to validate_absence_of(:delivery_partner_id) }
+          it { is_expected.to validate_absence_of(:secondary_delivery_partner_id) }
         end
       end
 

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -129,7 +129,9 @@ RSpec.describe Declaration, type: :model do
         end
 
         context "with application from another country" do
-          let(:declaration) { build(:declaration, cohort:, application:) }
+          subject do
+            build(:declaration, cohort:, application:, delivery_partner: DeliveryPartner.first)
+          end
 
           let :application do
             create(:application, teacher_catchment: nil,
@@ -139,18 +141,21 @@ RSpec.describe Declaration, type: :model do
 
           it { is_expected.not_to validate_presence_of(:delivery_partner) }
           it { is_expected.not_to validate_presence_of(:secondary_delivery_partner) }
-          it { is_expected.to validate_absence_of(:delivery_partner_id) }
-          it { is_expected.to validate_absence_of(:secondary_delivery_partner_id) }
+          it { is_expected.to validate_absence_of(:delivery_partner_id).with_message(/outside of England/) }
+          it { is_expected.to validate_absence_of(:secondary_delivery_partner_id).with_message(/outside of England/) }
         end
 
         context "with application from a non-english home nation" do
-          let(:declaration) { build(:declaration, cohort:, application:) }
+          subject do
+            build(:declaration, cohort:, application:, delivery_partner: DeliveryPartner.first)
+          end
+
           let(:application) { build(:application, teacher_catchment: "wales") }
 
           it { is_expected.not_to validate_presence_of(:delivery_partner) }
           it { is_expected.not_to validate_presence_of(:secondary_delivery_partner) }
-          it { is_expected.to validate_absence_of(:delivery_partner_id) }
-          it { is_expected.to validate_absence_of(:secondary_delivery_partner_id) }
+          it { is_expected.to validate_absence_of(:delivery_partner_id).with_message(/outside of England/) }
+          it { is_expected.to validate_absence_of(:secondary_delivery_partner_id).with_message(/outside of England/) }
         end
       end
 


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2731](https://dfedigital.atlassian.net/browse/CPDNPQ-2731)

Overseas applications will not have a delivery partner, so once a delivery partner is required then declarations would be prevented.

### Changes proposed in this pull request

1. Allow declarations from overseas without delivery_partner_id
2. Actually prevent declarations from overseas with a delivery_partner_id as this would imply an incorrect declaration

[CPDNPQ-2731]: https://dfedigital.atlassian.net/browse/CPDNPQ-2731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ