### PR TITLE
[CPDNPQ-2375] make seeds reflect production

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -88,6 +88,7 @@ class Application < ApplicationRecord
   }, suffix: true
 
   validates :funded_place, inclusion: { in: [true, false] }, if: :validate_funded_place?
+  validate :funded_place_nil_for_cohort_with_no_funding_cap
   validate :eligible_for_funded_place
   validate :validate_permitted_schedule_for_course
 
@@ -208,6 +209,12 @@ private
 
   def validate_funded_place?
     accepted_lead_provider_approval_status? && errors.blank? && cohort&.funding_cap?
+  end
+
+  def funded_place_nil_for_cohort_with_no_funding_cap
+    if accepted_lead_provider_approval_status? && errors.blank? && !cohort&.funding_cap? && !funded_place.nil?
+      errors.add(:funded_place, :should_not_be_set)
+    end
   end
 
   def eligible_for_funded_place

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -40,6 +40,6 @@ private
   def changing_funding_cap_with_dependent_applications
     return unless funding_cap_changed? && Application.where(cohort: self).any?
 
-    errors.add(:funding_cap, "Cannot change from false to true when there are existing applications for this cohort")
+    errors.add(:funding_cap, "Cannot change funding_cap when there are existing applications for this cohort")
   end
 end

--- a/app/services/participants/change_schedule.rb
+++ b/app/services/participants/change_schedule.rb
@@ -20,7 +20,6 @@ module Participants
       return false if invalid?
 
       ActiveRecord::Base.transaction do
-        update_funded_place!
         update_application!
         participant.reload
       end
@@ -49,14 +48,11 @@ module Participants
         params[:cohort] = cohort
       end
 
+      if !application.cohort.funding_cap? && cohort.funding_cap?
+        params[:funded_place] = application.eligible_for_funding
+      end
+
       application.update!(params)
-    end
-
-    def update_funded_place!
-      return if application&.cohort&.funding_cap? && cohort.funding_cap?
-      return unless cohort.funding_cap?
-
-      application.update!(funded_place: application.eligible_for_funding)
     end
 
     def validate_new_schedule_found

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,6 +58,8 @@ en:
   funded_place: &funded_place
     inclusion: Set '#/%{parameterized_attribute}' to true or false.
     not_eligible: "The participant is not eligible for funding, so '#/funded_place' cannot be set to true."
+    should_not_be_set: "The '#//funded_place' field should not be set for cohorts that do not have a funding cap."
+
 
   participant_id: &participant_id
     blank: "The property '#/participant_id' must be present"

--- a/db/seeds/base/add_applications.rb
+++ b/db/seeds/base/add_applications.rb
@@ -104,17 +104,15 @@ LeadProvider.find_each do |lead_provider|
     FactoryBot.create_list(
       :application,
       2,
-      :eligible_for_funded_place,
+      :accepted,
+      :eligible_for_funding,
       :with_random_user,
       :with_random_work_setting,
       :with_participant_id_change,
       lead_provider:,
       course: all_courses.sample,
       funded_place: Faker::Boolean.boolean(true_ratio: 0.6),
-      cohort: Cohort.where(funding_cap: true).sample || all_cohorts.sample.tap do |c|
-                c.funding_cap = true
-                c.save!
-              end,
+      cohort: Cohort.where(funding_cap: true).sample,
     )
 
     # users with one not eligible for funded place application each (cohort funding_cap true)
@@ -128,10 +126,7 @@ LeadProvider.find_each do |lead_provider|
       lead_provider:,
       course: all_courses.sample,
       funded_place: false,
-      cohort: Cohort.where(funding_cap: true).sample || all_cohorts.sample.tap do |c|
-                c.funding_cap = true
-                c.save!
-              end,
+      cohort: Cohort.where(funding_cap: true).sample,
     )
 
     # users with one funded place nil application each (cohort funding_cap false)
@@ -141,14 +136,11 @@ LeadProvider.find_each do |lead_provider|
       :accepted,
       :with_random_user,
       :with_random_work_setting,
-      :with_random_eligible_for_funding_seeds_only,
       :with_participant_id_change,
+      eligible_for_funding: Faker::Boolean.boolean,
       lead_provider:,
       course: all_courses.sample,
-      cohort: Cohort.where(funding_cap: false).sample || all_cohorts.sample.tap do |c|
-                c.funding_cap = false
-                c.save!
-              end,
+      cohort: Cohort.where(funding_cap: false).sample,
     )
   end
 end

--- a/db/seeds/base/add_cohorts.rb
+++ b/db/seeds/base/add_cohorts.rb
@@ -1,9 +1,11 @@
-FactoryBot.create(:cohort, start_year: 2021)
+(2021..2023).each do |start_year|
+  FactoryBot.create(:cohort, :without_funding_cap, start_year: start_year)
+end
 
 # Ensure Cohort.next is always created
 registration_start_month = Cohort.find_by(start_year: 2021).registration_start_date.month
 next_cohort_start_year = Date.current.year + (Date.current.month < registration_start_month ? 0 : 1)
 
-(2022..next_cohort_start_year).each do |start_year|
-  FactoryBot.create(:cohort, start_year:)
+(2024..next_cohort_start_year).each do |start_year|
+  FactoryBot.create(:cohort, :with_funding_cap, start_year:)
 end

--- a/db/seeds/base/add_declarations.rb
+++ b/db/seeds/base/add_declarations.rb
@@ -10,7 +10,7 @@ lead_providers.each do |lead_provider|
       application_count.times do
         application = FactoryBot.create(
           :application,
-          :eligible_for_funded_place_do_not_update_cohort,
+          :eligible_for_funded_place,
           :with_random_user,
           :with_random_work_setting,
           cohort: schedule.cohort,
@@ -48,7 +48,7 @@ lead_providers.each do |lead_provider|
           end
 
           # create some voided declarations
-          if schedule.allowed_declaration_types.count < 4 && declaration_type == "retained-1"
+          if schedule.allowed_declaration_types.count < 4 && declaration_type == "retained-1" && declaration.statements.any?
             voidable_statement = declaration.statements.first
             helpers.travel_to voidable_statement.deadline_date + 1.month do
               Declarations::Void.new(declaration:).void

--- a/db/seeds/base/add_declarations.rb
+++ b/db/seeds/base/add_declarations.rb
@@ -10,7 +10,7 @@ lead_providers.each do |lead_provider|
       application_count.times do
         application = FactoryBot.create(
           :application,
-          :eligible_for_funded_place,
+          :eligible_for_funded_place_do_not_update_cohort,
           :with_random_user,
           :with_random_work_setting,
           cohort: schedule.cohort,

--- a/spec/factories/applications.rb
+++ b/spec/factories/applications.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     headteacher_status { "no" }
     lead_provider_approval_status { :pending }
     ecf_id { SecureRandom.uuid }
-    cohort { Cohort.current || create(:cohort, :current, :without_funding_cap) }
+    cohort { create(:cohort, :current) }
     teacher_catchment { "england" }
     teacher_catchment_country { "United Kingdom of Great Britain and Northern Ireland" }
     teacher_catchment_iso_country_code { "GBR" }
@@ -18,6 +18,7 @@ FactoryBot.define do
     funding_choice { Application.funding_choices.keys.first }
     lead_mentor { false }
     ukprn { rand(10_000_000..99_999_999).to_s }
+    funded_place { cohort&.funding_cap ? !!eligible_for_funding : nil }
 
     trait :with_school do
       school
@@ -78,17 +79,18 @@ FactoryBot.define do
 
     trait :eligible_for_funded_place do
       accepted
-      with_funded_place
-    end
-
-    trait :with_funded_place do
       eligible_for_funding
       funded_place { cohort.funding_cap ? true : nil }
     end
 
+    trait :with_funded_place do
+      eligible_for_funding
+      funded_place { true }
+    end
+
     trait :without_funded_place do
       eligible_for_funding { false }
-      funded_place { cohort.funding_cap ? false : nil }
+      funded_place { false }
     end
 
     trait :previously_funded do

--- a/spec/factories/cohorts.rb
+++ b/spec/factories/cohorts.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :cohort do
     sequence(:start_year, 0) { |n| 2021 + n % 9 }
     registration_start_date { Date.new(start_year, 4, 3) }
+    funding_cap { true }
 
     initialize_with do
       Cohort.find_or_create_by(start_year:)

--- a/spec/factories/cohorts.rb
+++ b/spec/factories/cohorts.rb
@@ -22,5 +22,9 @@ FactoryBot.define do
     trait :with_funding_cap do
       funding_cap { true }
     end
+
+    trait :without_funding_cap do
+      funding_cap { false }
+    end
   end
 end

--- a/spec/factories/declarations.rb
+++ b/spec/factories/declarations.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
 
     application { association :application, :accepted, user:, course: }
     lead_provider { application&.lead_provider || build(:lead_provider) }
-    cohort { application&.cohort || build(:cohort, :current) }
+    cohort { application&.cohort || build(:cohort, :current, :without_funding_cap) }
     declaration_type { "started" }
     declaration_date { Date.current }
     state { "submitted" }

--- a/spec/features/audit_trail_spec.rb
+++ b/spec/features/audit_trail_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.feature "Recording audit trail via papertrail", :versioning, type: :request do
   include Helpers::NPQSeparationAdminLogin
 
+  let(:cohort) { create(:cohort, :current, :without_funding_cap) }
+
   describe "an admin making changes" do
     subject(:change_author) { application.versions.last.whodunnit }
 
@@ -13,7 +15,7 @@ RSpec.feature "Recording audit trail via papertrail", :versioning, type: :reques
     end
 
     let :application do
-      create(:application, :accepted).tap do |application|
+      create(:application, :accepted, cohort:).tap do |application|
         create(:declaration, application:)
       end
     end
@@ -51,7 +53,7 @@ RSpec.feature "Recording audit trail via papertrail", :versioning, type: :reques
     let(:raw_token) { "a-token" }
     let(:course) { create :"npq-senior-leadership" }
     let(:lead_provider) { create :lead_provider }
-    let(:application) { create :application, lead_provider:, course: }
+    let(:application) { create :application, lead_provider:, course:, cohort: }
 
     let :headers do
       {

--- a/spec/features/npq_separation/admin/applications_in_review_spec.rb
+++ b/spec/features/npq_separation/admin/applications_in_review_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 RSpec.feature "Applications in review", type: :feature do
   include Helpers::AdminLogin
 
-  let(:cohort_21) { create :cohort, start_year: 2021 }
-  let(:cohort_22) { create :cohort, start_year: 2022 }
+  let(:cohort_21) { create :cohort, :without_funding_cap, start_year: 2021 }
+  let(:cohort_22) { create :cohort, :without_funding_cap, start_year: 2022 }
 
   let!(:normal_application)                         { create(:application, :with_random_user) }
   let!(:application_for_hospital_school)            { create(:application, :with_random_user, :manual_review, created_at: 10.days.ago, employment_type: "hospital_school", employer_name: Faker::Company.name, cohort: cohort_21, referred_by_return_to_teaching_adviser: "yes") }

--- a/spec/features/npq_separation/admin/applications_in_review_spec.rb
+++ b/spec/features/npq_separation/admin/applications_in_review_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Applications in review", type: :feature do
   let!(:application_for_rtta_yes)                   { create(:application, :with_random_user, :manual_review, created_at: 4.days.ago, referred_by_return_to_teaching_adviser: "yes", school: nil, works_in_school: false) }
   let!(:application_for_rtta_no)                    { create(:application, :with_random_user, created_at: 3.days.ago, referred_by_return_to_teaching_adviser: "no") }
   let!(:application_eligible_for_funding)           { create(:application, :with_random_user, :manual_review, :eligible_for_funding, created_at: 11.days.ago, employment_type: "other") }
-  let!(:application_with_funding_decision)          { create(:application, :with_random_user, :accepted, created_at: 12.days.ago, employment_type: "hospital_school", review_status: "decision_made") }
+  let!(:application_with_funding_decision)          { create(:application, :with_random_user, :accepted, :without_funded_place, created_at: 12.days.ago, employment_type: "hospital_school", review_status: "decision_made") }
 
   let(:serialized_application) { { application: 1 } }
 

--- a/spec/features/npq_separation/admin/applications_spec.rb
+++ b/spec/features/npq_separation/admin/applications_spec.rb
@@ -60,7 +60,7 @@ RSpec.feature "Listing and viewing applications", type: :feature do
 
   scenario "filtering applications by provider approval status" do
     application = applications_in_order.last
-    application.update! lead_provider_approval_status: :accepted
+    application.update! lead_provider_approval_status: :accepted, funded_place: false
 
     visit(npq_separation_admin_applications_path)
     select "Accepted", from: "Provider approval status"
@@ -131,6 +131,7 @@ RSpec.feature "Listing and viewing applications", type: :feature do
     application = applications_in_order.first
     application.update!(
       eligible_for_funding: true,
+      funded_place: true,
       lead_provider_approval_status: :accepted,
       funding_eligiblity_status_code: 123,
       employment_type: :full_time,

--- a/spec/features/npq_separation/admin/cohorts_spec.rb
+++ b/spec/features/npq_separation/admin/cohorts_spec.rb
@@ -22,9 +22,9 @@ RSpec.feature "Managing cohorts", :ecf_api_disabled, type: :feature do
     expect(Cohort.count).to eq(3)
 
     expect(page).to have_table(rows: [
-      ["2028 to 2029", "3 April 2028", "No"],
-      ["2027 to 2028", "3 April 2027", "No"],
-      ["2026 to 2027", "3 April 2026", "No"],
+      ["2028 to 2029", "3 April 2028", "Yes"],
+      ["2027 to 2028", "3 April 2027", "Yes"],
+      ["2026 to 2027", "3 April 2026", "Yes"],
     ])
   end
 
@@ -36,7 +36,7 @@ RSpec.feature "Managing cohorts", :ecf_api_disabled, type: :feature do
     within(".govuk-summary-list") do |summary_list|
       expect(summary_list).to have_summary_item("Start year", "2026")
       expect(summary_list).to have_summary_item("Registration start date", "3 April 2026")
-      expect(summary_list).to have_summary_item("Funding cap", "No")
+      expect(summary_list).to have_summary_item("Funding cap", "Yes")
     end
   end
 

--- a/spec/features/npq_separation/admin/users_spec.rb
+++ b/spec/features/npq_separation/admin/users_spec.rb
@@ -103,7 +103,7 @@ RSpec.feature "User administration", type: :feature do
           expect(summary_card).to have_summary_item("Provider", application.lead_provider.name)
           expect(summary_card).to have_summary_item("Eligible for funding", "No")
           expect(summary_card).to have_summary_item("Provider approval status", "Pending")
-          expect(summary_card).to have_summary_item("Funded place", "–")
+          expect(summary_card).to have_summary_item("Funded place", "No")
           expect(summary_card).to have_summary_item("Training milestone reached", "Completed (paid)")
           expect(summary_card).to have_summary_item("Registration submission date", application.created_at.to_fs(:govuk_short))
         end

--- a/spec/lib/tasks/update_application_spec.rb
+++ b/spec/lib/tasks/update_application_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe "update_application" do
   include_context "with default schedules"
 
+  let(:cohort) { create(:cohort, :current, :without_funding_cap) }
+
   shared_examples "outputting an error" do
     it "outputs an error message" do
       expect { run_task }.to raise_error(RuntimeError, /Application not found: /)
@@ -14,7 +16,7 @@ RSpec.describe "update_application" do
 
     after { Rake::Task["update_application:accept"].reenable }
 
-    let(:application) { create(:application, :pending) }
+    let(:application) { create(:application, :pending, cohort:) }
 
     it "accepts the application" do
       run_task

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -67,13 +67,13 @@ RSpec.describe Application do
       it { is_expected.to have_error(:schedule, :cohort_mismatch, "The schedule cohort must match the application cohort") }
     end
 
-    context "when accepted" do
+    context "when the cohort has a funding cap" do
       let(:cohort) { create(:cohort, :current, :with_funding_cap) }
 
-      context "when funding_cap" do
+      context "when accepted" do
         subject { build(:application, :accepted, cohort:) }
 
-        it "validates funded_place boolean" do
+        it "validates funded_place is boolean" do
           subject.funded_place = nil
 
           expect(subject).to have_error(:funded_place, :inclusion, "Set '#/funded_place' to true or false.")
@@ -97,6 +97,18 @@ RSpec.describe Application do
 
           expect(subject).to have_error(:schedule, :invalid_for_course, "The selected schedule is not valid for the course")
         end
+      end
+    end
+
+    context "when the cohort does not have a funding cap" do
+      let(:cohort) { create(:cohort, :current) }
+
+      subject { build(:application, :accepted, cohort:) }
+
+      it "validates funded_place is nil" do
+        subject.funded_place = false
+
+        expect(subject).to have_error(:funded_place, :should_not_be_set, "The '#//funded_place' field should not be set for cohorts that do not have a funding cap.")
       end
     end
   end
@@ -310,7 +322,9 @@ RSpec.describe Application do
 
   describe "#previously_funded?" do
     let(:user) { create(:user) }
-    let(:application) { create(:application, :previously_funded, user:, course: Course.ehco) }
+    let(:application) { create(:application, :previously_funded, user:, course: Course.ehco, cohort: cohort_with_funding_cap) }
+    let(:cohort_with_funding_cap) { create(:cohort, :with_funding_cap) }
+    let(:cohort_without_funding_cap) { create(:cohort, :without_funding_cap) }
     let(:previous_application) { user.applications.where.not(id: application.id).first! }
 
     subject { application }
@@ -319,7 +333,13 @@ RSpec.describe Application do
       it { is_expected.to be_previously_funded }
 
       context "when funded place is `nil`" do
-        before { previous_application.update!(funded_place: nil) }
+        before do
+          previous_application.update!(
+            cohort: cohort_without_funding_cap,
+            funded_place: nil,
+            schedule: Schedule.find_by(cohort: cohort_without_funding_cap, course_group: previous_application.course.course_group),
+          )
+        end
 
         it { is_expected.to be_previously_funded }
       end
@@ -353,7 +373,7 @@ RSpec.describe Application do
     end
 
     context "when the application has not been previously funded (previous application is not eligible for funding)" do
-      before { previous_application.update!(eligible_for_funding: false) }
+      before { previous_application.update!(eligible_for_funding: false, funded_place: false) }
 
       it { is_expected.not_to be_previously_funded }
     end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Application do
     end
 
     context "when the cohort does not have a funding cap" do
-      let(:cohort) { create(:cohort, :current) }
+      let(:cohort) { create(:cohort, :without_funding_cap) }
 
       subject { build(:application, :accepted, cohort:) }
 
@@ -278,7 +278,7 @@ RSpec.describe Application do
       let(:application) { create(:application, lead_provider_approval_status: "pending", participant_outcome_state: nil) }
 
       before do
-        application.update!(lead_provider_approval_status: "accepted", participant_outcome_state: "passed")
+        application.update!(lead_provider_approval_status: "accepted", participant_outcome_state: "passed", funded_place: false)
       end
 
       it "has history of changes" do

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Cohort, type: :model do
     it { is_expected.not_to allow_value(nil).for(:funding_cap).with_message("Choose true or false for funding cap") }
     it { is_expected.to validate_uniqueness_of(:ecf_id).case_insensitive.with_message("ECF ID must be unique").allow_nil }
 
-    describe "#registration_start_date_matches_start_year" do
+    describe "registration_start_date year should match start_year" do
       it "adds an error when the registration_start_date year does not match the start_year" do
         cohort = Cohort.new(start_year: 2022, registration_start_date: Date.new(2023, 4, 10))
 
@@ -34,7 +34,7 @@ RSpec.describe Cohort, type: :model do
       end
     end
 
-    describe "#start_year" do
+    describe "start_year" do
       it { is_expected.to validate_presence_of(:start_year) }
 
       it {
@@ -52,6 +52,30 @@ RSpec.describe Cohort, type: :model do
 
         new_cohort.valid?
         expect(new_cohort.errors[:start_year]).to include("has already been taken")
+      end
+    end
+
+    describe "changing funding_cap when there are applications" do
+      before do
+        create(:application, cohort: cohort)
+      end
+
+      context "when the funding cap is true" do
+        let(:cohort) { create(:cohort, :with_funding_cap) }
+
+        it "does not allow changing the funding_cap" do
+          cohort.funding_cap = false
+          expect(cohort).to have_error(:funding_cap, "Cannot change from false to true when there are existing applications for this cohort")
+        end
+      end
+
+      context "when the funding cap is false" do
+        let(:cohort) { create(:cohort, :without_funding_cap) }
+
+        it "does not allow changing the funding_cap" do
+          cohort.funding_cap = true
+          expect(cohort).to have_error(:funding_cap, "Cannot change from false to true when there are existing applications for this cohort")
+        end
       end
     end
   end

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Cohort, type: :model do
 
         it "does not allow changing the funding_cap" do
           cohort.funding_cap = false
-          expect(cohort).to have_error(:funding_cap, "Cannot change from false to true when there are existing applications for this cohort")
+          expect(cohort).to have_error(:funding_cap, "Cannot change funding_cap when there are existing applications for this cohort")
         end
       end
 
@@ -74,7 +74,7 @@ RSpec.describe Cohort, type: :model do
 
         it "does not allow changing the funding_cap" do
           cohort.funding_cap = true
-          expect(cohort).to have_error(:funding_cap, "Cannot change from false to true when there are existing applications for this cohort")
+          expect(cohort).to have_error(:funding_cap, "Cannot change funding_cap when there are existing applications for this cohort")
         end
       end
     end

--- a/spec/requests/api/docs/v1/applications_spec.rb
+++ b/spec/requests/api/docs/v1/applications_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe "NPQ Applications endpoint", :with_default_schedules, openapi_spe
                     "The NPQ application after changing the funded place",
                     "#/components/schemas/ApplicationResponse",
                     "#/components/schemas/ApplicationChangeFundedPlaceRequest" do
-      let(:application) { create(:application, :eligible_for_funded_place, lead_provider:) }
+      let(:application) { create(:application, :eligible_for_funded_place, lead_provider:, cohort:) }
       let(:resource) { application }
       let(:type) { "npq-application-change-funded-place" }
       let(:attributes) { { funded_place: true } }

--- a/spec/requests/api/docs/v2/applications_spec.rb
+++ b/spec/requests/api/docs/v2/applications_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe "NPQ Applications endpoint", :with_default_schedules, openapi_spe
                     "The NPQ application after changing the funded place",
                     "#/components/schemas/ApplicationResponse",
                     "#/components/schemas/ApplicationChangeFundedPlaceRequest" do
-      let(:application) { create(:application, :eligible_for_funded_place, lead_provider:) }
+      let(:application) { create(:application, :eligible_for_funded_place, lead_provider:, cohort:) }
       let(:resource) { application }
       let(:type) { "npq-application-change-funded-place" }
       let(:attributes) { { funded_place: true } }

--- a/spec/serializers/api/applications_csv_serializer_spec.rb
+++ b/spec/serializers/api/applications_csv_serializer_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe API::ApplicationsCsvSerializer, type: :serializer do
     let(:applications) do
       create_list(:application, 2,
                   :accepted,
+                  :without_funded_place,
                   :with_private_childcare_provider,
                   employer_name: "Employer Name",
-                  employment_role: "Employment Role",
-                  funded_place: true)
+                  employment_role: "Employment Role")
     end
     let(:rows) { CSV.parse(csv, headers: true) }
     let(:first_application) { applications.first }

--- a/spec/serializers/api/applications_csv_serializer_spec.rb
+++ b/spec/serializers/api/applications_csv_serializer_spec.rb
@@ -108,6 +108,7 @@ RSpec.describe API::ApplicationsCsvSerializer, type: :serializer do
           school: nil,
           schedule: nil,
           cohort: nil,
+          funded_place: nil,
         )
       end
 

--- a/spec/serializers/assurance_reports/csv_serializer_spec.rb
+++ b/spec/serializers/assurance_reports/csv_serializer_spec.rb
@@ -10,10 +10,11 @@ RSpec.describe AssuranceReports::CsvSerializer, type: :serializer do
   let(:data)          { AssuranceReports::Query.new(statement).declarations }
   let(:lead_provider) { create(:lead_provider) }
   let(:statement)     { create(:statement, lead_provider:) }
+  let(:application)   { create(:application, :eligible_for_funded_place, lead_provider:) }
 
   let :declaration do
     travel_to(statement.deadline_date) do
-      create(:declaration, lead_provider:) do |declaration|
+      create(:declaration, lead_provider:, application:) do |declaration|
         create(:statement_item, statement:, declaration:)
       end
     end

--- a/spec/services/applications/accept_spec.rb
+++ b/spec/services/applications/accept_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe Applications::Accept, :with_default_schedules, type: :model do
     let(:course_group) { create(:course_group, name: "leadership") }
     let(:course) { create(:course, :senior_leadership, course_group:) }
     let(:lead_provider) { create(:lead_provider) }
-    let(:cohort) { create(:cohort, :current) }
-    let(:cohort_next) { create(:cohort, :next) }
+    let(:cohort) { create(:cohort, :current, :without_funding_cap) }
+    let(:cohort_next) { create(:cohort, :next, :without_funding_cap) }
 
     let(:application) do
       create(
@@ -355,7 +355,7 @@ RSpec.describe Applications::Accept, :with_default_schedules, type: :model do
         end
 
         context "when funding_cap is false" do
-          let(:cohort) { create(:cohort, :current) }
+          let(:cohort) { create(:cohort, :current, :without_funding_cap) }
 
           it "does not validate funded_place" do
             service.accept
@@ -404,7 +404,7 @@ RSpec.describe Applications::Accept, :with_default_schedules, type: :model do
     end
 
     describe "changing schedule on accept" do
-      let(:cohort) { create(:cohort, :current) }
+      let(:cohort) { create(:cohort, :current, :without_funding_cap) }
       let(:course_group) { create(:course_group, name: "leadership") }
       let(:course) { create(:course, :senior_leadership, course_group:) }
 

--- a/spec/services/applications/change_funded_place_spec.rb
+++ b/spec/services/applications/change_funded_place_spec.rb
@@ -78,21 +78,19 @@ RSpec.describe Applications::ChangeFundedPlace, type: :model do
           expect(service).to have_error(:application, :cannot_change_funded_status_non_eligible, "This participant is not eligible for funding. Contact us if you think this is wrong.")
         end
 
-        it "is invalid if the cohort does not accept capping and we have a true funded_place param" do
-          cohort.update!(funding_cap: false)
+        context "when the cohort does not accept capping" do
+          let(:cohort) { create(:cohort, :current, :without_funding_cap) }
 
-          service.change
+          it "is invalid when we have a true funded_place param" do
+            service.change
+            expect(service).to have_error(:application, :cohort_does_not_accept_capping, "Leave the '#/funded_place' field blank. It's only needed for participants starting NPQs from autumn 2024 onwards.")
+          end
 
-          expect(service).to have_error(:application, :cohort_does_not_accept_capping, "Leave the '#/funded_place' field blank. It's only needed for participants starting NPQs from autumn 2024 onwards.")
-        end
-
-        it "is invalid if the cohort does not accept capping and we have a false funded_place param" do
-          params.merge!(funded_place: false)
-          cohort.update!(funding_cap: false)
-
-          service.change
-
-          expect(service).to have_error(:application, :cohort_does_not_accept_capping, "Leave the '#/funded_place' field blank. It's only needed for participants starting NPQs from autumn 2024 onwards.")
+          it "is invalid when we have a false funded_place param" do
+            params.merge!(funded_place: false)
+            service.change
+            expect(service).to have_error(:application, :cohort_does_not_accept_capping, "Leave the '#/funded_place' field blank. It's only needed for participants starting NPQs from autumn 2024 onwards.")
+          end
         end
 
         context "when the application is not accepted" do

--- a/spec/services/applications/change_funding_eligibility_spec.rb
+++ b/spec/services/applications/change_funding_eligibility_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Applications::ChangeFundingEligibility, type: :model do
     end
 
     context "with valid update from true to false" do
-      let(:application) { create(:application, :pending, :eligible_for_funding) }
+      let(:application) { create(:application, :pending, :eligible_for_funding, funded_place: false) }
 
       before { service.eligible_for_funding = false }
 

--- a/spec/services/applications/query_spec.rb
+++ b/spec/services/applications/query_spec.rb
@@ -344,11 +344,14 @@ RSpec.describe Applications::Query do
       end
 
       context "when there is a previous, accepted application that was eligible for funding and funded place is `nil`" do
+        let(:cohort) { create(:cohort, :without_funding_cap) }
+
         before do
           create(
             :application,
             :accepted,
             lead_provider:,
+            cohort:,
             user_id: application.user_id,
             eligible_for_funding: true,
             funded_place: nil,

--- a/spec/services/applications/revert_to_pending_spec.rb
+++ b/spec/services/applications/revert_to_pending_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Applications::RevertToPending, type: :model do
   subject(:instance) { described_class.new(application:) }
 
   let :application do
-    create(:application, :accepted) do |application|
+    create(:application, :accepted, :without_funded_place) do |application|
       create(:application_state, application:)
     end
   end
@@ -83,7 +83,7 @@ RSpec.describe Applications::RevertToPending, type: :model do
 
     context "when status set to no" do
       let :application do
-        create(:application, :accepted, funded_place: true).tap do |application|
+        create(:application, :eligible_for_funded_place).tap do |application|
           create(:declaration, :voided, application:)
           create(:application_state, application:)
         end
@@ -114,7 +114,7 @@ RSpec.describe Applications::RevertToPending, type: :model do
 
     context "when already pending" do
       let :application do
-        create(:application, :pending, funded_place: true).tap do |application|
+        create(:application, :pending, :with_funded_place).tap do |application|
           create(:declaration, :voided, application:)
           create(:application_state, application:)
         end

--- a/spec/services/participants/change_schedule_spec.rb
+++ b/spec/services/participants/change_schedule_spec.rb
@@ -157,9 +157,10 @@ RSpec.describe Participants::ChangeSchedule, type: :model do
       end
 
       context "when moving from funding cohort to funding cohort" do
+        let(:cohort) { create(:cohort, :current, :with_funding_cap) }
+        let(:new_cohort) { create(:cohort, :next, :with_funding_cap) }
+
         before do
-          cohort.update!(funding_cap: true)
-          new_cohort.update!(funding_cap: true)
           application.update!(funded_place: false, eligible_for_funding: true)
         end
 
@@ -171,8 +172,8 @@ RSpec.describe Participants::ChangeSchedule, type: :model do
       end
 
       context "when moving from non funding cohort to funding cohort" do
-        let(:cohort) { create(:cohort, :current, funding_cap: false) }
-        let(:new_cohort) { create(:cohort, :next, funding_cap: true) }
+        let(:cohort) { create(:cohort, :current, :without_funding_cap) }
+        let(:new_cohort) { create(:cohort, :next, :with_funding_cap) }
         let!(:application) do
           create(
             :application,
@@ -208,10 +209,8 @@ RSpec.describe Participants::ChangeSchedule, type: :model do
       end
 
       context "when moving from funding cohort to non funding cohort" do
-        before do
-          cohort.update!(funding_cap: true)
-          new_cohort.update!(funding_cap: false)
-        end
+        let(:cohort) { create(:cohort, :current, :with_funding_cap) }
+        let(:new_cohort) { create(:cohort, :next, :without_funding_cap) }
 
         it "does not change the application to the new cohort" do
           expect(subject.change_schedule).to be_falsey


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2375

### Changes proposed in this pull request

* make the seeded cohorts match production: 
  * cohorts 2021, 2022, and 2023 have `funding_cap`: `false`
  * cohorts 2024, 2025 and 2026 have `funding_cap`: `true`
  * accepted applications for the 2021/2022/2023 cohorts have `funded_place`: `nil`
* added validation on the application model to ensure `funded_place` is `nil` when `funding_cap` is `false`, and it is populated when `funding_cap` is `true`
* added a validation on Cohort to stop `funding_cap` being updated when there are applications for that cohort (this was happening in the seeds and specs)
  * this does have the side effect of now not allowing funding cap updates via the admin console
* updated the application factory, so that it sets `funded_place` correctly, based on whether the cohort has a funding cap
* updated the cohort factory, so that `funding_cap` is now `true` by default
* changed `Participants::ChangeSchedule` to make a single update, instead of 2 (which it used to do when the cohort `funding_cap` was changing), because the new validation needs this to be a single update