### PR TITLE
[BAU] Drop byebug and pry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,14 +64,12 @@ end
 
 group :development, :test do
   gem "amazing_print"
-  gem "byebug", platforms: %i[mri mingw x64_mingw]
   gem "capybara"
   gem "capybara-screenshot"
+  gem "debug"
   gem "dotenv-rails"
   gem "knapsack"
   gem "parallel_tests", "~> 5.1"
-  gem "pry-byebug"
-  gem "pry-rails"
   gem "rspec-rails", "~> 7.1"
   gem "rspec-sonarqube-formatter", require: false
   gem "rswag-specs"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,7 +134,6 @@ GEM
     bullet (8.0.1)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
-    byebug (11.1.3)
     canonical-rails (0.2.17)
       actionview (>= 4.1, < 8.1)
     capybara (3.40.0)
@@ -153,7 +152,6 @@ GEM
     childprocess (5.1.0)
       logger (~> 1.5)
     choice (0.2.0)
-    coderay (1.1.3)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.3.5)
@@ -172,6 +170,9 @@ GEM
       ferrum (~> 0.15.0)
     daemons (1.4.1)
     date (3.4.1)
+    debug (1.10.0)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     declarative (0.0.20)
     delayed_cron_job (0.9.0)
       fugit (>= 1.5)
@@ -440,14 +441,6 @@ GEM
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
-    pry (0.14.2)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
-    pry-byebug (3.10.1)
-      byebug (~> 11.0)
-      pry (>= 0.13, < 0.15)
-    pry-rails (0.3.11)
-      pry (>= 0.13.0)
     psych (5.2.3)
       date
       stringio
@@ -755,7 +748,6 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   brakeman
   bullet
-  byebug
   canonical-rails
   capybara
   capybara-screenshot
@@ -763,6 +755,7 @@ DEPENDENCIES
   cssbundling-rails (~> 1.4)
   cuprite
   daemons
+  debug
   delayed_cron_job
   delayed_job (~> 4.1)
   delayed_job_active_record
@@ -799,8 +792,6 @@ DEPENDENCIES
   parallel_tests (~> 5.1)
   pg (>= 0.18, < 2.0)
   pg_search
-  pry-byebug
-  pry-rails
   puma (~> 6.6.0)
   rack-attack
   rails (~> 7.1.5)


### PR DESCRIPTION
### Context

Ticket: BAU

We are currently using bye-bug and pry but byebug is superceded by the ruby debugging library and IRB has improved sufficiently to reduce the value of PRY.

### Changes proposed in this pull request

1. Replace the PRY and byebug dependencies with a dependency on ruby's built in debugging library. We're using the gem version to ensure we benefit from the latest release without being on the latest ruby release