### PR TITLE
[BAU] Restrict loading seeds to review environment

### DIFF
--- a/.github/actions/deploy-environment-to-aks/action.yml
+++ b/.github/actions/deploy-environment-to-aks/action.yml
@@ -70,7 +70,7 @@ runs:
         PULL_REQUEST_NUMBER: ${{ inputs.pull-request-number }}
 
     - name: Seed database
-      if: inputs.pull-request-number != '' && inputs.environment != 'production'
+      if: inputs.pull-request-number != '' && inputs.environment == 'review'
       shell: bash
       run: |
         make ci review get-cluster-credentials


### PR DESCRIPTION
Previously it could be accidentally run in non-production environments if a pull request number was supplied to the action.

This is dangerous and unnecessary because any other environment is going to be a 'special' action so can be manually run

### Context

Ticket: BAU

Currently if the deploy action is supplied with a PR number param, it will wipe the environments database and install the seeds in all environments except production.

If (eg through a mistake in a workflow action) this param is supplied then an unintended overwrite of data could occur. Changing this to explicitly only allow it for review apps means other environments will require a manual loading of seeds which is probably whats needed anyway. 

### Changes proposed in this pull request

1. Ensure seeds are not run in non-review environments

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
