### PR TITLE
[CPDNPQ-2475] Automatically restore snapshot DB every sunday night

### DIFF
--- a/.github/workflows/restore_snapshot_database.yml
+++ b/.github/workflows/restore_snapshot_database.yml
@@ -1,5 +1,7 @@
 name: Restore Snapshot DB from production DB
 on:
+  schedule:
+    - cron: "0 22 * * 0"
   workflow_dispatch:
     inputs:
       environment:


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2475

> We have a snapshot copy of the production database available for debugging
>
>This requires manual updating in the middle of the day when the app is in use if we wish to view recent data (assuming its not recently been updated)
>
>There is already a GitHub action requiring manual triggering, this should also run automatically on a Sunday nigth