### PR TITLE
[CPDNPQ-2811] application accept error messages

### DIFF
--- a/app/services/applications/accept.rb
+++ b/app/services/applications/accept.rb
@@ -15,8 +15,8 @@ module Applications
     validate :cannot_change_from_rejected
     validate :other_accepted_applications_with_same_course_and_cohort?
     validate :eligible_for_funded_place
-    validate :validate_permitted_schedule_for_course
     validate :validate_schedule_exists
+    validate :validate_permitted_schedule_for_course
 
     def accept
       return false unless valid?
@@ -134,8 +134,12 @@ module Applications
       return unless application
 
       unless schedule
-        errors.add(:schedule, :blank)
-        Sentry.capture_message("Schedule could not be determined for application #{application.ecf_id}")
+        if schedule_identifier.present?
+          errors.add(:schedule_identifier, :not_found)
+        else
+          errors.add(:schedule, :blank)
+          Sentry.capture_message("Schedule could not be determined for application #{application.ecf_id}")
+        end
       end
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -117,6 +117,7 @@ en:
     invalidates_declaration: Changing schedule would invalidate existing declarations. Please void them first.
     schedule_has_not_changed: The participant already has the specified schedule
     invalid_for_course: The selected schedule is not valid for the course
+    not_found: The selected schedule cannot be found in the application cohort
 
   state: &state
     blank: "The '#/%{parameterized_attribute}' is missing from your request. Please include a 'passed' or 'failed' value and try again."

--- a/db/seeds/base/add_schedules.rb
+++ b/db/seeds/base/add_schedules.rb
@@ -1,4 +1,20 @@
-Cohort.find_each do |cohort|
+# cohorts up to 2025 reflect production
+{
+  2021 => %i[npq_leadership_spring npq_leadership_autumn npq_specialist_spring npq_specialist_autumn npq_aso_december npq_aso_june npq_aso_march npq_aso_november npq_ehco_june],
+  2022 => %i[npq_leadership_spring npq_leadership_autumn npq_specialist_spring npq_specialist_autumn npq_ehco_june npq_ehco_march npq_ehco_november npq_ehco_december],
+  2023 => %i[npq_leadership_spring npq_leadership_autumn npq_specialist_spring npq_specialist_autumn npq_ehco_june npq_ehco_march npq_ehco_november npq_ehco_december],
+  2024 => %i[npq_leadership_autumn npq_specialist_autumn npq_ehco_june npq_ehco_november npq_ehco_december],
+  2025 => %i[npq_leadership_spring npq_specialist_spring npq_ehco_march npq_ehco_june],
+}.each do |start_year, schedules|
+  funding_cap = start_year >= 2024
+  cohort = FactoryBot.create(:cohort, start_year:, funding_cap:)
+  schedules.each do |schedule_identifier|
+    FactoryBot.create(:schedule, schedule_identifier, cohort:, change_applies_dates: false)
+  end
+end
+
+# cohorts from 2026 onwards have all schedules
+Cohort.where(start_year: 2026..).find_each do |cohort|
   %i[
     npq_aso_december
     npq_aso_june

--- a/spec/services/applications/accept_spec.rb
+++ b/spec/services/applications/accept_spec.rb
@@ -447,7 +447,8 @@ RSpec.describe Applications::Accept, :with_default_schedules, type: :model do
         it "returns validation error" do
           expect(service.accept).to be_falsey
           expect(service.application.schedule).not_to eql(new_schedule)
-          expect(service.errors.messages_for(:schedule_identifier)).to include("The selected schedule is not valid for the course")
+          expect(service).to have_error(:schedule_identifier, :invalid_for_course, "The selected schedule is not valid for the course")
+          expect(service).to have_error_count(1)
         end
       end
 
@@ -456,7 +457,8 @@ RSpec.describe Applications::Accept, :with_default_schedules, type: :model do
 
         it "returns validation error" do
           expect(service.accept).to be_falsey
-          expect(service).to have_error(:schedule_identifier, :invalid_for_course, "The selected schedule is not valid for the course")
+          expect(service).to have_error(:schedule_identifier, :not_found, "The selected schedule cannot be found in the application cohort")
+          expect(service).to have_error_count(1)
         end
       end
     end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2811

currently, 3 scenarios are covered by the "Schedule cannot be determined" error:
1. A schedule identifier has been specified when accepting the application, but that schedule does not exist in the application's cohort - this is something under the user's control - they can specify a different identifier, or not specify one, and we'll determine the correct schedule.
2. No schedule identifier has been specified, and we have not been able to determine what schedule to use - this is a problem on our end.
3. When the selected schedule is not valid for the application's course, we currently show 2 errors: "The selected schedule is not valid for the course" and "Schedule cannot be determined" - we shouldn't be showing the second error really

### Changes proposed in this pull request

- For scenario (1.) above - I'm suggesting we should have a better error: "The selected schedule cannot be found in the application cohort"
- For scenario (2.) we still have the same error message, and we still send an error to Sentry, as this is something we need to look into.
- For scenario (3.) we will only show the one error: "The selected schedule is not valid for the course"
- Make our seeded schedules look more like production

