### PR TITLE
[CPDNPQ-2861] Include delivery_partner_id in the declarations example

### DIFF
--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -2693,6 +2693,7 @@ components:
         declaration_type: started
         declaration_date: '2021-05-31T02:21:32Z'
         course_identifier: npq-senior-leadership
+        delivery_partner_id: 524df095-f9bf-4f9d-ba4c-772545a99e60
     ParticipantDeclarationRetainedRequest:
       description: An NPQ participant retained declaration
       type: object

--- a/spec/swagger_schemas/requests/v3/participant_declaration_started_request.rb
+++ b/spec/swagger_schemas/requests/v3/participant_declaration_started_request.rb
@@ -65,5 +65,6 @@ V3_PARTICIPANT_DECLARATION_STARTED_REQUEST = {
     declaration_type: "started",
     declaration_date: "2021-05-31T02:21:32Z",
     course_identifier: Course::IDENTIFIERS.first,
+    delivery_partner_id: "524df095-f9bf-4f9d-ba4c-772545a99e60",
   },
 }.freeze


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2861](https://dfedigital.atlassian.net/browse/CPDNPQ-2861)

Most declarations going forward will require a `delivery_partner_id` so it makes sense to include it in the example

### Changes proposed in this pull request

1. Include `delivery_partner_id` in the api docs example for creating a new declaration


[CPDNPQ-2861]: https://dfedigital.atlassian.net/browse/CPDNPQ-2861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ