### PR TITLE
[CPDNPQ-2930] Rework k8s liveness probe

### DIFF
--- a/app/controllers/monitoring_controller.rb
+++ b/app/controllers/monitoring_controller.rb
@@ -12,6 +12,10 @@ class MonitoringController < PublicPagesController
     }
   end
 
+  def up
+    head(database_connected? ? :ok : :service_unavailable)
+  end
+
 private
 
   def status

--- a/app/controllers/monitoring_controller.rb
+++ b/app/controllers/monitoring_controller.rb
@@ -18,7 +18,7 @@ private
     if database_connected? && database_populated?
       :ok
     else
-      :internal_server_error
+      :service_unavailable
     end
   end
 

--- a/bin/smoke
+++ b/bin/smoke
@@ -41,6 +41,15 @@ else
   exit 1
 fi
 
+redis_connected=$(jq ".redis" <<< $response)
+
+if [[ $redis_connected == 'true' ]]; then
+  echo "✅ Redis is connected"
+else
+  echo "Fail: redis is not connected"
+  exit 1
+fi
+
 database_connected=$(jq ".database.connected" <<< $response)
 
 if [[ $database_connected == 'true' ]]; then

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
              controllers: { omniauth_callbacks: "omniauth" }
 
   get "/healthcheck", to: "monitoring#healthcheck", format: :json
+  get "/up", to: "monitoring#up"
 
   resources :schools, only: [:index]
   resources :institutions, only: [:index]

--- a/lib/tasks/courses.rake
+++ b/lib/tasks/courses.rake
@@ -7,7 +7,7 @@ namespace :courses do
       support
       ehco
     ].each do |name|
-      FactoryBot.create(:course_group, name:)
+      CourseGroup.find_or_create_by!(name:)
     end
 
     CourseService::DefinitionLoader.call

--- a/spec/requests/monitoring_spec.rb
+++ b/spec/requests/monitoring_spec.rb
@@ -42,4 +42,16 @@ RSpec.describe "Monitoring" do
       it { expect(response_body[:database]).to include({ connected: true, populated: false }) }
     end
   end
+
+  describe "GET /up" do
+    subject { get(up_path) && response }
+
+    it { is_expected.to be_successful }
+
+    context "when database not connected" do
+      before { allow(ApplicationRecord).to receive(:connected?).and_return false }
+
+      it { is_expected.to have_http_status :service_unavailable }
+    end
+  end
 end

--- a/spec/requests/monitoring_spec.rb
+++ b/spec/requests/monitoring_spec.rb
@@ -23,14 +23,14 @@ RSpec.describe "Monitoring" do
       context "when ApplicationRecord#connected? raises an error" do
         before { allow(ApplicationRecord).to receive(:connected?).and_raise(RuntimeError) }
 
-        it { is_expected.to be_server_error }
+        it { is_expected.to have_http_status :service_unavailable }
         it { expect(response_body[:database]).to include({ connected: false, populated: false }) }
       end
 
       context "when ApplicationRecord#connected? returns false" do
         before { allow(ApplicationRecord).to receive(:connected?).and_return(false) }
 
-        it { is_expected.to be_server_error }
+        it { is_expected.to have_http_status :service_unavailable }
         it { expect(response_body[:database]).to include({ connected: false, populated: false }) }
       end
     end
@@ -38,7 +38,7 @@ RSpec.describe "Monitoring" do
     context "when the database is not populated" do
       before { Course.destroy_all }
 
-      it { is_expected.to be_server_error }
+      it { is_expected.to have_http_status :service_unavailable }
       it { expect(response_body[:database]).to include({ connected: true, populated: false }) }
     end
   end

--- a/spec/requests/monitoring_spec.rb
+++ b/spec/requests/monitoring_spec.rb
@@ -7,8 +7,14 @@ RSpec.describe "Monitoring" do
     let(:git_sha) { "911403d" }
     let(:migration_version) { ApplicationRecord.connection_pool.migration_context.current_version }
     let(:response_body) { JSON.parse(perform_request.body, symbolize_names: true) }
+    let(:redis_cache) { ActiveSupport::Cache::RedisCacheStore.new(url: "redis://randomhostname:6379/", timeout: 0.2) }
 
-    before { allow(ENV).to receive(:[]).with("COMMIT_SHA") { git_sha } }
+    before do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("COMMIT_SHA") { git_sha }
+      allow(Rails).to receive(:cache).and_return redis_cache
+      allow_any_instance_of(Redis).to receive(:ping).and_return "PONG"
+    end
 
     subject(:perform_request) do
       get healthcheck_path
@@ -17,6 +23,7 @@ RSpec.describe "Monitoring" do
 
     it { is_expected.to be_successful }
     it { expect(response_body[:database]).to match({ connected: true, migration_version:, populated: true }) }
+    it { expect(response_body[:redis]).to be true }
     it { expect(response_body[:git_commit_sha]).to eq(git_sha) }
 
     context "when the database is not connected" do
@@ -40,6 +47,17 @@ RSpec.describe "Monitoring" do
 
       it { is_expected.to have_http_status :service_unavailable }
       it { expect(response_body[:database]).to include({ connected: true, populated: false }) }
+    end
+
+    context "when Redis is not connected" do
+      before do
+        allow_any_instance_of(Redis).to receive(:ping) do
+          raise Redis::CannotConnectError, "Could not connect"
+        end
+      end
+
+      it { is_expected.to have_http_status :service_unavailable }
+      it { expect(response_body[:redis]).to be false }
     end
   end
 

--- a/terraform/application/application.tf
+++ b/terraform/application/application.tf
@@ -56,6 +56,7 @@ module "web_application" {
 
   docker_image = var.docker_image
   command = var.command
+  probe_path = "/up"
 
   replicas   = var.webapp_replicas
   max_memory = var.webapp_memory_max

--- a/terraform/application/config/review.tfvars.json
+++ b/terraform/application/config/review.tfvars.json
@@ -4,7 +4,7 @@
     "environment": "review",
     "deploy_azure_backing_services": false,
     "enable_postgres_ssl" : false,
-    "command": ["/bin/sh", "-c", "RAILS_ENV=review bundle exec rails db:environment:set db:migrate && bundle exec rake courses:update && bundle exec rails server -b 0.0.0.0"],
+    "command": ["/bin/sh", "-c", "RAILS_ENV=review bundle exec rails db:environment:set db:migrate && bundle exec rails server -b 0.0.0.0"],
     "enable_logit": true,
     "enable_dfe_analytics_federated_auth": true,
     "dataset_name": "npq_events_review"


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2930](https://dfedigital.atlassian.net/browse/CPDNPQ-2930)

During the disaster recovery test it was found the application was failing to boot with an empty database. This complicated DR recovery.

### Changes proposed in this pull request

1. Remove the review app specific workaround for the failing to boot with an empty database
2. Change the failure response from the healthcheck to be service unavailable instead of the generic error
3. Added a more minimal `/up` endpoint which only checks the app has booted and connected to the DB
4. Added Redis connection checks to the more thorough `/healthcheck` endpoint

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/


[CPDNPQ-2930]: https://dfedigital.atlassian.net/browse/CPDNPQ-2930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ