### PR TITLE
[BAU] Prevent terraform apply from being cancelled prematurely

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: "Deploy"
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
### Context

Ticket: BAU

If an update is pushed to a branch when terraform is deploying then the running terraform deploy is sent a kill signal. This leads to premature termination of the `terraform apply` and results in resources get created but not persisted in the tf state file.

Some of these resources we as team members cannot remove and require other teams such as infra to remove for us.

### Changes proposed in this pull request

1. Prevent auto cancelling running workflows - _note: this will still cancel pending workflows so 3 pushes in quick succession will only result in a running workflow, plus a single pending one for the latest push_

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
