### PR TITLE
CPDNPQ-2753 Disable nonce compat and allow plain text style

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -29,9 +29,10 @@ SecureHeaders::Configuration.default do |config|
   config.csp = SecureHeaders::OPT_OUT
 
   config.csp_report_only = {
+    upgrade_insecure_requests: true,
+    disable_nonce_backwards_compatibility: true,
     default_src: %w['none'],
     base_uri: %w['self'],
-    upgrade_insecure_requests: true,
     child_src: %w['self'],
     connect_src: %w['self'] + google_analytics + flippercloud + sentry,
     font_src: %w['self' *.gov.uk fonts.gstatic.com],

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -21,16 +21,18 @@ SecureHeaders::Configuration.default do |config|
     sentry += [URI(sentry_report_uri).host]
   end
 
+  # These are for the inline CSS in the flipper admin UI
   flipper_ui_hashes = %w[
     'sha256-NNzAJMHPK9KuPslppuoTz2azqZcpUO0IJZosehbmhHA='
     'sha256-zuOhDbTpAZjaeemuptCNLaf/7IaV06c8De4EMGOhtzM='
   ]
 
-  non_html_inline_style_hash = %w[
+  # This is for the inline style browsers apply to robots.txt file
+  robots_txt_inline_style_hash = %w[
     'sha256-4Su6mBWzEIFnH4pAGMOuaeBrstwJN4Z3pq/s1Kn4/KQ='
   ]
 
-  all_hashes = flipper_ui_hashes + non_html_inline_style_hash
+  all_hashes = flipper_ui_hashes + robots_txt_inline_style_hash
 
   config.csp = SecureHeaders::OPT_OUT
 

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -26,6 +26,12 @@ SecureHeaders::Configuration.default do |config|
     'sha256-zuOhDbTpAZjaeemuptCNLaf/7IaV06c8De4EMGOhtzM='
   ]
 
+  non_html_inline_style_hash = %w[
+    'sha256-4Su6mBWzEIFnH4pAGMOuaeBrstwJN4Z3pq/s1Kn4/KQ='
+  ]
+
+  all_hashes = flipper_ui_hashes + non_html_inline_style_hash
+
   config.csp = SecureHeaders::OPT_OUT
 
   config.csp_report_only = {
@@ -43,7 +49,7 @@ SecureHeaders::Configuration.default do |config|
     manifest_src: %w['self'],
     media_src: %w['self'],
     script_src: %w['self' *.gov.uk https://cdn.jsdelivr.net/npm/chart.js] + google_analytics + sentry,
-    style_src: %w['self' *.gov.uk fonts.googleapis.com] + google_analytics + %w['unsafe-hashes'] + flipper_ui_hashes,
+    style_src: %w['self' *.gov.uk fonts.googleapis.com] + google_analytics + %w['unsafe-hashes'] + all_hashes,
     worker_src: %w['self'],
     report_uri: [sentry_report_uri],
   }


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2753](https://dfedigital.atlassian.net/browse/CPDNPQ-2753)

We want a working content security policy which we can turn into enforcement mode

### Changes proposed in this pull request

1. Drop the old `insecure-inline` option from SecureHeaders output - this is for backwards compatibility but shouldn't be needed in 2025.
2. Add a hash for the default inline styling applied to plain text files in browsers. If robots.txt is crawled using a browser (likely chrome) then this will trigger an error whenever its called. Adding the hash solves that

[CPDNPQ-2753]: https://dfedigital.atlassian.net/browse/CPDNPQ-2753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ