### PR TITLE
[CPDNPQ-2789] Fix join triggering duplicate delivery partners in list

### DIFF
--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -111,8 +111,6 @@ class LeadProvider < ApplicationRecord
   end
 
   def delivery_partners_for_cohort(cohort)
-    delivery_partners
-      .joins(:delivery_partnerships)
-      .where(delivery_partnerships: { cohort: })
+    delivery_partners.where(delivery_partnerships: { cohort: })
   end
 end

--- a/spec/models/lead_provider_spec.rb
+++ b/spec/models/lead_provider_spec.rb
@@ -204,10 +204,10 @@ RSpec.describe LeadProvider do
     subject { lead_provider.delivery_partners_for_cohort(twenty_three) }
 
     let :lead_provider do
-      create :lead_provider, delivery_partners: {
+      create_list(:lead_provider, 2, delivery_partners: {
         twenty_three => twenty_three_partner,
         create(:cohort, start_year: 2024) => twenty_four_partner,
-      }
+      }).first
     end
 
     let(:twenty_three) { create(:cohort, start_year: 2023) }
@@ -215,6 +215,7 @@ RSpec.describe LeadProvider do
     let(:twenty_four_partner) { create(:delivery_partner) }
     let(:unrelated_partner) { create(:delivery_partner) }
 
+    it { is_expected.to have_attributes length: 1 }
     it { is_expected.to include twenty_three_partner }
     it { is_expected.not_to include twenty_four_partner }
     it { is_expected.not_to include unrelated_partner }


### PR DESCRIPTION


ActiveRecord's where clause is doing the join automatically, by adding a manual `join`, it ends up aliased and so unconstrained

It doesn't actually cause incorrect records to be included but does cause duplicate entries in the returned results

### Context

Ticket: [CPDNPQ-2789](https://dfedigital.atlassian.net/browse/CPDNPQ-2789)

The length of the `#available_delivery_partners` list on a declaration ends up as the product of the number of partnerships for that declarations lead provider and cohort, multiplied by the total number of partnerships.

These are all repeat entries so wont allow incorrect declarations but may slow down the application if its loading lots of records. (eg number of cohorts * number of lead providers * number delivery partners * partnerships for particular cohort)

### Changes proposed in this pull request

1. Remove the extra `joins` causing the problem - ActiveRecord does the join itself automatically, the manual one was then getting aliased and so unscoped/unconstrained.


[CPDNPQ-2789]: https://dfedigital.atlassian.net/browse/CPDNPQ-2789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ