### PR TITLE
Increase Flipper limit actors

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -118,4 +118,5 @@ Rails.application.configure do
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 
   config.session_store :active_record_store, key: "_npq_registration_session", secure: true, expire_after: 2.weeks
+  config.flipper.actor_limit = 1000
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -118,5 +118,7 @@ Rails.application.configure do
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 
   config.session_store :active_record_store, key: "_npq_registration_session", secure: true, expire_after: 2.weeks
+  # increase the actor limit from the default of 100
+  # this limits the number of users that can use the late registration route
   config.flipper.actor_limit = 1000
 end


### PR DESCRIPTION
### Context

We have hit the default flipper limit of 100 on the closed registration route:
https://dfe-teacher-services.sentry.io/issues/6593675525/?referrer=slack&notification_uuid=d42a8537-a82a-4f3b-877a-094ce3abc124&environment=production&alert_rule_id=14507801&alert_type=issue

### Changes proposed in this pull request

Increase the limit to 1000