### PR TITLE
[CPDNPQ-2607] Improve resilience if the DQT service goes slowly

### DIFF
--- a/app/services/dqt/v1/teacher.rb
+++ b/app/services/dqt/v1/teacher.rb
@@ -6,6 +6,7 @@ module Dqt
       format :json
       base_uri ENV["DQT_API_URL"]
       headers "Authorization" => "Bearer #{ENV["DQT_API_KEY"]}"
+      default_timeout 5.seconds
 
       def self.find(trn:, birthdate:, nino: nil)
         path = "/v1/teachers/#{trn}"
@@ -30,6 +31,9 @@ module Dqt
             "active_alert",
           )
         end
+      rescue Timeout::Error => e
+        Rails.logger.error("DQT API request timed out: #{e.class} #{e.message}")
+        raise e
       end
     end
   end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2607

- Changes the DQT API client from the default `Net::HTTP` timeout of 60 seconds to an explicitly defined 5 second timeout
- Automically retries the DQT API call once, in case of network issues that Jeremy has previously observed
- Makes both the timeout and the number of retries easily reconfigurable
- Preserves current behaviour that if the DQT call fails, the applicant can continue to register but their TRN will be treated as unverified