### PR TITLE
[BAU] Fix flaky spec on statements page

### DIFF
--- a/spec/support/matchers/component_matcher.rb
+++ b/spec/support/matchers/component_matcher.rb
@@ -13,10 +13,14 @@ RSpec::Matchers.define :have_component do |expected_component|
   end
 
   def expected_html(component)
-    ApplicationController.renderer.render(component, layout: false)
+    CGI.unescapeHTML render_component(component)
   end
 
   def actual_html(page)
     page.is_a?(ActiveSupport::SafeBuffer) ? page : page.html
+  end
+
+  def render_component(component)
+    ApplicationController.renderer.render(component, layout: false)
   end
 end


### PR DESCRIPTION
### Context

Ticket: BAU

We have a flaky spec on the statements page. This is caused by Lead Provider names (generated by Faker) sometimes having non ascii characters in them. This is resulting in escaped HTML for the rendered component we are expecting _but_ the browser is returning the unescaped version of the HTML.

### Changes proposed in this pull request

1. Unescape the rendered HTML from the tests rendered copy of the component
