### PR TITLE
[CPDNPQ-2800] cope with late acceptance from 2023 and earlier cohorts

### DIFF
--- a/app/services/applications/accept.rb
+++ b/app/services/applications/accept.rb
@@ -16,6 +16,7 @@ module Applications
     validate :other_accepted_applications_with_same_course?
     validate :eligible_for_funded_place
     validate :validate_permitted_schedule_for_course
+    validate :validate_schedule_exists
 
     def accept
       return false unless valid?
@@ -124,6 +125,15 @@ module Applications
 
     def schedule
       @schedule ||= schedule_identifier.present? ? new_schedule : fallback_schedule
+    end
+
+    def validate_schedule_exists
+      return unless application
+
+      unless schedule
+        errors.add(:schedule, :blank)
+        Sentry.capture_message("Schedule could not be determined for application #{application.ecf_id}")
+      end
     end
 
     def validate_permitted_schedule_for_course

--- a/app/services/course_groups/ehco.rb
+++ b/app/services/course_groups/ehco.rb
@@ -5,7 +5,7 @@ module CourseGroups
 
     attribute :course_group
     attribute :cohort
-    attribute :schedule_date, :date
+    attribute :schedule_date, :date # TODO: remove this attribute - it is always set to Date.current
 
     delegate :schedules, to: :course_group
 

--- a/app/services/course_groups/leadership.rb
+++ b/app/services/course_groups/leadership.rb
@@ -5,17 +5,15 @@ module CourseGroups
 
     attribute :course_group
     attribute :cohort
-    attribute :schedule_date, :date
+    attribute :schedule_date, :date # TODO: remove this attribute - it is always set to Date.current
 
     delegate :schedules, to: :course_group
 
     def schedule
-      if autumn_schedule_2024?(schedule_date)
-        if cohort.start_year == 2025
-          schedules.find_by!(cohort:, identifier: "npq-leadership-spring")
-        elsif cohort.start_year == 2024
-          schedules.find_by!(cohort:, identifier: "npq-leadership-autumn")
-        end
+      if autumn_schedule_2024?(schedule_date) && cohort.start_year == 2025
+        schedules.find_by!(cohort:, identifier: "npq-leadership-spring")
+      elsif autumn_schedule_2024?(schedule_date) && cohort.start_year == 2024
+        schedules.find_by!(cohort:, identifier: "npq-leadership-autumn")
       elsif spring_schedule?(schedule_date)
         schedules.find_by!(cohort:, identifier: "npq-leadership-spring")
       elsif autumn_schedule?(schedule_date)

--- a/app/services/course_groups/specialist.rb
+++ b/app/services/course_groups/specialist.rb
@@ -5,17 +5,15 @@ module CourseGroups
 
     attribute :course_group
     attribute :cohort
-    attribute :schedule_date, :date
+    attribute :schedule_date, :date # TODO: remove this attribute - it is always set to Date.current
 
     delegate :schedules, to: :course_group
 
     def schedule
-      if autumn_schedule_2024?(schedule_date)
-        if cohort.start_year == 2025
-          schedules.find_by!(cohort:, identifier: "npq-specialist-spring")
-        elsif cohort.start_year == 2024
-          schedules.find_by!(cohort:, identifier: "npq-specialist-autumn")
-        end
+      if autumn_schedule_2024?(schedule_date) && cohort.start_year == 2025
+        schedules.find_by!(cohort:, identifier: "npq-specialist-spring")
+      elsif autumn_schedule_2024?(schedule_date) && cohort.start_year == 2024
+        schedules.find_by!(cohort:, identifier: "npq-specialist-autumn")
       elsif spring_schedule?(schedule_date)
         schedules.find_by!(cohort:, identifier: "npq-specialist-spring")
       elsif autumn_schedule?(schedule_date)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -544,6 +544,8 @@ en:
               <<: *schedule_identifier
             funded_place:
               <<: *funded_place
+            schedule:
+              blank: Schedule cannot be determined
         applications/reject:
           attributes:
             application:

--- a/spec/services/applications/accept_spec.rb
+++ b/spec/services/applications/accept_spec.rb
@@ -61,6 +61,18 @@ RSpec.describe Applications::Accept, :with_default_schedules, type: :model do
           expect { service.accept }.to raise_error(ActiveRecord::RecordInvalid)
         end
       end
+
+      context "when a schedule cannot be found" do
+        before { allow(CourseGroups::Leadership).to receive(:new).and_return(instance_double(CourseGroups::Leadership, schedule: nil)) }
+
+        it { is_expected.to have_error(:schedule, :blank, "Schedule cannot be determined") }
+
+        it "notifies sentry" do
+          allow(Sentry).to receive(:capture_message)
+          subject.valid?
+          expect(Sentry).to have_received(:capture_message)
+        end
+      end
     end
 
     context "when user applies for EHCO but has accepted ASO" do

--- a/spec/support/shared_examples/course_group_schedule_support.rb
+++ b/spec/support/shared_examples/course_group_schedule_support.rb
@@ -5,30 +5,24 @@ require "rails_helper"
 RSpec.shared_examples "leadership and specialist #schedule" do
   let(:course_group) { CourseGroup.find_by(name: course_group_name) }
 
-  subject { described_class.new(course_group:, cohort:, schedule_date: date).schedule }
+  subject { described_class.new(course_group:, cohort:, schedule_date: Date.current).schedule }
 
   before { travel_to(date) }
+
+  let(:date) { Date.new(2025, 6, 1) }
 
   context "when the course is only in the spring schedule (like the 2025 cohort)" do
     let!(:spring_schedule) { create(:schedule, spring_schedule_identifier, course_group:, cohort:) }
     let(:cohort) { create(:cohort, start_year: 2025) }
 
-    context "when date is between 28th June 2024 and 6th June 2025" do
-      let(:date) { Date.new(2025, 6, 1) }
-
-      it { is_expected.to eq(spring_schedule) }
-    end
+    it { is_expected.to eq(spring_schedule) }
   end
 
   context "when the course is only in the autumn schedule (like the 2024 cohort)" do
     let!(:autumn_schedule) { create(:schedule, autumn_schedule_identifier, course_group:, cohort:) }
     let(:cohort) { create(:cohort, start_year: 2024) }
 
-    context "when date is between 28th June 2024 and 6th June 2025" do
-      let(:date) { Date.new(2025, 6, 1) }
-
-      it { is_expected.to eq(autumn_schedule) }
-    end
+    it { is_expected.to eq(autumn_schedule) }
   end
 
   context "when course is in both autumn and spring schedules (like 2021-2023 cohorts)" do
@@ -37,19 +31,19 @@ RSpec.shared_examples "leadership and specialist #schedule" do
     let(:cohort) { create(:cohort, start_year: 2023) }
 
     context "when date is between 1st January and 2nd April" do
-      let(:date) { Date.new(2023, 4, 2) }
+      before { travel_to(Date.new(2025, 4, 2)) }
 
       it { is_expected.to eq(spring_schedule) }
     end
 
     context "when date is between 26th December and 31st December" do
-      let(:date) { Date.new(2023, 12, 31) }
+      before { travel_to(Date.new(2025, 12, 31)) }
 
       it { is_expected.to eq(spring_schedule) }
     end
 
     context "when date is between 3rd April and 25th December" do
-      let(:date) { Date.new(2023, 12, 25) }
+      before { travel_to(Date.new(2025, 12, 25)) }
 
       it { is_expected.to eq(autumn_schedule) }
     end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2800

lead providers accepting an application from the 2023 cohort will end up with a nil schedule

### Changes proposed in this pull request

* added a TODO to remove schedule_date from these classes - it is never set to anything other than `Date.current`, which is confusing, as it implies it could be set to something else.
* for applications in the 2024 and 2025 cohorts, it will pick the one schedule we have for each of those cohorts
* for applications in 2023 and earlier cohorts, the default date ranges will be used to pick spring or autumn cohorts
* for applications after 6/6/25 - the same default date ranges will be used
* add validation on `Applications::Accept` so that if in the future, our code fails to determine a schedule, then the accept will fail.
* send a message to sentry when our code fails to determine a schedule