### PR TITLE
[CPDNPQ-3068] fix requests to OmniauthController#passthru

### DIFF
--- a/app/controllers/omniauth_controller.rb
+++ b/app/controllers/omniauth_controller.rb
@@ -1,6 +1,6 @@
 class OmniauthController < Devise::OmniauthCallbacksController
   skip_before_action :verify_authenticity_token, only: %i[tra_openid_connect]
-  skip_before_action :authenticate_user!, only: %i[tra_openid_connect failure]
+  skip_before_action :authenticate_user!
 
   def tra_openid_connect
     # Let user continue using current TRA login

--- a/spec/requests/omniauth_spec.rb
+++ b/spec/requests/omniauth_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Omniauth passthru", type: :request do
+  describe "GET /users/auth/tra_openid_connect" do
+    it "returns a 404 status" do
+      get "/users/auth/tra_openid_connect"
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).to include("Not found. Authentication passthru.")
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-3068

The recent change in CPDNPQ-2398 introduced this error when making a GET request to  `/users/auth/tra_openid_connect`.
We've seen Sentry errors for this.

### Changes proposed in this pull request

Skip the authentication checks for OmniauthController.
There are only 3 methods on that controller: `tra_openid_connect`, `failure` and inherited from [Devise::OmniauthCallbacksController](https://github.com/heartcombo/devise/blob/main/app/controllers/devise/omniauth_callbacks_controller.rb): `passthru`.
