### PR TITLE
Ensure correct item is underlined in nav component

### DIFF
--- a/app/components/npq_separation/navigation_structures/admin_navigation_structure.rb
+++ b/app/components/npq_separation/navigation_structures/admin_navigation_structure.rb
@@ -23,7 +23,7 @@ module NpqSeparation
           Node.new(
             name: "Reopening email subscriptions",
             href: npq_separation_admin_reopening_email_subscriptions_path,
-            prefix: "/npq-separation/admin/reopening-email-subscriptions",
+            prefix: "/npq-separation/admin/reopening_email_subscriptions",
           ) => [],
 
           Node.new(
@@ -92,12 +92,12 @@ module NpqSeparation
           Node.new(
             name: "Lead providers",
             href: npq_separation_admin_lead_providers_path,
-            prefix: "/npq-separation/admin/lead_providers",
+            prefix: "/npq-separation/admin/lead-providers",
           ) => [],
           Node.new(
             name: "Bulk operations",
             href: npq_separation_admin_bulk_operations_path,
-            prefix: "/npq-separation/admin/bulk_operations",
+            prefix: "/npq-separation/admin/bulk-operations",
           ) => [],
           Node.new(
             name: "Delivery partners",


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2897

In some cases, 'Dashboard' is being underlined instead of the nav item that was selected.

For example, 'Bulk operations' is selected but 'Dashboard' is underlined:

![image](https://github.com/user-attachments/assets/f7862199-0ed7-418f-ab7c-7f66f56cafbb)

Another example - 'Closed registration users' is selected but 'Dashboard' is underlined:

![image](https://github.com/user-attachments/assets/d98ae9b9-1c81-4092-add6-59d32e32e64a)

This PR fixes the 'prefix' sections in the nav component so that we're using the correct paths. 
