### PR TITLE
[CPDNPQ-2808] fix n+1 query

### DIFF
--- a/app/services/declarations/create.rb
+++ b/app/services/declarations/create.rb
@@ -41,6 +41,11 @@ module Declarations
 
       ApplicationRecord.transaction do
         find_or_create_declaration!
+
+        # CPDNPQ-2808: this reload is here to stop bullet complaining about an unoptimized query
+        # the issue could not be replicated locally or in a review app
+        declaration.reload
+
         set_eligibility!
 
         statement_attacher.attach unless declaration.submitted_state?


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2808

Bullet::Notification::UnoptimizedQueryError seen in sentry on review apps

### Changes proposed in this pull request
I did see the issue locally, once,
but when I tried to reproduce the issue again on a reseeded database, I could not reproduce the error.
Adding a reload fixed the problem when I did have it locally - I've no idea why.