### PR TITLE
[CPDNPQ-2771] redirect to start when removed step

### DIFF
--- a/app/controllers/registration_wizard_controller.rb
+++ b/app/controllers/registration_wizard_controller.rb
@@ -4,6 +4,8 @@ class RegistrationWizardController < PublicPagesController
   before_action :set_form
   before_action :check_end_of_journey, only: %i[update]
 
+  rescue_from RegistrationWizard::RemovedStep, with: :redirect_to_course_start_date
+
   def show
     @form.flag_as_changing_answer if params[:changing_answer] == "1"
 
@@ -17,7 +19,7 @@ class RegistrationWizardController < PublicPagesController
     @wizard.after_render
   rescue ActionView::Template::Error => e
     if e.cause.instance_of?(Questionnaires::IneligibleForFunding::UnexpectedEligibilityStatusCode)
-      redirect_to registration_wizard_show_path(:"course-start-date")
+      redirect_to_course_start_date
     else
       raise e
     end
@@ -58,6 +60,10 @@ class RegistrationWizardController < PublicPagesController
   end
 
 private
+
+  def redirect_to_course_start_date
+    redirect_to registration_wizard_show_path("course-start-date")
+  end
 
   def set_wizard
     @wizard = RegistrationWizard.new(current_step: params[:step].underscore, store:, params: wizard_params, request:, current_user:)

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -6,6 +6,7 @@ class RegistrationWizard
   include ActionView::Helpers::TranslationHelper
 
   class InvalidStep < StandardError; end
+  class RemovedStep < StandardError; end
 
   Answer = Struct.new(:key, :value, :change_step)
 
@@ -62,6 +63,12 @@ class RegistrationWizard
     cannot_register_yet
   ].freeze
 
+  REMOVED_REGISTRATION_STEPS = %i[
+    about_npq
+    choosen_start_date
+    confirmation
+  ].freeze
+
   attr_reader :current_step, :params, :store, :request, :current_user
 
   delegate :before_render,
@@ -74,6 +81,8 @@ class RegistrationWizard
   class << self
     def validate_step!(step)
       return step.to_sym if VALID_REGISTRATION_STEPS.include?(step.to_sym)
+
+      raise RemovedStep, "This step has been removed: #{step}" if REMOVED_REGISTRATION_STEPS.include?(step.to_sym)
 
       raise InvalidStep, "Could not find step: #{step}"
     end

--- a/spec/features/journeys/sad_paths/step_does_not_exist_spec.rb
+++ b/spec/features/journeys/sad_paths/step_does_not_exist_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.feature "visiting steps that do not exist", type: :feature do
+  include_context "Stub Get An Identity Omniauth Responses"
+
+  context "when not logged in" do
+    scenario "visiting steps that used to exist", :no_js do
+      visit "/registration/confirmation"
+      expect(page).to have_current_path "/"
+
+      visit "/registration/about_npq"
+      expect(page).to have_current_path "/"
+
+      visit "/registration/choosen_start_date"
+      expect(page).to have_current_path "/"
+    end
+  end
+
+  context "when logged in" do
+    before do
+      visit "/"
+      page.click_button("Start now")
+    end
+
+    scenario "visiting steps that used to exist", :no_js do
+      visit "/registration/confirmation"
+      expect(page).to have_current_path "/registration/course-start-date"
+
+      visit "/registration/about_npq"
+      expect(page).to have_current_path "/registration/course-start-date"
+
+      visit "/registration/choosen_start_date"
+      expect(page).to have_current_path "/registration/course-start-date"
+    end
+  end
+
+  scenario "visiting steps that never existed", :no_js do
+    expect { visit("/registration/this-step-never-existed") }.to raise_error(RegistrationWizard::InvalidStep)
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2771

certain steps were removed from the journey, but we still get requests to these steps

### Changes proposed in this pull request

For the removed steps, redirect to the course-start-date step.
For other steps, continue to raise the `InvalidStep` error.