### PR TITLE
[BAU] Fix visualisation github action not to use ancient ubuntu release

### DIFF
--- a/.github/workflows/build_flow_visualisation.yml
+++ b/.github/workflows/build_flow_visualisation.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/restore_snapshot_database.yml
+++ b/.github/workflows/restore_snapshot_database.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   backup-and-restore-production:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     environment: production
     permissions:
       contents: write


### PR DESCRIPTION
### Context

Ticket: BAU

Visualisation step has failed because of GH Actions ubuntu 20.04 brownout. We shouldn't be using version 20.04

### Changes proposed in this pull request

1. Use Ubuntu 24.04
