### PR TITLE
[CPDNPQ-3039] Deploy missing feature flags as part of deploy process

### DIFF
--- a/lib/tasks/initialize_feature_flags.rake
+++ b/lib/tasks/initialize_feature_flags.rake
@@ -5,3 +5,7 @@ namespace :feature_flags do
     Feature.initialize_feature_flags
   end
 end
+
+Rake::Task["db:migrate"].enhance do
+  Rake::Task["feature_flags:initialize"].invoke
+end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-3039

Automatically runs the `feature_flags:initialize` task on `db:migrate`, with the end result of making sure the feature flags table has all current keys after every deploy

From the ticket:

> May need to consider concurrency though - ensuring we’re not creating multiples of the feature flag definitions.

Tying into `db:migrate` _should_ cause this only to be run once, since migrations should theoretically only be run on one host. Having looked, it seems that this isn't currently the case, so we may want to look at that.

However, in this case, we're protected from duplicate feature flags by the `index_flipper_features_on_key` database index even if this does run concurrently 🙏 