### PR TITLE
[CPDNPQ-2375] make seeds reflect production

### DIFF
--- a/db/seeds/base/add_cohorts.rb
+++ b/db/seeds/base/add_cohorts.rb
@@ -1,9 +1,11 @@
-FactoryBot.create(:cohort, start_year: 2021)
+FactoryBot.create(:cohort, start_year: 2021, funding_cap: false)
+FactoryBot.create(:cohort, start_year: 2022, funding_cap: false)
+FactoryBot.create(:cohort, start_year: 2023, funding_cap: false)
 
 # Ensure Cohort.next is always created
 registration_start_month = Cohort.find_by(start_year: 2021).registration_start_date.month
 next_cohort_start_year = Date.current.year + (Date.current.month < registration_start_month ? 0 : 1)
 
-(2022..next_cohort_start_year).each do |start_year|
-  FactoryBot.create(:cohort, start_year:)
+(2024..next_cohort_start_year).each do |start_year|
+  FactoryBot.create(:cohort, :with_funding_cap, start_year:)
 end

--- a/spec/factories/applications.rb
+++ b/spec/factories/applications.rb
@@ -59,7 +59,7 @@ FactoryBot.define do
     trait :accepted do
       lead_provider_approval_status { :accepted }
       schedule { Schedule.find_by(cohort:, course_group: course.course_group) || create(:schedule, course_group: course.course_group, cohort:) }
-      funded_place { !!eligible_for_funding }
+      funded_place { cohort.funding_cap ? !!eligible_for_funding : nil }
       accepted_at { Time.zone.now }
       training_status { :active }
     end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2375

### Changes proposed in this pull request

In production, cohorts 2021, 2022, and 2023 have `funding_cap`: `false` - only 2024 and 2025 have `funding_cap`: `true`.
Also, accepted applications for the 2021/2022/2023 cohorts have `funded_place`: nil.

This PR makes the seeded data reflect production.
