### PR TITLE
NPDNPQ-2753 fix wrong class causing pixels to show

### DIFF
--- a/app/views/shared/analytics/_tracking_pixels.html.erb
+++ b/app/views/shared/analytics/_tracking_pixels.html.erb
@@ -3,9 +3,9 @@
 <% end %>
 
 <!-- Meta tracking pixel code -->
-<img height="1" width="1" class=".tracking-pixels" alt="" src="https://www.facebook.com/tr?id=1097336884491509&ev=PageView&noscript=1" />
+<img height="1" width="1" class="tracking-pixels" alt="" src="https://www.facebook.com/tr?id=1097336884491509&ev=PageView&noscript=1" />
 <!-- End Meta tracking pixel code -->
 
 <!-- LinkedIn tracking pixel code -->
-<img height="1" width="1" class=".tracking-pixels" alt="" src="https://px.ads.linkedin.com/collect/?pid=3176284&fmt=gif" />
+<img height="1" width="1" class="tracking-pixels" alt="" src="https://px.ads.linkedin.com/collect/?pid=3176284&fmt=gif" />
 <!-- End LinkedIn tracking pixel code -->


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2753](https://dfedigital.atlassian.net/browse/CPDNPQ-2753)

I used the wrong class name when changing how tracking pixels are hidden

### Changes proposed in this pull request

1. use correct name

[CPDNPQ-2753]: https://dfedigital.atlassian.net/browse/CPDNPQ-2753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ