### PR TITLE
[CPDNPQ-2566] Allow for nil #lead_provider_approval_status

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -61,6 +61,8 @@ module ApplicationHelper
   end
 
   def lead_provider_approval_status_badge(lead_provider_approval_status)
+    return nil unless lead_provider_approval_status
+
     colour = {
       pending: "blue",
       accepted: "green",

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -126,4 +126,38 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe "#lead_provider_approval_status_badge" do
+    subject { lead_provider_approval_status_badge(status) }
+
+    context "with pending" do
+      let(:status) { "pending" }
+
+      it { is_expected.to have_css ".govuk-tag--blue", text: "Pending" }
+    end
+
+    context "with accepted" do
+      let(:status) { "accepted" }
+
+      it { is_expected.to have_css ".govuk-tag--green", text: "Accepted" }
+    end
+
+    context "with rejected" do
+      let(:status) { "rejected" }
+
+      it { is_expected.to have_css ".govuk-tag--red", text: "Rejected" }
+    end
+
+    context "with something else" do
+      let(:status) { "something_else" }
+
+      it { is_expected.to have_css ".govuk-tag--grey", text: "Something else" }
+    end
+
+    context "without a lead_provider_approval_status" do
+      let(:status) { nil }
+
+      it { is_expected.to be_nil }
+    end
+  end
 end


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2566](https://dfedigital.atlassian.net/browse/CPDNPQ-2566)

Discovered that the reviews page does not allow for blank lead provider approval statuses during testing of review_status feature on sandbox

### Changes proposed in this pull request

1. Missing specs were added for the helper method
2. The helper method was corrected to handle being passed a nil status

[CPDNPQ-2566]: https://dfedigital.atlassian.net/browse/CPDNPQ-2566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ