### PR TITLE
[BAU] Fix broken reg wizard visualiser + add specs

### DIFF
--- a/app/services/registration_wizard_visualiser.rb
+++ b/app/services/registration_wizard_visualiser.rb
@@ -1,3 +1,5 @@
+require "method_source"
+
 class RegistrationWizardVisualiser
   class << self
     def call
@@ -91,9 +93,21 @@ private
 
   # Image Generation
 
+  def output_dir
+    tmp_dir = Rails.env.test? ? "visualisations_test" : "visualisations"
+
+    Rails.root.join("tmp", tmp_dir)
+  end
+
+  def make_output_dir
+    FileUtils.mkdir_p(output_dir)
+  end
+
   def generate_and_save_graph(digraph_output)
-    output_digraph_filename = "tmp/visualisations/registration_wizard_visualisation.dot"
-    output_graph_filename = "tmp/visualisations/registration_wizard_visualisation.png"
+    make_output_dir
+
+    output_digraph_filename = output_dir.join("registration_wizard_visualisation.dot")
+    output_graph_filename = output_dir.join("registration_wizard_visualisation.png")
 
     save_file(output_digraph_filename, digraph_output)
 

--- a/spec/services/registration_wizard_visualiser_spec.rb
+++ b/spec/services/registration_wizard_visualiser_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe RegistrationWizardVisualiser do
+  before { FileUtils.rm_rf Rails.root.join("tmp/visualisations_test") }
+
+  let :dot_file do
+    Rails.root.join("tmp/visualisations_test/registration_wizard_visualisation.dot")
+  end
+
+  let :png_file do
+    Rails.root.join("tmp/visualisations_test/registration_wizard_visualisation.dot")
+  end
+
+  it "generates an dot graph of the wizard" do
+    expect { described_class.call }
+      .to change(dot_file, :exist?).from(false).to(true)
+  end
+
+  it "generates a png graph of the wizard" do
+    expect { described_class.call }
+      .to change(png_file, :exist?).from(false).to(true)
+  end
+end


### PR DESCRIPTION
### Context

Ticket: BAU

Removing byebug and pry broke the registration wizard visualisation

### Changes proposed in this pull request

1. Manually require the method_source gem _- we were eager loading this in production anyway, just not in development_
2. Added specs to check the visualisation code works