### PR TITLE
Add a new row to the participant details table to show whether a trn …

### DIFF
--- a/app/views/npq_separation/admin/users/show.html.erb
+++ b/app/views/npq_separation/admin/users/show.html.erb
@@ -37,13 +37,18 @@
     end
 
     sl.with_row do |row|
-      row.with_key(text: "TRN validated")
-      row.with_value(text: boolean_red_green_tag(@user.trn_verified) + (" (automatically)" if @user.trn_auto_verified))
-    end
 
-    sl.with_row do |row|
-      row.with_key(text: "TRN auto validated")
-      row.with_value(text: boolean_red_green_tag(@user.trn_auto_verified))
+      row.with_key(text: "TRN status")
+
+      if @user.trn_auto_verified
+        value = govuk_tag(text: "TRN verified", colour: "green") + " - automatically"
+      elsif @user.trn_verified
+        value = govuk_tag(text: "TRN verified", colour: "green") + " - manually"
+      else
+        value = govuk_tag(text: "TRN not verified", colour: "red")
+      end
+
+      row.with_value(text: value)
     end
 
     sl.with_row do |row|

--- a/app/views/npq_separation/admin/users/show.html.erb
+++ b/app/views/npq_separation/admin/users/show.html.erb
@@ -37,17 +37,13 @@
     end
 
     sl.with_row do |row|
-
       row.with_key(text: "TRN status")
-
-      if @user.trn_auto_verified
-        value = govuk_tag(text: "TRN verified", colour: "green") + " - automatically"
-      elsif @user.trn_verified
-        value = govuk_tag(text: "TRN verified", colour: "green") + " - manually"
-      else
-        value = govuk_tag(text: "TRN not verified", colour: "red")
-      end
-
+      value = if @user.trn_verified == false
+                govuk_tag(text: "TRN not verified", colour: "red")
+              else
+                verified_method = @user.trn_auto_verified ? "automatically" : "manually"
+                govuk_tag(text: "TRN verified", colour: "green") + " - #{verified_method}"
+              end
       row.with_value(text: value)
     end
 

--- a/app/views/npq_separation/admin/users/show.html.erb
+++ b/app/views/npq_separation/admin/users/show.html.erb
@@ -42,6 +42,11 @@
     end
 
     sl.with_row do |row|
+      row.with_key(text: "TRN auto validated")
+      row.with_value(text: boolean_red_green_tag(@user.trn_auto_verified))
+    end
+
+    sl.with_row do |row|
       row.with_key(text: "Get an Identity ID")
       row.with_value(text: @user.uid)
     end

--- a/spec/features/npq_separation/admin/users_spec.rb
+++ b/spec/features/npq_separation/admin/users_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature "User administration", type: :feature do
         expect(summary_list).to have_summary_item("Email", user.email)
         expect(summary_list).to have_summary_item("Name", user.full_name)
         expect(summary_list).to have_summary_item("TRN", user.trn)
-        expect(summary_list).to have_summary_item("TRN validated", "No")
+        expect(summary_list).to have_summary_item("TRN status", "TRN not verified")
         expect(summary_list).to have_summary_item("Get an Identity ID", user.get_an_identity_id)
       end
     end

--- a/spec/features/npq_separation/admin/users_trn_verification_spec.rb
+++ b/spec/features/npq_separation/admin/users_trn_verification_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.feature "viewing a user's TRN status", type: :feature do
+  include Helpers::AdminLogin
+
+  feature "when TRN verified is true and TRN auto verified is true" do
+    scenario "shows TRN verified automatically" do
+      user = create(:user, trn_verified: true, trn_auto_verified: true)
+      sign_in_as(create(:admin))
+      visit npq_separation_admin_user_path(user)
+      within(first(".govuk-summary-list")) do |summary_list|
+        expect(summary_list).to have_summary_item("TRN status", "TRN verified - automatically")
+      end
+    end
+  end
+
+  feature "when TRN verified is true and TRN auto verified is false" do
+    scenario "shows TRN verified manually" do
+      user = create(:user, trn_verified: true, trn_auto_verified: false)
+      sign_in_as(create(:admin))
+      visit npq_separation_admin_user_path(user)
+      within(first(".govuk-summary-list")) do |summary_list|
+        expect(summary_list).to have_summary_item("TRN status", "TRN verified - manually")
+      end
+    end
+  end
+
+  feature "when TRN verified is false and TRN auto verified is true" do
+    scenario "shows TRN verified automatically" do
+      user = create(:user, trn_verified: false, trn_auto_verified: true)
+      sign_in_as(create(:admin))
+      visit npq_separation_admin_user_path(user)
+      within(first(".govuk-summary-list")) do |summary_list|
+        expect(summary_list).to have_summary_item("TRN status", "TRN verified - automatically")
+      end
+    end
+  end
+
+  feature "when TRN verified is false and TRN auto verified is false" do
+    scenario "shows TRN not verified" do
+      user = create(:user, trn_verified: false, trn_auto_verified: false)
+      sign_in_as(create(:admin))
+      visit npq_separation_admin_user_path(user)
+      within(first(".govuk-summary-list")) do |summary_list|
+        expect(summary_list).to have_summary_item("TRN status", "TRN not verified")
+      end
+    end
+  end
+end

--- a/spec/features/npq_separation/admin/users_trn_verification_spec.rb
+++ b/spec/features/npq_separation/admin/users_trn_verification_spec.rb
@@ -26,12 +26,12 @@ RSpec.feature "viewing a user's TRN status", type: :feature do
   end
 
   feature "when TRN verified is false and TRN auto verified is true" do
-    scenario "shows TRN verified automatically" do
+    scenario "shows TRN not verified" do
       user = create(:user, trn_verified: false, trn_auto_verified: true)
       sign_in_as(create(:admin))
       visit npq_separation_admin_user_path(user)
       within(first(".govuk-summary-list")) do |summary_list|
-        expect(summary_list).to have_summary_item("TRN status", "TRN verified - automatically")
+        expect(summary_list).to have_summary_item("TRN status", "TRN not verified")
       end
     end
   end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2758

The new admin participants #show screen does not include the TRN auto validated field which is present in the legacy admin users section. 

### Changes proposed in this pull request

Make it clear whether a TRN is automatically or manually validated:

![Screenshot 2025-04-23 at 16 01 05](https://github.com/user-attachments/assets/5541991c-e46b-4dab-aad6-24f8eb3812bd)



