### PR TITLE
[CPDNPQ-2931] Move manual_deploy to own workflow

### DIFF
--- a/.github/actions/deploy-environment-to-aks/action.yml
+++ b/.github/actions/deploy-environment-to-aks/action.yml
@@ -20,8 +20,8 @@ inputs:
   pull-request-number:
     description: The pull request number which triggered this deploy. If set, this will automatically seed the database.
     required: false
-  current-commit-sha:
-    description: The commit sha for the current commit
+  deploy-commit-sha:
+    description: The commit sha for the commit being deployed
     required: true
   statuscake-api-token:
     description: The Statuscake token
@@ -81,4 +81,4 @@ runs:
     - uses: ./.github/actions/smoke-test
       with:
         url: ${{ steps.apply-terraform.outputs.url }}
-        current-commit-sha: ${{ inputs.current-commit-sha }}
+        deploy-commit-sha: ${{ inputs.deploy-commit-sha }}

--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -6,8 +6,8 @@ inputs:
     description: The URL of the deployed environment.
     required: true
 
-  current-commit-sha:
-    description: The sha of the current commit
+  deploy-commit-sha:
+    description: The sha of the commit being deployed
     required: true
 
 runs:
@@ -16,4 +16,4 @@ runs:
   steps:
     - name: Run smoke tests
       shell: bash
-      run: bin/smoke ${{ inputs.url }} ${{ inputs.current-commit-sha }}
+      run: bin/smoke ${{ inputs.url }} ${{ inputs.deploy-commit-sha }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,7 +74,7 @@ jobs:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           pull-request-number: ${{ github.event.pull_request.number }}
-          current-commit-sha: ${{ github.event.pull_request.head.sha }}
+          deploy-commit-sha: ${{ github.event.pull_request.head.sha }}
 
       - name: Post sticky pull request comment
         if: github.event_name == 'pull_request'
@@ -104,7 +104,7 @@ jobs:
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          current-commit-sha: ${{ github.sha }}
+          deploy-commit-sha: ${{ github.sha }}
           statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
 
       - name: Notify on failure
@@ -135,7 +135,7 @@ jobs:
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          current-commit-sha: ${{ github.sha }}
+          deploy-commit-sha: ${{ github.sha }}
           statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
 
       - name: Notify on failure
@@ -166,7 +166,7 @@ jobs:
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          current-commit-sha: ${{ github.sha }}
+          deploy-commit-sha: ${{ github.sha }}
           statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
 
       - name: Notify on failure

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,7 +116,7 @@ jobs:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           pull-request-number: ${{ github.event.pull_request.number }}
-          current-commit-sha: ${{ github.sha }}
+          current-commit-sha: ${{ github.event.pull_request.head.sha }}
 
       - name: Post sticky pull request comment
         if: github.event_name == 'pull_request'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,24 +5,6 @@ concurrency:
   cancel-in-progress: false
 
 on:
-  workflow_dispatch:
-    inputs:
-      environment:
-        description: "Deploy environment"
-        required: true
-        type: choice
-        default: review
-        options:
-          - review
-      docker-image-tag:
-        description: "Docker image tag to deploy"
-        required: true
-        type: string
-      pull-request-number:
-        description: "PR number of review app to deploy to"
-        required: false
-        type: string
-
   push:
     branches:
       - main
@@ -71,33 +53,6 @@ jobs:
           snyk-token: ${{ secrets.SNYK_TOKEN }}
           max-cache: true
           reuse-cache: true
-
-  manual_deploy:
-    name: Manual deploy to ${{ inputs.environment }}
-    if: ${{ github.event_name == 'workflow_dispatch' }}
-    needs: [docker]
-    environment:
-      name: ${{ inputs.environment }}
-    runs-on: ubuntu-24.04
-    permissions:
-      id-token: write
-      pull-requests: write
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: ./.github/actions/deploy-environment-to-aks
-        name: Deploy app to ${{ inputs.environment }}
-        id: deploy_manual
-        with:
-          environment: ${{ inputs.environment }}
-          docker-image: ghcr.io/dfe-digital/npq-registration:${{ inputs.docker-image-tag }}
-          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          current-commit-sha: ${{ inputs.docker-image-tag }}
-          statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
-          pull-request-number: ${{ inputs.pull-request-number }}
 
   deploy_review:
     name: Deploy review

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,12 +13,14 @@ on:
         type: choice
         default: review
         options:
-          - staging
-          - sandbox
-          - production
+          - review
       docker-image-tag:
         description: "Docker image tag to deploy"
         required: true
+        type: string
+      pull-request-number:
+        description: "PR number of review app to deploy to"
+        required: false
         type: string
 
   push:
@@ -95,6 +97,7 @@ jobs:
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           current-commit-sha: ${{ inputs.docker-image-tag }}
           statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
+          pull-request-number: ${{ inputs.pull-request-number }}
 
   deploy_review:
     name: Deploy review

--- a/.github/workflows/manual_deploy.yml
+++ b/.github/workflows/manual_deploy.yml
@@ -56,7 +56,7 @@ jobs:
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          current-commit-sha: ${{ inputs.docker-image-tag }}
+          deploy-commit-sha: ${{ inputs.docker-image-tag }}
           statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
           pull-request-number: ${{ inputs.pull-request-number }}
 

--- a/.github/workflows/manual_deploy.yml
+++ b/.github/workflows/manual_deploy.yml
@@ -1,0 +1,62 @@
+name: "Manual deploy"
+
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: false
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Deploy environment"
+        required: true
+        type: choice
+        default: review
+        options:
+          - review
+      docker-image-tag:
+        description: "Docker image tag to deploy"
+        required: true
+        type: string
+      pull-request-number:
+        description: "PR number of review app to deploy to"
+        required: false
+        type: string
+
+env:
+  TERRAFORM_BASE: terraform/application
+  HEALTHCHECK_CMD: "healthcheck"
+
+permissions:
+  id-token: write
+  pull-requests: write
+  packages: write
+
+jobs:
+
+  manual_deploy:
+    name: Manual deploy to ${{ inputs.environment }}
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    environment:
+      name: ${{ inputs.environment }}
+    runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/deploy-environment-to-aks
+        name: Deploy app to ${{ inputs.environment }}
+        id: deploy_manual
+        with:
+          environment: ${{ inputs.environment }}
+          docker-image: ghcr.io/dfe-digital/npq-registration:${{ inputs.docker-image-tag }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          current-commit-sha: ${{ inputs.docker-image-tag }}
+          statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}
+          pull-request-number: ${{ inputs.pull-request-number }}
+

--- a/.github/workflows/manual_deploy.yml
+++ b/.github/workflows/manual_deploy.yml
@@ -14,6 +14,9 @@ on:
         default: review
         options:
           - review
+          - staging
+          - production
+          - sandbox
       docker-image-tag:
         description: "Docker image tag to deploy"
         required: true

--- a/bin/smoke
+++ b/bin/smoke
@@ -23,10 +23,10 @@ for ((i=1; i<=max_retries; i++)); do
     break
   fi
 
-  # if [[ $i -eq $max_retries ]]; then
-  #   echo "Fail: healthcheck sha is $response_sha but current commit is $current_commit_sha"
-  #   exit 1
-  # fi
+  if [[ $i -eq $max_retries ]]; then
+    echo "Fail: healthcheck sha is $response_sha but current commit is $current_commit_sha"
+    exit 1
+  fi
 
   sleep 1 # Wait for 1 second before retrying
 done

--- a/bin/smoke
+++ b/bin/smoke
@@ -6,8 +6,8 @@ if [[ -z $url ]]; then
   exit 1
 fi
 
-current_commit_sha=\"$2\"
-if [[ -z $current_commit_sha ]]; then
+deploy_commit_sha=\"$2\"
+if [[ -z $deploy_commit_sha ]]; then
   echo `date`" - smoke test failed (head sha is missing)"
   exit 1
 fi
@@ -18,13 +18,13 @@ for ((i=1; i<=max_retries; i++)); do
   response=$(curl -sL $url/healthcheck)
   response_sha=$(jq ".git_commit_sha" <<< $response)
   
-  if [[ $response_sha == $current_commit_sha ]]; then
+  if [[ $response_sha == $deploy_commit_sha ]]; then
     echo "✅ Correct version deployed"
     break
   fi
 
   if [[ $i -eq $max_retries ]]; then
-    echo "Fail: healthcheck sha is $response_sha but current commit is $current_commit_sha"
+    echo "Fail: healthcheck sha is $response_sha but deploy commit should be $deploy_commit_sha"
     exit 1
   fi
 


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2931

We want to check the SHA being deployed is the expected one but currently we are checking it is the SHA of the branch being deployed. This causes problems with manual deploys - as part of testing it was discovered that manual deploys also continued on and deployed the subsequent environments.

The references to `current-commit-sha` are misleading in the manual deploy scenario where the current commit on the branch may not be the sha being deployed. This has also been renamed to avoid confusion.

### Changes proposed in this pull request

1. The existing check was re-enabled
2. The manual_deploy step was moved to its own workflow - this resolves the manual deploy continuing on and deploying other later environments - whilst also avoiding waiting on spec runs and docker image builds
3. Replaced references to `current-commit-sha` with `deploy-commit-sha`

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
