### PR TITLE
[CPDNPQ-2753] More tweaks to content security policy

### DIFF
--- a/app/views/layouts/api_docs.html.erb
+++ b/app/views/layouts/api_docs.html.erb
@@ -1,6 +1,6 @@
 <% content_for :head do %>
-  <%= javascript_include_tag "swagger-ui", defer: true %>
-  <%= stylesheet_link_tag "swagger-ui", media: "all" %>
+  <%= nonced_javascript_include_tag "swagger-ui", defer: true %>
+  <%= nonced_stylesheet_link_tag "swagger-ui", media: "all" %>
 <% end %>
 
 <!DOCTYPE html>

--- a/app/views/layouts/api_docs.html.erb
+++ b/app/views/layouts/api_docs.html.erb
@@ -9,6 +9,11 @@
 
   <body class="govuk-template__body js-enabled <%= yield :body_class %>">
     <%= render partial: "layouts/shared/govuk_javascript" %>
+
+    <% if show_tracking_pixels? %>
+      <%= render partial: "shared/analytics/tracking_pixels" %>
+    <% end %>
+
     <%= render partial: "shared/analytics/google_noscript" %>
 
     <%= nonced_javascript_tag do %>

--- a/app/views/layouts/api_guidance.html.erb
+++ b/app/views/layouts/api_guidance.html.erb
@@ -8,6 +8,10 @@
 <body class="govuk-template__body js-enabled <%= yield :body_class %>">
   <%= render partial: "layouts/shared/govuk_javascript" %>
 
+  <% if show_tracking_pixels? %>
+    <%= render partial: "shared/analytics/tracking_pixels" %>
+  <% end %>
+
   <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 
   <%= render partial: "layouts/api_guidance/header" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,11 @@
 
   <body class="govuk-template__body ">
     <%= render partial: "shared/analytics/google_noscript" %>
+
+    <% if show_tracking_pixels? %>
+      <%= render partial: "shared/analytics/tracking_pixels" %>
+    <% end %>
+
     <%= render partial: "layouts/shared/govuk_javascript" %>
 
     <%= render partial: "shared/cookies/banner" %>

--- a/app/views/layouts/shared/_head.html.erb
+++ b/app/views/layouts/shared/_head.html.erb
@@ -24,10 +24,6 @@
 
   <%= render partial: "shared/analytics/google" %>
 
-  <% if show_tracking_pixels? %>
-    <%= render partial: "shared/analytics/tracking_pixels" %>
-  <% end %>
-
   <%= yield :head %>
 
   <% if Rails.env.development? %>

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -72,7 +72,7 @@ SecureHeaders::Configuration.default do |config|
     form_action: %w['self'] + identity_domain, # needed because the POST to /users/auth/tra_openid_connect' redirects to the identity domain
     frame_ancestors: %w['self'],
     frame_src: %w['self'] + google_analytics,
-    img_src: %w['self' data: *.gov.uk] + google_analytics + tracking_pixels,
+    img_src: %w['self' *.gov.uk] + google_analytics + tracking_pixels + %w[data:],
     manifest_src: %w['self'],
     media_src: %w['self'],
     script_src: %w['self' *.gov.uk https://cdn.jsdelivr.net/npm/chart.js] + google_analytics + sentry,


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2753

We are still getting reports through for the tracking pixels, this is a bit of an experiment to see if different ordering will help. I doubt it will but it shouldn't cause any issues either

### Changes proposed in this pull request

1. Moved `data:` to end of `img_src` in content security policy
2. Added nonces to the swagger srcs
3. Moved tracking img's out of head - they aren't legimate in a HEAD tag anyway so shouldn't be there - maybe that might relate to the CSP errors?