### PR TITLE
[CPDNPQ-2810] Extract mermaid JS bundle

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -10,8 +10,6 @@ import countryPicker from "./country-picker";
 import ittProviderPicker from "./itt-provider-picker.js";
 import cookieBanner from "./cookie-banner";
 import print from "./print";
-import mermaid from 'mermaid';
-import svgPanZoom from 'svg-pan-zoom';
 
 Rails.start();
 import * as GOVUKFrontend from 'govuk-frontend'
@@ -47,36 +45,3 @@ if (document.querySelector('#private-childcare-provider-picker')) {
     lookupPath: 'private_childcare_providers'
   })
 }
-
-mermaid.initialize({
-  startOnLoad: false,
-  theme: "base",
-  fontSize: "19px",
-  themeVariables: {
-    primaryColor: "#1D70B8",
-    primaryTextColor: "#FFFFFF",
-    primaryBorderColor: "#B1B4B6",
-    actorBorder: "#B1B4B6",
-    noteBkgColor: "#B1B4B6",
-    noteBorderColor: "#B1B4B6",
-    textColor: "#000000",
-    fontFamily: '"GDS Transport", arial, sans-serif',
-  },
-});
-
-mermaid.run({
-  querySelector: ".mermaid",
-  postRenderCallback: (id) => {
-    const svg = document.querySelector(`#${id}`)
-    const svgHeight = svg.parentElement.offsetHeight
-    svg.style.height = svgHeight
-    svgPanZoom(svg, { 
-      controlIconsEnabled: true,
-      customEventsHandler: { init: () => {
-        // Position controls in the bottom left.
-        const controls = svg.querySelector("#svg-pan-zoom-controls")
-        controls.setAttribute("transform", `translate(0, ${svgHeight - 75}) scale(0.75, 0.75)`)
-      }, destroy: () => {}},
-    })
-  }
-});

--- a/app/javascript/mermaid.js
+++ b/app/javascript/mermaid.js
@@ -1,0 +1,35 @@
+import mermaid from 'mermaid';
+import svgPanZoom from 'svg-pan-zoom';
+
+mermaid.initialize({
+  startOnLoad: false,
+  theme: "base",
+  fontSize: "19px",
+  themeVariables: {
+    primaryColor: "#1D70B8",
+    primaryTextColor: "#FFFFFF",
+    primaryBorderColor: "#B1B4B6",
+    actorBorder: "#B1B4B6",
+    noteBkgColor: "#B1B4B6",
+    noteBorderColor: "#B1B4B6",
+    textColor: "#000000",
+    fontFamily: '"GDS Transport", arial, sans-serif',
+  },
+});
+
+mermaid.run({
+  querySelector: ".mermaid",
+  postRenderCallback: (id) => {
+    const svg = document.querySelector(`#${id}`)
+    const svgHeight = svg.parentElement.offsetHeight
+    svg.style.height = svgHeight
+    svgPanZoom(svg, {
+      controlIconsEnabled: true,
+      customEventsHandler: { init: () => {
+        // Position controls in the bottom left.
+        const controls = svg.querySelector("#svg-pan-zoom-controls")
+        controls.setAttribute("transform", `translate(0, ${svgHeight - 75}) scale(0.75, 0.75)`)
+      }, destroy: () => {}},
+    })
+  }
+});

--- a/app/views/layouts/api_guidance.html.erb
+++ b/app/views/layouts/api_guidance.html.erb
@@ -1,5 +1,8 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template admin--wide">
+<% content_for :head do %>
+  <%= nonced_javascript_include_tag 'mermaid', defer: true %>
+<% end %>
 <%= render partial: "layouts/shared/head" %>
 
 <body class="govuk-template__body js-enabled <%= yield :body_class %>">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,7 @@ module.exports = {
   },
   entry: {
     application: "./app/javascript/application.js",
+    mermaid: "./app/javascript/mermaid.js",
     "swagger-ui": "./app/javascript/swagger-ui.js",
   },
   module: {


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2810

I traced [this JavaScript exception](https://dfe-teacher-services.sentry.io/issues/6566120475/?alert_rule_id=14507801&alert_type=issue&environment=production&notification_uuid=4c9efe8d-17a6-4bdf-8d8f-482d2afac58c&project=5817541&referrer=slack) to some older browsers we're mandated to support (most significantly Safari 16.1 and lower) reporting a syntax error in the outer closure of our JavaScript bundle, which stops the whole `application.js` bundle from running. The error location was misleading, it actually originates from the Mermaid library.

Mermaid is only used on API guidance pages, which have relatively little traffic and it's reasonable to assume are mostly accessed by technical people (i.e. legacy browsers less likely), so extracting Mermaid into a separate bundle and loading it only on those pages is a quick route to resolving the problem for normal service users.

This PR gets our `application.js` JavaScript working in legacy supported browsers with the exception no longer being raised, and as a bonus drastically reduces the bundle size and webpack compilation time, while keeping Mermaid where it's needed. There's a good chance this fixes [CPDNPQ-2761](https://dfedigital.atlassian.net/browse/CPDNPQ-2761), too.

[CPDNPQ-2761]: https://dfedigital.atlassian.net/browse/CPDNPQ-2761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ