### PR TITLE
[BAU] Improve error message from have_component matcher

### DIFF
--- a/spec/support/matchers/component_matcher.rb
+++ b/spec/support/matchers/component_matcher.rb
@@ -1,11 +1,22 @@
 RSpec::Matchers.define :have_component do |expected_component|
   match do |page|
-    expected_html = ApplicationController.renderer.render(expected_component, layout: false)
+    actual_html(page).include? expected_html(expected_component)
+  end
 
-    if page.is_a? ActiveSupport::SafeBuffer
-      page.include?(expected_html)
-    else
-      page.html.include?(expected_html)
-    end
+  failure_message do |page|
+    [
+      "expected to find",
+      expected_html(expected_component),
+      "within page content",
+      actual_html(page),
+    ].join("\n\n")
+  end
+
+  def expected_html(component)
+    ApplicationController.renderer.render(component, layout: false)
+  end
+
+  def actual_html(page)
+    page.is_a?(ActiveSupport::SafeBuffer) ? page : page.html
   end
 end


### PR DESCRIPTION
### Context

Ticket: BAU

We have a flaky spec which is failing on a call to the have_component matcher and its proving difficult to understand the source of the failure.

Improving the error message will help debug future occurrances of this flaky spec

### Changes proposed in this pull request

1. Improved the error message for the `have_component` rspec matcher

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
