### PR TITLE
Add ingress rate limit

### DIFF
--- a/terraform/domains/environment_domains/config/production.tfvars.json
+++ b/terraform/domains/environment_domains/config/production.tfvars.json
@@ -12,5 +12,16 @@
       "environment_short": "pd",
       "origin_hostname": "npq-registration-production-web.teacherservices.cloud"
     }
-  }
+  },
+    "rate_limit": [
+      {
+        "agent": "all",
+        "priority": 100,
+        "duration": 5,
+        "limit": 1500,
+        "selector": "Host",
+        "operator": "GreaterThanOrEqual",
+        "match_values": "0"
+      }
+    ]
 }

--- a/terraform/domains/environment_domains/config/sandbox.tfvars.json
+++ b/terraform/domains/environment_domains/config/sandbox.tfvars.json
@@ -12,5 +12,16 @@
       "environment_short": "sb",
       "origin_hostname": "npq-registration-sandbox-web.teacherservices.cloud"
     }
-  }
+  },
+    "rate_limit": [
+      {
+        "agent": "all",
+        "priority": 100,
+        "duration": 5,
+        "limit": 1500,
+        "selector": "Host",
+        "operator": "GreaterThanOrEqual",
+        "match_values": "0"
+      }
+    ]
 }

--- a/terraform/domains/environment_domains/main.tf
+++ b/terraform/domains/environment_domains/main.tf
@@ -10,4 +10,5 @@ module "domains" {
   host_name           = each.value.origin_hostname
   null_host_header    = try(each.value.null_host_header, false)
   cached_paths        = try(each.value.cached_paths, [])
+  rate_limit          = try(var.rate_limit, null)
 }

--- a/terraform/domains/environment_domains/variables.tf
+++ b/terraform/domains/environment_domains/variables.tf
@@ -2,3 +2,16 @@ variable "hosted_zone" {
   type    = map(any)
   default = {}
 }
+
+variable "rate_limit" {
+  type = list(object({
+    agent        = optional(string)
+    priority     = optional(number)
+    duration     = optional(number)
+    limit        = optional(number)
+    selector     = optional(string)
+    operator     = optional(string)
+    match_values = optional(string)
+  }))
+  default = null
+}


### PR DESCRIPTION
### Context

Configure rate limiting for production & sandbox

### Changes proposed in this pull request

Add global rate limit per IP for 5 minute intervals
Value for global rate set from checking ingress logs for the last 4 weeks plus and is not lower than the app rate limit

### Guidance to review

make production|sandbox domains-plan

### Link to Trello card

https://trello.com/c/rmljcE5W/2345-add-rate-limiting-for-services
