### PR TITLE
CPDNPQ-2832 Rake tasks for delivery partners

### DIFF
--- a/lib/tasks/delivery_partners.rake
+++ b/lib/tasks/delivery_partners.rake
@@ -1,0 +1,18 @@
+require "csv"
+
+namespace :delivery_partners do
+  namespace :partners do
+    desc "Export all delivery partners to a csv"
+    task :export, %i[export_file] => :environment do |_t, args|
+      raise "Export file not specified" if args[:export_file].blank?
+
+      CSV.open(args[:export_file], "w") do |csv|
+        csv << ["ECF Id", "Name"]
+
+        DeliveryPartner.order(id: :asc).find_each do |delivery_partner|
+          csv << [delivery_partner.ecf_id, delivery_partner.name]
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/delivery_partners.rake
+++ b/lib/tasks/delivery_partners.rake
@@ -4,6 +4,8 @@ namespace :delivery_partners do
   namespace :partners do
     desc "Import delivery partners from csv"
     task :import, %i[import_file dry_run] => :environment do |_t, args|
+      Rails.logger = Logger.new($stdout) unless Rails.env.test?
+
       raise "Import file not specified" if args[:import_file].blank?
       raise "Import file not present" unless File.exist?(args[:import_file])
       raise "Import file is empty" if File.size(args[:import_file]).zero?
@@ -41,6 +43,8 @@ namespace :delivery_partners do
   namespace :partnerships do
     desc "Import delivery partnerships from csv"
     task :import, %i[import_file dry_run] => :environment do |_t, args|
+      Rails.logger = Logger.new($stdout) unless Rails.env.test?
+
       raise "Import file not specified" if args[:import_file].blank?
       raise "Import file not present" unless File.exist?(args[:import_file])
       raise "Import file is empty" if File.size(args[:import_file]).zero?

--- a/lib/tasks/delivery_partners.rake
+++ b/lib/tasks/delivery_partners.rake
@@ -2,6 +2,28 @@ require "csv"
 
 namespace :delivery_partners do
   namespace :partners do
+    desc "Import delivery partners from csv"
+    task :import, %i[import_file dry_run] => :environment do |_t, args|
+      raise "Import file not specified" if args[:import_file].blank?
+      raise "Import file not present" unless File.exist?(args[:import_file])
+      raise "Import file is empty" if File.size(args[:import_file]).zero?
+
+      DeliveryPartner.transaction do
+        raise "Delivery Partners already exist" unless DeliveryPartner.count.zero?
+
+        CSV.foreach(args[:import_file], headers: true) do |row|
+          DeliveryPartner.create!(ecf_id: row["ECF Id"], name: row["Name"])
+        end
+
+        unless args[:dry_run] == "false"
+          Rails.logger.info \
+            "DRY RUN: Imported #{DeliveryPartner.count} Delivery Partners, now rolling back"
+
+          raise ActiveRecord::Rollback
+        end
+      end
+    end
+
     desc "Export all delivery partners to a csv"
     task :export, %i[export_file] => :environment do |_t, args|
       raise "Export file not specified" if args[:export_file].blank?

--- a/lib/tasks/delivery_partners.rake
+++ b/lib/tasks/delivery_partners.rake
@@ -15,4 +15,26 @@ namespace :delivery_partners do
       end
     end
   end
+
+  namespace :partnerships do
+    desc "Export all delivery partnerships to a csv"
+    task :export, %i[export_file] => :environment do |_t, args|
+      raise "Export file not specified" if args[:export_file].blank?
+
+      CSV.open(args[:export_file], "w") do |csv|
+        csv << ["Lead Provider ECF Id", "Cohort Start Year", "Delivery Partner ECF Id"]
+
+        DeliveryPartnership
+            .order(id: :asc)
+            .includes(:lead_provider, :cohort, :delivery_partner)
+            .find_each(batch_size: 500) do |partnership|
+          csv << [
+            partnership.lead_provider.ecf_id,
+            partnership.cohort.start_year,
+            partnership.delivery_partner.ecf_id,
+          ]
+        end
+      end
+    end
+  end
 end

--- a/spec/lib/tasks/delivery_partners_spec.rb
+++ b/spec/lib/tasks/delivery_partners_spec.rb
@@ -33,4 +33,49 @@ RSpec.describe "Delivery Partners rake tasks" do
       it { expect { csv_data }.to raise_exception "Export file not specified" }
     end
   end
+
+  describe "delivery_partners:partnerships:export" do
+    subject :csv_data do
+      Rake::Task["delivery_partners:partnerships:export"].invoke(csv_file)
+      CSV.read(csv_file, headers: true)
+    end
+
+    before { partnerships }
+    after { Rake::Task["delivery_partners:partnerships:export"].reenable }
+
+    let(:csv_file) { Tempfile.new.path }
+    let :partnerships do
+      create_list(:delivery_partner, 3, lead_provider: create(:lead_provider))
+        .flat_map(&:delivery_partnerships)
+    end
+
+    it { is_expected.to have_attributes length: 3 }
+
+    context "with heading row" do
+      subject { csv_data[0].to_h.keys }
+
+      let :expected_header do
+        ["Lead Provider ECF Id", "Cohort Start Year", "Delivery Partner ECF Id"]
+      end
+
+      it { is_expected.to eq expected_header }
+    end
+
+    context "with data row" do
+      subject { csv_data[0].to_h }
+
+      let(:partnership) { partnerships[0] }
+
+      it { is_expected.to have_attributes length: 3 }
+      it { is_expected.to include "Lead Provider ECF Id" => partnership.lead_provider.ecf_id }
+      it { is_expected.to include "Cohort Start Year" => partnership.cohort.start_year.to_s }
+      it { is_expected.to include "Delivery Partner ECF Id" => partnership.delivery_partner.ecf_id }
+    end
+
+    context "without specifying export file" do
+      let(:csv_file) { nil }
+
+      it { expect { csv_data }.to raise_exception "Export file not specified" }
+    end
+  end
 end

--- a/spec/lib/tasks/delivery_partners_spec.rb
+++ b/spec/lib/tasks/delivery_partners_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe "Delivery Partners rake tasks" do
+  describe "delivery_partners:partners:export" do
+    subject :csv_data do
+      Rake::Task["delivery_partners:partners:export"].invoke(csv_file)
+      CSV.read(csv_file)
+    end
+
+    before { partners }
+    after { Rake::Task["delivery_partners:partners:export"].reenable }
+
+    let(:csv_file) { Tempfile.new.path }
+    let(:partners) { create_list :delivery_partner, 3 }
+
+    it { is_expected.to have_attributes length: 4 }
+
+    context "with heading row" do
+      subject { csv_data[0] }
+
+      it { is_expected.to eq ["ECF Id", "Name"] }
+    end
+
+    context "with data row" do
+      subject { csv_data[1] }
+
+      it { is_expected.to eq [partners[0].ecf_id, partners[0].name] }
+    end
+
+    context "without specifying export file" do
+      let(:csv_file) { nil }
+
+      it { expect { csv_data }.to raise_exception "Export file not specified" }
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2832](https://dfedigital.atlassian.net/browse/CPDNPQ-2832)

We need to move delivery partner and delivery partnership data from Sandbox to Production so require a mechanism to both import and export those records

### Changes proposed in this pull request

1. Add a rake task to export all Delivery Partners to a nominated CSV file
2. Add a rake task to export all Delivery Partnerships to a nominated CSV file
3. Add a rake task to import all Delivery Partners from a nominated CSV file
4. Add a rake task to import all Delivery Partnerships from a nominated CSV file

[CPDNPQ-2832]: https://dfedigital.atlassian.net/browse/CPDNPQ-2832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ