### PR TITLE
[CPDNPQ-2903] course provider page and rename all instances of "Lead provider"

### DIFF
--- a/app/components/npq_separation/admin/statements_table_component.rb
+++ b/app/components/npq_separation/admin/statements_table_component.rb
@@ -17,7 +17,7 @@ module NpqSeparation
 
       def head
         [
-          ("Lead provider" if show_lead_provider),
+          ("Course provider" if show_lead_provider),
           "Cohort",
           "Statement",
           "Status",

--- a/app/components/npq_separation/application_tally_component.html.erb
+++ b/app/components/npq_separation/application_tally_component.html.erb
@@ -2,7 +2,7 @@
   govuk_table do |table|
     table.with_head do |header|
       header.with_row do |row|
-        row.with_cell(text: dimension.to_s.titleize)
+        row.with_cell(text: dimension_header)
         row.with_cell(text: 'Applications', numeric: true)
       end
     end

--- a/app/components/npq_separation/application_tally_component.rb
+++ b/app/components/npq_separation/application_tally_component.rb
@@ -1,10 +1,11 @@
 module NpqSeparation
   class ApplicationTallyComponent < ViewComponent::Base
-    attr_reader :applications, :dimension
+    attr_reader :applications, :dimension, :dimension_header
 
-    def initialize(applications, dimension)
+    def initialize(applications, dimension, dimension_header: nil)
       @applications = applications
       @dimension = dimension
+      @dimension_header = dimension_header || dimension.to_s.titleize
     end
 
     def rows

--- a/app/components/npq_separation/navigation_structures/admin_navigation_structure.rb
+++ b/app/components/npq_separation/navigation_structures/admin_navigation_structure.rb
@@ -23,7 +23,7 @@ module NpqSeparation
           Node.new(
             name: "Reopening email subscriptions",
             href: npq_separation_admin_reopening_email_subscriptions_path,
-            prefix: "/npq-separation/admin/reopening_email_subscriptions",
+            prefix: "/npq-separation/admin/reopening-email-subscriptions",
           ) => [],
 
           Node.new(
@@ -90,10 +90,10 @@ module NpqSeparation
             prefix: "/npq-separation/admin/schools",
           ) => [],
           Node.new(
-            name: "Lead providers",
+            name: "Course providers",
             href: npq_separation_admin_lead_providers_path,
             prefix: "/npq-separation/admin/lead-providers",
-          ) => [],
+          ) => course_provider_nodes,
           Node.new(
             name: "Bulk operations",
             href: npq_separation_admin_bulk_operations_path,
@@ -112,7 +112,7 @@ module NpqSeparation
           Node.new(
             name: "Closed registration users",
             href: npq_separation_admin_closed_registration_users_path,
-            prefix: "/npq-separation/admin/closed_registration_users",
+            prefix: "/npq-separation/admin/closed-registration-users",
           ) => [],
         }
       end
@@ -144,6 +144,16 @@ module NpqSeparation
             name: "Cohort #{format_cohort(cohort)}",
             href: npq_separation_admin_cohort_path(cohort),
             prefix: "/npq-separation/admin/cohorts/#{cohort.id}",
+          )
+        end
+      end
+
+      def course_provider_nodes
+        LeadProvider.order(:name).map do |lead_provider|
+          Node.new(
+            name: lead_provider.name,
+            href: npq_separation_admin_lead_provider_path(lead_provider),
+            prefix: "/npq-separation/admin/lead-providers/#{lead_provider.id}",
           )
         end
       end

--- a/app/services/applications/change_lead_provider.rb
+++ b/app/services/applications/change_lead_provider.rb
@@ -10,7 +10,7 @@ module Applications
     attribute :lead_provider_id, :integer
 
     validates :application, presence: true
-    validates :lead_provider_id, presence: { message: "Choose a lead provider" }
+    validates :lead_provider_id, presence: { message: "Choose a course provider" }
     validate :different_lead_provider, if: :application
 
     def change_lead_provider

--- a/app/views/npq_separation/admin/applications/change_lead_provider/show.html.erb
+++ b/app/views/npq_separation/admin/applications/change_lead_provider/show.html.erb
@@ -3,14 +3,14 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      Transfer lead provider
+      Transfer course provider
     </h1>
 
     <%= govuk_warning_text(text: "Before continuing with this transfer, make sure the provider has submitted their declarations for this application") %>
 
     <div class="govuk-inset-text">
       <p class="govuk-body">
-        <strong>Lead Provider</strong>
+        <strong>Course provider</strong>
         <br/>
         <%= @application.lead_provider.name %>
       </p>

--- a/app/views/npq_separation/admin/applications/revert_to_pending/new.html.erb
+++ b/app/views/npq_separation/admin/applications/revert_to_pending/new.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-inset-text">
   <p class="govuk-body">
-    Lead provider approval status:
+    Course provider approval status:
     <br />
     <strong><%= @application.lead_provider_approval_status&.humanize %></strong>
   </p>

--- a/app/views/npq_separation/admin/applications/reviews/show.html.erb
+++ b/app/views/npq_separation/admin/applications/reviews/show.html.erb
@@ -103,6 +103,6 @@
   end
 %>
 
-<%= govuk_details(summary_text: "View registration as it appears on the Lead Provider API V3") do %>
+<%= govuk_details(summary_text: "View registration as it appears on the Course provider API V3") do %>
 <pre class="govuk-!-font-size-16 api-view"><code><%= JSON.pretty_generate API::ApplicationSerializer.render_as_hash(@application, view: :v3, root: "data") %></code></pre>
 <% end %>

--- a/app/views/npq_separation/admin/applications/show.html.erb
+++ b/app/views/npq_separation/admin/applications/show.html.erb
@@ -139,7 +139,7 @@
         end
 
         sl.with_row do |row|
-          row.with_key(text: "Lead provider")
+          row.with_key(text: "Course provider")
           row.with_value(text: declaration.lead_provider.name)
         end
 

--- a/app/views/npq_separation/admin/dashboards/summary/show.html.erb
+++ b/app/views/npq_separation/admin/dashboards/summary/show.html.erb
@@ -1,4 +1,4 @@
 <h1 class="govuk-heading-l">Summary</h1>
 
 <%= render NpqSeparation::ApplicationTallyComponent.new(@applications, :course) %>
-<%= render NpqSeparation::ApplicationTallyComponent.new(@applications, :lead_provider) %>
+<%= render NpqSeparation::ApplicationTallyComponent.new(@applications, :lead_provider, dimension_header: "Course provider") %>

--- a/app/views/npq_separation/admin/delivery_partners/index.html.erb
+++ b/app/views/npq_separation/admin/delivery_partners/index.html.erb
@@ -17,7 +17,7 @@
           row.with_cell(text: delivery_partner.name)
           row.with_cell do
             tag.div class: "govuk-button-group govuk-!-margin-bottom-0" do
-              govuk_link_to("Assign lead providers", edit_npq_separation_admin_delivery_partner_delivery_partnerships_path(delivery_partner), class: "govuk-!-margin-bottom-0") +
+              govuk_link_to("Assign course providers", edit_npq_separation_admin_delivery_partner_delivery_partnerships_path(delivery_partner), class: "govuk-!-margin-bottom-0") +
               govuk_link_to("Update name", edit_npq_separation_admin_delivery_partner_path(delivery_partner), class: "govuk-!-margin-bottom-0")
             end
           end

--- a/app/views/npq_separation/admin/delivery_partnerships/edit.html.erb
+++ b/app/views/npq_separation/admin/delivery_partnerships/edit.html.erb
@@ -1,6 +1,6 @@
 <%= govuk_back_link(href: npq_separation_admin_delivery_partners_path) %>
 
-<h1 class="govuk-heading-l">Add a lead provider</h1>
+<h1 class="govuk-heading-l">Add a course provider</h1>
 <p class="govuk-caption-m">Select all that apply</p>
 
 <%= form_with model: [:npq_separation, :admin, @delivery_partner], method: :patch, id: 'delivery-partnerships-form' do |form| %>
@@ -30,7 +30,7 @@
 <% end %>
 
 <%= nonced_javascript_tag do %>
-  // uncheck all cohorts when a lead provider is deselected
+  // uncheck all cohorts when a course provider is deselected
   document
     .getElementById("delivery-partnerships-form")
     .addEventListener("change", function(event) {

--- a/app/views/npq_separation/admin/finance/statements/adjustments/_adjustment_form.html.erb
+++ b/app/views/npq_separation/admin/finance/statements/adjustments/_adjustment_form.html.erb
@@ -4,7 +4,7 @@
   <%= f.govuk_text_field(
       :description,
       label: { text: "Make adjustment", tag: "h1", size: "l" },
-      hint: { text: "Describe what the adjustment is for, such as 'IT consultant fee' for example. We'll share this information with the lead provider." }
+      hint: { text: "Describe what the adjustment is for, such as 'IT consultant fee' for example. We'll share this information with the course provider." }
   ) %>
 
   <%= f.govuk_text_field :amount,

--- a/app/views/npq_separation/admin/lead_providers/index.html.erb
+++ b/app/views/npq_separation/admin/lead_providers/index.html.erb
@@ -1,12 +1,9 @@
-<h1 class="govuk-heading-l">Lead providers</h1>
+<h1 class="govuk-heading-l">Course providers</h1>
 
-<ul class="govuk-list govuk-list--bullet">
-  <% @lead_providers.each do |lead_provider| %>
-    <%= tag.li(
-      govuk_link_to(
-        lead_provider.name, npq_separation_admin_lead_provider_path(lead_provider),
-        no_visited_state: true,
-      )
-    ) %>
-  <% end %>
-</ul>
+<p class="govuk-body">
+  Here is a list of all course providers that offer national professional qualification (NPQ) courses.
+</p>
+
+<p class="govuk-body">
+  Select a course provider to reveal which delivery partners they work with to deliver NPQs.
+</p>

--- a/app/views/npq_separation/admin/statements/create.html.erb
+++ b/app/views/npq_separation/admin/statements/create.html.erb
@@ -2,7 +2,7 @@
 
 <h1 class="govuk-heading-l">Confirm new cohort <%= format_cohort(@cohort) %> statements</h1>
 
-<p class="govuk-body govuk-body--l"><%= @preview[:statements].count %> statements will be created for <%= pluralize @preview[:lead_providers_count], 'lead provider' %> (<%= number_with_delimiter @statements.count %> statements in total).</p>
+<p class="govuk-body govuk-body--l"><%= @preview[:statements].count %> statements will be created for <%= pluralize @preview[:lead_providers_count], 'course provider' %> (<%= number_with_delimiter @statements.count %> statements in total).</p>
 
 <%=
   govuk_details(summary_text: "Statement dates") do

--- a/app/views/npq_separation/admin/statements/new.html.erb
+++ b/app/views/npq_separation/admin/statements/new.html.erb
@@ -11,7 +11,7 @@
       <%= f.file_field :statements_csv_file, class: "govuk-file-upload" %>
     </div>
     <%= govuk_details(summary_text: "Example statements CSV", classes: 'govuk-!-margin-top-3') do %>
-      <p class="govuk-body">One row per statement to be created for each contracted lead provider, e.g.:</p>
+      <p class="govuk-body">One row per statement to be created for each contracted course provider, e.g.:</p>
 <pre class="govuk-!-padding-5 govuk-!-font-size-16 statement-example">
 <%= Statements::BulkCreator::StatementRow.example_csv %>
 </pre>
@@ -29,13 +29,13 @@
       <%= f.file_field :contracts_csv_file, class: "govuk-file-upload" %>
     </div>
     <%= govuk_details(summary_text: "Example contracts CSV", classes: 'govuk-!-margin-top-3') do %>
-      <p class="govuk-body">One row per course to be added to each lead provider's statements, e.g.:</p>
+      <p class="govuk-body">One row per course to be added to each course provider's statements, e.g.:</p>
 <pre class="govuk-!-padding-5 govuk-!-font-size-16 statement-example">
 <%= Statements::BulkCreator::ContractRow.example_csv %>
 </pre>
       <div class="govuk-button-group">
         <%= govuk_link_to "Download empty contracts template", npq_separation_admin_cohort_statement_path(@cohort, 'contracts.csv') %>
-        <%= govuk_link_to "Find lead provider names", npq_separation_admin_lead_providers_path %>
+        <%= govuk_link_to "Find course provider names", npq_separation_admin_lead_providers_path %>
         <%= govuk_link_to "Find course identifiers", npq_separation_admin_courses_path %>
       </div>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -297,7 +297,7 @@ en:
             change_status_to_pending:
               inclusion: Confirm you wish to change the status to Pending
             lead_provider_approval_status:
-              inclusion: Current lead provider approval status is not Accepted
+              inclusion: Current course provider approval status is not Accepted
             base:
               pending_unremoveable_declarations: There are already declarations for this participant on this course, please ask the provider to void any declarations they have made before attempting to revert the application.
         applications/change_cohort:
@@ -754,7 +754,7 @@ en:
             <p class="govuk-body">When this feature is turned on, submitting a declaration for the 2024 cohort onwards will require the delivery partner to be included.</p>
             <p class="govuk-body">When this feature is turned off, submitting a declaration does not require a delivery partner, but will still accept a declaration with a delivery partner.</p>
           include_delivery_partners_in_declarations_api_html: |
-            <p class="govuk-body">When this feature is turned on, lead providers can use the API to see which delivery partners are associated with declarations.</p>
+            <p class="govuk-body">When this feature is turned on, course providers can use the API to see which delivery partners are associated with declarations.</p>
       course_payment_overview_component:
         course_total: Course total
         output_payment: Output payment
@@ -890,7 +890,7 @@ en:
       applications_change_funding_eligibility:
         eligible_for_funding: Is eligible for funding?
       applications_change_lead_provider:
-        lead_provider_id: Choose a different lead provider
+        lead_provider_id: Choose a different course provider
       applications_change_cohort:
         cohort_id: Choose a cohort
       registration_wizard:

--- a/spec/components/npq_separation/admin/statements_table_component_spec.rb
+++ b/spec/components/npq_separation/admin/statements_table_component_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe NpqSeparation::Admin::StatementsTableComponent, type: :component 
 
   let(:statements) { FactoryBot.create_list(:statement, 3) }
   let(:show_lead_provider) { true }
-  let(:expected_columns) { ["Lead provider", "Cohort", "Status"] }
+  let(:expected_columns) { ["Course provider", "Cohort", "Status"] }
 
-  it "renders a table with Lead provider, Cohort and Status columns" do
+  it "renders a table with Course provider, Cohort and Status columns" do
     expected_columns.each do |heading|
       expect(rendered_content).to have_css("th", text: heading)
     end
@@ -33,11 +33,11 @@ RSpec.describe NpqSeparation::Admin::StatementsTableComponent, type: :component 
     let(:show_lead_provider) { false }
 
     it "renders no lead provider column" do
-      expect(rendered_content).not_to have_css("th", text: "Lead provider")
+      expect(rendered_content).not_to have_css("th", text: "Course provider")
     end
 
     it "does render the other columns" do
-      expected_columns.excluding("Lead provider").each do |heading|
+      expected_columns.excluding("Course provider").each do |heading|
         expect(rendered_content).to have_css("th", text: heading)
       end
     end

--- a/spec/components/npq_separation/application_tally_component_spec.rb
+++ b/spec/components/npq_separation/application_tally_component_spec.rb
@@ -13,10 +13,22 @@ RSpec.describe NpqSeparation::ApplicationTallyComponent, type: :component do
     create(:application, cohort:, course: course_2)
   end
 
+  it "returns the correct dimension haeder" do
+    expect(subject.dimension_header).to eq("Course")
+  end
+
   it "returns the correct rows" do
     expect(subject.rows).to eq([
       [course_2.name, 1],
       [course_1.name, 2],
     ])
+  end
+
+  context "when the dimension has a different label" do
+    subject { described_class.new(Application.where(cohort:), :lead_provider, dimension_header: "Course provider") }
+
+    it "returns the correct dimension header" do
+      expect(subject.dimension_header).to eq("Course provider")
+    end
   end
 end

--- a/spec/components/npq_separation/navigation_structures/admin_navigation_structure_spec.rb
+++ b/spec/components/npq_separation/navigation_structures/admin_navigation_structure_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe NpqSeparation::NavigationStructures::AdminNavigationStructure, ty
       "Users" => "/npq-separation/admin/users",
       "Finance" => "/npq-separation/admin/finance/statements",
       "Workplaces" => "/npq-separation/admin/schools",
-      "Lead providers" => "/npq-separation/admin/lead-providers",
+      "Course providers" => "/npq-separation/admin/lead-providers",
       "Bulk operations" => "/npq-separation/admin/bulk-operations",
       "Delivery partners" => "/npq-separation/admin/delivery-partners",
       "Settings" => "#",

--- a/spec/features/npq_separation/admin/applications_in_review_spec.rb
+++ b/spec/features/npq_separation/admin/applications_in_review_spec.rb
@@ -243,7 +243,7 @@ RSpec.feature "Applications in review", type: :feature do
       expect(summary_list).to have_summary_item("Last updated date", application.updated_at.to_fs(:govuk_short))
     end
 
-    find("summary", text: "View registration as it appears on the Lead Provider API V3").click
+    find("summary", text: "View registration as it appears on the Course provider API V3").click
     expect(page).to have_text JSON.pretty_generate(serialized_application)
   end
 

--- a/spec/features/npq_separation/admin/applications_spec.rb
+++ b/spec/features/npq_separation/admin/applications_spec.rb
@@ -214,7 +214,7 @@ RSpec.feature "Listing and viewing applications", type: :feature do
         expect(summary_list).to have_summary_item("Declaration ID", started_declaration.ecf_id)
         expect(summary_list).to have_summary_item("Declaration date", started_declaration.declaration_date.to_fs(:govuk_short))
         expect(summary_list).to have_summary_item("Declaration cohort", started_declaration.cohort.start_year)
-        expect(summary_list).to have_summary_item("Lead provider", started_declaration.lead_provider.name)
+        expect(summary_list).to have_summary_item("Course provider", started_declaration.lead_provider.name)
         expect(summary_list).to have_summary_item("Created at", started_declaration.created_at.to_fs(:govuk_short))
         expect(summary_list).to have_summary_item("Updated at", started_declaration.updated_at.to_fs(:govuk_short))
         expect(summary_list).to have_summary_item("Statements", "")
@@ -228,7 +228,7 @@ RSpec.feature "Listing and viewing applications", type: :feature do
         expect(summary_list).to have_summary_item("Declaration ID", "-")
         expect(summary_list).to have_summary_item("Declaration date", completed_declaration.declaration_date.to_fs(:govuk_short))
         expect(summary_list).to have_summary_item("Declaration cohort", completed_declaration.cohort.start_year)
-        expect(summary_list).to have_summary_item("Lead provider", completed_declaration.lead_provider.name)
+        expect(summary_list).to have_summary_item("Course provider", completed_declaration.lead_provider.name)
         expect(summary_list).to have_summary_item("Created at", completed_declaration.created_at.to_fs(:govuk_short))
         expect(summary_list).to have_summary_item("Updated at", completed_declaration.updated_at.to_fs(:govuk_short))
         expect(summary_list).to have_summary_item("Statements", "")
@@ -352,10 +352,10 @@ RSpec.feature "Listing and viewing applications", type: :feature do
       click_link("Transfer")
     end
 
-    expect(page).to have_css("h1", text: "Transfer lead provider")
+    expect(page).to have_css("h1", text: "Transfer course provider")
 
     click_button "Continue"
-    expect(page).to have_css(".govuk-error-message", text: "Choose a lead provider")
+    expect(page).to have_css(".govuk-error-message", text: "Choose a course provider")
 
     choose "Best Practice Network", visible: :all
     click_button "Continue"

--- a/spec/features/npq_separation/admin/dashboards/summary_spec.rb
+++ b/spec/features/npq_separation/admin/dashboards/summary_spec.rb
@@ -13,6 +13,6 @@ RSpec.feature "Viewing summary dashboard", type: :feature do
 
     expect(page).to have_css("h1", text: "Summary")
     expect(page).to have_css("th", text: "Course")
-    expect(page).to have_css("th", text: "Lead Provider")
+    expect(page).to have_css("th", text: "Course provider")
   end
 end

--- a/spec/features/npq_separation/admin/delivery_partnerships_spec.rb
+++ b/spec/features/npq_separation/admin/delivery_partnerships_spec.rb
@@ -20,33 +20,33 @@ RSpec.feature "NPQ Separation Admin Delivery Partnerships", type: :feature do
 
     scenario "viewing the edit page for a delivery partner's partnerships" do
       visit npq_separation_admin_delivery_partners_path
-      click_link "Assign lead providers", match: :first
+      click_link "Assign course providers", match: :first
 
       expect(page).to have_current_path(edit_npq_separation_admin_delivery_partner_delivery_partnerships_path(delivery_partner))
 
       within "main" do
-        expect(page).to have_content("Add a lead provider")
+        expect(page).to have_content("Add a course provider")
 
-        # All lead providers are displayed
+        # All course providers are displayed
         lead_providers.each do |lead_provider|
           expect(page).to have_content(lead_provider.name)
         end
 
-        # Cohorts are hidden until a lead provider is selected
+        # Cohorts are hidden until a course provider is selected
         expect(page).not_to have_content("Cohort")
       end
     end
 
-    scenario "assigning lead providers and cohorts to a delivery partner" do
+    scenario "assigning course providers and cohorts to a delivery partner" do
       lead_provider = lead_providers.first
       cohort = cohorts.first
 
       visit edit_npq_separation_admin_delivery_partner_delivery_partnerships_path(delivery_partner)
 
-      # Check the lead provider checkbox
+      # Check the course provider checkbox
       check lead_provider.name, visible: :all
 
-      # Check the cohort checkbox for this lead provider
+      # Check the cohort checkbox for this course provider
       within("#delivery-partner-lead-provider-id-#{lead_provider.id}-conditional") do
         check cohort_label(cohort), visible: :all
       end
@@ -58,7 +58,7 @@ RSpec.feature "NPQ Separation Admin Delivery Partnerships", type: :feature do
       expect(DeliveryPartnership.where(delivery_partner:, lead_provider:, cohort:)).to exist
     end
 
-    scenario "removing a lead provider partnership" do
+    scenario "removing a course provider partnership" do
       # Create an existing partnership
       lead_provider = lead_providers.first
       cohort = cohorts.first
@@ -70,7 +70,7 @@ RSpec.feature "NPQ Separation Admin Delivery Partnerships", type: :feature do
 
       visit edit_npq_separation_admin_delivery_partner_delivery_partnerships_path(delivery_partner)
 
-      # The lead provider should be checked
+      # The course provider should be checked
       expect(page).to have_field("delivery_partner[lead_provider_id][]", with: lead_provider.id.to_s, checked: true, visible: :all)
 
       # The cohort should be checked
@@ -78,7 +78,7 @@ RSpec.feature "NPQ Separation Admin Delivery Partnerships", type: :feature do
         expect(page).to have_field(cohort_label(cohort), checked: true, visible: :all)
       end
 
-      # Uncheck the lead provider (this should also uncheck all cohorts via JS)
+      # Uncheck the course provider (this should also uncheck all cohorts via JS)
       uncheck lead_provider.name, visible: :all
 
       click_button "Save"
@@ -88,7 +88,7 @@ RSpec.feature "NPQ Separation Admin Delivery Partnerships", type: :feature do
       expect(DeliveryPartnership.find_by(id: delivery_partnership.id)).to be_nil
     end
 
-    scenario "removing a specific cohort from a lead provider partnership" do
+    scenario "removing a specific cohort from a course provider partnership" do
       # Create existing partnerships for two cohorts
       lead_provider = lead_providers.first
       cohort1 = cohorts.first
@@ -106,7 +106,7 @@ RSpec.feature "NPQ Separation Admin Delivery Partnerships", type: :feature do
 
       visit edit_npq_separation_admin_delivery_partner_delivery_partnerships_path(delivery_partner)
 
-      # The lead provider should be checked
+      # The course provider should be checked
       expect(page).to have_field("delivery_partner[lead_provider_id][]", with: lead_provider.id.to_s, checked: true, visible: :all)
 
       # Both cohorts should be checked

--- a/spec/features/npq_separation/admin/lead_providers_spec.rb
+++ b/spec/features/npq_separation/admin/lead_providers_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Listing and viewing lead providers", type: :feature do
+RSpec.feature "Listing and viewing course providers", type: :feature do
   include Helpers::AdminLogin
 
   before do
@@ -8,17 +8,17 @@ RSpec.feature "Listing and viewing lead providers", type: :feature do
     sign_in_as(create(:admin))
   end
 
-  scenario "viewing the list of lead providers" do
+  scenario "viewing the list of course providers" do
     visit(npq_separation_admin_lead_providers_path)
 
-    expect(page).to have_css("h1", text: "Lead providers")
+    expect(page).to have_css("h1", text: "Course providers")
 
     LeadProvider.all.find_each do |lead_provider|
       expect(page).to have_link(lead_provider.name, href: npq_separation_admin_lead_provider_path(lead_provider))
     end
   end
 
-  scenario "viewing lead provider details" do
+  scenario "viewing course provider details" do
     visit(npq_separation_admin_lead_providers_path)
 
     lead_provider = LeadProvider.first

--- a/spec/models/bulk_operation/revert_applications_to_pending_spec.rb
+++ b/spec/models/bulk_operation/revert_applications_to_pending_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe BulkOperation::RevertApplicationsToPending do
     context "when the application is already pending" do
       let(:application) { create(:application, :pending) }
 
-      it_behaves_like "does not change to pending", /lead provider approval status is not Accepted/
+      it_behaves_like "does not change to pending", /course provider approval status is not Accepted/
     end
 
     context "when the application doesn't exist" do

--- a/spec/services/applications/change_lead_provider_spec.rb
+++ b/spec/services/applications/change_lead_provider_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Applications::ChangeLeadProvider, type: :model do
 
   describe "validation" do
     it { is_expected.to validate_presence_of :application }
-    it { is_expected.to validate_presence_of(:lead_provider_id).with_message "Choose a lead provider" }
+    it { is_expected.to validate_presence_of(:lead_provider_id).with_message "Choose a course provider" }
 
     context "when lead_provider_id is not different to the current lead provider" do
       let(:lead_provider_id) { application.lead_provider.id }

--- a/spec/services/one_off/migrate_declarations_between_statements_spec.rb
+++ b/spec/services/one_off/migrate_declarations_between_statements_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe OneOff::MigrateDeclarationsBetweenStatements, type: :model do
   let(:to_statement_updates) { {} }
   let(:lead_provider) { create(:lead_provider) }
   let(:from_statement) { create(:statement, month: 4, year: 2023, lead_provider:, cohort:, output_fee: true) }
-  let(:to_statement) { create(:statement, :next_output_fee, month: 5, year: 2023, lead_provider:, cohort:) }
+  let(:to_statement) { create(:statement, :next_output_fee, month: 5, year: 2023, lead_provider:, cohort:, payment_date: 1.day.from_now) }
   let(:from_month) { from_statement.month }
   let(:from_year) { from_statement.year }
   let(:to_month) { to_statement.month }

--- a/spec/views/npq_separation/admin/applications/show.html.erb_spec.rb
+++ b/spec/views/npq_separation/admin/applications/show.html.erb_spec.rb
@@ -20,11 +20,16 @@ RSpec.describe "npq_separation/admin/applications/show.html.erb", type: :view do
 
     it { is_expected.to have_css "h1", text: application.user.full_name }
     it { is_expected.to have_text "TRN: #{application.user.trn}", normalize_ws: true }
-    it { is_expected.to have_summary_item "Application ID", application.ecf_id }
-    it { is_expected.to have_summary_item "Course provider", application.lead_provider.name }
-    it { is_expected.to have_summary_item "Course", application.course.name }
     it { is_expected.to have_summary_item "Unique reference number (URN)", application.school.urn }
     it { is_expected.to have_summary_item "UK Provider Reference Number (UKPRN)", application.school.ukprn }
+
+    context "with application overview summary card" do
+      subject { Capybara.string(render).find(".govuk-summary-card", text: "Application overview") }
+
+      it { is_expected.to have_summary_item "Application ID", application.ecf_id }
+      it { is_expected.to have_summary_item "Course provider", application.lead_provider.name }
+      it { is_expected.to have_summary_item "Course", application.course.name }
+    end
   end
 
   describe "a row for a minimal application" do


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2903

### Changes proposed in this pull request

New side nav on the Course provider page.

All instances of the words "Lead provider" renamed to "Course provider" across the admin console.
API error messages and API guidance are left untouched.