### PR TITLE
[CPDNPQ-2891] Link applications to workplaces

### DIFF
--- a/app/views/npq_separation/admin/applications/show.html.erb
+++ b/app/views/npq_separation/admin/applications/show.html.erb
@@ -83,7 +83,11 @@
   govuk_summary_list(card: { title: "Workplace" }) do |sl|
     sl.with_row do |row|
       row.with_key(text: "Name")
-      row.with_value(text: @application.employer_name_to_display)
+      if @application.employer_urn.present?
+        row.with_value(text: govuk_link_to(@application.employer_name_to_display, npq_separation_admin_schools_path(q: @application.employer_urn)))
+      else
+        row.with_value(text: @application.employer_name_to_display)
+      end
     end
     sl.with_row do |row|
       row.with_key(text: "UK Provider Reference Number (UKPRN)")

--- a/spec/views/npq_separation/admin/applications/show.html.erb_spec.rb
+++ b/spec/views/npq_separation/admin/applications/show.html.erb_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe "npq_separation/admin/applications/show.html.erb", type: :view do
   subject { Capybara.string(render) }
 
+  let(:declarations) { [] }
+
   before do
     assign(:application, application)
     assign(:declarations, declarations)
@@ -20,6 +22,7 @@ RSpec.describe "npq_separation/admin/applications/show.html.erb", type: :view do
 
     it { is_expected.to have_css "h1", text: application.user.full_name }
     it { is_expected.to have_text "TRN: #{application.user.trn}", normalize_ws: true }
+    it { is_expected.to have_link(application.employer_name_to_display, href: npq_separation_admin_schools_path(q: application.school.urn)) }
     it { is_expected.to have_summary_item "Unique reference number (URN)", application.school.urn }
     it { is_expected.to have_summary_item "UK Provider Reference Number (UKPRN)", application.school.ukprn }
 
@@ -32,12 +35,19 @@ RSpec.describe "npq_separation/admin/applications/show.html.erb", type: :view do
     end
   end
 
+  describe "a row for an employer with no URN" do
+    let :application do
+      build_stubbed :application, school: nil, employer_name: "No URN"
+    end
+
+    it { is_expected.to have_text(application.employer_name_to_display) }
+    it { is_expected.not_to have_link(application.employer_name_to_display) }
+  end
+
   describe "a row for a minimal application" do
     let :application do
       build_stubbed :application, cohort: nil, itt_provider: nil, school: nil
     end
-
-    let(:declarations) { [] }
 
     it { is_expected.to have_css "h1", text: application.user.full_name }
     it { is_expected.to have_text "TRN: #{application.user.trn}", normalize_ws: true }


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2891

Now that the "workplaces" screen has been revamped, we can implement the desired link from the application view.

The link is only rendered for types of workplace that are listed on the Workplaces screen.