### PR TITLE
fix flaky spec - move file creation into spec

### DIFF
--- a/spec/factories/bulk_operation/update_and_verify_trns.rb
+++ b/spec/factories/bulk_operation/update_and_verify_trns.rb
@@ -5,14 +5,5 @@ FactoryBot.define do
     end
 
     admin { create(:admin) }
-
-    after(:build) do |bulk_operation, evaluator|
-      tempfile = Tempfile.new.tap do |file|
-        file.write("#{BulkOperation::UpdateAndVerifyTrns::FILE_HEADERS.join(",")}\n")
-        file.write(evaluator.trns_to_update.map { |columns| columns.join(",") }.join("\n"))
-        file.rewind
-      end
-      bulk_operation.file.attach(tempfile.open)
-    end
   end
 end


### PR DESCRIPTION
### Context

occasional `IOError` when running this spec

### Changes proposed in this pull request

move tempfile creation into spec, so its reference is not lost whilst running the spec, so that the file is not garbage collected.
