### PR TITLE
[CPDNPQ-2713] Downscale our production redis instance

### DIFF
--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -20,6 +20,6 @@
   "enable_logit": true,
   "deploy_redis_cache": true,
   "redis_cache_family": "P",
-  "redis_cache_capacity": 2,
+  "redis_cache_capacity": 1,
   "redis_cache_sku_name": "Premium"
 }


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2713](https://dfedigital.atlassian.net/browse/CPDNPQ-2713)

We are using a larger redis instance in production than required, downscaling will reduce costs

### Changes proposed in this pull request

1. Downscaling from a P2 instance to a P1 instance

### Notes

Rollout was tested by creating an equivalent 'real azure' redis in a review app then downscaling it and verifying there was no loss of connectivity

[CPDNPQ-2713]: https://dfedigital.atlassian.net/browse/CPDNPQ-2713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ