### PR TITLE
[CPDNPQ-2991] change when manual adjustments allowed

### DIFF
--- a/app/forms/admin/adjustments/concerns/adjustment_form.rb
+++ b/app/forms/admin/adjustments/concerns/adjustment_form.rb
@@ -1,0 +1,22 @@
+module Admin::Adjustments
+  module Concerns
+    module AdjustmentForm
+      extend ActiveSupport::Concern
+
+      included do
+        include ActiveModel::Model
+        include ActiveModel::Attributes
+
+        validate :adjustments_allowed
+      end
+
+    private
+
+      def adjustments_allowed
+        return unless statement.paid?
+
+        errors.add(:statement, :adjustments_not_allowed)
+      end
+    end
+  end
+end

--- a/app/forms/admin/adjustments/create_adjustment_form.rb
+++ b/app/forms/admin/adjustments/create_adjustment_form.rb
@@ -12,7 +12,7 @@ module Admin::Adjustments
     attribute :adjustment
 
     validate :adjustment_valid
-    validate :statement_open
+    validate :adjustment_allowed
 
     def initialize(*)
       super
@@ -47,10 +47,10 @@ module Admin::Adjustments
       errors.merge!(adjustment.errors) unless adjustment.valid?
     end
 
-    def statement_open
-      return if statement.open?
+    def adjustment_allowed
+      return unless statement.paid?
 
-      errors.add(:statement, :not_open)
+      errors.add(:statement, :adjustments_not_allowed)
     end
   end
 end

--- a/app/forms/admin/adjustments/create_adjustment_form.rb
+++ b/app/forms/admin/adjustments/create_adjustment_form.rb
@@ -2,8 +2,7 @@
 
 module Admin::Adjustments
   class CreateAdjustmentForm
-    include ActiveModel::Model
-    include ActiveModel::Attributes
+    include Concerns::AdjustmentForm
 
     attribute :created_adjustment_ids
     attribute :statement
@@ -12,7 +11,6 @@ module Admin::Adjustments
     attribute :adjustment
 
     validate :adjustment_valid
-    validate :adjustment_allowed
 
     def initialize(*)
       super
@@ -45,12 +43,6 @@ module Admin::Adjustments
 
     def adjustment_valid
       errors.merge!(adjustment.errors) unless adjustment.valid?
-    end
-
-    def adjustment_allowed
-      return unless statement.paid?
-
-      errors.add(:statement, :adjustments_not_allowed)
     end
   end
 end

--- a/app/forms/admin/adjustments/destroy_adjustment_form.rb
+++ b/app/forms/admin/adjustments/destroy_adjustment_form.rb
@@ -8,7 +8,7 @@ module Admin::Adjustments
     attribute :statement
     attribute :adjustment
 
-    validate :statement_open
+    validate :adjustments_allowed
 
     delegate :id, :description, :amount, to: :adjustment
 
@@ -26,10 +26,10 @@ module Admin::Adjustments
 
   private
 
-    def statement_open
-      return if statement.open?
+    def adjustments_allowed
+      return unless statement.paid?
 
-      errors.add(:statement, :not_open)
+      errors.add(:statement, :adjustments_not_allowed)
     end
   end
 end

--- a/app/forms/admin/adjustments/destroy_adjustment_form.rb
+++ b/app/forms/admin/adjustments/destroy_adjustment_form.rb
@@ -2,13 +2,10 @@
 
 module Admin::Adjustments
   class DestroyAdjustmentForm
-    include ActiveModel::Model
-    include ActiveModel::Attributes
+    include Concerns::AdjustmentForm
 
     attribute :statement
     attribute :adjustment
-
-    validate :adjustments_allowed
 
     delegate :id, :description, :amount, to: :adjustment
 
@@ -22,14 +19,6 @@ module Admin::Adjustments
       adjustment.destroy # rubocop:disable Rails/SaveBang - we don't want to raise an error if destroy fails
 
       adjustment.destroyed?
-    end
-
-  private
-
-    def adjustments_allowed
-      return unless statement.paid?
-
-      errors.add(:statement, :adjustments_not_allowed)
     end
   end
 end

--- a/app/forms/admin/adjustments/update_adjustment_form.rb
+++ b/app/forms/admin/adjustments/update_adjustment_form.rb
@@ -11,7 +11,7 @@ module Admin::Adjustments
     attribute :adjustment
 
     validate :adjustment_valid
-    validate :statement_open
+    validate :adjustments_allowed
 
     delegate :id, to: :adjustment
 
@@ -34,10 +34,10 @@ module Admin::Adjustments
       errors.merge!(adjustment.errors) unless adjustment.valid?
     end
 
-    def statement_open
-      return if statement.open?
+    def adjustments_allowed
+      return unless statement.paid?
 
-      errors.add(:statement, :not_open)
+      errors.add(:statement, :adjustments_not_allowed)
     end
   end
 end

--- a/app/forms/admin/adjustments/update_adjustment_form.rb
+++ b/app/forms/admin/adjustments/update_adjustment_form.rb
@@ -2,8 +2,7 @@
 
 module Admin::Adjustments
   class UpdateAdjustmentForm
-    include ActiveModel::Model
-    include ActiveModel::Attributes
+    include Concerns::AdjustmentForm
 
     attribute :statement
     attribute :description
@@ -11,7 +10,6 @@ module Admin::Adjustments
     attribute :adjustment
 
     validate :adjustment_valid
-    validate :adjustments_allowed
 
     delegate :id, to: :adjustment
 
@@ -32,12 +30,6 @@ module Admin::Adjustments
 
     def adjustment_valid
       errors.merge!(adjustment.errors) unless adjustment.valid?
-    end
-
-    def adjustments_allowed
-      return unless statement.paid?
-
-      errors.add(:statement, :adjustments_not_allowed)
     end
   end
 end

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -58,4 +58,8 @@ class Statement < ApplicationRecord
   def show_targeted_delivery_funding?
     cohort.start_year >= 2022
   end
+
+  def allow_adjustments?
+    open?
+  end
 end

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -39,7 +39,7 @@ class Statement < ApplicationRecord
     update!(marked_as_paid_at: Time.zone.now)
   end
 
-  def has_marked_as_paid_at_date?
+  def marked_as_paid_with_date?
     marked_as_paid_at.present? && paid?
   end
 

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -39,7 +39,7 @@ class Statement < ApplicationRecord
     update!(marked_as_paid_at: Time.zone.now)
   end
 
-  def marked_as_paid?
+  def has_marked_as_paid_at_date?
     marked_as_paid_at.present? && paid?
   end
 
@@ -57,9 +57,5 @@ class Statement < ApplicationRecord
 
   def show_targeted_delivery_funding?
     cohort.start_year >= 2022
-  end
-
-  def allow_adjustments?
-    open?
   end
 end

--- a/app/services/statements/summary_calculator.rb
+++ b/app/services/statements/summary_calculator.rb
@@ -66,7 +66,7 @@ module Statements
 
     def contracts
       statement.contracts
-        .joins(:contract_template, :course)
+        .includes(:contract_template, :course)
         .where(contract_template: { special_course: false })
         .order("courses.identifier")
     end

--- a/app/views/npq_separation/admin/finance/statements/show.html.erb
+++ b/app/views/npq_separation/admin/finance/statements/show.html.erb
@@ -74,7 +74,7 @@
 
     <%= render NpqSeparation::Admin::AdjustmentsTableComponent.new(adjustments: @statement.adjustments, show_total: true) %>
 
-    <% if @statement.open? %>
+    <% if @statement.allow_adjustments? %>
       <div class="govuk-button-group">
         <%= govuk_button_link_to "Make adjustment", new_npq_separation_admin_finance_statement_adjustment_path(@statement) %>
         <% if @statement.adjustments.any? %>

--- a/app/views/npq_separation/admin/finance/statements/show.html.erb
+++ b/app/views/npq_separation/admin/finance/statements/show.html.erb
@@ -40,7 +40,7 @@
           @statement.ecf_id
         end %>
 
-    <% if @statement.has_marked_as_paid_at_date? %>
+    <% if @statement.marked_as_paid_with_date? %>
       <p class="govuk-!-margin-bottom-2">
         <strong class="govuk-tag govuk-tag--green">Authorised for payment at <%= @statement.marked_as_paid_at.in_time_zone("London").strftime("%-I:%M%P on %-e %b %Y") %></strong>
       </p>

--- a/app/views/npq_separation/admin/finance/statements/show.html.erb
+++ b/app/views/npq_separation/admin/finance/statements/show.html.erb
@@ -40,7 +40,7 @@
           @statement.ecf_id
         end %>
 
-    <% if @statement.marked_as_paid? %>
+    <% if @statement.has_marked_as_paid_at_date? %>
       <p class="govuk-!-margin-bottom-2">
         <strong class="govuk-tag govuk-tag--green">Authorised for payment at <%= @statement.marked_as_paid_at.in_time_zone("London").strftime("%-I:%M%P on %-e %b %Y") %></strong>
       </p>
@@ -74,7 +74,7 @@
 
     <%= render NpqSeparation::Admin::AdjustmentsTableComponent.new(adjustments: @statement.adjustments, show_total: true) %>
 
-    <% if @statement.allow_adjustments? %>
+    <% unless @statement.paid? %>
       <div class="govuk-button-group">
         <%= govuk_button_link_to "Make adjustment", new_npq_separation_admin_finance_statement_adjustment_path(@statement) %>
         <% if @statement.adjustments.any? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -306,7 +306,7 @@ en:
         admin/adjustments/create_adjustment_form: &create_adjustment_form
           attributes:
             statement:
-              not_open: The statement has to be open for adjustments to be made
+              adjustments_not_allowed: Adjustments can no longer be made to this statement, as it is marked as paid
         admin/adjustments/update_adjustment_form:
           <<: *create_adjustment_form
         admin/adjustments/destroy_adjustment_form:

--- a/db/seeds/base/process_statements.rb
+++ b/db/seeds/base/process_statements.rb
@@ -12,6 +12,12 @@ Cohort.all.find_each do |cohort|
       Statements::MarkAsPayable.new(statement:).mark
       Statements::MarkAsPaid.new(statement).mark
     end
+    # Set mark_as_paid_at for paid statements from 2023, to match production
+    Statement.where(state: "paid", year: 2023..).find_each do |statement|
+      helpers.travel_to statement.payment_date - 8.days do
+        statement.mark_as_paid_at!
+      end
+    end
 
     # Void some declarations on the previous paid output fee statement to create clawbacks on the latest statement
     helpers.travel_to latest_statement.deadline_date - 1.day do

--- a/spec/features/npq_separation/admin/finance/adjustments_spec.rb
+++ b/spec/features/npq_separation/admin/finance/adjustments_spec.rb
@@ -233,7 +233,7 @@ RSpec.feature "Adjustments", type: :feature do
       fill_in "adjustment[description]", with: "new adjustment"
       click_on "Continue"
 
-      expect(page).to have_text("Adjustments can no longer be made to this statement, as it is marked as paid")
+      expect(page).to have_text I18n.t("activemodel.errors.models.admin/adjustments/create_adjustment_form.attributes.statement.adjustments_not_allowed")
       expect(Adjustment.count).to be_zero
     end
 
@@ -247,7 +247,7 @@ RSpec.feature "Adjustments", type: :feature do
       fill_in "adjustment[description]", with: "adjustment edited"
       click_on "Continue"
 
-      expect(page).to have_text("Adjustments can no longer be made to this statement, as it is marked as paid")
+      expect(page).to have_text I18n.t("activemodel.errors.models.admin/adjustments/create_adjustment_form.attributes.statement.adjustments_not_allowed")
       expect(Adjustment.last.description).to eq("adjustment description")
     end
 
@@ -260,7 +260,7 @@ RSpec.feature "Adjustments", type: :feature do
 
       click_on "Remove"
 
-      expect(page).to have_text("Adjustments can no longer be made to this statement, as it is marked as paid")
+      expect(page).to have_text I18n.t("activemodel.errors.models.admin/adjustments/create_adjustment_form.attributes.statement.adjustments_not_allowed")
       expect(Adjustment.count).to eq 1
     end
   end

--- a/spec/features/npq_separation/admin/finance/adjustments_spec.rb
+++ b/spec/features/npq_separation/admin/finance/adjustments_spec.rb
@@ -216,7 +216,7 @@ RSpec.feature "Adjustments", type: :feature do
     scenario "statement is marked as payable" do
       visit(npq_separation_admin_finance_statement_path(payable_statement))
 
-      expect(page).not_to have_link "Make adjustment"
+      expect(page).to have_link "Make adjustment"
     end
 
     scenario "statement is marked as paid" do
@@ -225,42 +225,42 @@ RSpec.feature "Adjustments", type: :feature do
       expect(page).not_to have_link "Make adjustment"
     end
 
-    scenario "statement moved to payable whilst creating adjustment" do
+    scenario "statement moved to paid whilst creating adjustment" do
       visit(new_npq_separation_admin_finance_statement_adjustment_path(statement))
 
-      statement.update!(state: :payable)
+      statement.update!(state: :paid)
 
       fill_in "adjustment[description]", with: "new adjustment"
       click_on "Continue"
 
-      expect(page).to have_text("The statement has to be open for adjustments to be made")
+      expect(page).to have_text("Adjustments can no longer be made to this statement, as it is marked as paid")
       expect(Adjustment.count).to be_zero
     end
 
-    scenario "statement moved to payable whilst editing adjustment" do
+    scenario "statement moved to paid whilst editing adjustment" do
       adjustment = create(:adjustment, statement:, description: "adjustment description", amount: 100)
 
       visit(edit_npq_separation_admin_finance_statement_adjustment_path(statement, adjustment))
 
-      statement.update!(state: :payable)
+      statement.update!(state: :paid)
 
       fill_in "adjustment[description]", with: "adjustment edited"
       click_on "Continue"
 
-      expect(page).to have_text("The statement has to be open for adjustments to be made")
+      expect(page).to have_text("Adjustments can no longer be made to this statement, as it is marked as paid")
       expect(Adjustment.last.description).to eq("adjustment description")
     end
 
-    scenario "statement moved to payable whilst deleting adjustment" do
+    scenario "statement moved to paid whilst deleting adjustment" do
       adjustment = create(:adjustment, statement:, description: "adjustment description", amount: 100)
 
       visit(delete_npq_separation_admin_finance_statement_adjustment_path(statement, adjustment))
 
-      statement.update!(state: :payable)
+      statement.update!(state: :paid)
 
       click_on "Remove"
 
-      expect(page).to have_text("The statement has to be open for adjustments to be made")
+      expect(page).to have_text("Adjustments can no longer be made to this statement, as it is marked as paid")
       expect(Adjustment.count).to eq 1
     end
   end

--- a/spec/features/npq_separation/admin/finance/statement_payment_spec.rb
+++ b/spec/features/npq_separation/admin/finance/statement_payment_spec.rb
@@ -10,6 +10,9 @@ RSpec.feature "Statement payment", type: :feature do
 
   before do
     create(:declaration, :payable, statement:)
+    # contracts needed to test queries in summary calculator are optimised
+    create(:contract, course: create(:course, :leading_teaching), statement:)
+    create(:contract, course: create(:course, :leading_behaviour_culture), statement:)
     sign_in_as(create(:admin))
     visit(npq_separation_admin_finance_statement_path(statement))
   end

--- a/spec/forms/admin/adjustments/destroy_adjustment_form_spec.rb
+++ b/spec/forms/admin/adjustments/destroy_adjustment_form_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Admin::Adjustments::DestroyAdjustmentForm, type: :model do
   describe "#destroy_adjustment" do
     subject(:destroy_adjustment) { form.destroy_adjustment }
 
-    context "when the statement is open" do
+    shared_examples "destroying an adjustment" do
       it { is_expected.to be true }
 
       it "the form should be valid" do
@@ -42,28 +42,14 @@ RSpec.describe Admin::Adjustments::DestroyAdjustmentForm, type: :model do
       end
     end
 
+    context "when the statement is open" do
+      it_behaves_like "destroying an adjustment"
+    end
+
     context "when the statement is payable" do
       let(:statement) { create(:statement, :payable) }
 
-      it { is_expected.to be false }
-
-      it "the form should not be valid" do
-        destroy_adjustment
-        expect(form).not_to be_valid
-      end
-
-      it "does not destroy the adjustment" do
-        expect { destroy_adjustment }.to(not_change { Adjustment.count })
-      end
-
-      it "sets the errors from the adjustment" do
-        destroy_adjustment
-        form.valid?
-
-        expect(form.errors.messages).to include(
-          statement: ["The statement has to be open for adjustments to be made"],
-        )
-      end
+      it_behaves_like "destroying an adjustment"
     end
 
     context "when the statement is paid" do
@@ -81,7 +67,7 @@ RSpec.describe Admin::Adjustments::DestroyAdjustmentForm, type: :model do
         form.valid?
 
         expect(form.errors.messages).to include(
-          statement: ["The statement has to be open for adjustments to be made"],
+          statement: ["Adjustments can no longer be made to this statement, as it is marked as paid"],
         )
       end
     end

--- a/spec/forms/admin/adjustments/update_adjustment_form_spec.rb
+++ b/spec/forms/admin/adjustments/update_adjustment_form_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Admin::Adjustments::UpdateAdjustmentForm, type: :model do
   describe "#save_adjustment" do
     subject(:save_adjustment) { form.save_adjustment }
 
-    context "when the adjustment is valid" do
+    shared_examples "updating an adjustment" do
       it "updates the adjustment description" do
         expect { save_adjustment }.to change { adjustment.reload.description }.from("old description").to("new description")
       end
@@ -57,29 +57,14 @@ RSpec.describe Admin::Adjustments::UpdateAdjustmentForm, type: :model do
       end
     end
 
+    context "when the statement is open" do
+      it_behaves_like "updating an adjustment"
+    end
+
     context "when the statement is payable" do
       let(:statement) { create(:statement, :payable) }
 
-      it { is_expected.to be false }
-
-      it "the form should not be valid" do
-        save_adjustment
-        expect(form).not_to be_valid
-      end
-
-      it "does not update the adjustment" do
-        expect { save_adjustment }.to not_change { adjustment.reload.description }
-          .and not_change(adjustment, :amount)
-      end
-
-      it "sets the errors from the adjustment" do
-        save_adjustment
-        form.valid?
-
-        expect(form.errors.messages).to include(
-          statement: ["The statement has to be open for adjustments to be made"],
-        )
-      end
+      it_behaves_like "updating an adjustment"
     end
 
     context "when the statement is paid" do
@@ -97,7 +82,7 @@ RSpec.describe Admin::Adjustments::UpdateAdjustmentForm, type: :model do
         form.valid?
 
         expect(form.errors.messages).to include(
-          statement: ["The statement has to be open for adjustments to be made"],
+          statement: ["Adjustments can no longer be made to this statement, as it is marked as paid"],
         )
       end
     end

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -151,15 +151,15 @@ RSpec.describe Statement, type: :model do
     end
   end
 
-  describe "#has_marked_as_paid_at_date?" do
+  describe "#marked_as_paid_with_date?" do
     context "with a statement marked as paid" do
       subject { create(:statement, :paid) }
 
-      it { is_expected.to have_marked_as_paid_at_date }
+      it { is_expected.to be_marked_as_paid_with_date }
     end
 
     context "with a statement not marked as paid" do
-      it { is_expected.not_to have_marked_as_paid_at_date }
+      it { is_expected.not_to be_marked_as_paid_with_date }
     end
   end
 

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -240,4 +240,32 @@ RSpec.describe Statement, type: :model do
       it { is_expected.to be false }
     end
   end
+
+  describe "#allow_adjustments?" do
+    subject { statement.allow_adjustments? }
+
+    context "when the statement is open" do
+      let(:statement) { build(:statement, :open) }
+
+      it { is_expected.to be true }
+    end
+
+    context "when the statement is payable" do
+      let(:statement) { build(:statement, :payable) }
+
+      it { is_expected.to be true }
+    end
+
+    context "when the statement is paid" do
+      let(:statement) { build(:statement, :paid) }
+
+      it { is_expected.to be true }
+    end
+
+    context "when the statement is marked as paid" do
+      let(:statement) { build(:statement, :paid, marked_as_paid_at: Time.zone.now) }
+
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -151,15 +151,15 @@ RSpec.describe Statement, type: :model do
     end
   end
 
-  describe "#marked_as_paid?" do
+  describe "#has_marked_as_paid_at_date?" do
     context "with a statement marked as paid" do
       subject { create(:statement, :paid) }
 
-      it { is_expected.to be_marked_as_paid }
+      it { is_expected.to have_marked_as_paid_at_date }
     end
 
     context "with a statement not marked as paid" do
-      it { is_expected.not_to be_marked_as_paid }
+      it { is_expected.not_to have_marked_as_paid_at_date }
     end
   end
 
@@ -236,34 +236,6 @@ RSpec.describe Statement, type: :model do
 
     context "with open statement with marked_as_paid_at_set" do
       let(:statement) { build(:statement, :open, marked_as_paid_at: Time.zone.now) }
-
-      it { is_expected.to be false }
-    end
-  end
-
-  describe "#allow_adjustments?" do
-    subject { statement.allow_adjustments? }
-
-    context "when the statement is open" do
-      let(:statement) { build(:statement, :open) }
-
-      it { is_expected.to be true }
-    end
-
-    context "when the statement is payable" do
-      let(:statement) { build(:statement, :payable) }
-
-      it { is_expected.to be true }
-    end
-
-    context "when the statement is paid" do
-      let(:statement) { build(:statement, :paid) }
-
-      it { is_expected.to be true }
-    end
-
-    context "when the statement is marked as paid" do
-      let(:statement) { build(:statement, :paid, marked_as_paid_at: Time.zone.now) }
 
       it { is_expected.to be false }
     end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2991

Adjustments are allowed, all the way up until a statement is marked as paid.

### Changes proposed in this pull request
You cannot make adjustments now if the statement is in state `paid`.

In production:
statements from 2021 to 2022 never have `marked_as_paid_at` set, because this change was introduced in 2023.
statements from 2023 have a mixture of `marked_as_paid_at`:`nil` and `marked_as_paid_at` set.
statements from 2024 onwards always have `marked_as_paid_at` set.

I've made the seeds always set `marked_as_paid_at` for statements 2023 onwards, so they better reflect what we have in production.

I've renamed the method `statement#marked_as_paid?`, to `statement#has_marked_as_paid_at_date?` - because it was confusing and wrong before - the method is only used to decide whether to show the `marked_as_paid_at` date on the admin console.
The key feature of a statement being `marked_as_paid?` is that it has a state of `paid` - older statements will have been marked as paid, but have no `marked_as_paid_at` date.

I also added contracts to the statement payment feature spec, because bullet was showing an unoptimised query in the summary calculator.


