### PR TITLE
Use gov-uk default style for p and a elements

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -1,6 +1,7 @@
 // Entry point for your Sass build
 $govuk-images-path: "";
 $govuk-fonts-path: "";
+$govuk-global-styles: true;
 
 @import "govuk-frontend/dist/govuk/base";
 @import "govuk-frontend/dist/govuk/core/index";


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2649

All links by default now will look gov links, even without `govuk-link` class.

![image](https://github.com/user-attachments/assets/a2af62bd-bd97-424a-8a23-9f4e637210e4)