### PR TITLE
Add change-delivery-partner documentation - v3 only

### DIFF
--- a/public/api/docs/v1/swagger.yaml
+++ b/public/api/docs/v1/swagger.yaml
@@ -234,7 +234,7 @@ paths:
                         teacher_catchment_iso_country_code: GBR
                         itt_provider: University of Southampton
                         lead_mentor: true
-                        funded_place:
+                        funded_place: 
                         created_at: '2021-05-31T02:21:32.000Z'
                         updated_at: '2021-05-31T02:22:32.000Z'
               schema:
@@ -420,7 +420,7 @@ paths:
                         course_identifier: npq-senior-leadership
                         declaration_date: '2021-05-31T02:22:32Z'
                         state: submitted
-                        has_passed:
+                        has_passed: 
                         voided: false
                         eligible_for_payment: true
                         updated_at: '2021-05-31T02:22:32.000Z'
@@ -511,7 +511,7 @@ paths:
                         course_identifier: npq-senior-leadership
                         declaration_date: '2021-05-31T02:22:32Z'
                         state: voided
-                        has_passed:
+                        has_passed: 
                         voided: true
                         eligible_for_payment: true
                         updated_at: '2021-05-31T02:22:32.000Z'
@@ -1271,7 +1271,7 @@ components:
                 being funded by DfE
               nullable: true
               type: boolean
-              example:
+              example: 
             created_at:
               description: The date the application was created
               type: string
@@ -2258,7 +2258,7 @@ components:
               description: Whether the participant has failed or passed
               type: string
               nullable: true
-              example:
+              example: 
             voided:
               description: "[Deprecated - use state instead] Indicates whether this
                 declaration has been voided"

--- a/public/api/docs/v2/swagger.yaml
+++ b/public/api/docs/v2/swagger.yaml
@@ -234,7 +234,7 @@ paths:
                         teacher_catchment_iso_country_code: GBR
                         itt_provider: University of Southampton
                         lead_mentor: true
-                        funded_place:
+                        funded_place: 
                         created_at: '2021-05-31T02:21:32.000Z'
                         updated_at: '2021-05-31T02:22:32.000Z'
               schema:
@@ -420,7 +420,7 @@ paths:
                         course_identifier: npq-senior-leadership
                         declaration_date: '2021-05-31T02:22:32Z'
                         state: submitted
-                        has_passed:
+                        has_passed: 
                         updated_at: '2021-05-31T02:22:32.000Z'
               schema:
                 "$ref": "#/components/schemas/ParticipantDeclarationResponse"
@@ -509,7 +509,7 @@ paths:
                         course_identifier: npq-senior-leadership
                         declaration_date: '2021-05-31T02:22:32Z'
                         state: voided
-                        has_passed:
+                        has_passed: 
                         updated_at: '2021-05-31T02:22:32.000Z'
               schema:
                 "$ref": "#/components/schemas/ParticipantDeclarationResponse"
@@ -1368,7 +1368,7 @@ components:
                 being funded by DfE
               nullable: true
               type: boolean
-              example:
+              example: 
             created_at:
               description: The date the application was created
               type: string
@@ -2475,7 +2475,7 @@ components:
               description: Whether the participant has failed or passed
               type: string
               nullable: true
-              example:
+              example: 
             updated_at:
               description: The date the application was last updated
               type: string

--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -214,7 +214,7 @@ paths:
                         teacher_catchment_iso_country_code: GBR
                         itt_provider: University of Southampton
                         lead_mentor: true
-                        funded_place:
+                        funded_place: 
                         created_at: '2021-05-31T02:21:32.000Z'
                         updated_at: '2021-05-31T02:22:32.000Z'
                         schedule_identifier: npq-aso-march
@@ -451,13 +451,17 @@ paths:
                         course_identifier: npq-senior-leadership
                         declaration_date: '2021-05-31T02:22:32Z'
                         state: voided
-                        has_passed:
+                        has_passed: 
                         statement_id: cd3a12347-7308-4879-942a-c4a70ced400a
-                        clawback_statement_id:
+                        clawback_statement_id: 
                         uplift_paid: true
                         lead_provider_name: Example Institute
                         ineligible_for_funding_reason: duplicate_declaration
                         created_at: '2021-05-31T02:22:32.000Z'
+                        delivery_partner_id: 524df095-f9bf-4f9d-ba4c-772545a99e60
+                        secondary_delivery_partner_id: f0de7abf-399b-4e68-83de-2c33b503810c
+                        delivery_partner_name: Foo education
+                        secondary_delivery_partner_name: Bar education
                         updated_at: '2021-05-31T02:22:32.000Z'
               schema:
                 "$ref": "#/components/schemas/ParticipantDeclarationResponse"
@@ -473,6 +477,56 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/NotFoundResponse"
+  "/api/v3/participant-declarations/{id}/change-delivery-partner":
+    put:
+      summary: Change declaration delivery partner
+      tags:
+      - Participant declarations
+      security:
+      - api_key: []
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          "$ref": "#/components/schemas/IDAttribute"
+      responses:
+        '200':
+          description: The declaration delivery partner is going to be changed
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ParticipantDeclarationResponse"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UnauthorisedResponse"
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/BadRequestResponse"
+        '422':
+          description: Unprocessable entity
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UnprocessableEntityResponse"
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/NotFoundResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ParticipantDeclarationChangeDeliveryPartnerRequest"
+        required: true
   "/api/v3/delivery-partners":
     get:
       summary: Retrieve multiple Delivery Partners
@@ -739,8 +793,8 @@ paths:
                           targeted_delivery_funding_eligibility: true
                           funded_place: true
                           email: isabelle.macdonald2@some-school.example.com
-                          withdrawal:
-                          deferral:
+                          withdrawal: 
+                          deferral: 
                           created_at: '2021-05-31T02:21:32.000Z'
                         participant_id_changes:
                         - from_participant_id: 23dd8d66-e11f-4139-9001-86b4f9abcb02
@@ -817,7 +871,7 @@ paths:
                           targeted_delivery_funding_eligibility: true
                           funded_place: true
                           email: isabelle.macdonald2@some-school.example.com
-                          withdrawal:
+                          withdrawal: 
                           deferral:
                             reason: bereavement
                             date: '2021-05-31T02:22:32.000Z'
@@ -900,7 +954,7 @@ paths:
                           withdrawal:
                             reason: insufficient-capacity-to-undertake-programme
                             date: '2021-05-31T02:22:32.000Z'
-                          deferral:
+                          deferral: 
                           created_at: '2021-05-31T02:21:32.000Z'
                         participant_id_changes:
                         - from_participant_id: 23dd8d66-e11f-4139-9001-86b4f9abcb02
@@ -1462,7 +1516,7 @@ components:
                 being funded by DfE
               nullable: true
               type: boolean
-              example:
+              example: 
             created_at:
               description: The date the application was created
               type: string
@@ -1733,7 +1787,7 @@ components:
                     required:
                     - reason
                     - date
-                    example:
+                    example: 
                     properties:
                       reason:
                         description: The reason a participant was withdrawn
@@ -1771,7 +1825,7 @@ components:
                     required:
                     - reason
                     - date
-                    example:
+                    example: 
                     properties:
                       reason:
                         description: The reason a participant was deferred
@@ -2376,7 +2430,7 @@ components:
             has_passed:
               description: Whether the participant has failed or passed
               type: string
-              example:
+              example: 
               nullable: true
             statement_id:
               description: Unique ID of the statement the declaration will be paid
@@ -2415,6 +2469,32 @@ components:
               nullable: false
               format: date-time
               example: '2021-05-31T02:22:32.000Z'
+            delivery_partner_id:
+              description: The delivery partner ID
+              type: string
+              format: uuid
+              required: true
+              nullable: true
+              example: 524df095-f9bf-4f9d-ba4c-772545a99e60
+            secondary_delivery_partner_id:
+              description: The secondary delivery partner ID
+              type: string
+              format: uuid
+              required: true
+              nullable: true
+              example: f0de7abf-399b-4e68-83de-2c33b503810c
+            delivery_partner_name:
+              description: The delivery partner name
+              type: string
+              required: true
+              nullable: true
+              example: Foo education
+            secondary_delivery_partner_name:
+              description: The secondary delivery partner name
+              type: string
+              required: true
+              nullable: true
+              example: Bar education
             updated_at:
               description: The date the application was last updated
               type: string
@@ -2439,6 +2519,85 @@ components:
           type: array
           items:
             "$ref": "#/components/schemas/ParticipantDeclaration"
+    ListDeliveryPartnersFilter:
+      description: Filter delivery partners to return more specific results
+      type: object
+      properties:
+        cohort:
+          description: Return only delivery partners from the specified cohort.
+          type: string
+          example: '2022'
+    DeliveryPartner:
+      description: A single delivery partner
+      type: object
+      required:
+      - id
+      - type
+      - attributes
+      properties:
+        id:
+          "$ref": "#/components/schemas/IDAttribute"
+        type:
+          description: The data type
+          type: string
+          example: delivery-partner
+          enum:
+          - delivery-partner
+        attributes:
+          properties:
+            name:
+              description: The name of the delivery partner
+              type: string
+              nullable: false
+              example: Awesome Delivery Partner Ltd
+            cohort:
+              description: The starting years of the cohorts the delivery partner
+                is valid for
+              type: array
+              items:
+                type: string
+                example: '2025'
+            created_at:
+              description: The date the delivery partner was created
+              type: string
+              nullable: false
+              format: date-time
+              example: '2025-03-25T02:21:32.000Z'
+            updated_at:
+              description: The date the delivery partner was last updated
+              type: string
+              nullable: false
+              format: date-time
+              example: '2025-03-25T02:22:32.000Z'
+    DeliveryPartnerResponse:
+      description: A single delivery partner
+      type: object
+      required:
+      - data
+      properties:
+        data:
+          "$ref": "#/components/schemas/DeliveryPartner"
+    DeliveryPartnersResponse:
+      description: A list of delivery partners
+      type: object
+      required:
+      - data
+      properties:
+        data:
+          type: array
+          items:
+            "$ref": "#/components/schemas/DeliveryPartner"
+    DeliveryPartnersSortingOptions:
+      description: Sort records being returned.
+      enum:
+      - name
+      - "-name"
+      - created_at
+      - "-created_at"
+      - updated_at
+      - "-updated_at"
+      default: name
+      example: created_at
     ParticipantDeclarationRequest:
       description: A participant declaration data request
       type: object
@@ -2683,82 +2842,63 @@ components:
         declaration_date: '2021-05-31T02:21:32Z'
         course_identifier: npq-senior-leadership
         has_passed: true
-    ListDeliveryPartnersFilter:
-      description: Filter delivery partners to return more specific results
-      type: object
-      properties:
-        cohort:
-          description: Return only delivery partners from the specified cohort.
-          type: string
-          example: '2022'
-    DeliveryPartner:
-      description: A single delivery partner
+    ParticipantDeclarationChangeDeliveryPartnerRequest:
+      description: A participant declaration change delivery partner request
       type: object
       required:
-      - id
-      - type
-      - attributes
+      - data
       properties:
-        id:
-          "$ref": "#/components/schemas/IDAttribute"
-        type:
-          description: The data type
-          type: string
-          example: delivery-partner
-          enum:
-          - delivery-partner
-        attributes:
+        data:
+          description: A participant declaration change delivery partner request
+          type: object
+          required:
+          - type
+          - attributes
           properties:
-            name:
-              description: The name of the delivery partner
+            type:
               type: string
-              nullable: false
-              example: Awesome Delivery Partner Ltd
-            cohort:
-              description: The starting years of the cohorts the delivery partner
-                is valid for
-              type: array
-              items:
-                type: string
-                example: '2025'
-            created_at:
-              description: The date the delivery partner was created
-              type: string
-              nullable: false
-              format: date-time
-              example: '2025-03-25T02:21:32.000Z'
-            updated_at:
-              description: The date the delivery partner was last updated
-              type: string
-              nullable: false
-              format: date-time
-              example: '2025-03-25T02:22:32.000Z'
-    DeliveryPartnerResponse:
-      description: A single delivery partner
-      type: object
-      required:
-      - data
-      properties:
-        data:
-          "$ref": "#/components/schemas/DeliveryPartner"
-    DeliveryPartnersResponse:
-      description: A list of delivery partners
-      type: object
-      required:
-      - data
-      properties:
-        data:
-          type: array
-          items:
-            "$ref": "#/components/schemas/DeliveryPartner"
-    DeliveryPartnersSortingOptions:
-      description: Sort records being returned.
-      enum:
-      - name
-      - "-name"
-      - created_at
-      - "-created_at"
-      - updated_at
-      - "-updated_at"
-      default: name
-      example: created_at
+              required: true
+              enum:
+              - participant-declaration
+              example: participant-declaration
+            attributes:
+              required: true
+              anyOf:
+              - description: An NPQ completed participant declaration
+                type: object
+                required:
+                - delivery_partner_id
+                additionalProperties: false
+                properties:
+                  participant_id:
+                    description: The unique id of the participant
+                    type: string
+                    format: uuid
+                    required: true
+                    nullable: false
+                    example: db3a7848-7308-4879-942a-c4a70ced400a
+                  declaration_type:
+                    description: The event declaration type
+                    type: string
+                    required: true
+                    nullable: false
+                    enum:
+                    - completed
+                    example: completed
+                  delivery_partner_id:
+                    description: The delivery partner ID
+                    type: string
+                    format: uuid
+                    required: true
+                    nullable: false
+                    example: 524df095-f9bf-4f9d-ba4c-772545a99e60
+                  secondary_delivery_partner_id:
+                    description: The secondary delivery partner ID
+                    type: string
+                    format: uuid
+                    required: false
+                    nullable: false
+                    example: f0de7abf-399b-4e68-83de-2c33b503810c
+                example:
+                  delivery_partner_id: db3a7848-7308-4879-942a-c4a70ced400a
+                  secondary_delivery_partner_id: f0de7abf-399b-4e68-83de-2c33b503810c

--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -459,8 +459,8 @@ paths:
                         ineligible_for_funding_reason: duplicate_declaration
                         created_at: '2021-05-31T02:22:32.000Z'
                         delivery_partner_id: 524df095-f9bf-4f9d-ba4c-772545a99e60
-                        secondary_delivery_partner_id: f0de7abf-399b-4e68-83de-2c33b503810c
                         delivery_partner_name: Foo education
+                        secondary_delivery_partner_id: f0de7abf-399b-4e68-83de-2c33b503810c
                         secondary_delivery_partner_name: Bar education
                         updated_at: '2021-05-31T02:22:32.000Z'
               schema:
@@ -2476,6 +2476,12 @@ components:
               required: true
               nullable: true
               example: 524df095-f9bf-4f9d-ba4c-772545a99e60
+            delivery_partner_name:
+              description: The delivery partner name
+              type: string
+              required: true
+              nullable: true
+              example: Foo education
             secondary_delivery_partner_id:
               description: The secondary delivery partner ID
               type: string
@@ -2483,12 +2489,6 @@ components:
               required: true
               nullable: true
               example: f0de7abf-399b-4e68-83de-2c33b503810c
-            delivery_partner_name:
-              description: The delivery partner name
-              type: string
-              required: true
-              nullable: true
-              example: Foo education
             secondary_delivery_partner_name:
               description: The secondary delivery partner name
               type: string

--- a/spec/requests/api/docs/v3/declarations_spec.rb
+++ b/spec/requests/api/docs/v3/declarations_spec.rb
@@ -4,6 +4,10 @@ require "swagger_helper"
 RSpec.describe "Participant Declarations endpoint", openapi_spec: "v3/swagger.yaml", type: :request do
   include_context "with authorization for api doc request"
 
+  before do
+    allow(Feature).to receive(:include_delivery_partners_in_declarations_api?).and_return(true)
+  end
+
   it_behaves_like "an API index endpoint documentation",
                   "/api/v3/participant-declarations",
                   "Participant declarations",
@@ -40,6 +44,43 @@ RSpec.describe "Participant Declarations endpoint", openapi_spec: "v3/swagger.ya
         end
       end
     end
+
+    describe "change delivery partner" do
+      it_behaves_like "an API update endpoint documentation",
+                      "/api/v3/participant-declarations/{id}/change-delivery-partner",
+                      "Participant declarations",
+                      "Change declaration delivery partner",
+                      "The declaration delivery partner is going to be changed",
+                      "#/components/schemas/ParticipantDeclarationResponse",
+                      "#/components/schemas/ParticipantDeclarationChangeDeliveryPartnerRequest" do
+      end
+      let(:lead_provider) { create(:lead_provider) }
+      let(:cohort) { create(:cohort, :current) }
+      let(:delivery_partner) { create(:delivery_partner, lead_providers: { cohort => lead_provider }) }
+      let(:secondary_delivery_partner) { create(:delivery_partner, lead_providers: { cohort => lead_provider }) }
+      let(:new_delivery_partner) { create(:delivery_partner, lead_providers: { cohort => lead_provider }) }
+      let(:new_secondary_delivery_partner) { create(:delivery_partner, lead_providers: { cohort => lead_provider }) }
+      let(:delivery_partner_id) { new_delivery_partner.ecf_id }
+      let(:secondary_delivery_partner_id) { new_secondary_delivery_partner.ecf_id }
+
+      let(:resource) { create(:declaration, lead_provider: lead_provider) }
+      let(:resource_id) { resource.ecf_id }
+
+      let(:service_args) { { declaration: resource, delivery_partner_id:, secondary_delivery_partner_id: } }
+
+      let(:invalid_attributes) do
+        {
+          delivery_partner_id: "foo",
+        }
+      end
+
+      let(:attributes) do
+        {
+          delivery_partner_id:,
+          secondary_delivery_partner_id:,
+        }
+      end
+    end
   end
 
   describe "create declarations" do
@@ -51,8 +92,8 @@ RSpec.describe "Participant Declarations endpoint", openapi_spec: "v3/swagger.ya
     let!(:schedule) { create(:schedule, :npq_leadership_autumn, course_group:, cohort:) }
     let(:application) { create(:application, :accepted, cohort:, course:, lead_provider:) }
     let(:declaration_date) { schedule.applies_from + 1.day }
-    let(:delivery_partner) { create(:delivery_partner) }
-    let(:secondary_delivery_partner) { create(:delivery_partner) }
+    let(:delivery_partner) { create(:delivery_partner, lead_providers: { cohort => lead_provider }) }
+    let(:secondary_delivery_partner) { create(:delivery_partner, lead_providers: { cohort => lead_provider }) }
     let(:invalid_attributes) { { participant_id: "invalid" } }
     let(:attributes) do
       {
@@ -60,8 +101,8 @@ RSpec.describe "Participant Declarations endpoint", openapi_spec: "v3/swagger.ya
         declaration_type: "started",
         declaration_date: application.schedule.applies_from.rfc3339,
         course_identifier: course.identifier,
-        delivery_partner_id: delivery_partner.id,
-        secondary_delivery_partner_id: secondary_delivery_partner.id,
+        delivery_partner_id: delivery_partner.ecf_id,
+        secondary_delivery_partner_id: secondary_delivery_partner.ecf_id,
       }
     end
 

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -111,6 +111,7 @@ RSpec.configure do |config|
       ParticipantDeclarationStartedRequest: V3_PARTICIPANT_DECLARATION_STARTED_REQUEST,
       ParticipantDeclarationRetainedRequest: V3_PARTICIPANT_DECLARATION_RETAINED_REQUEST,
       ParticipantDeclarationCompletedRequest: V3_PARTICIPANT_DECLARATION_COMPLETED_REQUEST,
+      ParticipantDeclarationChangeDeliveryPartnerRequest: V3_PARTICIPANT_DECLARATION_CHANGE_DELIVERY_PARTNER_REQUEST,
     )
   end
 

--- a/spec/swagger_schemas/models/participant_declaration.rb
+++ b/spec/swagger_schemas/models/participant_declaration.rb
@@ -149,6 +149,13 @@ PARTICIPANT_DECLARATION = {
     nullable: true,
     example: "524df095-f9bf-4f9d-ba4c-772545a99e60",
   }
+  h[:v3][:properties][:attributes][:properties][:delivery_partner_name] = {
+    description: "The delivery partner name",
+    type: :string,
+    required: true,
+    nullable: true,
+    example: "Foo education",
+  }
   h[:v3][:properties][:attributes][:properties][:secondary_delivery_partner_id] = {
     description: "The secondary delivery partner ID",
     type: :string,
@@ -156,13 +163,6 @@ PARTICIPANT_DECLARATION = {
     required: true,
     nullable: true,
     example: "f0de7abf-399b-4e68-83de-2c33b503810c",
-  }
-  h[:v3][:properties][:attributes][:properties][:delivery_partner_name] = {
-    description: "The delivery partner name",
-    type: :string,
-    required: true,
-    nullable: true,
-    example: "Foo education",
   }
   h[:v3][:properties][:attributes][:properties][:secondary_delivery_partner_name] = {
     description: "The secondary delivery partner name",

--- a/spec/swagger_schemas/models/participant_declaration.rb
+++ b/spec/swagger_schemas/models/participant_declaration.rb
@@ -141,6 +141,36 @@ PARTICIPANT_DECLARATION = {
     format: :"date-time",
     example: "2021-05-31T02:22:32.000Z",
   }
+  h[:v3][:properties][:attributes][:properties][:delivery_partner_id] = {
+    description: "The delivery partner ID",
+    type: :string,
+    format: :uuid,
+    required: true,
+    nullable: true,
+    example: "524df095-f9bf-4f9d-ba4c-772545a99e60",
+  }
+  h[:v3][:properties][:attributes][:properties][:secondary_delivery_partner_id] = {
+    description: "The secondary delivery partner ID",
+    type: :string,
+    format: :uuid,
+    required: true,
+    nullable: true,
+    example: "f0de7abf-399b-4e68-83de-2c33b503810c",
+  }
+  h[:v3][:properties][:attributes][:properties][:delivery_partner_name] = {
+    description: "The delivery partner name",
+    type: :string,
+    required: true,
+    nullable: true,
+    example: "Foo education",
+  }
+  h[:v3][:properties][:attributes][:properties][:secondary_delivery_partner_name] = {
+    description: "The secondary delivery partner name",
+    type: :string,
+    required: true,
+    nullable: true,
+    example: "Bar education",
+  }
   # Re-add updated_at to fix ordering
   updated_at = h[:v3][:properties][:attributes][:properties].delete(:updated_at)
   h[:v3][:properties][:attributes][:properties][:updated_at] = updated_at

--- a/spec/swagger_schemas/requests/v3/participant_declaration_change_delivery_partner_request.rb
+++ b/spec/swagger_schemas/requests/v3/participant_declaration_change_delivery_partner_request.rb
@@ -1,0 +1,69 @@
+V3_PARTICIPANT_DECLARATION_CHANGE_DELIVERY_PARTNER_REQUEST = {
+  description: "A participant declaration change delivery partner request",
+  type: :object,
+  required: %w[data],
+  properties: {
+    data: {
+      description: "A participant declaration change delivery partner request",
+      type: :object,
+      required: %w[type attributes],
+      properties: {
+        type: {
+          type: :string,
+          required: true,
+          enum: %w[
+            participant-declaration
+          ],
+          example: "participant-declaration",
+        },
+        attributes: {
+          required: true,
+          anyOf: [{
+            description: "An NPQ completed participant declaration",
+            type: :object,
+            required: %i[delivery_partner_id],
+            additionalProperties: false,
+            properties: {
+              participant_id: {
+                description: "The unique id of the participant",
+                type: :string,
+                format: :uuid,
+                required: true,
+                nullable: false,
+                example: "db3a7848-7308-4879-942a-c4a70ced400a",
+              },
+              declaration_type: {
+                description: "The event declaration type",
+                type: :string,
+                required: true,
+                nullable: false,
+                enum: %w[completed],
+                example: "completed",
+              },
+              delivery_partner_id: {
+                description: "The delivery partner ID",
+                type: :string,
+                format: :uuid,
+                required: true,
+                nullable: false,
+                example: "524df095-f9bf-4f9d-ba4c-772545a99e60",
+              },
+              secondary_delivery_partner_id: {
+                description: "The secondary delivery partner ID",
+                type: :string,
+                format: :uuid,
+                required: false,
+                nullable: false,
+                example: "f0de7abf-399b-4e68-83de-2c33b503810c",
+              },
+            },
+            example: {
+              delivery_partner_id: "db3a7848-7308-4879-942a-c4a70ced400a",
+              secondary_delivery_partner_id: "f0de7abf-399b-4e68-83de-2c33b503810c",
+            },
+          }],
+        },
+      },
+    },
+  },
+}.freeze


### PR DESCRIPTION
Missing fields documentation - for `declaration` response and `change-delivery-partner` endpoint:
![image](https://github.com/user-attachments/assets/eb527b30-0f3a-4656-9119-d4c26efddac8)
![image](https://github.com/user-attachments/assets/e2faf360-87d4-4bb5-94e8-3b7d6df14021)

