### PR TITLE
fix flaky spec - specify cohort, so that factory does not attempt to update current cohort

### DIFF
--- a/spec/services/applications/query_spec.rb
+++ b/spec/services/applications/query_spec.rb
@@ -344,7 +344,7 @@ RSpec.describe Applications::Query do
       end
 
       context "when there is a previous, accepted application that was eligible for funding and funded place is `nil`" do
-        let(:cohort) { create(:cohort, :without_funding_cap) }
+        let(:cohort) { create(:cohort, :previous, :without_funding_cap) }
 
         before do
           create(


### PR DESCRIPTION
### Context

occasional failure of spec: `spec/services/applications/query_spec.rb:362`

### Changes proposed in this pull request

specify previous cohort, otherwise the cohort factory will attempt to update the existing current cohort, which causes the validation failure.