### PR TITLE
[CPDNPQ-2718] Support unicode in email address usernames

### DIFF
--- a/app/validators/notify_email_validator.rb
+++ b/app/validators/notify_email_validator.rb
@@ -4,7 +4,7 @@
 class NotifyEmailValidator < ActiveModel::EachValidator
   HOSTNAME_PART_REGEX = /\A(xn|[a-z0-9]+)(-?-[a-z0-9]+)*\z/i
   TLD_REGEX = /\A([a-z]{2,63}|xn--([a-z0-9]+-)*[a-z0-9]+)\z/i
-  EMAIL_REGEX = /\A[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~\\-]+@([^.@][^@\s]+)\z/
+  EMAIL_REGEX = /\A[\p{L}\p{N}.!#$%&'*+\/=?^_`{|}~\\-]+@([^.@][^@\s]+)\z/
 
   def validate_each(record, attribute, value)
     record.errors.add(attribute, I18n.t("errors.email.invalid")) unless NotifyEmailValidator.valid?(value)

--- a/spec/validators/notify_email_validator_spec.rb
+++ b/spec/validators/notify_email_validator_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe NotifyEmailValidator do
       firstname-lastname@domain.com
       info@german-financial-services.reallylongarbitrarytldthatiswaytoohugejustincase
       email@double--hyphen.com
+      uñicode@domain.com
     ]
     valid_email_addresses.each do |email|
       expect(user_model.new(email:)).to be_valid


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2718

Users with unicode in the username of their email address cannot use the service: the OAuth callback is unable to persist a `User` because the the email validation regex fails to match.

This PR expands the alphanumeric part of that regex to match any Unicode letter or digit.