### PR TITLE
[CPDNPQ-2788] add validation to check the delivery partners exist

### DIFF
--- a/app/services/declarations/create.rb
+++ b/app/services/declarations/create.rb
@@ -30,6 +30,8 @@ module Declarations
     validate :output_fee_statement_available
     validate :validate_has_passed_field, if: :validate_has_passed?
     validate :validates_billable_slot_available
+    validate :delivery_partner_exists, if: :delivery_partner_id
+    validate :secondary_delivery_partner_exists, if: :secondary_delivery_partner_id
     validate :declaration_valid
 
     attr_reader :raw_declaration_date, :declaration
@@ -208,6 +210,18 @@ module Declarations
 
       declaration = Declaration.new(declaration_parameters_for_create)
       errors.merge!(declaration.errors) unless declaration.valid?
+    end
+
+    def delivery_partner_exists
+      return if DeliveryPartner.exists?(ecf_id: delivery_partner_id)
+
+      errors.add(:delivery_partner_id, :not_found)
+    end
+
+    def secondary_delivery_partner_exists
+      return if DeliveryPartner.exists?(ecf_id: secondary_delivery_partner_id)
+
+      errors.add(:secondary_delivery_partner_id, :not_found)
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -516,6 +516,10 @@ en:
               missing_contract_for_cohort_and_course: You cannot submit a declaration for this participant as you do not have a contract for the cohort and course. Contact the DfE for assistance.
             application:
               application_schedule_missing: The application is missing a schedule.
+            delivery_partner_id:
+              not_found: The property '#/delivery_partner_id' does not exist
+            secondary_delivery_partner_id:
+              not_found: The property '#/secondary_delivery_partner_id' does not exist
         participant_outcomes/create:
           attributes:
             base:

--- a/spec/services/declarations/create_spec.rb
+++ b/spec/services/declarations/create_spec.rb
@@ -314,6 +314,25 @@ RSpec.describe Declarations::Create, type: :model do
 
       it { is_expected.to validate_presence_of(:delivery_partner_id).with_message("The property '#/delivery_partner_id' must be present") }
       it { is_expected.not_to validate_presence_of(:secondary_delivery_partner_id) }
+
+      context "when the delivery partner does not exist" do
+        let(:delivery_partner_id) { SecureRandom.uuid }
+        let(:secondary_delivery_partner_id) { nil }
+
+        it "only has one validation error" do
+          subject.valid?
+          expect(subject.errors[:delivery_partner_id]).to eq(["The property '#/delivery_partner_id' does not exist"])
+        end
+      end
+
+      context "when the secondary delivery partner does not exist" do
+        let(:secondary_delivery_partner_id) { SecureRandom.uuid }
+
+        it "only has one validation error" do
+          subject.valid?
+          expect(subject.errors[:secondary_delivery_partner_id]).to eq(["The property '#/secondary_delivery_partner_id' does not exist"])
+        end
+      end
     end
 
     context "when delivery_partner is blank but secondary_delivery_partner is not" do
@@ -326,6 +345,19 @@ RSpec.describe Declarations::Create, type: :model do
       let(:secondary_delivery_partner_id) { delivery_partner_id }
 
       it { is_expected.to have_error(:secondary_delivery_partner_id, :duplicate_delivery_partner, "The property '#/secondary_delivery_partner_id' cannot have the same value as the property '#/delivery_partner_id'") }
+    end
+
+    context "when the delivery partner does not exist" do
+      let(:delivery_partner_id) { SecureRandom.uuid }
+      let(:secondary_delivery_partner_id) { nil }
+
+      it { is_expected.to have_error(:delivery_partner_id, :not_found, "The property '#/delivery_partner_id' does not exist") }
+    end
+
+    context "when the secondary delivery partner does not exist" do
+      let(:secondary_delivery_partner_id) { SecureRandom.uuid }
+
+      it { is_expected.to have_error(:secondary_delivery_partner_id, :not_found, "The property '#/secondary_delivery_partner_id' does not exist") }
     end
   end
 


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2788

currently, if an ID is specified that refers to a non-existent delivery partner, no error is raised, the delivery partner is just set to nil.

### Changes proposed in this pull request

Add validation to check there is a delivery partner for the specified ID
