### PR TITLE
[CPDNPQ-2804] registration screen changes

### DIFF
--- a/app/views/pages/closed_registration_exception.html.erb
+++ b/app/views/pages/closed_registration_exception.html.erb
@@ -8,24 +8,31 @@
 
     <h2 class="govuk-heading-m">Before you start</h2>
 
-<p class="govuk-body">
-      You’ll need to know which NPQ you want to take and who your provider is. If you have not chosen yet, <%= govuk_link_to("find out about NPQ courses", "https://www.gov.uk/guidance/national-professional-qualification-npq-courses") %>.
+    <p class="govuk-body">
+      You should have already chosen which NPQ you want to do and who your provider is.
+      If you have not chosen yet,
+      <%= govuk_link_to("find out about NPQ courses",
+                        "https://www.gov.uk/guidance/national-professional-qualification-npq-courses") %>.
     </p>
 
     <p class="govuk-body">
-      You’ll also need a teacher reference number (TRN) to register, even if you’re not a teacher. If you are a teacher, you can find your TRN on your payslip, teaching contract or teachers’ pension records.
+      You’ll also need a teacher reference number (TRN) to register, even if
+      you’re not a teacher.
+      <%= govuk_link_to "Learn about TRNs",
+                        "https://www.gov.uk/guidance/teacher-reference-number-trn" %>
+      including how to request on if you do not have one.
     </p>
 
     <p class="govuk-body">
-      If you’ve lost your TRN, you can use the <%= govuk_link_to("Find a lost TRN", "https://find-a-lost-trn.education.gov.uk/start") %> service. If you’ve never had one, use the <%= govuk_link_to("Get a TRN", "https://authorise-access-to-a-teaching-record.education.gov.uk/request-trn") %> service.
+      If you work in early years or childcare,
+      <%= govuk_link_to("check if your workplace is registered with Ofsted",
+                        "https://reports.ofsted.gov.uk/childcare") %>
+      and get their Ofsted unique reference number (URN), if they have one.
     </p>
 
     <p class="govuk-body">
-      If you work in early years or childcare, <%= govuk_link_to("check if your workplace is registered with Ofsted", "https://reports.ofsted.gov.uk/childcare") %> and get their Ofsted unique reference number (URN), if available.
-    </p>
-
-    <p class="govuk-body">
-      You’ll need to create or sign in to your DfE Identity account.
+      Before registering for an NPQ you'll be asked to create a DfE Identity
+      account or sign in to your existing account.
     </p>
 
     <p class="govuk-body">
@@ -40,6 +47,5 @@
         )
       %>
     <% end %>
-
   </div>
 </div>

--- a/app/views/registration_closed/show.html.erb
+++ b/app/views/registration_closed/show.html.erb
@@ -3,39 +3,82 @@
     <h1 class="govuk-heading-xl">
       Register for a national professional qualification (NPQ)
     </h1>
-    <p class="govuk-body">Registration for NPQs and the early headship coaching offer is now closed.</p>
-    <p class="govuk-body">You can request email updates to tell you when registration reopens.</p>
+
+    <h2 class="govuk-heading-l">
+      Registration is temporarily closed
+    </h2>
+
+    <p class="govuk-body">
+      You can register for an NPQ or the early headship coaching offer when
+      registration reopens for courses starting in autumn 2025.
+    </p>
+
+    <p class="govuk-body">
+      Sign up for email updates to find out when registration reopens. You can
+      also express interest in the special education needs coordinator (SENCO)
+      NPQ course.
+    </p>
 
     <% if current_user.persisted? %>
       <%=
         render GovukComponent::ContinueButtonComponent.new(
-          text: "Request email updates",
+          text: "Sign up for email updates",
           href: new_email_update_path,
         )
       %>
     <% else %>
       <%=
         render GovukComponent::ContinueButtonComponent.new(
-          text: "Request email updates",
+          text: "Sign up for email updates",
           href: user_tra_openid_connect_omniauth_authorize_path(request_email_updates: "true"),
           as_button: true
         )
       %>
     <% end %>
     
-    <p class="govuk-body">You’ll be asked to create a DfE Identity account or sign in to your account.</p>
+    <h3 class="govuk-heading-m">
+      How to register
+    </h3>
 
-    <p class="govuk-body">If you’re starting an NPQ course before April 2025, contact your course provider for support.</p>
+    <p class="govuk-body">
+      You'll need to:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>create a DfE Identity account or sign in to your existing account</li>
+      <li>provide a teacher reference number (TRN), even if you’re not a teacher</li>
+    </ul>
+
+
+    <p class="govuk-body">
+      If you’ve lost your TRN, use the
+        <%= govuk_link_to "Find a lost TRN",
+                          "https://find-a-lost-trn.education.gov.uk/start" %>
+        service. If you’ve never had one, use the
+        <%= govuk_link_to "Get a TRN",
+                          "https://authorise-access-to-a-teaching-record.education.gov.uk/request-trn?AccessToken=8TDf7xiqoMKATHhx" %>
+        service.
+    </p>
+
+    <p class="govuk-body">
+      If you're starting a national professional qualification (NPQ) course
+      before July 2025, contact your course provider for support.
+    </p>
 
     <h3 class="govuk-heading-m">Check your existing registrations</h3>
-    <p class="govuk-body">You can still sign in to your DfE Identity account to check your: </p>
+
+    <p class="govuk-body">
+      You can still sign in to your DfE Identity account to check your:
+    </p>
+
     <ul class="govuk-list govuk-list--bullet">
-      <li>registration details, if you already registered </li>
-      <li>course outcome, if you have completed your course </li>
+      <li>registration details, if you already registered</li>
+      <li>course outcome, if you have completed your course</li>
     </ul>
+
     <%=
       render GovukComponent::ContinueButtonComponent.new(
-        text: "Sign in to your account",
+        text: "Sign in to your DfE Identity account",
         href: user_tra_openid_connect_omniauth_authorize_path,
         classes: "govuk-button--secondary",
         as_button: true,

--- a/spec/features/service_closed_spec.rb
+++ b/spec/features/service_closed_spec.rb
@@ -11,10 +11,10 @@ RSpec.feature "Service is closed", type: :feature do
     close_registration!
 
     visit "/"
-    expect(page).to have_content("Registration for NPQs and the early headship coaching offer is now closed")
+    expect(page).to have_content("Registration is temporarily closed")
     expect(page).to be_accessible
 
-    page.click_button("Request email updates")
+    page.click_button("Sign up for email updates")
 
     expect(page).to have_current_path(new_email_update_path)
     expect(page).to have_content("Request email updates about registration opening")
@@ -50,7 +50,7 @@ RSpec.feature "Service is closed", type: :feature do
 
     scenario "Allow user to register" do
       visit "/"
-      expect(page).to have_content("Registration for NPQs and the early headship coaching offer is now closed")
+      expect(page).to have_content("Registration is temporarily closed")
 
       sign_in_as(super_admin)
 
@@ -148,7 +148,7 @@ RSpec.feature "Service is closed", type: :feature do
 
     scenario "When user is not whitelisted" do
       visit "/"
-      expect(page).to have_content("Registration for NPQs and the early headship coaching offer is now closed")
+      expect(page).to have_content("Registration is temporarily closed")
 
       visit "/closed_registration_exception"
 
@@ -163,7 +163,7 @@ RSpec.feature "Service is closed", type: :feature do
 
     scenario "Register to email and unsubscribe" do
       visit "/"
-      click_button "Sign in to your account"
+      click_button "Sign in to your DfE Identity account"
 
       visit new_email_update_path
 


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2804](https://dfedigital.atlassian.net/browse/CPDNPQ-2804)

We want to improve clarity of content for our users

### Changes proposed in this pull request

1. Content on 'start late registration' screen
2. Content on home page when registration is closed

[CPDNPQ-2804]: https://dfedigital.atlassian.net/browse/CPDNPQ-2804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ