### PR TITLE
[CPDNPQ-2809] Fix registration closed banner link

### DIFF
--- a/app/views/layouts/shared/_header.html.erb
+++ b/app/views/layouts/shared/_header.html.erb
@@ -1,6 +1,5 @@
-<% service_url = Feature.registration_closed?(current_user) ? "/registration/closed" : "/" %>
 <%=
-  govuk_header(service_name: "Register for a national professional qualification", service_url: service_url) do |header|
+  govuk_header(service_name: "Register for a national professional qualification", service_url: root_path) do |header|
     if current_admin
       header.with_navigation_item(text: "Legacy Admin", href: admin_path)
       header.with_navigation_item(text: "Separation Admin", href: npq_separation_admin_path)


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2809

The banner (service name in the header) link currently links to /registration/closed, which has different content to /registration_closed — the ticket specifies we prefer the latter.

This PR is a quick fix for that. I removed the conditional `service_url` assignment because `RegistrationWizardController` already handles this in `before_action :registration_closed`.

n.b. I looked at removing the `/registration/closed` RegistrationWizard step altogether, but it's tangled into various spots so will take a bit more effort than this ticket allows for.