### PR TITLE
[CPDNPQ-2935] dated registration reopening emails

### DIFF
--- a/app/views/npq_separation/admin/reopening_email_subscriptions/index.html.erb
+++ b/app/views/npq_separation/admin/reopening_email_subscriptions/index.html.erb
@@ -11,7 +11,7 @@
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header">Email address</th>
         <th scope="col" class="govuk-table__header">Interested in SENCO?</th>
-        <th scope="col" class="govuk-table__header">Date Added</th>
+        <th scope="col" class="govuk-table__header">Subscription Date</th>
         <th scope="col" class="govuk-table__header">Unsubscribe</th>
       </tr>
       </thead>


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2935

This is so that admins can see when people have signed up for email subscriptions.

### Changes proposed in this pull request
Adding the created at date to the table on the reopening email subscriptions Admin page.

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
