### PR TITLE
[BAU] Use rails 7.1 defaults

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -18,7 +18,7 @@ Bundler.require(*Rails.groups)
 module NpqRegistration
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 7.0
+    config.load_defaults 7.1
 
     config.exceptions_app = routes
 


### PR DESCRIPTION
### Context

Ticket: BAU

We are using the Rails 7.1 framework and should use those defaults

### Changes proposed in this pull request

1. Change from using the rails 7.0 defaults to the rails 7.1 defaults

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
