### PR TITLE
[CPDNPQ-2713] Use redis for review apps

### DIFF
--- a/config/environments/review.rb
+++ b/config/environments/review.rb
@@ -2,7 +2,6 @@ require Rails.root.join("config/environments/production")
 
 Rails.application.configure do
   config.ssl_options = { redirect: { exclude: ->(request) { request.path.include?("/healthcheck") } } }
-  config.cache_store = :memory_store
 
   config.after_initialize do
     Bullet.enable                       = true

--- a/config/environments/sandbox.rb
+++ b/config/environments/sandbox.rb
@@ -3,5 +3,4 @@ require Rails.root.join("config/environments/production")
 Rails.application.configure do
   config.log_level = :info
   config.ssl_options = { redirect: { exclude: ->(request) { request.path.include?("/healthcheck") } } }
-  config.cache_store = :memory_store
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -3,5 +3,4 @@ require Rails.root.join("config/environments/production")
 Rails.application.configure do
   config.log_level = :debug
   config.ssl_options = { redirect: { exclude: ->(request) { request.path.include?("/healthcheck") } } }
-  config.cache_store = :memory_store
 end

--- a/terraform/application/config/review.tfvars.json
+++ b/terraform/application/config/review.tfvars.json
@@ -5,6 +5,5 @@
     "deploy_azure_backing_services": false,
     "enable_postgres_ssl" : false,
     "command": ["/bin/sh", "-c", "RAILS_ENV=review bundle exec rails db:environment:set db:migrate && bundle exec rake courses:update && bundle exec rails server -b 0.0.0.0"],
-    "deploy_redis_cache": true,
     "enable_logit": true
 }

--- a/terraform/application/config/review.tfvars.json
+++ b/terraform/application/config/review.tfvars.json
@@ -5,5 +5,6 @@
     "deploy_azure_backing_services": false,
     "enable_postgres_ssl" : false,
     "command": ["/bin/sh", "-c", "RAILS_ENV=review bundle exec rails db:environment:set db:migrate && bundle exec rake courses:update && bundle exec rails server -b 0.0.0.0"],
+    "deploy_redis_cache": true,
     "enable_logit": true
 }

--- a/terraform/application/config/sandbox.tfvars.json
+++ b/terraform/application/config/sandbox.tfvars.json
@@ -3,5 +3,7 @@
     "namespace": "cpd-production",
     "environment": "sandbox",
     "enable_postgres_backup_storage" : true,
+    "deploy_redis_cache": true,
+    "redis_cache_capacity": 0,
     "enable_logit": true
 }

--- a/terraform/application/config/sandbox.tfvars.json
+++ b/terraform/application/config/sandbox.tfvars.json
@@ -3,7 +3,6 @@
     "namespace": "cpd-production",
     "environment": "sandbox",
     "enable_postgres_backup_storage" : true,
-    "deploy_redis_cache": true,
     "redis_cache_capacity": 0,
     "enable_logit": true
 }

--- a/terraform/application/config/staging.tfvars.json
+++ b/terraform/application/config/staging.tfvars.json
@@ -2,7 +2,6 @@
     "cluster": "test",
     "namespace": "cpd-development",
     "environment": "staging",
-    "deploy_redis_cache": true,
     "redis_cache_capacity": 0,
     "enable_logit": true
 }

--- a/terraform/application/config/staging.tfvars.json
+++ b/terraform/application/config/staging.tfvars.json
@@ -2,5 +2,7 @@
     "cluster": "test",
     "namespace": "cpd-development",
     "environment": "staging",
+    "deploy_redis_cache": true,
+    "redis_cache_capacity": 0,
     "enable_logit": true
 }

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -53,7 +53,7 @@ variable "deploy_snapshot_database" {
 }
 variable "deploy_redis_cache" {
   type    = bool
-  default = false
+  default = true
 }
 variable "enable_postgres_ssl" {
   default     = true


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2713](https://dfedigital.atlassian.net/browse/CPDNPQ-2713)

We want to use redis instances for the cache in all environments so they more closely mimic production.

### Changes proposed in this pull request

1. `staging` and `sandbox` environments are swapped to use 'real' azure redis instances
2. `review` apps are swapped to use a redis container instance in the 'test' AKS cluster (the same as we do with postgres at the moment)

### Notes

An azure backed redis instance was created in earlier revisions of this PR to verify we can correctly create a real azure redis instance in the `staging` and `sandbox` environments


[CPDNPQ-2713]: https://dfedigital.atlassian.net/browse/CPDNPQ-2713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ