### PR TITLE
[CPDNPQ-2767] admin console - edit and delete adjustments

### DIFF
--- a/app/components/npq_separation/admin/adjustments_table_component.html.erb
+++ b/app/components/npq_separation/admin/adjustments_table_component.html.erb
@@ -2,11 +2,12 @@
   <p class="govuk-body">There are no adjustments.</p>
 <% else %>
   <%=
-    govuk_table(classes: 'govuk-!-font-size-16') do |table|
+    govuk_table do |table|
       table.with_head do |head|
         head.with_row do |row|
           row.with_cell(text: t(".description"))
           row.with_cell(text: t(".amount"), numeric: true)
+          row.with_cell(text: t(".actions")) if show_actions
         end
       end
 
@@ -15,13 +16,21 @@
           body.with_row do |row|
             row.with_cell(text: adjustment.description)
             row.with_cell(text: number_to_currency(adjustment.amount), numeric: true)
+            row.with_cell do
+              if show_actions
+                govuk_link_to(t(".edit"), edit_npq_separation_admin_finance_statement_adjustment_path(adjustment.statement, adjustment, show_all_adjustments:)) +
+                  tag.br +
+                  govuk_link_to(t(".remove"), delete_npq_separation_admin_finance_statement_adjustment_path(adjustment.statement, adjustment, show_all_adjustments:))
+              end
+            end
           end
         end
 
         if show_total
           body.with_row do |row|
             row.with_cell(text: t(".total"), header: true)
-            row.with_cell(text: number_to_currency(adjustments.sum(&:amount)), numeric: true)
+            row.with_cell(text: number_to_currency(adjustments.sum(&:amount)), numeric: true, header: true)
+            row.with_cell
           end
         end
       end

--- a/app/components/npq_separation/admin/adjustments_table_component.rb
+++ b/app/components/npq_separation/admin/adjustments_table_component.rb
@@ -1,11 +1,13 @@
 module NpqSeparation
   module Admin
     class AdjustmentsTableComponent < ViewComponent::Base
-      attr_reader :adjustments, :show_total
+      attr_reader :adjustments, :show_total, :show_actions, :show_all_adjustments
 
-      def initialize(adjustments:, show_total: false)
+      def initialize(adjustments:, show_total: false, show_actions: false, show_all_adjustments: false)
         @adjustments = adjustments
         @show_total = show_total
+        @show_actions = show_actions
+        @show_all_adjustments = show_all_adjustments
       end
     end
   end

--- a/app/controllers/npq_separation/admin/finance/statements/adjustments_controller.rb
+++ b/app/controllers/npq_separation/admin/finance/statements/adjustments_controller.rb
@@ -3,10 +3,15 @@
 class NpqSeparation::Admin::Finance::Statements::AdjustmentsController < NpqSeparation::AdminController
   before_action :set_statement
   before_action :find_adjustment, only: %i[edit update delete destroy]
-  before_action :set_show_all_adjustments
+  before_action :set_show_all_adjustments, except: %i[create add_another]
 
   def new
     @adjustment = @statement.adjustments.new
+    @cancel_url = if @show_all_adjustments
+                    npq_separation_admin_finance_statement_adjustments_path(@statement, show_all_adjustments: @show_all_adjustments)
+                  else
+                    npq_separation_admin_finance_statement_path(@statement)
+                  end
   end
 
   def create
@@ -16,7 +21,8 @@ class NpqSeparation::Admin::Finance::Statements::AdjustmentsController < NpqSepa
 
     if @create_adjustment_form.save_adjustment
       session[:created_adjustment_ids] = @create_adjustment_form.created_adjustment_ids
-      redirect_to npq_separation_admin_finance_statement_adjustments_path(@statement)
+      show_all_adjustments = params[:adjustment][:show_all_adjustments] == "true"
+      redirect_to npq_separation_admin_finance_statement_adjustments_path(@statement, show_all_adjustments:)
     else
       @adjustment = @create_adjustment_form
       render :new
@@ -55,7 +61,8 @@ class NpqSeparation::Admin::Finance::Statements::AdjustmentsController < NpqSepa
     if @add_another_form.invalid?
       render :index, status: :unprocessable_entity
     elsif @add_another_form.adding_another_adjustment?
-      redirect_to new_npq_separation_admin_finance_statement_adjustment_path(@statement)
+      show_all_adjustments = params[:add_another_form][:show_all_adjustments] == "true"
+      redirect_to new_npq_separation_admin_finance_statement_adjustment_path(@statement, show_all_adjustments:)
     else
       session[:created_adjustment_ids] = nil
       redirect_to npq_separation_admin_finance_statement_path(@statement)

--- a/app/forms/admin/adjustments/destroy_adjustment_form.rb
+++ b/app/forms/admin/adjustments/destroy_adjustment_form.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Admin::Adjustments
+  class DestroyAdjustmentForm
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :statement
+    attribute :adjustment
+
+    validate :statement_open
+
+    delegate :id, :description, :amount, to: :adjustment
+
+    def initialize(*)
+      super
+    end
+
+    def destroy_adjustment
+      return false unless valid?
+
+      adjustment.destroy # rubocop:disable Rails/SaveBang - we don't want to raise an error if destroy fails
+
+      adjustment.destroyed?
+    end
+
+  private
+
+    def statement_open
+      return if statement.open?
+
+      errors.add(:statement, :not_open)
+    end
+  end
+end

--- a/app/forms/admin/adjustments/update_adjustment_form.rb
+++ b/app/forms/admin/adjustments/update_adjustment_form.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
 module Admin::Adjustments
-  class CreateAdjustmentForm
+  class UpdateAdjustmentForm
     include ActiveModel::Model
     include ActiveModel::Attributes
 
-    attribute :created_adjustment_ids
     attribute :statement
     attribute :description
     attribute :amount, :integer
@@ -14,34 +13,22 @@ module Admin::Adjustments
     validate :adjustment_valid
     validate :statement_open
 
+    delegate :id, to: :adjustment
+
     def initialize(*)
       super
-      self.created_adjustment_ids ||= []
     end
 
     def save_adjustment
+      adjustment.description = description
+      adjustment.amount = amount
+
       return false unless valid?
 
-      success = adjustment.save
-
-      if success
-        created_adjustment_ids << adjustment.id
-      else
-        errors.merge!(adjustment.errors)
-      end
-
-      success
-    end
-
-    def adjustments
-      statement.adjustments.where(id: created_adjustment_ids)
+      adjustment.save # rubocop:disable Rails/SaveBang - result used by caller
     end
 
   private
-
-    def adjustment
-      @adjustment ||= statement.adjustments.new(description:, amount:)
-    end
 
     def adjustment_valid
       errors.merge!(adjustment.errors) unless adjustment.valid?

--- a/app/views/npq_separation/admin/finance/statements/adjustments/_adjustment_form.html.erb
+++ b/app/views/npq_separation/admin/finance/statements/adjustments/_adjustment_form.html.erb
@@ -13,6 +13,8 @@
     prefix_text: "£",
     suffix_text: ".00" %>
 
+  <%= f.hidden_field :show_all_adjustments, value: @show_all_adjustments %>
+
   <div class="govuk-button-group">
     <%= f.govuk_submit t("shared.continue") %>
     <%= govuk_link_to t("shared.cancel"), cancel_url %>

--- a/app/views/npq_separation/admin/finance/statements/adjustments/_adjustment_form.html.erb
+++ b/app/views/npq_separation/admin/finance/statements/adjustments/_adjustment_form.html.erb
@@ -1,0 +1,20 @@
+<%= form_for @adjustment, url: url, method: method, as: :adjustment do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= f.govuk_text_field(
+      :description,
+      label: { text: "Make adjustment", tag: "h1", size: "l" },
+      hint: { text: "Describe what the adjustment is for, such as 'IT consultant fee' for example. We'll share this information with the lead provider." }
+  ) %>
+
+  <%= f.govuk_text_field :amount,
+    width: 5,
+    label: { hint: "Do not include decimal points, commas or pound signs, for example enter 19000 for £19,000." },
+    prefix_text: "£",
+    suffix_text: ".00" %>
+
+  <div class="govuk-button-group">
+    <%= f.govuk_submit t("shared.continue") %>
+    <%= govuk_link_to t("shared.cancel"), cancel_url %>
+  </div>
+<% end %>

--- a/app/views/npq_separation/admin/finance/statements/adjustments/delete.html.erb
+++ b/app/views/npq_separation/admin/finance/statements/adjustments/delete.html.erb
@@ -1,0 +1,14 @@
+<%= form_for @adjustment,
+  url: npq_separation_admin_finance_statement_adjustment_path(
+    @statement, @adjustment.id, show_all_adjustments: @show_all_adjustments
+  ), method: :delete do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <h1 class="govuk-heading-l">Are you sure you want to remove this adjustment?</h1>
+
+  <%= render NpqSeparation::Admin::AdjustmentsTableComponent.new(adjustments: [@adjustment]) %>
+
+  <%= f.govuk_submit "Remove", warning: true do %>
+    <%= govuk_link_to "Cancel", npq_separation_admin_finance_statement_adjustments_path(@statement, show_all_adjustments: @show_all_adjustments) %>
+  <% end %>
+<% end %>

--- a/app/views/npq_separation/admin/finance/statements/adjustments/edit.html.erb
+++ b/app/views/npq_separation/admin/finance/statements/adjustments/edit.html.erb
@@ -2,6 +2,6 @@
 
 <%= render partial: "npq_separation/admin/finance/statements/adjustments/adjustment_form",
   locals: {
-    url: npq_separation_admin_finance_statement_adjustments_path(@statement),
-    cancel_url: npq_separation_admin_finance_statement_path(@statement),
-    method: :post} %>
+    url: npq_separation_admin_finance_statement_adjustment_path( @statement, @adjustment.id, show_all_adjustments: @show_all_adjustments),
+    cancel_url: @cancel_url,
+    method: :put} %>

--- a/app/views/npq_separation/admin/finance/statements/adjustments/index.html.erb
+++ b/app/views/npq_separation/admin/finance/statements/adjustments/index.html.erb
@@ -15,6 +15,7 @@
         <%= f.govuk_radio_button :add_another, "yes", label: { text: "Yes" }, link_errors: true %>
         <%= f.govuk_radio_button :add_another, "no", label: { text: "No" } %>
       <% end %>
+      <%= f.hidden_field :show_all_adjustments, value: @show_all_adjustments %>
 
       <%= f.govuk_submit %>
     <% end %>

--- a/app/views/npq_separation/admin/finance/statements/adjustments/index.html.erb
+++ b/app/views/npq_separation/admin/finance/statements/adjustments/index.html.erb
@@ -1,11 +1,15 @@
-<h1 class="govuk-heading-l">You’ve made an adjustment</h1>
+<% unless @show_all_adjustments %>
+  <h1 class="govuk-heading-l">You’ve made an adjustment</h1>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @add_another_form, url: add_another_npq_separation_admin_finance_statement_adjustments_path(@statement), as: :add_another_form do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= render NpqSeparation::Admin::AdjustmentsTableComponent.new(adjustments: @adjustments) %>
+      <%= render NpqSeparation::Admin::AdjustmentsTableComponent.new(
+        adjustments: @adjustments, show_actions: true, show_all_adjustments: @show_all_adjustments
+      ) %>
 
       <%= f.govuk_radio_buttons_fieldset :add_adjustment, legend: { text: "Do you need to add another adjustment?", tag: 'h1', size: 'm' } do %>
         <%= f.govuk_radio_button :add_another, "yes", label: { text: "Yes" }, link_errors: true %>

--- a/app/views/npq_separation/admin/finance/statements/adjustments/new.html.erb
+++ b/app/views/npq_separation/admin/finance/statements/adjustments/new.html.erb
@@ -1,7 +1,7 @@
-<%= govuk_back_link href: npq_separation_admin_finance_statement_path(@statement) %>
+<%= govuk_back_link href: @cancel_url %>
 
 <%= render partial: "npq_separation/admin/finance/statements/adjustments/adjustment_form",
   locals: {
     url: npq_separation_admin_finance_statement_adjustments_path(@statement),
-    cancel_url: npq_separation_admin_finance_statement_path(@statement),
+    cancel_url: @cancel_url,
     method: :post} %>

--- a/app/views/npq_separation/admin/finance/statements/show.html.erb
+++ b/app/views/npq_separation/admin/finance/statements/show.html.erb
@@ -54,7 +54,12 @@
     <%= render NpqSeparation::Admin::AdjustmentsTableComponent.new(adjustments: @statement.adjustments, show_total: true) %>
 
     <% if @statement.open? %>
-      <%= govuk_button_link_to "Make adjustment", new_npq_separation_admin_finance_statement_adjustment_path(@statement) %>
+      <div class="govuk-button-group">
+        <%= govuk_button_link_to "Make adjustment", new_npq_separation_admin_finance_statement_adjustment_path(@statement) %>
+        <% if @statement.adjustments.any? %>
+          <%= govuk_link_to "Change or remove", npq_separation_admin_finance_statement_adjustments_path(@statement, show_all_adjustments: true) %>
+        <% end %>
+      </div>
     <% end %>
 
     <h1 class="govuk-heading-l govuk-!-margin-bottom-5">Course finance details</h1>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -263,10 +263,14 @@ en:
         checks_done: Yes, I'm ready to authorise this for payment
     errors:
       models:
-        admin/adjustments/create_adjustment_form:
+        admin/adjustments/create_adjustment_form: &create_adjustment_form
           attributes:
             statement:
               not_open: The statement has to be open for adjustments to be made
+        admin/adjustments/update_adjustment_form:
+          <<: *create_adjustment_form
+        admin/adjustments/destroy_adjustment_form:
+          <<: *create_adjustment_form
         admin/adjustments/add_another_adjustment_form:
           attributes:
             add_another:
@@ -777,6 +781,9 @@ en:
       adjustments_table_component:
         description: Description
         amount: Amount
+        actions: Actions
+        edit: Edit
+        remove: Remove
         total: Total
       finance:
         statements:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -264,9 +264,13 @@ Rails.application.routes.draw do
 
       namespace :finance do
         resources :statements, only: %i[index show] do
-          resources :adjustments, controller: "statements/adjustments", only: %i[new create index] do
+          resources :adjustments, controller: "statements/adjustments" do
             collection do
               post :add_another
+            end
+
+            member do
+              get :delete
             end
           end
 

--- a/spec/components/npq_separation/admin/adjustments_table_component_spec.rb
+++ b/spec/components/npq_separation/admin/adjustments_table_component_spec.rb
@@ -1,7 +1,9 @@
 require "rails_helper"
 
 RSpec.describe NpqSeparation::Admin::AdjustmentsTableComponent, type: :component do
-  subject { render_inline described_class.new(adjustments: adjustments, show_total: show_total) }
+  include Rails.application.routes.url_helpers
+
+  subject { render_inline described_class.new(adjustments: adjustments, show_total: show_total, show_actions: show_actions) }
 
   let(:statement) { create(:statement) }
   let(:adjustment_1) { create(:adjustment, statement:, amount: 100) }
@@ -9,6 +11,7 @@ RSpec.describe NpqSeparation::Admin::AdjustmentsTableComponent, type: :component
   let(:adjustment_3) { create(:adjustment, statement:, amount: 300) }
   let(:adjustments) { [adjustment_1, adjustment_2, adjustment_3] }
   let(:show_total) { nil }
+  let(:show_actions) { nil }
 
   describe "table of adjustments" do
     it { is_expected.to have_css "thead th", text: t(".description") }
@@ -20,6 +23,18 @@ RSpec.describe NpqSeparation::Admin::AdjustmentsTableComponent, type: :component
     it { is_expected.to have_css "tbody td", text: "£#{adjustment_2.amount}" }
     it { is_expected.to have_css "tbody td", text: adjustment_3.description }
     it { is_expected.to have_css "tbody td", text: "£#{adjustment_3.amount}" }
+
+    context "when show_actions is true" do
+      let(:show_actions) { true }
+
+      it { is_expected.to have_link t(".edit"), href: edit_npq_separation_admin_finance_statement_adjustment_path(statement, adjustment_1, show_all_adjustments: false) }
+      it { is_expected.to have_link t(".edit"), href: edit_npq_separation_admin_finance_statement_adjustment_path(statement, adjustment_2, show_all_adjustments: false) }
+      it { is_expected.to have_link t(".edit"), href: edit_npq_separation_admin_finance_statement_adjustment_path(statement, adjustment_3, show_all_adjustments: false) }
+
+      it { is_expected.to have_link t(".remove"), href: delete_npq_separation_admin_finance_statement_adjustment_path(statement, adjustment_1, show_all_adjustments: false) }
+      it { is_expected.to have_link t(".remove"), href: delete_npq_separation_admin_finance_statement_adjustment_path(statement, adjustment_2, show_all_adjustments: false) }
+      it { is_expected.to have_link t(".remove"), href: delete_npq_separation_admin_finance_statement_adjustment_path(statement, adjustment_3, show_all_adjustments: false) }
+    end
   end
 
   describe "adjustment total" do
@@ -32,7 +47,7 @@ RSpec.describe NpqSeparation::Admin::AdjustmentsTableComponent, type: :component
       let(:show_total) { true }
 
       it { is_expected.to have_css "tbody th", text: t(".total") }
-      it { is_expected.to have_css "tbody td", text: "£600" }
+      it { is_expected.to have_css "tbody th", text: "£600" }
     end
   end
 end

--- a/spec/components/npq_separation/admin/adjustments_table_component_spec.rb
+++ b/spec/components/npq_separation/admin/adjustments_table_component_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe NpqSeparation::Admin::AdjustmentsTableComponent, type: :component do
-  include Rails.application.routes.url_helpers
-
   subject { render_inline described_class.new(adjustments: adjustments, show_total: show_total, show_actions: show_actions) }
 
   let(:statement) { create(:statement) }
@@ -12,6 +10,7 @@ RSpec.describe NpqSeparation::Admin::AdjustmentsTableComponent, type: :component
   let(:adjustments) { [adjustment_1, adjustment_2, adjustment_3] }
   let(:show_total) { nil }
   let(:show_actions) { nil }
+  let(:urls) { Rails.application.routes.url_helpers }
 
   describe "table of adjustments" do
     it { is_expected.to have_css "thead th", text: t(".description") }
@@ -27,13 +26,13 @@ RSpec.describe NpqSeparation::Admin::AdjustmentsTableComponent, type: :component
     context "when show_actions is true" do
       let(:show_actions) { true }
 
-      it { is_expected.to have_link t(".edit"), href: edit_npq_separation_admin_finance_statement_adjustment_path(statement, adjustment_1, show_all_adjustments: false) }
-      it { is_expected.to have_link t(".edit"), href: edit_npq_separation_admin_finance_statement_adjustment_path(statement, adjustment_2, show_all_adjustments: false) }
-      it { is_expected.to have_link t(".edit"), href: edit_npq_separation_admin_finance_statement_adjustment_path(statement, adjustment_3, show_all_adjustments: false) }
+      it { is_expected.to have_link t(".edit"), href: urls.edit_npq_separation_admin_finance_statement_adjustment_path(statement, adjustment_1, show_all_adjustments: false) }
+      it { is_expected.to have_link t(".edit"), href: urls.edit_npq_separation_admin_finance_statement_adjustment_path(statement, adjustment_2, show_all_adjustments: false) }
+      it { is_expected.to have_link t(".edit"), href: urls.edit_npq_separation_admin_finance_statement_adjustment_path(statement, adjustment_3, show_all_adjustments: false) }
 
-      it { is_expected.to have_link t(".remove"), href: delete_npq_separation_admin_finance_statement_adjustment_path(statement, adjustment_1, show_all_adjustments: false) }
-      it { is_expected.to have_link t(".remove"), href: delete_npq_separation_admin_finance_statement_adjustment_path(statement, adjustment_2, show_all_adjustments: false) }
-      it { is_expected.to have_link t(".remove"), href: delete_npq_separation_admin_finance_statement_adjustment_path(statement, adjustment_3, show_all_adjustments: false) }
+      it { is_expected.to have_link t(".remove"), href: urls.delete_npq_separation_admin_finance_statement_adjustment_path(statement, adjustment_1, show_all_adjustments: false) }
+      it { is_expected.to have_link t(".remove"), href: urls.delete_npq_separation_admin_finance_statement_adjustment_path(statement, adjustment_2, show_all_adjustments: false) }
+      it { is_expected.to have_link t(".remove"), href: urls.delete_npq_separation_admin_finance_statement_adjustment_path(statement, adjustment_3, show_all_adjustments: false) }
     end
   end
 

--- a/spec/features/npq_separation/admin/finance/adjustments_spec.rb
+++ b/spec/features/npq_separation/admin/finance/adjustments_spec.rb
@@ -26,47 +26,44 @@ RSpec.feature "Adjustments", type: :feature do
 
     scenario "add adjustment" do
       visit(npq_separation_admin_finance_statement_path(statement))
-
       expect(page).to have_text("There are no adjustments")
 
       click_on "Make adjustment"
-
       expect(page).to have_css("h1", text: "Make adjustment")
 
+      # check cancel link
+      click_on "Cancel"
+      expect(page).to have_current_path(npq_separation_admin_finance_statement_path(statement))
+
       # check presence validation
+      click_on "Make adjustment"
       fill_in "Amount", with: ""
       click_on "Continue"
-
       expect(page).to have_text("You must enter a description for the adjustment")
       expect(page).to have_text("You must enter an adjustment amount")
 
       # check adjustment creation
-      fill_in "adjustment[description]", with: "Adjustment description"
+      fill_in "adjustment[description]", with: "First adjustment"
       fill_in "Amount", with: "100"
       click_on "Continue"
-
       expect(page).to have_css("h1", text: "You’ve made an adjustment")
-      expect(page).to have_text("Adjustment description")
+      expect(page).to have_text("First adjustment")
       expect(page).to have_text("£100")
       expect(page).to have_text("Do you need to add another adjustment?")
 
       # check "add another" radio button validation
       click_on "Continue"
-
       expect(page).to have_text("Select if you need to add another adjustment")
-
       choose "Yes", visible: :all
       click_on "Continue"
-
       expect(page).to have_css("h1", text: "Make adjustment")
 
       # check creating a second adjustment
       fill_in "adjustment[description]", with: "Second adjustment"
       fill_in "Amount", with: "200"
       click_on "Continue"
-
       expect(page).to have_css("h1", text: "You’ve made an adjustment")
-      expect(page).to have_text("Adjustment description")
+      expect(page).to have_text("First adjustment")
       expect(page).to have_text("£100")
       expect(page).to have_text("Second adjustment")
       expect(page).to have_text("£200")
@@ -77,7 +74,7 @@ RSpec.feature "Adjustments", type: :feature do
 
       # check adjustments appear on statement page
       expect(page).to have_current_path(npq_separation_admin_finance_statement_path(statement))
-      expect(page).to have_text("Adjustment description")
+      expect(page).to have_text("First adjustment")
       expect(page).to have_text("£100")
       expect(page).to have_text("Second adjustment")
       expect(page).to have_text("£200")
@@ -88,15 +85,132 @@ RSpec.feature "Adjustments", type: :feature do
 
       # add further adjustment
       click_on "Make adjustment"
-
       fill_in "adjustment[description]", with: "Third adjustment"
-      fill_in "Amount", with: "300"
+      fill_in "Amount", with: "400"
       click_on "Continue"
-
-      expect(page).not_to have_text("Adjustment description")
+      expect(page).not_to have_text("First adjustment")
       expect(page).not_to have_text("£100")
       expect(page).not_to have_text("Second adjustment")
       expect(page).not_to have_text("£200")
+      expect(page).to have_text("Third adjustment")
+      expect(page).to have_text("£400")
+
+      # check editing adjustment from adjustments list page
+      click_on "Edit"
+      # check cancel link
+      click_on "Cancel"
+      expect(page).to have_current_path(npq_separation_admin_finance_statement_adjustments_path(statement, show_all_adjustments: false))
+      # edit for real
+      click_on "Edit"
+      fill_in "adjustment[description]", with: "Third adjustment edited"
+      fill_in "Amount", with: "300"
+      click_on "Continue"
+      expect(page).not_to have_text("First adjustment")
+      expect(page).not_to have_text("£100")
+      expect(page).not_to have_text("Second adjustment")
+      expect(page).not_to have_text("£200")
+      expect(page).to have_text("Third adjustment edited")
+      expect(page).to have_text("£300")
+
+      # check deleting adjustment
+      click_on "Remove"
+      expect(page).to have_css("h1", text: "Are you sure you want to remove this adjustment?")
+      # check cancel link
+      click_on "Cancel"
+      expect(page).not_to have_text("First adjustment")
+      expect(page).not_to have_text("£100")
+      expect(page).not_to have_text("Second adjustment")
+      expect(page).not_to have_text("£200")
+      expect(page).to have_text("Third adjustment edited")
+      expect(page).to have_text("£300")
+      expect(page).to have_current_path(npq_separation_admin_finance_statement_adjustments_path(statement, show_all_adjustments: false))
+      # delete for real
+      click_on "Remove"
+      expect(page).to have_css("h1", text: "Are you sure you want to remove this adjustment?")
+      click_on "Remove"
+      expect(page).to have_text("There are no adjustments")
+
+      choose "No", visible: :all
+      click_on "Continue"
+      expect(page).to have_text("First adjustment")
+      expect(page).to have_text("£100")
+      expect(page).to have_text("Second adjustment")
+      expect(page).to have_text("£200")
+      expect(page).not_to have_text("Third adjustment edited")
+
+      # edit adjustment from statement page
+      click_on "Change or remove"
+      expect(page).not_to have_text("You’ve made an adjustment")
+      expect(page).to have_text("First adjustment")
+      expect(page).to have_text("£100")
+      expect(page).to have_text("Second adjustment")
+      expect(page).to have_text("£200")
+
+      within ".govuk-table__row:nth-of-type(2)" do
+        click_on "Edit"
+      end
+      # check cancel link
+      click_on "Cancel"
+      expect(page).to have_current_path(npq_separation_admin_finance_statement_adjustments_path(statement, show_all_adjustments: true))
+      # edit for real
+      within ".govuk-table__row:nth-of-type(2)" do
+        click_on "Edit"
+      end
+      fill_in "adjustment[description]", with: "Second adjustment edited"
+      fill_in "Amount", with: "500"
+      click_on "Continue"
+      expect(page).to have_text("Second adjustment edited")
+      expect(page).to have_text("£500")
+      expect(page).to have_text("Do you need to add another adjustment?")
+
+      choose "No", visible: :all
+      click_on "Continue"
+      expect(page).to have_text("Second adjustment edited")
+      expect(page).to have_text("£500")
+
+      # delete adjustment from statement page
+      click_on "Change or remove"
+      within ".govuk-table__row:nth-of-type(2)" do
+        click_on "Remove"
+      end
+      # check cancel link
+      click_on "Cancel"
+      expect(page).to have_current_path(npq_separation_admin_finance_statement_adjustments_path(statement, show_all_adjustments: true))
+      expect(page).to have_text("Second adjustment edited")
+      expect(page).to have_text("£500")
+      # delete for real
+      within ".govuk-table__row:nth-of-type(2)" do
+        click_on "Remove"
+      end
+      click_on "Remove"
+      expect(page).to have_text("First adjustment")
+      expect(page).to have_text("£100")
+      expect(page).not_to have_text("Second adjustment edited")
+      expect(page).not_to have_text("£500")
+
+      choose "No", visible: :all
+      click_on "Continue"
+
+      expect(page).not_to have_text("Second adjustment edited")
+      expect(page).not_to have_text("£500")
+
+      # check adding another adjustment when going via the 'Change or remove' link
+      click_on "Change or remove"
+      choose "Yes", visible: :all
+      click_on "Continue"
+      # check cancel link
+      click_on "Cancel"
+      expect(page).to have_current_path(npq_separation_admin_finance_statement_adjustments_path(statement, show_all_adjustments: true))
+      # add another for real
+      choose "Yes", visible: :all
+      click_on "Continue"
+      fill_in "adjustment[description]", with: "Fourth adjustment"
+      fill_in "Amount", with: "600"
+      click_on "Continue"
+      expect(page).to have_text("First adjustment")
+      expect(page).to have_text("£100")
+      expect(page).to have_text("Fourth adjustment")
+      expect(page).to have_text("£600")
     end
 
     scenario "statement is marked as payable" do
@@ -109,6 +223,45 @@ RSpec.feature "Adjustments", type: :feature do
       visit(npq_separation_admin_finance_statement_path(paid_statement))
 
       expect(page).not_to have_link "Make adjustment"
+    end
+
+    scenario "statement moved to payable whilst creating adjustment" do
+      visit(new_npq_separation_admin_finance_statement_adjustment_path(statement))
+
+      statement.update!(state: :payable)
+
+      fill_in "adjustment[description]", with: "new adjustment"
+      click_on "Continue"
+
+      expect(page).to have_text("The statement has to be open for adjustments to be made")
+      expect(Adjustment.count).to be_zero
+    end
+
+    scenario "statement moved to payable whilst editing adjustment" do
+      adjustment = create(:adjustment, statement:, description: "adjustment description", amount: 100)
+
+      visit(edit_npq_separation_admin_finance_statement_adjustment_path(statement, adjustment))
+
+      statement.update!(state: :payable)
+
+      fill_in "adjustment[description]", with: "adjustment edited"
+      click_on "Continue"
+
+      expect(page).to have_text("The statement has to be open for adjustments to be made")
+      expect(Adjustment.last.description).to eq("adjustment description")
+    end
+
+    scenario "statement moved to payable whilst deleting adjustment" do
+      adjustment = create(:adjustment, statement:, description: "adjustment description", amount: 100)
+
+      visit(delete_npq_separation_admin_finance_statement_adjustment_path(statement, adjustment))
+
+      statement.update!(state: :payable)
+
+      click_on "Remove"
+
+      expect(page).to have_text("The statement has to be open for adjustments to be made")
+      expect(Adjustment.count).to eq 1
     end
   end
 end

--- a/spec/forms/admin/adjustments/create_adjustment_form_spec.rb
+++ b/spec/forms/admin/adjustments/create_adjustment_form_spec.rb
@@ -23,9 +23,7 @@ RSpec.describe Admin::Adjustments::CreateAdjustmentForm, type: :model do
         expect(form.created_adjustment_ids).to include(Adjustment.last.id)
       end
 
-      it "returns true" do
-        expect(save_adjustment).to be true
-      end
+      it { is_expected.to be true }
 
       it "the form should be valid" do
         expect(form).to be_valid
@@ -40,9 +38,7 @@ RSpec.describe Admin::Adjustments::CreateAdjustmentForm, type: :model do
         expect { save_adjustment }.not_to change(statement.adjustments, :count)
       end
 
-      it "returns false" do
-        expect(save_adjustment).to be false
-      end
+      it { is_expected.to be false }
 
       it "the form should not be valid" do
         expect(form).not_to be_valid
@@ -65,9 +61,7 @@ RSpec.describe Admin::Adjustments::CreateAdjustmentForm, type: :model do
         expect { save_adjustment }.not_to change(statement.adjustments, :count)
       end
 
-      it "returns false" do
-        expect(save_adjustment).to be false
-      end
+      it { is_expected.to be false }
 
       it "the form should not be valid" do
         expect(form).not_to be_valid
@@ -89,9 +83,7 @@ RSpec.describe Admin::Adjustments::CreateAdjustmentForm, type: :model do
         expect { save_adjustment }.not_to change(statement.adjustments, :count)
       end
 
-      it "returns false" do
-        expect(save_adjustment).to be false
-      end
+      it { is_expected.to be false }
 
       it "the form should not be valid" do
         expect(form).not_to be_valid

--- a/spec/forms/admin/adjustments/destroy_adjustment_form_spec.rb
+++ b/spec/forms/admin/adjustments/destroy_adjustment_form_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::Adjustments::DestroyAdjustmentForm, type: :model do
+  let(:form) { described_class.new(statement:, adjustment:) }
+
+  let(:statement) { create(:statement) }
+  let!(:adjustment) { create(:adjustment, statement:) }
+
+  describe "#id" do
+    it "returns the adjustment ID" do
+      expect(form.id).to eq(adjustment.id)
+    end
+  end
+
+  describe "#description" do
+    it "returns the adjustment description" do
+      expect(form.description).to eq(adjustment.description)
+    end
+  end
+
+  describe "#amount" do
+    it "returns the adjustment amount" do
+      expect(form.amount).to eq(adjustment.amount)
+    end
+  end
+
+  describe "#destroy_adjustment" do
+    subject(:destroy_adjustment) { form.destroy_adjustment }
+
+    context "when the statement is open" do
+      it "returns true" do
+        expect(destroy_adjustment).to be true
+      end
+
+      it "the form should be valid" do
+        destroy_adjustment
+        expect(form).to be_valid
+      end
+
+      it "destroys the adjustment" do
+        expect { destroy_adjustment }.to change(statement.adjustments, :count).by(-1)
+      end
+    end
+
+    context "when the statement is payable" do
+      let(:statement) { create(:statement, :payable) }
+
+      it "returns false" do
+        expect(destroy_adjustment).to be false
+      end
+
+      it "the form should not be valid" do
+        destroy_adjustment
+        expect(form).not_to be_valid
+      end
+
+      it "does not destroy the adjustment" do
+        expect { destroy_adjustment }.to(not_change { Adjustment.count })
+      end
+
+      it "sets the errors from the adjustment" do
+        destroy_adjustment
+        form.valid?
+
+        expect(form.errors.messages).to include(
+          statement: ["The statement has to be open for adjustments to be made"],
+        )
+      end
+    end
+
+    context "when the statement is paid" do
+      let(:statement) { create(:statement, :paid) }
+
+      it "returns false" do
+        expect(destroy_adjustment).to be false
+      end
+
+      it "the form should not be valid" do
+        destroy_adjustment
+        expect(form).not_to be_valid
+      end
+
+      it "sets the errors from the adjustment" do
+        destroy_adjustment
+        form.valid?
+
+        expect(form.errors.messages).to include(
+          statement: ["The statement has to be open for adjustments to be made"],
+        )
+      end
+    end
+  end
+end

--- a/spec/forms/admin/adjustments/destroy_adjustment_form_spec.rb
+++ b/spec/forms/admin/adjustments/destroy_adjustment_form_spec.rb
@@ -30,9 +30,7 @@ RSpec.describe Admin::Adjustments::DestroyAdjustmentForm, type: :model do
     subject(:destroy_adjustment) { form.destroy_adjustment }
 
     context "when the statement is open" do
-      it "returns true" do
-        expect(destroy_adjustment).to be true
-      end
+      it { is_expected.to be true }
 
       it "the form should be valid" do
         destroy_adjustment
@@ -47,9 +45,7 @@ RSpec.describe Admin::Adjustments::DestroyAdjustmentForm, type: :model do
     context "when the statement is payable" do
       let(:statement) { create(:statement, :payable) }
 
-      it "returns false" do
-        expect(destroy_adjustment).to be false
-      end
+      it { is_expected.to be false }
 
       it "the form should not be valid" do
         destroy_adjustment
@@ -73,9 +69,7 @@ RSpec.describe Admin::Adjustments::DestroyAdjustmentForm, type: :model do
     context "when the statement is paid" do
       let(:statement) { create(:statement, :paid) }
 
-      it "returns false" do
-        expect(destroy_adjustment).to be false
-      end
+      it { is_expected.to be false }
 
       it "the form should not be valid" do
         destroy_adjustment

--- a/spec/forms/admin/adjustments/update_adjustment_form_spec.rb
+++ b/spec/forms/admin/adjustments/update_adjustment_form_spec.rb
@@ -2,25 +2,30 @@
 
 require "rails_helper"
 
-RSpec.describe Admin::Adjustments::CreateAdjustmentForm, type: :model do
-  let(:form) { described_class.new(created_adjustment_ids:, statement:, description:, amount:) }
+RSpec.describe Admin::Adjustments::UpdateAdjustmentForm, type: :model do
+  let(:form) { described_class.new(statement:, description:, amount:, adjustment:) }
 
-  let(:created_adjustment_ids) { nil }
   let(:statement) { create(:statement) }
-  let(:description) { "Adjustment description" }
-  let(:amount) { 100 }
+  let(:adjustment) { create(:adjustment, statement:, description: "old description", amount: 200) }
+  let(:description) { "new description" }
+  let(:amount) { 400 }
+
+  describe "#id" do
+    it "returns the adjustment ID" do
+      expect(form.id).to eq(adjustment.id)
+    end
+  end
 
   describe "#save_adjustment" do
     subject(:save_adjustment) { form.save_adjustment }
 
     context "when the adjustment is valid" do
-      it "saves the adjustment" do
-        expect { save_adjustment }.to change(statement.adjustments, :count).by(1)
+      it "updates the adjustment description" do
+        expect { save_adjustment }.to change { adjustment.reload.description }.from("old description").to("new description")
       end
 
-      it "adds the adjustment ID to the created_adjustment_ids" do
-        save_adjustment
-        expect(form.created_adjustment_ids).to include(Adjustment.last.id)
+      it "updates the adjustment amount" do
+        expect { save_adjustment }.to change { adjustment.reload.amount }.from(200).to(400)
       end
 
       it "returns true" do
@@ -33,22 +38,20 @@ RSpec.describe Admin::Adjustments::CreateAdjustmentForm, type: :model do
     end
 
     context "when the adjustment is invalid" do
-      let(:description) { nil }
+      let(:description) { "" }
       let(:amount) { nil }
-
-      it "does not save the adjustment" do
-        expect { save_adjustment }.not_to change(statement.adjustments, :count)
-      end
 
       it "returns false" do
         expect(save_adjustment).to be false
       end
 
       it "the form should not be valid" do
+        save_adjustment
         expect(form).not_to be_valid
       end
 
       it "sets the errors from the adjustment" do
+        save_adjustment
         form.valid?
 
         expect(form.errors.messages).to include(
@@ -61,19 +64,22 @@ RSpec.describe Admin::Adjustments::CreateAdjustmentForm, type: :model do
     context "when the statement is payable" do
       let(:statement) { create(:statement, :payable) }
 
-      it "does not save the adjustment" do
-        expect { save_adjustment }.not_to change(statement.adjustments, :count)
-      end
-
       it "returns false" do
         expect(save_adjustment).to be false
       end
 
       it "the form should not be valid" do
+        save_adjustment
         expect(form).not_to be_valid
       end
 
+      it "does not update the adjustment" do
+        expect { save_adjustment }.to not_change { adjustment.reload.description }
+          .and not_change(adjustment, :amount)
+      end
+
       it "sets the errors from the adjustment" do
+        save_adjustment
         form.valid?
 
         expect(form.errors.messages).to include(
@@ -85,19 +91,17 @@ RSpec.describe Admin::Adjustments::CreateAdjustmentForm, type: :model do
     context "when the statement is paid" do
       let(:statement) { create(:statement, :paid) }
 
-      it "does not save the adjustment" do
-        expect { save_adjustment }.not_to change(statement.adjustments, :count)
-      end
-
       it "returns false" do
         expect(save_adjustment).to be false
       end
 
       it "the form should not be valid" do
+        save_adjustment
         expect(form).not_to be_valid
       end
 
       it "sets the errors from the adjustment" do
+        save_adjustment
         form.valid?
 
         expect(form.errors.messages).to include(

--- a/spec/forms/admin/adjustments/update_adjustment_form_spec.rb
+++ b/spec/forms/admin/adjustments/update_adjustment_form_spec.rb
@@ -28,9 +28,7 @@ RSpec.describe Admin::Adjustments::UpdateAdjustmentForm, type: :model do
         expect { save_adjustment }.to change { adjustment.reload.amount }.from(200).to(400)
       end
 
-      it "returns true" do
-        expect(save_adjustment).to be true
-      end
+      it { is_expected.to be true }
 
       it "the form should be valid" do
         expect(form).to be_valid
@@ -41,9 +39,7 @@ RSpec.describe Admin::Adjustments::UpdateAdjustmentForm, type: :model do
       let(:description) { "" }
       let(:amount) { nil }
 
-      it "returns false" do
-        expect(save_adjustment).to be false
-      end
+      it { is_expected.to be false }
 
       it "the form should not be valid" do
         save_adjustment
@@ -64,9 +60,7 @@ RSpec.describe Admin::Adjustments::UpdateAdjustmentForm, type: :model do
     context "when the statement is payable" do
       let(:statement) { create(:statement, :payable) }
 
-      it "returns false" do
-        expect(save_adjustment).to be false
-      end
+      it { is_expected.to be false }
 
       it "the form should not be valid" do
         save_adjustment
@@ -91,9 +85,7 @@ RSpec.describe Admin::Adjustments::UpdateAdjustmentForm, type: :model do
     context "when the statement is paid" do
       let(:statement) { create(:statement, :paid) }
 
-      it "returns false" do
-        expect(save_adjustment).to be false
-      end
+      it { is_expected.to be false }
 
       it "the form should not be valid" do
         save_adjustment


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2767

### Changes proposed in this pull request

Adding the ability to edit and delete adjustments.

There are 3 different flows to consider:
* editing and deleting adjustments whilst creating them - the adjustments index page only shows the adjustments created since leaving the statement page
* editing and deleting adjustments by clicking on the 'Change or remove' link on the statement page - the adjustments index page shows all adjustments
* creating adjustments by clicking the 'Change or remove` link on the statement page, and then choosing the 'Yes' radio button - this flow means all the adjustments are shown on the adjustments index page, and also the cancel links go to back to the adjustments index page
