### PR TITLE
Re-apply "[CPDNPQ-2905] config file updates"

### DIFF
--- a/app/models/api_token.rb
+++ b/app/models/api_token.rb
@@ -1,7 +1,7 @@
 class APIToken < ApplicationRecord
   belongs_to :lead_provider, optional: true
 
-  enum scope: {
+  enum :scope, {
     lead_provider: "lead_provider",
     teacher_record_service: "teacher_record_service",
   }

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -43,42 +43,42 @@ class Application < ApplicationRecord
 
   after_commit :touch_user_if_changed
 
-  enum kind_of_nursery: {
+  enum :kind_of_nursery, {
     local_authority_maintained_nursery: "local_authority_maintained_nursery",
     preschool_class_as_part_of_school: "preschool_class_as_part_of_school",
     private_nursery: "private_nursery",
     another_early_years_setting: "another_early_years_setting",
     childminder: "childminder",
-  }, _suffix: true
+  }, suffix: true
 
-  enum headteacher_status: {
+  enum :headteacher_status, {
     no: "no",
     yes_when_course_starts: "yes_when_course_starts",
     yes_in_first_two_years: "yes_in_first_two_years",
     yes_over_two_years: "yes_over_two_years",
     yes_in_first_five_years: "yes_in_first_five_years",
     yes_over_five_years: "yes_over_five_years",
-  }, _suffix: true
+  }, suffix: true
 
-  enum funding_choice: {
+  enum :funding_choice, {
     school: "school",
     trust: "trust",
     self: "self",
     another: "another",
     employer: "employer",
-  }, _suffix: true
+  }, suffix: true
 
-  enum lead_provider_approval_status: {
+  enum :lead_provider_approval_status, {
     pending: "pending",
     accepted: "accepted",
     rejected: "rejected",
-  }, _suffix: true
+  }, suffix: true
 
-  enum training_status: {
+  enum :training_status, {
     active: "active",
     deferred: "deferred",
     withdrawn: "withdrawn",
-  }, _suffix: true
+  }, suffix: true
 
   enum :review_status, {
     "Needs review" => "needs_review",

--- a/app/models/application_state.rb
+++ b/app/models/application_state.rb
@@ -6,11 +6,11 @@ class ApplicationState < ApplicationRecord
 
   validates :ecf_id, uniqueness: { case_sensitive: false }, allow_nil: true
 
-  enum state: {
+  enum :state, {
     active: "active",
     deferred: "deferred",
     withdrawn: "withdrawn",
-  }, _suffix: true
+  }, suffix: true
 
   scope :most_recent, -> { order("created_at desc").limit(1) }
   scope :for_lead_provider, ->(lead_provider) { where(lead_provider:) }

--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -42,7 +42,7 @@ class Declaration < ApplicationRecord
     .latest_first
   }
 
-  enum state: {
+  enum :state, {
     submitted: "submitted",
     eligible: "eligible",
     payable: "payable",
@@ -51,7 +51,7 @@ class Declaration < ApplicationRecord
     ineligible: "ineligible",
     awaiting_clawback: "awaiting_clawback",
     clawed_back: "clawed_back",
-  }, _suffix: true
+  }, suffix: true
 
   state_machine :state, initial: :submitted do
     event :mark_eligible do
@@ -94,9 +94,9 @@ class Declaration < ApplicationRecord
     completed: "completed",
   }, suffix: true, validate: true
 
-  enum state_reason: {
+  enum :state_reason, {
     duplicate: "duplicate",
-  }, _suffix: true
+  }, suffix: true
 
   validates :declaration_date, :declaration_type, presence: true
   validate :validate_declaration_date_within_schedule

--- a/app/models/ecf_sync_request_log.rb
+++ b/app/models/ecf_sync_request_log.rb
@@ -5,16 +5,16 @@ class EcfSyncRequestLog < ApplicationRecord
   validates :status, presence: true
   validates :sync_type, presence: true
 
-  enum status: {
+  enum :status, {
     success: "success",
     failed: "failed",
-  }, _suffix: true
+  }, suffix: true
 
-  enum sync_type: {
+  enum :sync_type, {
     user_lookup: "user_lookup",
     user_update: "user_update",
     user_creation: "user_creation",
     get_an_identity_id_sync: "get_an_identity_id_sync",
     application_creation: "application_creation",
-  }, _suffix: true
+  }, suffix: true
 end

--- a/app/models/get_an_identity/webhook_message.rb
+++ b/app/models/get_an_identity/webhook_message.rb
@@ -1,11 +1,11 @@
 class GetAnIdentity::WebhookMessage < ApplicationRecord
-  enum status: {
+  enum :status, {
     pending: "pending",
     processing: "processing",
     processed: "processed",
     failed: "failed",
     unhandled_message_type: "unhandled_message_type",
-  }, _suffix: true
+  }, suffix: true
 
   def processor_klass
     case message_type

--- a/app/models/participant_outcome.rb
+++ b/app/models/participant_outcome.rb
@@ -11,11 +11,11 @@ class ParticipantOutcome < ApplicationRecord
   delegate :trn, to: :user
   delegate :short_code, to: :course, prefix: true
 
-  enum state: {
+  enum :state, {
     passed: "passed",
     failed: "failed",
     voided: "voided",
-  }, _suffix: true
+  }, suffix: true
 
   class << self
     def latest

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,7 +42,7 @@ class User < ApplicationRecord
   EMAIL_UPDATES_STATES = %i[senco other_npq].freeze
   EMAIL_UPDATES_ALL_STATES = [:empty] + EMAIL_UPDATES_STATES
 
-  enum email_updates_status: EMAIL_UPDATES_ALL_STATES, _suffix: true
+  enum :email_updates_status, EMAIL_UPDATES_ALL_STATES, suffix: true
 
   attr_accessor :version_note, :skip_touch_significantly_updated_at
 

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-APP_PATH = File.expand_path('../config/application', __dir__)
-require_relative '../config/boot'
-require 'rails/commands'
+APP_PATH = File.expand_path("../config/application", __dir__)
+require_relative "../config/boot"
+require "rails/commands"

--- a/bin/rake
+++ b/bin/rake
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-require_relative '../config/boot'
-require 'rake'
+require_relative "../config/boot"
+require "rake"
 Rake.application.run

--- a/bin/setup
+++ b/bin/setup
@@ -1,36 +1,36 @@
 #!/usr/bin/env ruby
-require 'fileutils'
+require "fileutils"
 
 # path to your application root.
-APP_ROOT = File.expand_path('..', __dir__)
+APP_ROOT = File.expand_path("..", __dir__)
 
 def system!(*args)
-  system(*args) || abort("\n== Command #{args} failed ==")
+  system(*args, exception: true)
 end
 
 FileUtils.chdir APP_ROOT do
-  # This script is a way to setup or update your development environment automatically.
-  # This script is idempotent, so that you can run it at anytime and get an expectable outcome.
+  # This script is a way to set up or update your development environment automatically.
+  # This script is idempotent, so that you can run it at any time and get an expectable outcome.
   # Add necessary setup steps to this file.
 
-  puts '== Installing dependencies =='
-  system! 'gem install bundler --conservative'
-  system('bundle check') || system!('bundle install')
+  puts "== Installing dependencies =="
+  system! "gem install bundler --conservative"
+  system("bundle check") || system!("bundle install")
 
   # Install JavaScript dependencies
-  # system('bin/yarn')
+  system!('bin/yarn')
 
   # puts "\n== Copying sample files =="
-  # unless File.exist?('config/database.yml')
-  #   FileUtils.cp 'config/database.yml.sample', 'config/database.yml'
+  # unless File.exist?("config/database.yml")
+  #   FileUtils.cp "config/database.yml.sample", "config/database.yml"
   # end
 
   puts "\n== Preparing database =="
-  system! 'bin/rails db:prepare'
+  system! "bin/rails db:prepare"
 
   puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rails log:clear tmp:clear'
+  system! "bin/rails log:clear tmp:clear"
 
   puts "\n== Restarting application server =="
-  system! 'bin/rails restart'
+  system! "bin/rails restart"
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,8 +8,12 @@ require "active_record/railtie"
 require "active_storage/engine"
 require "action_controller/railtie"
 require "action_mailer/railtie"
+# require "action_mailbox/engine"
+# require "action_text/engine"
 require "action_view/railtie"
 require "sprockets/railtie"
+# require "action_cable/engine"
+# require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -18,8 +22,25 @@ Bundler.require(*Rails.groups)
 module NpqRegistration
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 7.0
+    config.load_defaults 7.1
 
+    # Please, add to the `ignore` list any other `lib` subdirectories that do
+    # not contain `.rb` files, or that should not be reloaded or eager loaded.
+    # Common ones are `templates`, `generators`, or `middleware`, for example.
+    # config.autoload_lib(ignore: %w[assets tasks])
+
+    # Configuration for the application, engines, and railties goes here.
+    #
+    # These settings can be overridden in specific environments using the files
+    # in config/environments, which are processed later.
+    #
+    # config.time_zone = "Central Time (US & Canada)"
+    # config.eager_load_paths << Rails.root.join("extras")
+
+    # Don't generate system test files.
+    config.generators.system_tests = nil
+
+    # NPQ specific changes
     config.exceptions_app = routes
 
     config.middleware.use Rack::Deflater
@@ -46,5 +67,10 @@ module NpqRegistration
 
     config.x.tracking_pixels_enabled = ENV["TRACKING_PIXELS"].to_s == "true"
     config.x.google_analytics_id = ENV["GOOGLE_ANALYTICS_ID"].presence
+
+    # Use active record session store in all environments for consistency
+    config.session_store :active_record_store, key: "_npq_registration_session",
+                                               secure: !Rails.env.local?,
+                                               expire_after: 2.weeks
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,22 +1,12 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
-  config.after_initialize do
-    Bullet.enable                       = true
-    Bullet.alert                        = true
-    Bullet.bullet_logger                = true
-    Bullet.console                      = true
-    Bullet.rails_logger                 = true
-    Bullet.add_footer                   = true
-    Bullet.unused_eager_loading_enable  = false # Disabled due to the way our queries are structured
-  end
-
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time
   # it changes. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
-  config.cache_classes = false
+  config.enable_reloading = true
 
   # Do not eager load code on boot.
   config.eager_load = false
@@ -48,7 +38,6 @@ Rails.application.configure do
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.delivery_method = :test
 
   config.action_mailer.perform_caching = false
 
@@ -67,20 +56,24 @@ Rails.application.configure do
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
 
+  # Highlight code that enqueued background job in logs.
+  config.active_job.verbose_enqueue_logs = true
+
+  # Suppress logger output for asset requests.
+  config.assets.quiet = true
+
   # Raises error for missing translations.
-  config.i18n.raise_on_missing_translations = ENV.fetch("RAISE_ON_MISSING_TRANSLATIONS", "false") == "true"
-
-  # Use an evented file watcher to asynchronously detect changes in source code,
-  # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
-
-  config.session_store :active_record_store, key: "_npq_registration_session", secure: false, expire_after: 2.weeks
+  # config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 
-  # Uncomment if you wish to allow Action Cable access from any origin.
-  # config.action_cable.disable_request_forgery_protection = true
+  # Raise error when a before_action's only/except options reference missing actions
+  config.action_controller.raise_on_missing_callback_actions = true
+
+  ### NPQ specific changes
+  config.action_mailer.delivery_method = :test
+  config.i18n.raise_on_missing_translations = true
 
   # Disable origin check for Cross-Site Request Forgery (CSRF) protection for codespaces.
   # I'm not sure why it doesn't work, but it doesn't.
@@ -88,9 +81,16 @@ Rails.application.configure do
     config.action_controller.forgery_protection_origin_check = false
   end
 
-  # Suppress logger output for asset requests.
-  config.assets.quiet = true
-
   # Disable middleware in development environment
   config.x.enable_api_request_middleware = false
+
+  config.after_initialize do
+    Bullet.enable                       = true
+    Bullet.alert                        = true
+    Bullet.bullet_logger                = true
+    Bullet.console                      = true
+    Bullet.rails_logger                 = true
+    Bullet.add_footer                   = true
+    Bullet.unused_eager_loading_enable  = false # Disabled due to the way our queries are structured
+  end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -4,7 +4,7 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.
-  config.cache_classes = true
+  config.enable_reloading = false
 
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers
@@ -13,37 +13,96 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local = false
   config.action_controller.perform_caching = true
 
-  # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
-  # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
+  # Ensures that a master key has been made available in ENV["RAILS_MASTER_KEY"], config/master.key, or an environment
+  # key such as config/credentials/production.key. This key is used to decrypt credentials (and other encrypted files).
   # config.require_master_key = true
 
-  # Disable serving static files from the `/public` folder by default since
-  # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
+  # Disable serving static files from `public/`, relying on NGINX/Apache to do so instead.
+  # config.public_file_server.enabled = false
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
 
+  # Do not fall back to assets pipeline if a precompiled asset is missed.
+  config.assets.compile = false
+
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = 'http://assets.example.com'
+  # config.asset_host = "http://assets.example.com"
 
   # Specifies the header that your server uses for sending files.
-  # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
-  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
+  # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
+  # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :microsoft
+  # config.active_storage.service = :local
+
+  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
+  # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.
+  # config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
+  # Log to STDOUT by default
+  config.logger = ActiveSupport::Logger.new($stdout)
+    .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
+    .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
+
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
 
+  # "info" includes generic and useful information about system operation, but avoids logging too much
+  # information to avoid inadvertent exposure of personally identifiable information (PII). If you
+  # want to log everything, set the level to "debug".
+  config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
+
   # Use a different cache store in production.
+  # config.cache_store = :mem_cache_store
+
+  # Use a real queuing backend for Active Job (and separate queues per environment).
+  # config.active_job.queue_adapter = :resque
+  # config.active_job.queue_name_prefix = "npq_registration_production"
+
+  config.action_mailer.perform_caching = false
+
+  # Ignore bad email addresses and do not raise email delivery errors.
+  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
+  # config.action_mailer.raise_delivery_errors = false
+
+  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
+  # the I18n.default_locale when a translation cannot be found).
+  config.i18n.fallbacks = true
+
+  # Don't log any deprecations.
+  config.active_support.report_deprecations = false
+
+  # Do not dump schema after migrations.
+  config.active_record.dump_schema_after_migration = false
+
+  # Enable DNS rebinding protection and other `Host` header attacks.
+  # config.hosts = [
+  #   "example.com",     # Allow requests from example.com
+  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
+  # ]
+  # Skip DNS rebinding protection for the default health check endpoint.
+  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+
+  ### NPQ specific changes
+
+  config.active_storage.service = :microsoft
+  config.active_job.queue_adapter = :delayed_job
+  config.flipper.actor_limit = 1000
+  config.active_record.logger = nil # Don't log SQL
+
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    $stdout.sync = true
+    config.rails_semantic_logger.add_file_appender = false
+    config.semantic_logger.add_appender(io: $stdout, level: Rails.application.config.log_level, formatter: :json)
+  end
+
   config.cache_store = :redis_cache_store,
                        {
                          url: ENV["REDIS_CACHE_URL"],
@@ -59,66 +118,4 @@ Rails.application.configure do
                                           end
                                         },
                        }
-
-  # Use a real queuing backend for Active Job (and separate queues per environment).
-  config.active_job.queue_adapter = :delayed_job
-  # config.active_job.queue_name_prefix = "govuk_rails_boilerplate_production"
-
-  config.action_mailer.perform_caching = false
-
-  # Ignore bad email addresses and do not raise email delivery errors.
-  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
-
-  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
-  # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = true
-
-  # Send deprecation notices to registered listeners.
-  config.active_support.deprecation = :notify
-
-  # Use a different logger for distributed setups.
-  # require 'syslog/logger'
-  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
-
-  # Don't log SQL
-  config.active_record.logger = nil
-
-  # Logging
-  config.log_level = :info
-
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    $stdout.sync = true
-    config.rails_semantic_logger.add_file_appender = false
-    config.semantic_logger.add_appender(io: $stdout, level: Rails.application.config.log_level, formatter: :json)
-  end
-
-  # Do not dump schema after migrations.
-  config.active_record.dump_schema_after_migration = false
-
-  # Inserts middleware to perform automatic connection switching.
-  # The `database_selector` hash is used to pass options to the DatabaseSelector
-  # middleware. The `delay` is used to determine how long to wait after a write
-  # to send a subsequent read to the primary.
-  #
-  # The `database_resolver` class is used by the middleware to determine which
-  # database is appropriate to use based on the time delay.
-  #
-  # The `database_resolver_context` class is used by the middleware to set
-  # timestamps for the last write to the primary. The resolver uses the context
-  # class timestamps to determine how long to wait before reading from the
-  # replica.
-  #
-  # By default Rails will store a last write timestamp in the session. The
-  # DatabaseSelector middleware is designed as such you can define your own
-  # strategy for connection switching and pass that into the middleware through
-  # these configuration options.
-  # config.active_record.database_selector = { delay: 2.seconds }
-  # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
-  # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
-
-  config.session_store :active_record_store, key: "_npq_registration_session", secure: true, expire_after: 2.weeks
-  # increase the actor limit from the default of 100
-  # this limits the number of users that can use the late registration route
-  config.flipper.actor_limit = 1000
 end

--- a/config/environments/review.rb
+++ b/config/environments/review.rb
@@ -1,8 +1,6 @@
 require Rails.root.join("config/environments/production")
 
 Rails.application.configure do
-  config.ssl_options = { redirect: { exclude: ->(request) { request.path.include?("/healthcheck") } } }
-
   config.after_initialize do
     Bullet.enable                       = true
     Bullet.bullet_logger                = true

--- a/config/environments/sandbox.rb
+++ b/config/environments/sandbox.rb
@@ -2,5 +2,4 @@ require Rails.root.join("config/environments/production")
 
 Rails.application.configure do
   config.log_level = :info
-  config.ssl_options = { redirect: { exclude: ->(request) { request.path.include?("/healthcheck") } } }
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -2,5 +2,4 @@ require Rails.root.join("config/environments/production")
 
 Rails.application.configure do
   config.log_level = :debug
-  config.ssl_options = { redirect: { exclude: ->(request) { request.path.include?("/healthcheck") } } }
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -6,21 +6,16 @@ require "active_support/core_ext/integer/time"
 # and recreated between test runs. Don't rely on the data there!
 
 Rails.application.configure do
-  config.after_initialize do
-    Bullet.enable                       = true
-    Bullet.bullet_logger                = true
-    Bullet.raise                        = true # Raise an error if n+1 query occurs
-    Bullet.unused_eager_loading_enable  = false # Disabled due to the way our queries are structured
-  end
-
   # Settings specified here will take precedence over those in config/application.rb.
 
-  config.cache_classes = false
+  # While tests run files are not watched, reloading is not necessary.
+  config.enable_reloading = false
 
-  # Do not eager load code on boot. This avoids loading your whole application
-  # just for the purpose of running a single test. If you are using a tool that
-  # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = false
+  # Eager loading loads your entire application. When running a single test locally,
+  # this is usually not necessary, and can slow down your test suite. However, it's
+  # recommended that you enable it in continuous integration systems to ensure eager
+  # loading is working properly before deploying your code.
+  config.eager_load = ENV["CI"].present?
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
@@ -29,12 +24,12 @@ Rails.application.configure do
   }
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
   config.cache_store = :null_store
 
-  # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = :none
+  # Render exception templates for rescuable exceptions and raise for other exceptions.
+  config.action_dispatch.show_exceptions = :rescuable
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
@@ -59,11 +54,23 @@ Rails.application.configure do
   config.active_support.disallowed_deprecation_warnings = []
 
   # Raises error for missing translations.
-  config.i18n.raise_on_missing_translations = true
+  # config.i18n.raise_on_missing_translations = true
 
+  # Annotate rendered view with file names.
+  # config.action_view.annotate_rendered_view_with_filenames = true
+
+  # Raise error when a before_action's only/except options reference missing actions
+  config.action_controller.raise_on_missing_callback_actions = true
+
+  ############ NPQ specific changes ##############
+  config.i18n.raise_on_missing_translations = true
+  config.dotenv.autorestore = false if config.respond_to?(:dotenv)
   config.active_job.queue_adapter = :test
 
-  config.session_store :active_record_store, key: "_npq_registration_session", secure: false, expire_after: 2.weeks
-
-  config.dotenv.autorestore = false if config.respond_to?(:dotenv)
+  config.after_initialize do
+    Bullet.enable                       = true
+    Bullet.bullet_logger                = true
+    Bullet.raise                        = true # Raise an error if n+1 query occurs
+    Bullet.unused_eager_loading_enable  = false # Disabled due to the way our queries are structured
+  end
 end

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,6 +1,15 @@
-# frozen_string_literal: true
-
 # Be sure to restart your server when you modify this file.
+
+# Version of your assets, change this if you want to expire all your assets.
+Rails.application.config.assets.version = "1.0"
+
+# Add additional assets to the asset load path.
+# Rails.application.config.assets.paths << Emoji.images_path
+
+# Precompile additional assets.
+# application.js, application.css, and all non-JS/CSS in the app/assets
+# folder are already added.
+# Rails.application.config.assets.precompile += %w( admin.js admin.css )
 
 # Because these paths are searched in order, we want the assets to come first
 # Add the GOVUK Frontend images path

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,6 +1,8 @@
 # Be sure to restart your server when you modify this file.
 
-# Configure sensitive parameters which will be filtered from the log file.
+# Configure parameters to be partially matched (e.g. passw matches password) and filtered from the log file.
+# Use this to limit dissemination of sensitive information.
+# See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 Rails.application.config.filter_parameters += %i[
   password
   passw

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -11,6 +11,10 @@
 # end
 
 # These inflection rules are supported but not enabled by default:
+# ActiveSupport::Inflector.inflections(:en) do |inflect|
+#   inflect.acronym "RESTful"
+# end
+
 ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym "API"
 end

--- a/config/initializers/permissions_policy.rb
+++ b/config/initializers/permissions_policy.rb
@@ -1,11 +1,13 @@
+# Be sure to restart your server when you modify this file.
+
 # Define an application-wide HTTP permissions policy. For further
-# information see https://developers.google.com/web/updates/2018/06/feature-policy
-#
-# Rails.application.config.permissions_policy do |f|
-#   f.camera      :none
-#   f.gyroscope   :none
-#   f.microphone  :none
-#   f.usb         :none
-#   f.fullscreen  :self
-#   f.payment     :self, "https://secure.example.com"
+# information see: https://developers.google.com/web/updates/2018/06/feature-policy
+
+# Rails.application.config.permissions_policy do |policy|
+#   policy.camera      :none
+#   policy.gyroscope   :none
+#   policy.microphone  :none
+#   policy.usb         :none
+#   policy.fullscreen  :self
+#   policy.payment     :self, "https://secure.example.com"
 # end

--- a/spec/requests/api/documentation_controller_spec.rb
+++ b/spec/requests/api/documentation_controller_spec.rb
@@ -27,14 +27,14 @@ RSpec.describe API::DocumentationController do
   end
 
   context "with v4" do
-    let(:make_request) { get api_documentation_path(version: "v4") }
+    before { get api_documentation_path(version: "v4") }
 
-    it { expect { make_request }.to raise_exception ActionController::RoutingError }
+    it { is_expected.to have_http_status :not_found }
   end
 
   context "without version" do
-    let(:make_request) { get api_documentation_path(version: "") }
+    before { get api_documentation_path(version: "") }
 
-    it { expect { make_request }.to raise_exception ActionController::RoutingError }
+    it { is_expected.to have_http_status :not_found }
   end
 end


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2905](https://dfedigital.atlassian.net/browse/CPDNPQ-2905)

We want to upgrade to Rails 7.2 in the near future, moving the application configs closer to the rails defaults will make upgrading them as part of the 7.2 upgrade more straight forward and reduce the change of running into odd behaviours because of legacy configs.

**Note:** this is the second attempt without enabling `force_ssl` - that will be enabled in a follow up PR

### Changes proposed in this pull request

1. Swapped to using the new enum format for the application models
2. Use the new `:rescuable` option for errors in the test environment
3. Configure the activerecord session plugin across all environments for consistency
4. Standardised the environment configs on the Rails templates with the NPQ specific changes after
5. Dropped the environment specific workarounds for `force_ssl` config option because these were missing from the production environment

[CPDNPQ-2905]: https://dfedigital.atlassian.net/browse/CPDNPQ-2905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ