### PR TITLE
[CPDNPQ-2808] add includes - recommended by bullet

### DIFF
--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -162,6 +162,7 @@ class Declaration < ApplicationRecord
       .class
       .billable_or_changeable
       .joins(application: %i[user course])
+      .includes([:application]) # added because Bullet::Notification::UnoptimizedQueryError seen on review apps. Not covered by a spec.
       .where(user: { trn: application.user.trn })
       .where.not(user: { trn: nil })
       .where.not(user: { id: application.user_id })


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2808

Bullet::Notification::UnoptimizedQueryError seen in sentry on review apps

### Changes proposed in this pull request

add the bullet recommended `includes`.

I couldn't reproduce this error locally, or in a review app.
I tried a user with multiple applications,
and I tried having another user with the same TRN, with multiple applications.