### PR TITLE
Remove `plpgsql` from `azure_extensions`

### DIFF
--- a/terraform/application/database.tf
+++ b/terraform/application/database.tf
@@ -36,7 +36,7 @@ module "postgres" {
   azure_enable_monitoring        = var.enable_monitoring
   azure_enable_backup_storage    = var.enable_postgres_backup_storage
   server_version                 = "14"
-  azure_extensions               = ["btree_gin", "citext", "plpgsql", "pg_trgm"]
+  azure_extensions               = ["btree_gin", "citext", "pg_trgm"]
   azure_enable_high_availability = var.postgres_enable_high_availability
   azure_sku_name                 = var.postgres_flexible_server_sku
   azure_maintenance_window       = var.azure_maintenance_window


### PR DESCRIPTION
### Context

This is causing errors when deploying as 'plpgsql' is being treated like an invalid value

@RMcVelia said this has happened before and Microsoft don't always make it clear when it's added/removed
