### PR TITLE
[CPDNPQ-2754] Handle nil admin in OTP helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -55,7 +55,7 @@ module ApplicationHelper
   end
 
   def show_otp_code_in_ui(current_env, admin)
-    return unless current_env.in?(%w[development review staging])
+    return unless current_env.in?(%w[development review staging]) && admin.present?
 
     tag.p("OTP code: #{admin.otp_hash}")
   end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2754

Before this change, if you attempt to sign in to a non-production admin console with an email address that doesn't match an admin account, you'll get the 500 error screen and an exception will be recorded/alerted via Sentry.

After this change, this scenario will behave the same as production:

<img width="1007" alt="Screenshot 2025-04-02 at 13 27 27" src="https://github.com/user-attachments/assets/7bf0b7f1-4076-44d2-aa6b-19d028b6a6a5" />