### PR TITLE
[CPDNPQ-2713] Use redis for cache in sandbox environment

### DIFF
--- a/config/environments/sandbox.rb
+++ b/config/environments/sandbox.rb
@@ -3,5 +3,4 @@ require Rails.root.join("config/environments/production")
 Rails.application.configure do
   config.log_level = :info
   config.ssl_options = { redirect: { exclude: ->(request) { request.path.include?("/healthcheck") } } }
-  config.cache_store = :memory_store
 end


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2713](https://dfedigital.atlassian.net/browse/CPDNPQ-2713)

We want to use redis for the rails cache in sandbox environment

### Changes proposed in this pull request

1. Removed the overrides to use the memory store for `sandbox`

[CPDNPQ-2713]: https://dfedigital.atlassian.net/browse/CPDNPQ-2713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ