### PR TITLE
Fix link to roadmap page in navigation

### DIFF
--- a/app/components/npq_separation/navigation_structures/guidance_navigation_structure.rb
+++ b/app/components/npq_separation/navigation_structures/guidance_navigation_structure.rb
@@ -34,7 +34,7 @@ module NpqSeparation
           ) => [],
           Node.new(
             name: "Roadmap",
-            href: api_guidance_page_path(page: "/", anchor: "roadmap"),
+            href: api_guidance_page_path(page: "roadmap"),
             prefix: "/api/guidance/roadmap",
           ) => [],
         }


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2791

Fixed the link to the roadmap page in the navigation.

### Changes proposed in this pull request

Swapped an anchor link to page link.

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
