### PR TITLE
[CPDNPQ-2347] Count voids (not participants with voids) in statements

### DIFF
--- a/app/services/statements/summary_calculator.rb
+++ b/app/services/statements/summary_calculator.rb
@@ -55,12 +55,7 @@ module Statements
     end
 
     def total_voided
-      statement.declarations
-               .joins(:application)
-               .select(:user_id)
-               .distinct(:user_id)
-               .where(state: "voided")
-               .count
+      statement.declarations.where(state: "voided").count
     end
 
   private

--- a/spec/services/statements/summary_calculator_spec.rb
+++ b/spec/services/statements/summary_calculator_spec.rb
@@ -267,7 +267,7 @@ RSpec.describe Statements::SummaryCalculator do
       end
 
       it "counts them" do
-        expect(subject.total_voided).to eq(2)
+        expect(subject.total_voided).to eq(3)
       end
     end
   end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2347

When we copied statement implementation from ECF, we also copied the definition of "Total Voids" as the number of participants for whom at least one void declaration was submitted, multiple voids submitted for a participant only counted once.

We now want Total Voids to be the number of void declarations submitted, regardless of the participant they relate to.