### PR TITLE
[CPDNPQ-2890] Fixed DB seeds to always have historical output statements

### DIFF
--- a/db/seeds/base/add_statements.rb
+++ b/db/seeds/base/add_statements.rb
@@ -1,7 +1,7 @@
 LeadProvider.find_each do |lead_provider|
   Cohort.find_each do |cohort|
     date    = cohort.registration_start_date.to_date
-    periods = ((date.end_of_month + 1.day)...(date + 2.years)).map { [_1.year, _1.month] }.uniq
+    periods = ((date.beginning_of_month - 2.months)...(date + 2.years)).map { [_1.year, _1.month] }.uniq
 
     periods.each.with_index(1) do |(year, month), i|
       final_statement  = i == periods.count


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2890](]https://dfedigital.atlassian.net/browse/CPDNPQ-2890)

Today we crossed the date where we had output statements, but not earlier output statements. This meant the statements code was trying to clawback from a non-existant earlier output statements and erroring

### Changes proposed in this pull request

1. Always create at least 1 earlier output statement to allow for clawing back in db seeds file


[CPDNPQ-2890]: https://dfedigital.atlassian.net/browse/CPDNPQ-2890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ