### PR TITLE
[CPDNPQ-3038] Resolve docker build annotation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,4 +77,4 @@ ENV PORT=8080
 EXPOSE ${PORT}
 
 SHELL ["/bin/sh", "-c"]
-CMD bundle exec rake db:migrate && bundle exec rails s -p ${PORT} --binding=0.0.0.0
+CMD bundle exec rake db:migrate && exec bundle exec rails s -p ${PORT} --binding=0.0.0.0


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-3038

The goal is to remove the Docker build annotations in GitHub actions e.g.:
![image](https://github.com/user-attachments/assets/e056fbfe-1d7e-43e8-865f-60427a0d24d2)

As per [Docker docs](https://docs.docker.com/reference/build-checks/json-args-recommended/#workarounds), variable expansion and command chaining used in the existing `CMD` aren't available in the exec form , so instead we can explicitly declare the shell wrapper to silence the annotation.