### PR TITLE
[CPDNPQ-2566] Add review status to Applications

### DIFF
--- a/app/controllers/npq_separation/admin/applications/reviews_controller.rb
+++ b/app/controllers/npq_separation/admin/applications/reviews_controller.rb
@@ -42,8 +42,7 @@ module NpqSeparation
         end
 
         def review_scope
-          Application.where(employment_type: employment_types)
-                     .or(Application.where(referred_by_return_to_teaching_adviser: "yes"))
+          Application.for_manual_review
         end
 
         def filter_scope

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -80,6 +80,13 @@ class Application < ApplicationRecord
     withdrawn: "withdrawn",
   }, _suffix: true
 
+  enum :review_status, {
+    needs_review: "needs_review",
+    awaiting_information: "awaiting_information",
+    reregister: "reregister",
+    decision_made: "decision_made",
+  }, suffix: true
+
   validates :funded_place, inclusion: { in: [true, false] }, if: :validate_funded_place?
   validate :eligible_for_funded_place
   validate :validate_permitted_schedule_for_course

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -35,6 +35,7 @@ class Application < ApplicationRecord
   scope :accepted, -> { where(lead_provider_approval_status: "accepted") }
   scope :eligible_for_funding, -> { where(eligible_for_funding: true) }
   scope :with_targeted_delivery_funding_eligibility, -> { where(targeted_delivery_funding_eligibility: true) }
+  scope :for_manual_review, -> { where.not(review_status: nil) }
 
   attr_accessor :version_note, :skip_touch_user_if_changed
 

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -254,6 +254,7 @@ shared:
     - senco_in_role
     - senco_start_date
     - on_submission_trn
+    - review_status
   :users:
     - id
     - created_at

--- a/db/migrate/20250521091744_add_review_status_to_applications.rb
+++ b/db/migrate/20250521091744_add_review_status_to_applications.rb
@@ -1,0 +1,14 @@
+class AddReviewStatusToApplications < ActiveRecord::Migration[7.1]
+  def up
+    create_enum :review_statuses,
+                %w[needs_review awaiting_information reregister decision_made]
+
+    add_column :applications, :review_status, :enum, enum_type: "review_statuses",
+                                                     null: true
+  end
+
+  def down
+    remove_column :applications, :review_status
+    drop_enum :review_statuses
+  end
+end

--- a/db/migrate/20250521091744_add_review_status_to_applications.rb
+++ b/db/migrate/20250521091744_add_review_status_to_applications.rb
@@ -5,6 +5,21 @@ class AddReviewStatusToApplications < ActiveRecord::Migration[7.1]
 
     add_column :applications, :review_status, :enum, enum_type: "review_statuses",
                                                      null: true
+
+    safety_assured do
+      execute <<~SQL
+        UPDATE applications
+        SET review_status='decision_made'
+        WHERE
+          referred_by_return_to_teaching_adviser='yes'
+          OR
+          "employment_type" IN (
+            'hospital_school', 'lead_mentor_for_accredited_itt_provider',
+            'local_authority_supply_teacher', 'local_authority_virtual_school',
+            'young_offender_institution', 'other'
+          )
+      SQL
+    end
   end
 
   def down

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_05_19_144551) do
+ActiveRecord::Schema[7.1].define(version: 2025_05_21_091744) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -29,6 +29,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_19_144551) do
   create_enum "kind_of_nurseries", ["local_authority_maintained_nursery", "preschool_class_as_part_of_school", "private_nursery", "another_early_years_setting", "childminder"]
   create_enum "lead_provider_approval_statuses", ["pending", "accepted", "rejected"]
   create_enum "outcome_states", ["passed", "failed", "voided"]
+  create_enum "review_statuses", ["needs_review", "awaiting_information", "reregister", "decision_made"]
   create_enum "statement_item_states", ["eligible", "payable", "paid", "voided", "ineligible", "awaiting_clawback", "clawed_back"]
   create_enum "statement_states", ["open", "payable", "paid"]
 
@@ -155,6 +156,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_19_144551) do
     t.string "senco_in_role"
     t.date "senco_start_date"
     t.string "on_submission_trn"
+    t.enum "review_status", enum_type: "review_statuses"
     t.index ["cohort_id"], name: "index_applications_on_cohort_id"
     t.index ["course_id"], name: "index_applications_on_course_id"
     t.index ["ecf_id"], name: "index_applications_on_ecf_id", unique: true

--- a/spec/factories/applications.rb
+++ b/spec/factories/applications.rb
@@ -146,5 +146,9 @@ FactoryBot.define do
     trait :lead_mentor do
       lead_mentor { true }
     end
+
+    trait :manual_review do
+      review_status { :needs_review }
+    end
   end
 end

--- a/spec/factories/registration_wizard_store.rb
+++ b/spec/factories/registration_wizard_store.rb
@@ -6,9 +6,9 @@ FactoryBot.define do
       course { create(Course::IDENTIFIERS.first.to_sym) }
       school { create(:school, :funding_eligible_establishment_type_code) }
       lead_provider { LeadProvider.first }
-      current_user { create(:user) }
     end
 
+    current_user { create(:user) }
     course_identifier { course.identifier }
     institution_identifier { "School-#{school.urn}" }
     lead_provider_id { lead_provider.id }

--- a/spec/features/journeys/happy_paths/able_to_receive_targeted_delivery_funding_spec.rb
+++ b/spec/features/journeys/happy_paths/able_to_receive_targeted_delivery_funding_spec.rb
@@ -158,6 +158,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
+      "review_status" => nil,
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",

--- a/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
@@ -189,6 +189,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
+      "review_status" => nil,
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",

--- a/spec/features/journeys/happy_paths/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
@@ -206,6 +206,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
+      "review_status" => nil,
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",

--- a/spec/features/journeys/happy_paths/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
@@ -220,6 +220,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
+      "review_status" => "needs_review",
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",

--- a/spec/features/journeys/happy_paths/changing_from_outside_of_catchment_area_to_inside_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_from_outside_of_catchment_area_to_inside_spec.rb
@@ -207,6 +207,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
+      "review_status" => nil,
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",

--- a/spec/features/journeys/happy_paths/changing_npq_to_one_leadprovider_no_longer_supports_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_npq_to_one_leadprovider_no_longer_supports_spec.rb
@@ -222,6 +222,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
+      "review_status" => nil,
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",

--- a/spec/features/journeys/happy_paths/funded_ehco_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/funded_ehco_registration_journey_spec.rb
@@ -192,6 +192,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
+      "review_status" => nil,
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",

--- a/spec/features/journeys/happy_paths/international_teacher_npqh_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/international_teacher_npqh_journey_spec.rb
@@ -162,6 +162,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
+      "review_status" => nil,
       "raw_application_data" => {
         "email_template" => "not_england_wrong_catchment",
         "lead_provider_id" => LeadProvider.find_by(name: "Teach First").id.to_s,

--- a/spec/features/journeys/happy_paths/other_funded_ehco_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/other_funded_ehco_registration_journey_spec.rb
@@ -190,6 +190,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
+      "review_status" => nil,
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",

--- a/spec/features/journeys/happy_paths/previously_received_targeted_delivery_funding_spec.rb
+++ b/spec/features/journeys/happy_paths/previously_received_targeted_delivery_funding_spec.rb
@@ -158,6 +158,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
+      "review_status" => nil,
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",

--- a/spec/features/journeys/happy_paths/via_using_old_name_and_not_headship_spec.rb
+++ b/spec/features/journeys/happy_paths/via_using_old_name_and_not_headship_spec.rb
@@ -155,6 +155,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
+      "review_status" => nil,
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",

--- a/spec/features/journeys/happy_paths/via_using_same_name_spec.rb
+++ b/spec/features/journeys/happy_paths/via_using_same_name_spec.rb
@@ -173,6 +173,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
+      "review_status" => nil,
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",

--- a/spec/features/journeys/happy_paths/when_choose_lead_mentor_course_spec.rb
+++ b/spec/features/journeys/happy_paths/when_choose_lead_mentor_course_spec.rb
@@ -191,6 +191,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
+      "review_status" => nil,
       "raw_application_data" => {
         "targeted_delivery_funding_eligibility" => false,
         "email_template" => "eligible_scholarship_funding_not_tsf",

--- a/spec/features/journeys/happy_paths/when_choose_maths_course_spec.rb
+++ b/spec/features/journeys/happy_paths/when_choose_maths_course_spec.rb
@@ -201,6 +201,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
+      "review_status" => nil,
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",

--- a/spec/features/journeys/happy_paths/when_get_an_identity_returns_no_trn_spec.rb
+++ b/spec/features/journeys/happy_paths/when_get_an_identity_returns_no_trn_spec.rb
@@ -221,6 +221,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => manually_entered_trn,
+      "review_status" => nil,
       "raw_application_data" => {
         "active_alert" => false,
         "can_share_choices" => "1",

--- a/spec/features/journeys/happy_paths/when_outside_of_catchment_area_crown_dependencies_spec.rb
+++ b/spec/features/journeys/happy_paths/when_outside_of_catchment_area_crown_dependencies_spec.rb
@@ -154,6 +154,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
+      "review_status" => nil,
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",

--- a/spec/features/journeys/happy_paths/when_outside_of_catchment_area_spec.rb
+++ b/spec/features/journeys/happy_paths/when_outside_of_catchment_area_spec.rb
@@ -149,6 +149,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
+      "review_status" => nil,
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",

--- a/spec/features/journeys/happy_paths/when_previously_funded_spec.rb
+++ b/spec/features/journeys/happy_paths/when_previously_funded_spec.rb
@@ -199,6 +199,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
+      "review_status" => nil,
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",

--- a/spec/features/journeys/happy_paths/when_referred_by_return_to_teaching_adviser_spec.rb
+++ b/spec/features/journeys/happy_paths/when_referred_by_return_to_teaching_adviser_spec.rb
@@ -143,6 +143,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
+      "review_status" => "needs_review",
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",

--- a/spec/features/journeys/happy_paths/when_working_at_an_eligible_primary_school_spec.rb
+++ b/spec/features/journeys/happy_paths/when_working_at_an_eligible_primary_school_spec.rb
@@ -188,6 +188,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
+      "review_status" => nil,
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",

--- a/spec/features/journeys/happy_paths/when_working_in_other_spec.rb
+++ b/spec/features/journeys/happy_paths/when_working_in_other_spec.rb
@@ -152,6 +152,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
+      "review_status" => nil,
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",

--- a/spec/features/journeys/happy_paths/while_not_currently_working_at_school_spec.rb
+++ b/spec/features/journeys/happy_paths/while_not_currently_working_at_school_spec.rb
@@ -153,6 +153,7 @@ RSpec.feature "Happy journeys",
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
+      "review_status" => nil,
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",

--- a/spec/features/journeys/happy_paths/while_working_at_private_childcare_provider_but_not_a_nursery_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_at_private_childcare_provider_but_not_a_nursery_spec.rb
@@ -183,6 +183,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
+      "review_status" => nil,
       "raw_application_data" => {
         "email_template" => "eligible_scholarship_funding_not_tsf",
         "funding_eligiblity_status_code" => "funded",

--- a/spec/features/journeys/happy_paths/while_working_at_private_nursery_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_at_private_nursery_spec.rb
@@ -181,6 +181,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
+      "review_status" => nil,
       "raw_application_data" => {
         "targeted_delivery_funding_eligibility" => false,
         "email_template" => "eligible_scholarship_funding_not_tsf",

--- a/spec/features/journeys/happy_paths/while_working_at_public_nursery_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_at_public_nursery_spec.rb
@@ -172,6 +172,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
+      "review_status" => nil,
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",

--- a/spec/features/journeys/happy_paths/while_working_in_neither_a_school_nor_childcare_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_in_neither_a_school_nor_childcare_spec.rb
@@ -151,6 +151,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
+      "review_status" => nil,
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",

--- a/spec/features/journeys/sad_paths/applying_for_ehco_but_not_new_headteacher_spec.rb
+++ b/spec/features/journeys/sad_paths/applying_for_ehco_but_not_new_headteacher_spec.rb
@@ -182,6 +182,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, type: :feature do
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
+      "review_status" => nil,
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",

--- a/spec/features/journeys/sad_paths/lead_mentor_journey_with_incorrect_course_spec.rb
+++ b/spec/features/journeys/sad_paths/lead_mentor_journey_with_incorrect_course_spec.rb
@@ -202,6 +202,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, type: :feature do
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
+      "review_status" => "needs_review",
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",

--- a/spec/features/journeys/sad_paths/works_in_childcare_but_not_in_england_spec.rb
+++ b/spec/features/journeys/sad_paths/works_in_childcare_but_not_in_england_spec.rb
@@ -152,6 +152,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, type: :feature do
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
+      "review_status" => nil,
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",

--- a/spec/features/npq_separation/admin/applications_in_review_spec.rb
+++ b/spec/features/npq_separation/admin/applications_in_review_spec.rb
@@ -7,13 +7,13 @@ RSpec.feature "Applications in review", type: :feature do
   let(:cohort_22) { create :cohort, start_year: 2022 }
 
   let!(:normal_application)                         { create(:application) }
-  let!(:application_for_hospital_school)            { create(:application, :accepted, created_at: 10.days.ago, employment_type: "hospital_school", employer_name: Faker::Company.name, cohort: cohort_21, referred_by_return_to_teaching_adviser: "yes") }
-  let!(:application_for_la_supply_teacher)          { create(:application, created_at: 9.days.ago, employment_type: "local_authority_supply_teacher", cohort: cohort_22, referred_by_return_to_teaching_adviser: "no") }
-  let!(:application_for_la_virtual_school)          { create(:application, created_at: 8.days.ago, employment_type: "local_authority_virtual_school") }
-  let!(:application_for_lead_mentor)                { create(:application, created_at: 7.days.ago, employment_type: "local_authority_virtual_school") }
-  let!(:application_for_young_offender_institution) { create(:application, created_at: 6.days.ago, employment_type: "young_offender_institution") }
-  let!(:application_for_other)                      { create(:application, created_at: 5.days.ago, employment_type: "other") }
-  let!(:application_for_rtta_yes)                   { create(:application, created_at: 4.days.ago, referred_by_return_to_teaching_adviser: "yes", school: nil, works_in_school: false) }
+  let!(:application_for_hospital_school)            { create(:application, :manual_review, :accepted, created_at: 10.days.ago, employment_type: "hospital_school", employer_name: Faker::Company.name, cohort: cohort_21, referred_by_return_to_teaching_adviser: "yes") }
+  let!(:application_for_la_supply_teacher)          { create(:application, :manual_review, created_at: 9.days.ago, employment_type: "local_authority_supply_teacher", cohort: cohort_22, referred_by_return_to_teaching_adviser: "no") }
+  let!(:application_for_la_virtual_school)          { create(:application, :manual_review, created_at: 8.days.ago, employment_type: "local_authority_virtual_school") }
+  let!(:application_for_lead_mentor)                { create(:application, :manual_review, created_at: 7.days.ago, employment_type: "local_authority_virtual_school") }
+  let!(:application_for_young_offender_institution) { create(:application, :manual_review, created_at: 6.days.ago, employment_type: "young_offender_institution") }
+  let!(:application_for_other)                      { create(:application, :manual_review, created_at: 5.days.ago, employment_type: "other") }
+  let!(:application_for_rtta_yes)                   { create(:application, :manual_review, created_at: 4.days.ago, referred_by_return_to_teaching_adviser: "yes", school: nil, works_in_school: false) }
   let!(:application_for_rtta_no)                    { create(:application, created_at: 3.days.ago, referred_by_return_to_teaching_adviser: "no") }
 
   let(:serialized_application) { { application: 1 } }

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -148,6 +148,15 @@ RSpec.describe Application do
         withdrawn: "withdrawn",
       ).backed_by_column_of_type(:enum).with_suffix
     }
+
+    it "defines an enum for review_status" do
+      expect(subject).to define_enum_for(:review_status).with_values(
+        needs_review: "needs_review",
+        awaiting_information: "awaiting_information",
+        reregister: "reregister",
+        decision_made: "decision_made",
+      ).backed_by_column_of_type(:enum).with_suffix
+    end
   end
 
   describe "scopes" do

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -192,6 +192,25 @@ RSpec.describe Application do
         expect(described_class.with_targeted_delivery_funding_eligibility).to contain_exactly(application_with_targeted_delivery_funding_eligibility)
       end
     end
+
+    describe ".for_manual_review" do
+      subject { described_class.for_manual_review.to_a }
+
+      before { application }
+
+      let(:application) { create(:application, review_status:) }
+      let(:review_status) { nil }
+
+      it { is_expected.not_to include(application) }
+
+      Application.review_statuses.each_value do |enum_value|
+        context "with review_status of #{enum_value}" do
+          let(:review_status) { enum_value }
+
+          it { is_expected.to include(application) }
+        end
+      end
+    end
   end
 
   describe "#inside_catchment?" do

--- a/spec/services/handle_submission_for_store_spec.rb
+++ b/spec/services/handle_submission_for_store_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe HandleSubmissionForStore do
-  subject { described_class.new(store:) }
+  subject(:service) { described_class.new(store:) }
 
   let(:user_record_trn) { "0012345" }
   let(:user) { create(:user, trn: user_record_trn, full_name: "John Doe", ecf_id: nil) }
@@ -146,6 +146,7 @@ RSpec.describe HandleSubmissionForStore do
           "senco_in_role" => "yes",
           "senco_start_date" => "2024-12-12",
           "on_submission_trn" => "1234321",
+          "review_status" => nil,
         })
       end
     end
@@ -265,6 +266,7 @@ RSpec.describe HandleSubmissionForStore do
           "senco_in_role" => nil,
           "senco_start_date" => nil,
           "on_submission_trn" => nil,
+          "review_status" => nil,
         })
       end
     end
@@ -433,6 +435,7 @@ RSpec.describe HandleSubmissionForStore do
           "senco_in_role" => nil,
           "senco_start_date" => nil,
           "on_submission_trn" => nil,
+          "review_status" => nil,
         })
       end
     end
@@ -507,6 +510,7 @@ RSpec.describe HandleSubmissionForStore do
           "senco_in_role" => nil,
           "senco_start_date" => nil,
           "on_submission_trn" => nil,
+          "review_status" => nil,
         })
       end
     end
@@ -591,7 +595,61 @@ RSpec.describe HandleSubmissionForStore do
           "senco_in_role" => nil,
           "senco_start_date" => nil,
           "on_submission_trn" => nil,
+          "review_status" => nil,
         })
+      end
+    end
+
+    describe "#review_status" do
+      subject { application.review_status }
+
+      let(:store) { build :registration_wizard_store }
+      let(:application) { service.tap(&:call).application }
+
+      it { is_expected.to be_nil }
+
+      context "when referred_by_return_to_teaching_adviser is set" do
+        let :store do
+          build :registration_wizard_store, referred_by_return_to_teaching_adviser: "yes"
+        end
+
+        it { is_expected.to eq "needs_review" }
+      end
+
+      %w[
+        hospital_school
+        lead_mentor_for_accredited_itt_provider
+        local_authority_supply_teacher
+        local_authority_virtual_school
+        young_offender_institution
+        other
+      ].each do |employment_type|
+        context "when employment_type is set to #{employment_type}" do
+          let :store do
+            build :registration_wizard_store, employment_type:,
+                                              work_setting: "another_setting"
+          end
+
+          it { is_expected.to eq "needs_review" }
+        end
+      end
+
+      context "when employment_type is set to a non in-review type" do
+        let :store do
+          build :registration_wizard_store, employment_type: "something else",
+                                            work_setting: "another_setting"
+        end
+
+        it { is_expected.to be_nil }
+      end
+
+      context "when employment_type is not relevant" do
+        let :store do
+          build :registration_wizard_store, employment_type: "hospital_school",
+                                            work_setting: "early_years_or_childcare"
+        end
+
+        it { is_expected.to be_nil }
       end
     end
   end


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2566](https://dfedigital.atlassian.net/browse/CPDNPQ-2566)

We wish to track the review status of applications requiring manual review.

Previously these 'in review' applications were determined dynamically via a query conditions. Going forward we are adding a 'review_status' column, and those conditions will set the new column to `needs_review` at application creation time.

### Changes proposed in this pull request

1. Add a new enum for the different `review_statuses`
2. Add a database column to applications to track the `review_status`, allowing it to be null for applications not requiring a review
3. Set the `review_status` to `decision_made` for all existing applications which would have shown on the 'in review' applications screen
4. Changed the In review applications screen to instead filter by appliations with a non-null review_status
5. Changed the registration wizard to set the `review_status` to `needs_review` for those applications which would have matched the filter used previously for the 'in review applications' screen