### PR TITLE
[CPDNPQ-2776] Added rake task to generate API Tokens

### DIFF
--- a/lib/tasks/api_token.rake
+++ b/lib/tasks/api_token.rake
@@ -8,4 +8,20 @@ namespace :api_token do
       logger.info "API Token created: #{token}"
     end
   end
+
+  namespace :lead_provider do
+    desc "Generate a new API token for the Lead Providers API"
+    task :generate_token, %i[lead_provider_id] => :environment do |_t, args|
+      logger = Rails.env.test? ? Rails.logger : Logger.new($stdout)
+
+      lead_provider = LeadProvider.find_by(id: args.lead_provider_id)
+      raise("Unknown lead_provider_id") unless lead_provider
+
+      scope = APIToken.scopes[:lead_provider]
+      unhashed_token = APIToken.create_with_random_token!(scope:, lead_provider:)
+
+      logger.info "API Token created: #{unhashed_token}"
+      logger.info "** Important: API Tokens should only be transferred via Galaxkey **"
+    end
+  end
 end

--- a/spec/lib/tasks/api_token_spec.rb
+++ b/spec/lib/tasks/api_token_spec.rb
@@ -1,9 +1,70 @@
 require "rails_helper"
 
-RSpec.describe "api_token:teacher_record_service:generate_token" do
-  subject(:run_task) { Rake::Task["api_token:teacher_record_service:generate_token"].invoke }
+RSpec.describe "API Token tasks" do
+  before { allow(Rails.logger).to receive(:info).and_call_original }
 
-  it "creates a new API token for the Teacher Record Service" do
-    expect { subject }.to change { APIToken.where(scope: APIToken.scopes[:teacher_record_service]).count }.by(1)
+  describe "api_token:teacher_record_service:generate_token" do
+    subject(:run_task) { Rake::Task["api_token:teacher_record_service:generate_token"].invoke }
+
+    after do
+      Rake::Task["api_token:teacher_record_service:generate_token"].reenable
+    end
+
+    let(:api_tokens) { APIToken.where(scope: APIToken.scopes[:teacher_record_service]) }
+
+    it "creates a new API token for the Teacher Record Service" do
+      expect { run_task }.to change(api_tokens, :count).by(1)
+    end
+
+    it "outputs the unhashed version of the new API Token" do
+      run_task
+
+      expect(Rails.logger).to have_received(:info).with(/\AAPI Token created: [\w-]+\z/)
+    end
+  end
+
+  describe "api_token:lead_provider:generate_token" do
+    subject :run_task do
+      Rake::Task["api_token:lead_provider:generate_token"].invoke(lead_provider_id)
+    end
+
+    after do
+      Rake::Task["api_token:lead_provider:generate_token"].reenable
+    end
+
+    context "without lead_provider_id" do
+      let(:lead_provider_id) { nil }
+
+      it "errors and does not create token" do
+        expect { run_task }
+          .to raise_exception(RuntimeError, "Unknown lead_provider_id")
+                .and(not_change(APIToken, :count))
+      end
+    end
+
+    context "with unknown lead provider_id" do
+      let(:lead_provider_id) { 99 }
+
+      it "errors and does not create token" do
+        expect { run_task }
+          .to raise_exception(RuntimeError, "Unknown lead_provider_id")
+                .and(not_change(APIToken, :count))
+      end
+    end
+
+    context "with known lead_provider_id" do
+      let(:api_tokens) { APIToken.where(scope: "lead_provider", lead_provider_id:) }
+      let(:lead_provider_id) { create(:lead_provider).id }
+
+      it "creates a new API Token for the lead provider" do
+        expect { run_task }.to change(api_tokens, :count).by(1)
+      end
+
+      it "outputs the unhashed version of the new API Token" do
+        run_task
+
+        expect(Rails.logger).to have_received(:info).with(/\AAPI Token created: [\w-]+\z/)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2776](https://dfedigital.atlassian.net/browse/CPDNPQ-2776)

We want a simple CLI tool for generating API tokens for the lead providers which also reminds explains appropriate mechanisms for transferring api tokens.

### Changes proposed in this pull request

1. Added a rake task for generating API tokens

[CPDNPQ-2776]: https://dfedigital.atlassian.net/browse/CPDNPQ-2776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ