### PR TITLE
Move 'Closed registration users' to new admin console

### DIFF
--- a/app/components/npq_separation/navigation_structures/admin_navigation_structure.rb
+++ b/app/components/npq_separation/navigation_structures/admin_navigation_structure.rb
@@ -99,7 +99,7 @@ module NpqSeparation
           ) => [],
           Node.new(
             name: "Closed registration users",
-            href: "#",
+            href: npq_separation_admin_closed_registration_users_path,
             prefix: "/npq-separation/admin/closed_registration_users",
           ) => [],
         }

--- a/app/components/npq_separation/navigation_structures/admin_navigation_structure.rb
+++ b/app/components/npq_separation/navigation_structures/admin_navigation_structure.rb
@@ -97,6 +97,11 @@ module NpqSeparation
             href: "#",
             prefix: "/npq-separation/admin/settings",
           ) => [],
+          Node.new(
+            name: "Closed registration users",
+            href: "#",
+            prefix: "/npq-separation/admin/closed_registration_users",
+          ) => [],
         }
       end
 

--- a/app/controllers/npq_separation/admin/closed_registration_users_controller.rb
+++ b/app/controllers/npq_separation/admin/closed_registration_users_controller.rb
@@ -1,4 +1,4 @@
-class Admin::ClosedRegistrationUsersController < AdminController
+class NpqSeparation::Admin::ClosedRegistrationUsersController < NpqSeparation::AdminController
   def index
     @users = ClosedRegistrationUser.all
     @user = ClosedRegistrationUser.new
@@ -12,7 +12,7 @@ class Admin::ClosedRegistrationUsersController < AdminController
     @user = ClosedRegistrationUser.new(params[:closed_registration_user].permit(:email))
     if @user.save
       flash[:success] = "New closed registration user added"
-      redirect_to admin_closed_registration_users_path
+      redirect_to npq_separation_admin_closed_registration_users_path
     else
       flash[:error] = "Can not create a closed registration user"
       render :index
@@ -26,7 +26,7 @@ class Admin::ClosedRegistrationUsersController < AdminController
       Flipper.disable_actor(Feature::REGISTRATION_OPEN, user) if user
       if @user.delete
         flash[:success] = "Closed registration user was deleted"
-        redirect_to admin_closed_registration_users_path
+        redirect_to npq_separation_admin_closed_registration_users_path
       else
         flash[:error] = "Can not delete a closed registration user"
         render :index

--- a/app/views/admin/_layout.html.erb
+++ b/app/views/admin/_layout.html.erb
@@ -37,10 +37,6 @@
     <%= t(".webhook_messages") %>
   <% end %>
 
-  <% component.with_nav_item(path: "/admin/closed_registration_users") do %>
-    <%= "Closed registration users" %>
-  <% end %>
-
   <% if super_admin? %>
     <% component.with_nav_item(path: admin_admins_path) do %>
       <%= t(".admins") %>

--- a/app/views/npq_separation/admin/closed_registration_users/destroy.html.erb
+++ b/app/views/npq_separation/admin/closed_registration_users/destroy.html.erb
@@ -3,8 +3,8 @@
     <%= render "admin/layout", title: "Closed registration users" %>
     <h2 class="govuk-heading-l">Are you sure you want to remove access for <%= @user.email %>?</h2>
     <div class="govuk-button-group">
-      <%= govuk_button_link_to("Remove access", admin_closed_registration_user_path(@user), method: :delete) %>
-      <%= govuk_button_link_to("Back", admin_closed_registration_users_path, secondary: :true) %>
+      <%= govuk_button_link_to("Remove access", npq_separation_admin_closed_registration_user_path(@user), method: :delete) %>
+      <%= govuk_button_link_to("Back", npq_separation_admin_closed_registration_users_path, secondary: :true) %>
     </div>
   </div>
 </div>

--- a/app/views/npq_separation/admin/closed_registration_users/destroy.html.erb
+++ b/app/views/npq_separation/admin/closed_registration_users/destroy.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= render "admin/layout", title: "Closed registration users" %>
-    <h2 class="govuk-heading-l">Are you sure you want to remove access for <%= @user.email %>?</h2>
+    <h1 class="govuk-heading-l">Closed registration users</h1>
+    <h2 class="govuk-heading-m">Are you sure you want to remove access for <%= @user.email %>?</h2>
     <div class="govuk-button-group">
       <%= govuk_button_link_to("Remove access", npq_separation_admin_closed_registration_user_path(@user), method: :delete) %>
       <%= govuk_button_link_to("Back", npq_separation_admin_closed_registration_users_path, secondary: :true) %>

--- a/app/views/npq_separation/admin/closed_registration_users/index.html.erb
+++ b/app/views/npq_separation/admin/closed_registration_users/index.html.erb
@@ -4,7 +4,7 @@
 
     <div class="admin-search-box">
       <h2 class="govuk-heading-l">Add closed registration user</h2>
-      <%= form_for [:admin, @user] do |f| %>
+      <%= form_for [:npq_separation, :admin, @user] do |f| %>
         <%= f.govuk_error_summary %>
         <%= f.govuk_text_field :email, label: { text: "Email address" }, legend: { text: 'Provide course start date' } %>
         <%= f.govuk_submit "Add user" %>
@@ -43,7 +43,7 @@
             <% end %>
           </td>
           <td class="govuk-table__cell">
-            <%= govuk_link_to "Remove access", admin_closed_registration_user_path(user) %>
+            <%= govuk_link_to "Remove access", npq_separation_admin_closed_registration_user_path(user) %>
           </td>
         </tr>
       <% end %>

--- a/app/views/npq_separation/admin/closed_registration_users/index.html.erb
+++ b/app/views/npq_separation/admin/closed_registration_users/index.html.erb
@@ -1,7 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= render "admin/layout", title: "Closed registration users" %>
-
+    <h1 class="govuk-heading-l">Closed registration users</h1>
     <div class="admin-search-box">
       <h2 class="govuk-heading-l">Add closed registration user</h2>
       <%= form_for [:npq_separation, :admin, @user] do |f| %>

--- a/app/views/npq_separation/admin/closed_registration_users/new.html.erb
+++ b/app/views/npq_separation/admin/closed_registration_users/new.html.erb
@@ -4,7 +4,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= render "admin/layout", title: "Settings" %>
-    <%= form_for [:admin, @user] do |f| %>
+    <%= form_for [:npq_separation, :admin, @user] do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_text_field :email,  legend: { text: 'Provide course start date' } %>
       <%= f.govuk_submit "Save" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,13 +75,6 @@ Rails.application.routes.draw do
       resources :processing_jobs, only: %i[create], controller: "webhook_messages/processing_jobs"
     end
 
-    resources :closed_registration_users do
-      member do
-        get "destroy"
-        delete "destroy"
-      end
-    end
-
     resources :reopening_email_subscriptions do
       member do
         get "unsubscribe"
@@ -221,6 +214,13 @@ Rails.application.routes.draw do
       resources :features, only: %i[index show update]
       namespace :dashboards do
         resource :summary, only: :show, controller: "summary"
+      end
+
+      resources :closed_registration_users do
+        member do
+          get "destroy"
+          delete "destroy"
+        end
       end
 
       resources :applications, only: %i[index show] do

--- a/spec/features/service_closed_spec.rb
+++ b/spec/features/service_closed_spec.rb
@@ -101,9 +101,7 @@ RSpec.feature "Service is closed", type: :feature do
         expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
       end
 
-      visit "/admin"
-
-      click_link("Closed registration user")
+      visit "/npq-separation/admin/closed_registration_users"
 
       click_link("Remove access")
       click_link("Remove access")

--- a/spec/features/service_closed_spec.rb
+++ b/spec/features/service_closed_spec.rb
@@ -54,8 +54,8 @@ RSpec.feature "Service is closed", type: :feature do
 
       sign_in_as(super_admin)
 
-      click_link("Closed registration user")
-      fill_in("Email", with: email)
+      visit "/npq-separation/admin/closed_registration_users"
+      fill_in("Email address", with: email)
       click_on("Add user")
 
       expect(page).to have_content("New closed registration user added")
@@ -87,7 +87,7 @@ RSpec.feature "Service is closed", type: :feature do
 
       sign_in_as(super_admin)
 
-      click_link("Closed registration user")
+      visit "/npq-separation/admin/closed_registration_users"
       fill_in("Email", with: email)
       click_on("Add user")
 
@@ -126,7 +126,7 @@ RSpec.feature "Service is closed", type: :feature do
 
       sign_in_as(super_admin)
 
-      click_link("Closed registration user")
+      visit "/npq-separation/admin/closed_registration_users"
       fill_in("Email", with: other_email)
       click_on("Add user")
 


### PR DESCRIPTION
Ticket:

https://dfedigital.atlassian.net/browse/CPDNPQ-2769

We're gradually moving sections of the old admin console to the new admin console. This PR covers moving the 'Closed registration users' section. 

| Description              | Before | After |
| :---------------- | :------: | :----: |
| 'Closed registration users' is currently in the 'Legacy Admin' area - this PR moves it to the 'Separation Admin' area        |   ![Screenshot 2025-05-13 at 14 38 27](https://github.com/user-attachments/assets/ba4afb7f-a064-4fa4-b5a5-629affa60ac3)   | ![Screenshot 2025-05-13 at 14 35 41](https://github.com/user-attachments/assets/f105bd37-1d12-4955-b620-30e7bb023aff) |




