### PR TITLE
[CPDNPQ-2460] Delay removal of postgres on review app teardown

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 # https://gds-way.cloudapps.digital/manuals/programming-languages/editorconfig
 root = true
 
-[*.{css,erb,js,json,rb,scss,sh,yml}]
+[*.{css,erb,js,json,rb,scss,sh,tf,yml}]
 indent_size = 2
 indent_style = space
 charset = utf-8

--- a/terraform/application/application.tf
+++ b/terraform/application/application.tf
@@ -83,4 +83,17 @@ module "worker_application" {
   max_memory = var.worker_memory_max
 
   enable_logit = var.enable_logit
+
+  depends_on = [time_sleep.wait_15_seconds]
+}
+
+// Delayed::Job can take several seconds to shutdown but terraform thinks it has
+// gone away as soon as the signal is sent. This means Delayed::Job errors out
+// when it is still running but the postgres container is removed.
+//
+// Adding a 15 second delay before removing postgres for review apps solves this
+resource "time_sleep" "wait_15_seconds" {
+  count = var.deploy_azure_backing_services ? 0 : 1
+  depends_on = [module.postgres]
+  destroy_duration = "15s"
 }


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2460](https://dfedigital.atlassian.net/browse/CPDNPQ-2460)

Currently Delayed::Job will sleep for a 5 second delay in between polling for new jobs. If it receives a signal to exit, it will continue to sleep until the sleep duration has passed only then does it exit.

This leads to a scenario in review apps where the worker application continues sleeping whilst the postgres container gets destroyed. I'd initially tried marking the worker app as explicitly depending upon postgres _but_ k8s reports back to terraform as having removed an application before the container has actually exited so that doesn't solve the problem.

### Changes proposed in this pull request

1. The worker container explicitly depends upon postgres, via a 'wait' resource
2. The wait resource, a 15 second delay, is introduced between worker removal and postgres removal
3. The wait resource is set to 'count' zero for environments using azure resources instead of k8s containers

This only impacts the **review** environment 

[CPDNPQ-2460]: https://dfedigital.atlassian.net/browse/CPDNPQ-2460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ