### PR TITLE
move tempfile creating into spec to stop it being garbage collected too early

### DIFF
--- a/spec/factories/bulk_operation/reject_applications.rb
+++ b/spec/factories/bulk_operation/reject_applications.rb
@@ -5,13 +5,5 @@ FactoryBot.define do
     end
 
     admin { create(:admin) }
-
-    after(:build) do |bulk_operation, evaluator|
-      tempfile = Tempfile.new.tap do |file|
-        file.write(evaluator.application_ecf_ids.join("\n"))
-        file.rewind
-      end
-      bulk_operation.file.attach(tempfile.open)
-    end
   end
 end

--- a/spec/factories/bulk_operation/revert_applications_to_pending.rb
+++ b/spec/factories/bulk_operation/revert_applications_to_pending.rb
@@ -5,13 +5,5 @@ FactoryBot.define do
     end
 
     admin { create(:admin) }
-
-    after(:build) do |bulk_operation, evaluator|
-      tempfile = Tempfile.new.tap do |file|
-        file.write(evaluator.application_ecf_ids.join("\n"))
-        file.rewind
-      end
-      bulk_operation.file.attach(tempfile.open)
-    end
   end
 end

--- a/spec/models/bulk_operation/reject_applications_spec.rb
+++ b/spec/models/bulk_operation/reject_applications_spec.rb
@@ -2,7 +2,10 @@ require "rails_helper"
 
 RSpec.describe BulkOperation::RejectApplications do
   let(:application_ecf_ids) { [application.ecf_id] }
-  let(:bulk_operation) { create(:reject_applications_bulk_operation, admin: create(:admin), application_ecf_ids:) }
+  let(:bulk_operation) { create(:reject_applications_bulk_operation, admin: create(:admin)) }
+  let(:file) { tempfile(application_ecf_ids.join("\n")) }
+
+  before { bulk_operation.file.attach(file.open) }
 
   describe "#run!" do
     subject(:run) { bulk_operation.run! }

--- a/spec/models/bulk_operation/revert_applications_to_pending_spec.rb
+++ b/spec/models/bulk_operation/revert_applications_to_pending_spec.rb
@@ -2,7 +2,10 @@ require "rails_helper"
 
 RSpec.describe BulkOperation::RevertApplicationsToPending do
   let(:application_ecf_ids) { [application.ecf_id] }
-  let(:bulk_operation) { create(:revert_applications_to_pending_bulk_operation, admin: create(:admin), application_ecf_ids:) }
+  let(:bulk_operation) { create(:revert_applications_to_pending_bulk_operation, admin: create(:admin)) }
+  let(:file) { tempfile(application_ecf_ids.join("\n")) }
+
+  before { bulk_operation.file.attach(file.open) }
 
   describe "#run!" do
     subject(:run) { bulk_operation.run! }

--- a/spec/models/bulk_operation_spec.rb
+++ b/spec/models/bulk_operation_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.describe BulkOperation, type: :model do
   let(:admin) { create(:admin) }
   let(:application_ecf_id) { "e857f4bc-9e19-4bf8-9874-02a60905dbdb" }
-  let(:application_ecf_ids) { [application_ecf_id] }
 
   let(:valid_file) do
     tempfile <<~CSV
@@ -57,7 +56,7 @@ RSpec.describe BulkOperation, type: :model do
   end
 
   describe "callbacks" do
-    subject(:bulk_operation) { build(:reject_applications_bulk_operation, application_ecf_ids: [], admin:) }
+    subject(:bulk_operation) { build(:reject_applications_bulk_operation, admin:) }
 
     describe "before_save" do
       context "when file is attached" do
@@ -126,7 +125,9 @@ RSpec.describe BulkOperation, type: :model do
   describe "#ids_to_update" do
     subject(:ids_to_update) { bulk_operation.ids_to_update }
 
-    let(:bulk_operation) { create(:reject_applications_bulk_operation, application_ecf_ids:) }
+    let(:bulk_operation) { create(:reject_applications_bulk_operation) }
+
+    before { bulk_operation.file.attach(valid_file.open) }
 
     it "returns an array of application ECF IDs" do
       expect(ids_to_update.to_a).to eq [application_ecf_id]


### PR DESCRIPTION
### Context

Sometimes, the bulk operations specs fail with an IOError

### Changes proposed in this pull request

move tempfile creation into the spec, so it's still referenced whilst the spec is running, which should avoid it being garbage collected.