### PR TITLE
[CPDNPQ-2803] rake task to update TRN on legacy passed participant outcomes

### DIFF
--- a/lib/tasks/update_legacy_passed_participant_outcomes.rake
+++ b/lib/tasks/update_legacy_passed_participant_outcomes.rake
@@ -1,0 +1,25 @@
+namespace :update_legacy_passed_participant_outcomes do
+  desc "Update TRNs for legacy passed participant outcomes"
+  task :update_trn, %i[old_trn new_trn] => :environment do |_t, args|
+    logger = Rails.env.test? ? Rails.logger : Logger.new($stdout)
+
+    raise "Missing required argument: old_trn" unless args.old_trn
+    raise "Missing required argument: new_trn" unless args.new_trn
+
+    legacy_outcomes_to_update = LegacyPassedParticipantOutcome.where(trn: args.old_trn).all
+    count = legacy_outcomes_to_update.count
+    outcome_s = "outcome".pluralize(count)
+
+    raise "No legacy passed participant outcomes found with TRN: #{args.old_trn}" if count.zero?
+
+    logger.info "Updating TRN from #{args.old_trn} to #{args.new_trn} for #{count} legacy passed participant #{outcome_s}"
+
+    LegacyPassedParticipantOutcome.transaction do
+      outcome_ids = legacy_outcomes_to_update.pluck(:id)
+      legacy_outcomes_to_update.update_all(trn: args.new_trn)
+      logger.info "Updated TRN for legacy passed participant #{outcome_s} with #{"ID".pluralize(count)}: " \
+        "#{outcome_ids.join(', ')}"
+      logger.info "#{count} legacy passed participant #{outcome_s} updated."
+    end
+  end
+end

--- a/spec/lib/tasks/update_legacy_passed_participant_outcomes_spec.rb
+++ b/spec/lib/tasks/update_legacy_passed_participant_outcomes_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe "update_legacy_passed_participant_outcomes" do
+  describe "update_trn" do
+    subject(:run_task) { Rake::Task["update_legacy_passed_participant_outcomes:update_trn"].invoke(old_trn, new_trn) }
+
+    let(:legacy_outcome) { create(:legacy_passed_participant_outcome, trn: "1234567") }
+    let(:another_legacy_outcome) { create(:legacy_passed_participant_outcome, trn: legacy_outcome.trn) }
+    let(:legacy_outcome_with_different_trn) { create(:legacy_passed_participant_outcome, trn: "2345678") }
+    let(:old_trn) { legacy_outcome.trn }
+    let(:new_trn) { "1010101" }
+
+    after { Rake::Task["update_legacy_passed_participant_outcomes:update_trn"].reenable }
+
+    it "updates the TRN for legacy passed participant outcomes that have the specified old_trn" do
+      run_task
+      expect(legacy_outcome.reload.trn).to eq new_trn
+      expect(another_legacy_outcome.reload.trn).to eq new_trn
+    end
+
+    it "does not update the TRN for legacy passed participant outcomes that do not have the specified old_trn" do
+      run_task
+      expect(legacy_outcome_with_different_trn.reload.trn).to eq "2345678"
+    end
+
+    context "when the old_trn is not provided" do
+      let(:old_trn) { nil }
+
+      it "raises an error" do
+        expect { run_task }.to raise_error(RuntimeError, "Missing required argument: old_trn")
+      end
+    end
+
+    context "when the new_trn is not provided" do
+      let(:new_trn) { nil }
+
+      it "raises an error" do
+        expect { run_task }.to raise_error(RuntimeError, "Missing required argument: new_trn")
+      end
+    end
+
+    context "when no legacy passed participant outcomes match the old_trn" do
+      let(:old_trn) { "7777777" }
+
+      it "raises an error" do
+        expect { run_task }.to raise_error(RuntimeError, "No legacy passed participant outcomes found with TRN: 7777777")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2803

This rake task will likely be used 2-4 times a year

### Changes proposed in this pull request

Rake task to update legacy passed participant outcomes that have the specified TRN to a new TRN
