### PR TITLE
2747 - remove users sections from feature flags index and show pages

### DIFF
--- a/app/controllers/admin/features_controller.rb
+++ b/app/controllers/admin/features_controller.rb
@@ -6,9 +6,7 @@ class Admin::FeaturesController < SuperAdminController
 
   def show
     @feature = params[:id]
-    if Feature::FEATURE_FLAG_KEYS.include?(@feature)
-      @users = User.with_feature_flag_enabled(@feature)
-    else
+    unless Feature::FEATURE_FLAG_KEYS.include?(@feature)
       redirect_back fallback_location: admin_features_path
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -63,12 +63,6 @@ class User < ApplicationRecord
     Users::FindOrCreateFromProviderData.new(provider_data: provider_data, feature_flag_id: feature_flag_id).call
   end
 
-  def self.with_feature_flag_enabled(feature_flag_name)
-    @actors = Flipper::Adapters::ActiveRecord::Gate.where(feature_key: feature_flag_name, key: "actors")
-    user_uids = @actors.map { |actor| actor.value.split(";").last }
-    User.where(feature_flag_id: user_uids)
-  end
-
   def get_an_identity_user
     return if get_an_identity_id.blank?
 

--- a/app/views/admin/features/index.html.erb
+++ b/app/views/admin/features/index.html.erb
@@ -10,7 +10,6 @@
                 <tr class="govuk-table__row">
                     <th scope="col" class="govuk-table__header">Feature name</th>
                     <th scope="col" class="govuk-table__header">Current state</th>
-                    <th scope="col" class="govuk-table__header">Users</th>
                     <th scope="col" class="govuk-table__header"></th>
                 </tr>
             </thead>
@@ -20,7 +19,6 @@
                 <tr class="govuk-table__row">
                     <td class="govuk-table__cell"><%= feature %></td>
                     <td class="govuk-table__cell"><strong class="govuk-tag <%= Flipper.enabled?(feature) ? 'govuk-tag--green' : 'govuk-tag--red' %>"><%= Flipper.enabled?(feature) ? 'On' : 'Off' %></strong></td>
-                    <td class="govuk-table__cell"><%= Flipper::Adapters::ActiveRecord::Gate.where(feature_key: feature, key: "actors").count %></td>
                     <td class="govuk-table__cell"><%= govuk_link_to("View", admin_feature_path(feature)) %><span class="govuk-visually-hidden"><%= ' '  + feature %></span></td>
                 </tr>
                 <% end %>

--- a/app/views/admin/features/show.html.erb
+++ b/app/views/admin/features/show.html.erb
@@ -26,35 +26,12 @@
 
     <div class="govuk-!-margin-top-8">
       <%= form_with url: admin_feature_path(@feature), method: :patch, local: true do |f| %>
-      <%= f.govuk_text_field :feature_flag_name, 
+      <%= f.govuk_text_field :feature_flag_name,
           label: { text: 'Confirm the feature flag name to change the state', tag: 'h2', size: 'm', class: 'govuk-!-margin-bottom-2' },
           hint: { text: 'Write the feature name exactly as it appears, including any capitalisation.' } %>
       <%= f.govuk_submit 'Change state' %>
       <% end %>
     </div>
 
-    <h2 class="govuk-heading-m govuk-!-margin-top-7">Users</h2>
-
-    <p class="govuk-body-m">
-      There <%= @users.count == 1 ? 'is' : 'are' %> currently <%= @users.count %>
-      <%= @users.count == 1 ? 'user' : 'users' %> for this feature.
-    </p>
-
-    <% if @users.any? %>
-    <table class="govuk-table govuk-!-margin-top-3">
-      <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header">Users</th>
-        </tr>
-      </thead>
-      <tbody class="govuk-table__body">
-        <% @users.each do |user| %>
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell"><%= user.full_name %></td>
-        </tr>
-        <% end %>
-      </tbody>
-    </table>
-    <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -579,8 +579,10 @@ en:
           <p class="govuk-body">Senco enabled</p>
           <p class="govuk-body">Hello</p>
         closed_registration_enabled_html: |
-          <p class="govuk-body">When this feature is turned on, you can allow some users to register even when the service is closed - that is, when <a href="/admin/features/Registration%20open" class="govuk-link">Registration open</a> is turned off.</p>
-          <p class="govuk-body">When this feature is turned off, and Registration open is also turned off, no one can register.</p>
+          <p class="govuk-body">When this feature is turned on, specified users can register for an NPQ even when the service is closed to the general public.</p>
+          <p class="govuk-body">Use the <a href="/admin/features/Registration%20open" class="govuk-link">Registration open</a> feature flag if you need to close the service to the general public.
+          <p class="govuk-body">To view or manage who can register while the service is closed, visit <a href="/admin/closed_registration_users" class="govuk-link">Closed registration users</a>.</p>
+          <p class="govuk-body">When both the Registration open and Closed registration enabled feature flags are turned off, no one will be able to register.</p>
         targeted_support_funding_html: |
           <p class="govuk-body">Targeted support funding</p>
           <p class="govuk-body">Hello</p>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -99,34 +99,6 @@ RSpec.describe User do
     end
   end
 
-  describe ".with_feature_flag_enabled" do
-    include_context("with activerecord flipper")
-    # we're calling the 'with_feature_flag_enabled' method ("subject") from the User ("described_class") class.
-    subject { described_class.with_feature_flag_enabled("test_flag") }
-
-    # uses factory bot to create a test user
-    let(:user) { create(:user) }
-
-    # context describes the scenario
-    context "with user who is not feature flagged" do
-      # this means that the method output should not include the test user
-      it { is_expected.not_to include(user) }
-    end
-
-    context "with user who is feature flagged" do
-      before { Flipper.enable("test_flag", user) }
-
-      # this means that the method output should include the test user
-      it { is_expected.to include(user) }
-
-      context "when the user gets removed" do
-        before { user.destroy }
-
-        it { is_expected.to be_empty }
-      end
-    end
-  end
-
   describe "#latest_participant_outcome" do
     let(:user) { create(:user) }
     let(:lead_provider) { create(:lead_provider) }

--- a/spec/support/shared_contexts/with_activerecord_flipper.rb
+++ b/spec/support/shared_contexts/with_activerecord_flipper.rb
@@ -1,9 +1,0 @@
-RSpec.shared_context("with activerecord flipper") do
-  before do
-    config = Flipper::Configuration.new
-    config.adapter { Flipper::Adapters::ActiveRecord.new }
-    config.default { Flipper.new(config.adapter) }
-
-    allow(Flipper).to receive(:instance) { config.default }
-  end
-end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2747

In the new feature flags section, we are currently trying to show how many actors (i.e. users) are feature-flagged for different features:

![image](https://github.com/user-attachments/assets/f602e001-8a50-4368-9fc8-924ab701846b)
![image](https://github.com/user-attachments/assets/5bd2165b-6327-4207-aee0-109bf18b4f89)

However, this does not work in an intuitive way.

Every time a feature-flagged user signs in to the NPQ service, they’re recorded as another actor - making it seem like there are more actors than there are. 

What’s more, the actors section is only relevant for the Registration Open feature flag - so it’s confusing to have the actors section for all flags. 

We want to prevent confusion by removing the actors information from these pages.

Instead, we can link users to the ‘Closed registration users’ page, which is a better source of truth to understand who is feature flagged.

![image](https://github.com/user-attachments/assets/bf52fed6-10cb-408c-8d68-6f6b7117c078)

**User story**
As a DFE admin 
I need to know who can register late for an NPQ

### Changes proposed in this pull request

- Remove the Users column from the ‘New feature flags’ index page.
- Remove the Users section from the feature flags show pages.
- Link users to the ‘Closed registration users’ page from relevant places.
- Remove now-redundant code from controller. 
