### PR TITLE
Fix broken links in feature flags content

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -741,10 +741,10 @@ en:
         show:
           registration_open_html: |
             <p class="govuk-body">When this feature is turned on, registration is open. Users can register for an NPQ as normal.</p>
-            <p class="govuk-body">When this feature is turned off, registration is closed. Users cannot register for an NPQ, unless the <a href="/admin/features/Closed%20registration%20enabled" class="govuk-link">Closed registration enabled</a> feature is turned on to allow certain users to register late.</p>
+            <p class="govuk-body">When this feature is turned off, registration is closed. Users cannot register for an NPQ, unless the <a href="/npq-separation/admin/features/Closed%20registration%20enabled" class="govuk-link">Closed registration enabled</a> feature is turned on to allow certain users to register late.</p>
           closed_registration_enabled_html: |
             <p class="govuk-body">When this feature is turned on, specified users can register for an NPQ even when the service is closed to the general public.</p>
-            <p class="govuk-body">Use the <a href="/admin/features/Registration%20open" class="govuk-link">Registration open</a> feature flag if you need to close the service to the general public.
+            <p class="govuk-body">Use the <a href="/npq-separation/admin/features/Registration%20open" class="govuk-link">Registration open</a> feature flag if you need to close the service to the general public.
             <p class="govuk-body">To view or manage who can register while the service is closed, visit <a href="/admin/closed_registration_users" class="govuk-link">Closed registration users</a>.</p>
             <p class="govuk-body">When both the Registration open and Closed registration enabled feature flags are turned off, no one will be able to register.</p>
           targeted_support_funding_html: |

--- a/spec/features/npq_separation/admin/feature_flags_spec.rb
+++ b/spec/features/npq_separation/admin/feature_flags_spec.rb
@@ -16,6 +16,7 @@ RSpec.feature "Administering feature flags", :rack_test_driver, type: :feature d
     within("tr", text: "Registration open") do
       page.click_link("View")
     end
+    expect(page).to have_link("Closed registration enabled", href: "/npq-separation/admin/features/Closed%20registration%20enabled")
 
     expect(page).to have_current_path("/npq-separation/admin/features/Registration open")
     expect(page).to have_content("Registration open")


### PR DESCRIPTION
Moving [this code](https://github.com/DFE-Digital/npq-registration/pull/2418) has resulted in a couple of broken links in the feature flags content. Changes in this PR:

- fix 2 links
- enhance the existing feature flags spec to alert us to the presence of links in feature flags descriptions, in case the links change again