### PR TITLE
[CPDNPQ-2753] Avoid inline styles on tracking pixels

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -35,7 +35,7 @@ module ApplicationHelper
   end
 
   def show_tracking_pixels?
-    cookies["consented-to-cookies"] == "accept"
+    Rails.configuration.x.tracking_pixels_enabled && cookies["consented-to-cookies"] == "accept"
   end
 
   def accepted?(application)

--- a/app/views/layouts/shared/_head.html.erb
+++ b/app/views/layouts/shared/_head.html.erb
@@ -20,7 +20,7 @@
 
   <%= render partial: "shared/analytics/google" %>
 
-  <% if show_tracking_pixels? && Rails.env.production? %>
+  <% if show_tracking_pixels? %>
     <%= render partial: "shared/analytics/tracking_pixels" %>
   <% end %>
 

--- a/app/views/shared/analytics/_tracking_pixels.html.erb
+++ b/app/views/shared/analytics/_tracking_pixels.html.erb
@@ -1,7 +1,11 @@
+<%= nonced_style_tag do %>
+  .tracking-pixels { display: none }
+<% end %>
+
 <!-- Meta tracking pixel code -->
-<img height="1" width="1" style="display:none" alt="" src="https://www.facebook.com/tr?id=1097336884491509&ev=PageView&noscript=1" />
+<img height="1" width="1" class=".tracking-pixels" alt="" src="https://www.facebook.com/tr?id=1097336884491509&ev=PageView&noscript=1" />
 <!-- End Meta tracking pixel code -->
 
 <!-- LinkedIn tracking pixel code -->
-<img height="1" width="1" style="display:none;" alt="" src="https://px.ads.linkedin.com/collect/?pid=3176284&fmt=gif" />
+<img height="1" width="1" class=".tracking-pixels" alt="" src="https://px.ads.linkedin.com/collect/?pid=3176284&fmt=gif" />
 <!-- End LinkedIn tracking pixel code -->

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,5 +43,7 @@ module NpqRegistration
 
     require "middleware/restore_secure_headers_request_config"
     config.middleware.use Middleware::RestoreSecureHeadersRequestConfig
+
+    config.x.tracking_pixels_enabled = ENV["TRACKING_PIXELS"].to_s == "true"
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -18,18 +18,37 @@ RSpec.describe ApplicationHelper, type: :helper do
   end
 
   describe "#show_tracking_pixels?" do
+    before do
+      allow(Rails.application.config.x)
+        .to receive(:tracking_pixels_enabled).and_return(pixels_enabled)
+    end
+
     let(:cookie_name) { "consented-to-cookies" }
 
-    context "when cookies haven't been consented to" do
-      specify "tracking pixels are disabled" do
-        expect(show_tracking_pixels?).to be(false)
+    context "when enabled in configuration" do
+      let(:pixels_enabled) { true }
+
+      context "when cookies haven't been consented to" do
+        specify "tracking pixels are disabled" do
+          expect(show_tracking_pixels?).to be(false)
+        end
+      end
+
+      context "when cookies have been consented to" do
+        specify "tracking pixels are enabled" do
+          cookies[cookie_name] = "accept"
+          expect(show_tracking_pixels?).to be(true)
+          cookies.delete(cookie_name)
+        end
       end
     end
 
-    context "when cookies have been consented to" do
+    context "when disabled by configuration" do
+      let(:pixels_enabled) { false }
+
       specify "tracking pixels are enabled" do
         cookies[cookie_name] = "accept"
-        expect(show_tracking_pixels?).to be(true)
+        expect(show_tracking_pixels?).to be(false)
         cookies.delete(cookie_name)
       end
     end


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2753](https://dfedigital.atlassian.net/browse/CPDNPQ-2753)

We want to enable CSP in production

### Changes proposed in this pull request

1. Replace use of inline styles for tracking pixels in `<head>`
2. Allow controlling whether to include tracking pixels via env var instead of hardcoding to production only, allows testing in earlier environments, including locally

[CPDNPQ-2753]: https://dfedigital.atlassian.net/browse/CPDNPQ-2753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ