### PR TITLE
[CPDNPQ-2807] Handle badly-formed participant_id parameter

### DIFF
--- a/app/controllers/api/v1/declarations_controller.rb
+++ b/app/controllers/api/v1/declarations_controller.rb
@@ -3,6 +3,7 @@ module API
     class DeclarationsController < BaseController
       include Pagination
       include FilterByDate
+      include FilterByParticipantIds
 
       def index
         conditions = { updated_since:, participant_ids: }
@@ -64,10 +65,6 @@ module API
           )
       rescue ActionController::ParameterMissing
         raise ActionController::BadRequest, I18n.t(:invalid_data_structure)
-      end
-
-      def participant_ids
-        params.dig(:filter, :participant_id)
       end
 
       def to_json(obj)

--- a/app/controllers/api/v2/declarations_controller.rb
+++ b/app/controllers/api/v2/declarations_controller.rb
@@ -3,6 +3,7 @@ module API
     class DeclarationsController < BaseController
       include Pagination
       include FilterByDate
+      include FilterByParticipantIds
 
       def index
         conditions = { updated_since:, participant_ids: }
@@ -64,10 +65,6 @@ module API
           )
       rescue ActionController::ParameterMissing
         raise ActionController::BadRequest, I18n.t(:invalid_data_structure)
-      end
-
-      def participant_ids
-        params.dig(:filter, :participant_id)
       end
 
       def to_json(obj)

--- a/app/controllers/api/v3/applications_controller.rb
+++ b/app/controllers/api/v3/applications_controller.rb
@@ -3,6 +3,7 @@ module API
     class ApplicationsController < BaseController
       include Pagination
       include FilterByDate
+      include FilterByParticipantIds
 
       def index
         conditions = { cohort_start_years:, participant_ids:, updated_since:, sort: }
@@ -58,10 +59,6 @@ module API
 
       def cohort_start_years
         application_params.dig(:filter, :cohort)
-      end
-
-      def participant_ids
-        application_params.dig(:filter, :participant_id)
       end
 
       def application_params

--- a/app/controllers/api/v3/declarations_controller.rb
+++ b/app/controllers/api/v3/declarations_controller.rb
@@ -3,6 +3,7 @@ module API
     class DeclarationsController < BaseController
       include Pagination
       include FilterByDate
+      include FilterByParticipantIds
 
       def index
         conditions = { updated_since:, participant_ids:, cohort_start_years: }
@@ -86,10 +87,6 @@ module API
           )
       rescue ActionController::ParameterMissing
         raise ActionController::BadRequest, I18n.t(:invalid_data_structure)
-      end
-
-      def participant_ids
-        params.dig(:filter, :participant_id)
       end
 
       def cohort_start_years

--- a/app/controllers/concerns/api/filter_by_participant_ids.rb
+++ b/app/controllers/concerns/api/filter_by_participant_ids.rb
@@ -1,0 +1,25 @@
+module API
+  module FilterByParticipantIds
+    extend ActiveSupport::Concern
+
+    UUID_FORMAT = /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
+
+  protected
+
+    def participant_ids
+      params.dig(:filter, :participant_id).tap do |ids|
+        break if ids.blank?
+
+        raise_participant_id_error unless ids.is_a?(String)
+
+        ids.split(",").each do |id|
+          raise_participant_id_error unless id.match?(UUID_FORMAT)
+        end
+      end
+    end
+
+    def raise_participant_id_error
+      raise ActionController::BadRequest, I18n.t(:invalid_participant_id_filter)
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,7 @@ en:
   bad_request: "Bad request"
   not_found: "Not found"
   invalid_date_filter: "The filter '#/%{parameterized_attribute}' must be a valid ISO 8601 date"
+  invalid_participant_id_filter: "The filter '#/participant_id' must be a comma-delimited list of valid UUIDs"
   invalid_training_status: "The filter '#/training_status' must be %{valid_training_status}"
   invalid_page_parameters: "The '#/page[page]' and '#/page[per_page]' parameter values must be a valid positive number"
   invalid_data_structure: correct json data structure required. See API docs for reference

--- a/spec/support/shared_examples/api_index_endpoint_support.rb
+++ b/spec/support/shared_examples/api_index_endpoint_support.rb
@@ -220,7 +220,7 @@ RSpec.shared_examples "an API index endpoint with filter by created_since" do
 end
 
 RSpec.shared_examples "an API index endpoint with filter by participant_id" do
-  context "when fitlering by participant_id" do
+  context "when filtering by participant_id" do
     it "returns resources with the given `participant_id`" do
       resource1 = create_resource(lead_provider: current_lead_provider, user: create(:user))
       resource2 = create_resource(lead_provider: current_lead_provider, user: create(:user))
@@ -242,7 +242,28 @@ RSpec.shared_examples "an API index endpoint with filter by participant_id" do
   context "when filtering with an invalid UUID" do
     it do
       api_get(path, params: { filter: { participant_id: "not-a-uuid" } })
-      expect(parsed_response["data"].size).to be_zero
+
+      expect(response.status).to eq 400
+      expect(parsed_response["errors"]).to eq([
+        {
+          "detail" => I18n.t(:invalid_participant_id_filter),
+          "title" => "Bad request",
+        },
+      ])
+    end
+  end
+
+  context "when filtering with incorrectly formed params" do
+    it do
+      api_get(path, params: { filter: { participant_id: { SecureRandom.uuid => nil } } })
+
+      expect(response.status).to eq 400
+      expect(parsed_response["errors"]).to eq([
+        {
+          "detail" => I18n.t(:invalid_participant_id_filter),
+          "title" => "Bad request",
+        },
+      ])
     end
   end
 end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2807

Currently, if you send wonky `participant_id` parameters to an API endpoint that accepts them, you'll get a HTTP 500 Internal Server Error response (and an exception will be recorded by Sentry — example in the ticket).

This PR validates that the parameters are in the expected form (a comma-delimited list of UUIDs), and responds with 400 Bad Request and an informative error message if not.