### PR TITLE
[CPDNPQ-2713] Swap back to memory store for now for non-prod environments

### DIFF
--- a/config/environments/review.rb
+++ b/config/environments/review.rb
@@ -2,6 +2,7 @@ require Rails.root.join("config/environments/production")
 
 Rails.application.configure do
   config.ssl_options = { redirect: { exclude: ->(request) { request.path.include?("/healthcheck") } } }
+  config.cache_store = :memory_store
 
   config.after_initialize do
     Bullet.enable                       = true

--- a/config/environments/sandbox.rb
+++ b/config/environments/sandbox.rb
@@ -3,4 +3,5 @@ require Rails.root.join("config/environments/production")
 Rails.application.configure do
   config.log_level = :info
   config.ssl_options = { redirect: { exclude: ->(request) { request.path.include?("/healthcheck") } } }
+  config.cache_store = :memory_store
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -3,4 +3,5 @@ require Rails.root.join("config/environments/production")
 Rails.application.configure do
   config.log_level = :debug
   config.ssl_options = { redirect: { exclude: ->(request) { request.path.include?("/healthcheck") } } }
+  config.cache_store = :memory_store
 end


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2713](https://dfedigital.atlassian.net/browse/CPDNPQ-2713)

When the new redis is created its not actually functional initially

### Changes proposed in this pull request

1. Swap back to using memory store so the app continues to work even though redis isn't functional

[CPDNPQ-2713]: https://dfedigital.atlassian.net/browse/CPDNPQ-2713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ