### PR TITLE
Api endpoint to change declaration delivery partner.

### DIFF
--- a/app/controllers/api/v3/declarations_controller.rb
+++ b/app/controllers/api/v3/declarations_controller.rb
@@ -36,6 +36,16 @@ module API
         end
       end
 
+      def change_delivery_partner
+        service = Declarations::ChangeDeliveryPartner.new(declaration:, delivery_partner_id:, secondary_delivery_partner_id:)
+
+        if service.change_delivery_partner
+          render json: to_json(service.declaration)
+        else
+          render json: API::Errors::Response.from(service), status: :unprocessable_entity
+        end
+      end
+
     private
 
       def declarations_query(conditions: {})
@@ -65,6 +75,19 @@ module API
         raise ActionController::BadRequest, I18n.t(:invalid_data_structure)
       end
 
+      def change_delivery_partner_params
+        params
+          .require(:data)
+          .require(:attributes)
+          .permit(:delivery_partner_id,
+                  :secondary_delivery_partner_id)
+          .merge(
+            lead_provider: current_lead_provider,
+          )
+      rescue ActionController::ParameterMissing
+        raise ActionController::BadRequest, I18n.t(:invalid_data_structure)
+      end
+
       def participant_ids
         params.dig(:filter, :participant_id)
       end
@@ -75,6 +98,14 @@ module API
 
       def to_json(obj)
         DeclarationSerializer.render(obj, view: :v3, root: "data")
+      end
+
+      def delivery_partner_id
+        change_delivery_partner_params["delivery_partner_id"]
+      end
+
+      def secondary_delivery_partner_id
+        change_delivery_partner_params["secondary_delivery_partner_id"]
       end
     end
   end

--- a/app/services/declarations/change_delivery_partner.rb
+++ b/app/services/declarations/change_delivery_partner.rb
@@ -1,0 +1,54 @@
+module Declarations
+  class ChangeDeliveryPartner
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :declaration
+    attribute :delivery_partner_id
+    attribute :secondary_delivery_partner_id
+    validate :declaration_valid
+    validate :delivery_partner_existence
+    validate :secondary_delivery_partner_existence
+
+    validates :declaration, presence: true
+    validates :delivery_partner_id, presence: true
+
+    def change_delivery_partner
+      declaration.delivery_partner = delivery_partner
+      declaration.secondary_delivery_partner = secondary_delivery_partner
+
+      return false unless declaration.valid? && valid?
+
+      declaration.save!
+      declaration.reload
+    end
+
+  private
+
+    def declaration_valid
+      return unless declaration
+
+      errors.merge!(declaration.errors) unless declaration.valid?
+    end
+
+    def delivery_partner_existence
+      if delivery_partner.nil?
+        errors.add(:delivery_partner, :presence)
+      end
+    end
+
+    def secondary_delivery_partner_existence
+      if secondary_delivery_partner_id.present? && secondary_delivery_partner.nil?
+        errors.add(:secondary_delivery_partner, :presence)
+      end
+    end
+
+    def delivery_partner
+      DeliveryPartner.find_by(ecf_id: delivery_partner_id)
+    end
+
+    def secondary_delivery_partner
+      DeliveryPartner.find_by(ecf_id: secondary_delivery_partner_id)
+    end
+  end
+end

--- a/app/services/declarations/change_delivery_partner.rb
+++ b/app/services/declarations/change_delivery_partner.rb
@@ -17,7 +17,7 @@ module Declarations
       declaration.delivery_partner = delivery_partner
       declaration.secondary_delivery_partner = secondary_delivery_partner
 
-      return false unless declaration.valid? && valid?
+      return false unless valid?
 
       declaration.save!
       declaration.reload

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -492,8 +492,6 @@ en:
           attributes:
             delivery_partner_id:
               blank: The property '#/delivery_partner_id' must be present
-            secondary_delivery_partner_id:
-              present: The property '#/secondary_delivery_partner_id' cannot be specified without the property '#/delivery_partner_id'
             delivery_partner:
               presence: The entered '#/delivery_partner_id' is not from your list of confirmed Delivery Partners for the Cohort
             secondary_delivery_partner:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -488,6 +488,17 @@ en:
             declaration:
               <<: *statement
               <<: *declaration
+        declarations/change_delivery_partner:
+          attributes:
+            delivery_partner_id:
+              blank: The property '#/delivery_partner_id' must be present
+            secondary_delivery_partner_id:
+              present: The property '#/secondary_delivery_partner_id' cannot be specified without the property '#/delivery_partner_id'
+            delivery_partner:
+              presence: The entered '#/delivery_partner_id' is not from your list of confirmed Delivery Partners for the Cohort
+            secondary_delivery_partner:
+              presence: The entered '#/secondary_delivery_partner_id' is not from your list of confirmed Delivery Partners for the Cohort
+
         declarations/void:
           attributes:
             declaration:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -204,6 +204,7 @@ Rails.application.routes.draw do
       resources :declarations, only: %i[create show index], path: "participant-declarations", param: :ecf_id do
         member do
           put :void, path: "void"
+          put :change_delivery_partner, path: "change-delivery-partner"
         end
       end
 

--- a/spec/requests/api/v3/declarations_spec.rb
+++ b/spec/requests/api/v3/declarations_spec.rb
@@ -80,6 +80,24 @@ RSpec.describe "Declaration endpoints", type: :request do
     end
 
     it_behaves_like "an API update endpoint"
+
+    context "when a parameter is missing" do
+      let(:attributes) do
+        {
+          secondary_delivery_partner_id:,
+        }
+      end
+
+      let(:params) { { data: {} } }
+
+      before do
+        api_put(path(resource_id), params:)
+      end
+
+      it "has proper response status" do
+        expect(response.status).to eq(400)
+      end
+    end
   end
 
   describe "POST /api/v3/participant-declarations" do

--- a/spec/requests/api/v3/declarations_spec.rb
+++ b/spec/requests/api/v3/declarations_spec.rb
@@ -51,6 +51,37 @@ RSpec.describe "Declaration endpoints", type: :request do
     it_behaves_like "an API update endpoint"
   end
 
+  describe "PUT /api/v3/participant-declarations/:ecf_id/change-delivery-partner" do
+    let(:cohort) { create(:cohort, :current) }
+
+    let(:delivery_partner) { create(:delivery_partner, lead_providers: { cohort => current_ }) }
+    let(:secondary_delivery_partner) { create(:delivery_partner, lead_providers: { cohort => current_lead_provider }) }
+    let(:new_delivery_partner) { create(:delivery_partner, lead_providers: { cohort => current_lead_provider }) }
+    let(:new_secondary_delivery_partner) { create(:delivery_partner, lead_providers: { cohort => current_lead_provider }) }
+    let(:delivery_partner_id) { new_delivery_partner.ecf_id }
+    let(:secondary_delivery_partner_id) { new_secondary_delivery_partner.ecf_id }
+
+    let(:resource) { create(:declaration, lead_provider: current_lead_provider) }
+    let(:resource_id) { resource.ecf_id }
+    let(:service) { Declarations::ChangeDeliveryPartner }
+    let(:action) { :change_delivery_partner }
+
+    let(:service_args) { { declaration: resource, delivery_partner_id:, secondary_delivery_partner_id: } }
+
+    let(:attributes) do
+      {
+        delivery_partner_id:,
+        secondary_delivery_partner_id:,
+      }
+    end
+
+    def path(id = nil)
+      change_delivery_partner_api_v3_declaration_path(ecf_id: id)
+    end
+
+    it_behaves_like "an API update endpoint"
+  end
+
   describe "POST /api/v3/participant-declarations" do
     let(:path) { api_v3_declarations_path }
 

--- a/spec/services/declarations/change_delivery_partner_spec.rb
+++ b/spec/services/declarations/change_delivery_partner_spec.rb
@@ -1,0 +1,117 @@
+require "rails_helper"
+
+RSpec.describe Declarations::ChangeDeliveryPartner, type: :model do
+  let(:lead_provider) { LeadProvider.first }
+  let(:cohort) { create(:cohort, :current) }
+
+  let(:delivery_partner) { create(:delivery_partner, lead_providers: { cohort => lead_provider }) }
+  let(:secondary_delivery_partner) { create(:delivery_partner, lead_providers: { cohort => lead_provider }) }
+  let(:new_delivery_partner) { create(:delivery_partner, lead_providers: { cohort => lead_provider }) }
+  let(:new_secondary_delivery_partner) { create(:delivery_partner, lead_providers: { cohort => lead_provider }) }
+  let(:delivery_partner_id) { new_delivery_partner.ecf_id }
+  let(:secondary_delivery_partner_id) { new_secondary_delivery_partner.ecf_id }
+
+  let(:declaration) do
+    create(:declaration,
+           lead_provider:,
+           delivery_partner:,
+           secondary_delivery_partner:)
+  end
+
+  let(:instance) { described_class.new(declaration:, delivery_partner_id:, secondary_delivery_partner_id:) }
+
+  describe "#change_delivery_partner" do
+    subject(:change_delivery_partner) { instance.change_delivery_partner }
+
+    it { is_expected.to be_truthy }
+
+    it "reloads declaration after action" do
+      allow(instance.declaration).to receive(:reload)
+      change_delivery_partner
+      expect(instance.declaration).to have_received(:reload)
+    end
+
+    context "when operation is performed" do
+      before { change_delivery_partner }
+
+      it "changes delivery partner" do
+        expect(declaration.reload.delivery_partner).to eq(new_delivery_partner)
+      end
+
+      it "changes secondary delivery partner" do
+        expect(declaration.reload.secondary_delivery_partner).to eq(new_secondary_delivery_partner)
+      end
+
+      context "when secondary delivery partner needs to be removed" do
+        let(:secondary_delivery_partner_id) { nil }
+
+        before { change_delivery_partner }
+
+        it "is performed correctly" do
+          expect(declaration.reload.secondary_delivery_partner).to be_nil
+        end
+      end
+    end
+  end
+
+  describe "validations" do
+    subject { instance }
+
+    before { instance.change_delivery_partner }
+
+    it { is_expected.to validate_presence_of(:declaration) }
+
+    context "when the delivery partner id is empty" do
+      let(:delivery_partner_id) { nil }
+
+      it { is_expected.to have_error(:delivery_partner_id, :blank, "The property '#/delivery_partner_id' must be present") }
+    end
+
+    context "when the delivery partner id is not found" do
+      let(:delivery_partner_id) { "9e5822b2-ff83-4c42-8938-b762261bff65" }
+      let(:secondary_delivery_partner_id) { nil }
+
+      it { is_expected.to have_error(:delivery_partner, :presence, "The entered '#/delivery_partner_id' is not from your list of confirmed Delivery Partners for the Cohort") }
+    end
+
+    context "when the secondary delivery partner is not found" do
+      let(:secondary_delivery_partner_id) { "9e5822b2-ff83-4c42-8938-b762261bff65" }
+
+      it { is_expected.to have_error(:secondary_delivery_partner, :presence, "The entered '#/secondary_delivery_partner_id' is not from your list of confirmed Delivery Partners for the Cohort") }
+    end
+
+    context "when the delivery partner is not on the available partners list" do
+      let(:delivery_partner_id) { create(:delivery_partner).ecf_id }
+
+      it { is_expected.to have_error(:delivery_partner_id, :inclusion, "The entered '#/delivery_partner_id' is not from your list of confirmed Delivery Partners for the Cohort") }
+    end
+
+    context "when the secondary delivery partner is not on the available partners list" do
+      let(:secondary_delivery_partner_id) { create(:delivery_partner).ecf_id }
+
+      it { is_expected.to have_error(:secondary_delivery_partner_id, :inclusion, "The entered '#/secondary_delivery_partner_id' is not from your list of confirmed Delivery Partners for the Cohort") }
+    end
+
+    context "with the declarations_require_delivery_partner feature flag enabled" do
+      before { allow(Feature).to receive(:declarations_require_delivery_partner?).and_return(true) }
+
+      it { is_expected.to validate_presence_of(:delivery_partner_id).with_message("The property '#/delivery_partner_id' must be present") }
+      it { is_expected.not_to validate_presence_of(:secondary_delivery_partner_id) }
+    end
+
+    context "when delivery_partner is blank but secondary_delivery_partner is not" do
+      let(:delivery_partner_id) { nil }
+
+      let(:delivery_partner) { nil }
+      let(:secondary_delivery_partner) { nil }
+
+      it { is_expected.to have_error(:secondary_delivery_partner_id, :present, "The property '#/secondary_delivery_partner_id' cannot be specified without the property '#/delivery_partner_id'") }
+    end
+
+    context "when delivery_partner and secondary_delivery partner are the same" do
+      let(:secondary_delivery_partner_id) { delivery_partner_id }
+
+      it { is_expected.to have_error(:secondary_delivery_partner_id, :duplicate_delivery_partner, "The property '#/secondary_delivery_partner_id' cannot have the same value as the property '#/delivery_partner_id'") }
+    end
+  end
+end

--- a/spec/services/declarations/change_delivery_partner_spec.rb
+++ b/spec/services/declarations/change_delivery_partner_spec.rb
@@ -35,11 +35,11 @@ RSpec.describe Declarations::ChangeDeliveryPartner, type: :model do
       before { change_delivery_partner }
 
       it "changes delivery partner" do
-        expect(declaration.reload.delivery_partner).to eq(new_delivery_partner)
+        expect(declaration.delivery_partner).to eq(new_delivery_partner)
       end
 
       it "changes secondary delivery partner" do
-        expect(declaration.reload.secondary_delivery_partner).to eq(new_secondary_delivery_partner)
+        expect(declaration.secondary_delivery_partner).to eq(new_secondary_delivery_partner)
       end
 
       context "when secondary delivery partner needs to be removed" do
@@ -48,7 +48,7 @@ RSpec.describe Declarations::ChangeDeliveryPartner, type: :model do
         before { change_delivery_partner }
 
         it "is performed correctly" do
-          expect(declaration.reload.secondary_delivery_partner).to be_nil
+          expect(declaration.secondary_delivery_partner).to be_nil
         end
       end
     end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2749

Allow delivery_partner_id and secondary_delivery_partner_id to changed using its own api endpoint: `/api/v3/participant-declarations/{id}/change-delivery-partner`

### Changes proposed in this pull request

Call the validations for delivery partners from the Declaration model. When either `delivery_partner` or `secondary_delivery_partner` does not exist, use the `The entered '#/delivery_partner_id' is not from your list of confirmed Delivery Partners for the Cohort` error method for convinience - end user need to use designated delivery partner.

The api endpoint allows to remove `secondary_delivery_partner` from declaration.