### PR TITLE
[CPDNPQ-2812] handle error scenario

### DIFF
--- a/app/controllers/registration_wizard_controller.rb
+++ b/app/controllers/registration_wizard_controller.rb
@@ -15,6 +15,12 @@ class RegistrationWizardController < PublicPagesController
     render @wizard.current_step
 
     @wizard.after_render
+  rescue ActionView::Template::Error => e
+    if e.cause.instance_of?(Questionnaires::IneligibleForFunding::UnexpectedEligibilityStatusCode)
+      redirect_to registration_wizard_show_path(:"course-start-date")
+    else
+      raise e
+    end
   end
 
   def update

--- a/app/forms/questionnaires/ineligible_for_funding.rb
+++ b/app/forms/questionnaires/ineligible_for_funding.rb
@@ -1,5 +1,7 @@
 module Questionnaires
   class IneligibleForFunding < Base
+    class UnexpectedEligibilityStatusCode < StandardError; end
+
     include Helpers::Institution
 
     NOT_ELIGIBLE_FOR_SCHOLARSHIP_FUNDING = "not_eligible_for_scholarship_funding".freeze
@@ -68,7 +70,7 @@ module Questionnaires
                                  return NOT_ELIGIBLE_FOR_SCHOLARSHIP_FUNDING
                                end
 
-      raise "Missing status code handling: #{funding_eligiblity_status_code}"
+      raise UnexpectedEligibilityStatusCode, "Missing status code handling: #{funding_eligiblity_status_code}"
     end
 
     def funding_eligiblity_status_code

--- a/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
@@ -72,6 +72,8 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       page.choose("Teach First", visible: :all)
     end
 
+    # check_back_journey_is_correct # FIXME: this currently fails # TODO: apply this check to all journeys
+
     expect_page_to_have(path: "/registration/share-provider", submit_form: true) do
       expect(page).to have_text("Sharing your NPQ information")
       page.check("Yes, I agree to share my information", visible: :all)

--- a/spec/features/journeys/happy_paths/when_referred_by_return_to_teaching_adviser_spec.rb
+++ b/spec/features/journeys/happy_paths/when_referred_by_return_to_teaching_adviser_spec.rb
@@ -60,6 +60,8 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       page.choose("Teach First", visible: :all)
     end
 
+    # check_back_journey_is_correct # FIXME: this currently fails
+
     expect_page_to_have(path: "/registration/share-provider", submit_form: true) do
       expect(page).to have_text("Sharing your NPQ information")
       page.check("Yes, I agree to share my information", visible: :all)

--- a/spec/features/journeys/happy_paths/when_working_in_other_spec.rb
+++ b/spec/features/journeys/happy_paths/when_working_in_other_spec.rb
@@ -68,6 +68,8 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       page.choose("Teach First", visible: :all)
     end
 
+    # check_back_journey_is_correct # FIXME: this currently fails
+
     expect_page_to_have(path: "/registration/share-provider", submit_form: true) do
       expect(page).to have_text("Sharing your NPQ information")
       page.check("Yes, I agree to share my information", visible: :all)

--- a/spec/features/journeys/sad_paths/going_back_and_changing_referred_by_return_to_teaching_adviser_spec.rb
+++ b/spec/features/journeys/sad_paths/going_back_and_changing_referred_by_return_to_teaching_adviser_spec.rb
@@ -1,5 +1,8 @@
 require "rails_helper"
 
+# This is the exact scenario from bug CPDNPQ-2812.
+# The main issue is the steps when clicking 'Back' are completely wrong.
+# The fix put in was just a quick fix - making the back steps correct will also fix the issue, but it's a larger piece of work (see CPDNPQ-3053).
 RSpec.feature "Sad journey", :with_default_schedules, type: :feature do
   include Helpers::JourneyAssertionHelper
   include ApplicationHelper

--- a/spec/features/journeys/sad_paths/going_back_and_changing_referred_by_return_to_teaching_adviser_spec.rb
+++ b/spec/features/journeys/sad_paths/going_back_and_changing_referred_by_return_to_teaching_adviser_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.feature "Sad journey", :with_default_schedules, type: :feature do
+  include Helpers::JourneyAssertionHelper
+  include ApplicationHelper
+
+  include_context "with default schedules"
+  include_context "Stub Get An Identity Omniauth Responses"
+
+  context "when JavaScript is disabled", :no_js do
+    scenario("when going back and changing referred by return to teaching adviser") { run_scenario }
+  end
+
+  def run_scenario
+    stub_participant_validation_request
+
+    navigate_to_page(path: "/", submit_form: false, axe_check: false) do
+      page.click_button("Start now")
+    end
+
+    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
+      page.choose("Yes", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
+      page.choose("Yes", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/teacher-catchment", axe_check: false, submit_form: true) do
+      page.choose("Yes", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/work-setting", submit_form: true) do
+      page.choose("Other", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/referred-by-return-to-teaching-adviser", submit_form: true) do
+      page.choose("No", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do
+      page.choose("Senior leadership", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false)
+
+    click_link "Back"
+    click_link "Back"
+    click_button "Continue"
+
+    expect_page_to_have(path: "/registration/referred-by-return-to-teaching-adviser", submit_form: true) do
+      page.choose("Yes", visible: :all)
+    end
+
+    click_button "Continue"
+    click_button "Continue"
+
+    click_link "Back"
+    click_link "Back"
+
+    expect_page_to_have(path: "/registration/course-start-date")
+  end
+end

--- a/spec/support/helpers/journey_assertion_helper.rb
+++ b/spec/support/helpers/journey_assertion_helper.rb
@@ -9,6 +9,9 @@ module Helpers
     def expect_page_to_have(path:, submit_form: false, click_continue: false, submit_button_text: "Continue", axe_check: true, &block)
       expect(page).to have_current_path(path)
 
+      @steps_visited ||= []
+      @steps_visited << page.current_path unless page.current_path == "/"
+
       if axe_check && Capybara.current_driver != :rack_test
         expect(page).to(be_accessible)
       end
@@ -40,6 +43,17 @@ module Helpers
 
       expect(User.count).to be(1)
       expect(Application.count).to be(total_number_of_created_applications)
+    end
+
+    def check_back_journey_is_correct
+      starting_path = page.current_path
+      until page.current_path == "/registration/course-start-date"
+        page.click_link("Back")
+        back_steps ||= []
+        back_steps << page.current_path
+      end
+      expect(back_steps.reverse).to eq @steps_visited
+      visit starting_path
     end
   end
 end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2812
The main issue is that clicking 'Back' on our steps ends up going to the wrong page.

To reproduce the error in this ticket:
* go through journey answering 'No' at RTTA step: `course-start-date` -> `provider-check` -> `teacher-catchment` -> `work-setting` ('Other') -> `referred-by-return-to-teaching-adviser` ('No') -> `choose-your-npq` ('senior-leadership') -> `ineligible-for-funding` -> `funding-your-npq`
* click 'Back' until you get to the work-setting: `funding-your-npq` -> `ineligible-for-funding` -> `choose-your-npq` -> `work-setting`
* go forwards again, but answer 'Yes' at the RTTA step:` work-setting` -> `referred-by-return-to-teaching-adviser` (yes) -> `choose-your-npq `-> `possible-funding` -> `choose-your-provider`
* click 'Back' - you end up at `funding-your-npq` - which is wrong
* click 'Back' again - you end up at `ineligible-for-funding` - which is wrong, and raises an error

### Changes proposed in this pull request

The fix in this PR is just a quick fix, for the scenario above - I have not corrected the steps, but when the `ineligible-for-funding` step raises an error, the user will be redirected to the `course-start-date` step.
