### PR TITLE
[CPDNPQ-2655] do not allow funded_place to change if there are billable or changeable declarations

### DIFF
--- a/app/services/applications/change_funded_place.rb
+++ b/app/services/applications/change_funded_place.rb
@@ -13,7 +13,7 @@ module Applications
     validate :accepted_application
     validate :eligible_for_funding
     validate :cohort_has_funding_cap
-    validate :eligible_for_removing_funding_place
+    validate :eligible_for_changing_funded_place
 
     def change
       return false unless valid?
@@ -46,8 +46,7 @@ module Applications
       errors.add(:application, :cohort_does_not_accept_capping)
     end
 
-    def eligible_for_removing_funding_place
-      return if funded_place
+    def eligible_for_changing_funded_place
       return unless application&.declarations&.billable_or_changeable&.any?
 
       errors.add(:application, :cannot_change_funded_place)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,7 +36,7 @@ en:
     cannot_change_funded_status_from_non_accepted: You must accept the application before attempting to change the '#/funded_place' setting.
     cannot_change_funded_status_non_eligible: This participant is not eligible for funding. Contact us if you think this is wrong.
     cohort_does_not_accept_capping: Leave the '#/funded_place' field blank. It's only needed for participants starting NPQs from autumn 2024 onwards.
-    cannot_change_funded_place: You must void or claw back your declarations for this participant before being able to set '#/funded_place' to false
+    cannot_change_funded_place: You cannot change the funded place because declarations have been submitted. You will need to void the existing declarations and resubmit them after changing the funded place.
 
   declaration: &declaration
     blank: You must specify a declaration

--- a/spec/services/applications/accept_spec.rb
+++ b/spec/services/applications/accept_spec.rb
@@ -348,7 +348,7 @@ RSpec.describe Applications::Accept, :with_default_schedules, type: :model do
         let(:params) { { application:, funded_place: nil } }
 
         context "when funding_cap is true" do
-          it "returns funding_place is required error" do
+          it "returns funded_place is required error" do
             service.accept
             expect(service).to have_error(:funded_place, :inclusion, "Set '#/funded_place' to true or false.")
           end
@@ -368,7 +368,7 @@ RSpec.describe Applications::Accept, :with_default_schedules, type: :model do
         context "when funded_place is `true`" do
           let(:params) { { application:, funded_place: "true" } }
 
-          it "returns funding_place is required error" do
+          it "returns funded_place is required error" do
             service.accept
             expect(service).to have_error(:funded_place, :inclusion, "Set '#/funded_place' to true or false.")
           end
@@ -377,7 +377,7 @@ RSpec.describe Applications::Accept, :with_default_schedules, type: :model do
         context "when funded_place is `false`" do
           let(:params) { { application:, funded_place: "false" } }
 
-          it "returns funding_place is required error" do
+          it "returns funded_place is required error" do
             service.accept
             expect(service).to have_error(:funded_place, :inclusion, "Set '#/funded_place' to true or false.")
           end
@@ -386,7 +386,7 @@ RSpec.describe Applications::Accept, :with_default_schedules, type: :model do
         context "when funded_place is `null`" do
           let(:params) { { application:, funded_place: "null" } }
 
-          it "returns funding_place is required error" do
+          it "returns funded_place is required error" do
             service.accept
             expect(service).to have_error(:funded_place, :inclusion, "Set '#/funded_place' to true or false.")
           end
@@ -395,7 +395,7 @@ RSpec.describe Applications::Accept, :with_default_schedules, type: :model do
         context "when funded_place is an empty string" do
           let(:params) { { application:, funded_place: "" } }
 
-          it "returns funding_place is required error" do
+          it "returns funded_place is required error" do
             service.accept
             expect(service).to have_error(:funded_place, :inclusion, "Set '#/funded_place' to true or false.")
           end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2655

The existing validation seems to be wrong

### Changes proposed in this pull request

If there are declarations for the application that are submitted, eligible, payable, or paid 
then raise a validation error:
"You cannot change the funded place because declarations have been submitted. You will need to void the existing declarations and resubmit them after changing the funded place."
