### PR TITLE
Remove the Flipper features panel

### DIFF
--- a/app/constraints/has_flipper_access.rb
+++ b/app/constraints/has_flipper_access.rb
@@ -1,9 +1,0 @@
-class HasFlipperAccess
-  def self.matches?(request)
-    current_user_id = request.session["admin_id"]
-
-    current_user = Admin.find_by(id: current_user_id)
-
-    current_user.present? && current_user.flipper_access?
-  end
-end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -8,9 +8,4 @@ class Admin < ApplicationRecord
   validates :email,
             presence: { message: "Enter an email address" },
             length: { maximum: 64, message: "Email must be shorter than 64 characters" }
-
-  # Whether this user has admin access to the feature flagging interface
-  def flipper_access?
-    super_admin?
-  end
 end

--- a/app/models/null_user.rb
+++ b/app/models/null_user.rb
@@ -7,11 +7,6 @@ class NullUser < User
     false
   end
 
-  # Whether this user has admin access to the feature flagging interface
-  def flipper_access?
-    false
-  end
-
   def flipper_id
     "User;#{feature_flag_id}"
   end

--- a/app/views/admin/_layout.html.erb
+++ b/app/views/admin/_layout.html.erb
@@ -46,12 +46,8 @@
       <%= t(".admins") %>
     <% end %>
 
-    <% component.with_nav_item(path: "/admin/feature_flags") do %>
-      <%= t(".feature_flags") %>
-    <% end %>
-
     <% component.with_nav_item(path: "/admin/features") do %>
-      <%= t(".new_feature_flags") %>
+      <%= t(".feature_flags") %>
     <% end %>
 
     <% component.with_nav_item(path: admin_settings_path) do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -624,7 +624,6 @@ en:
       webhook_messages: "Webhook Messages"
       admins: "Admin Users"
       feature_flags: "Feature Flags"
-      new_feature_flags: "New Feature Flags"
       settings: "Settings"
       bulk_operations: "Bulk operations"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,10 +76,6 @@ Rails.application.routes.draw do
       resources :processing_jobs, only: %i[create], controller: "webhook_messages/processing_jobs"
     end
 
-    constraints HasFlipperAccess do
-      mount Flipper::UI.app(Flipper) => "/feature_flags"
-    end
-
     resources "settings"
     resources :closed_registration_users do
       member do

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -43,9 +43,7 @@ RSpec.feature "admin", :rack_test_driver, type: :feature do
       # Check the links are present
       expect(page).to have_link(text, href:)
     end
-
-    expect(page).not_to have_link("Feature Flags", href: "/admin/feature_flags")
-    expect(page).not_to have_link("New Feature Flags", href: "/admin/features")
+    expect(page).not_to have_link("Feature Flags", href: "/admin/features")
     expect(page).not_to have_link("Admin Users", href: "/admin/admins")
     expect(page).not_to have_link("Settings", href: "/admin/settings")
   end
@@ -56,16 +54,14 @@ RSpec.feature "admin", :rack_test_driver, type: :feature do
     sign_in_as_super_admin
 
     page.click_link("Legacy Admin")
-
-    expect(page).to have_link("Feature Flags", href: "/admin/feature_flags")
-    expect(page).to have_link("New Feature Flags", href: "/admin/features")
+    expect(page).to have_link("Feature Flags", href: "/admin/features")
     expect(page).to have_link("Admin Users", href: "/admin/admins")
     expect(page).to have_link("Settings", href: "/admin/settings")
   end
 
-  scenario "when logged in a super admin, the user can access the new feature flags interface and change the state of a feature flag" do
+  scenario "when logged in a super admin, the user can access the feature flags interface and change the state of a feature flag" do
     sign_in_as_super_admin
-    page.click_link("New Feature Flags")
+    page.click_link("Feature Flags")
     expect(page).to have_current_path("/admin/features")
     within("tr", text: "Registration open") do
       page.click_link("View")


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2768

We have a new section of the admin console for turning feature flags on and off. This was intended to replace the Flipper panel provided by Flipper. 

### Changes proposed in this pull request

Remove the Flipper panel and remove the link to it from the nav bar, as well as associated methods/code. 

See acceptance criteria on the ticket ⬆️
