### PR TITLE
[CPDNPQ-3098] Deactivate legacy APIs in sandbox

### DIFF
--- a/app/views/api/guidance/release-notes.md
+++ b/app/views/api/guidance/release-notes.md
@@ -2,10 +2,19 @@
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
+## V1 and V2 APIs are deactivated in sandbox
+### 28 July 2025
+
+<strong class="govuk-tag govuk-tag--yellow">SANDBOX</strong>
+
+The legacy V1 and V2 APIs have now been removed from `sandbox` ahead of removal from `production`.
+
+V1 and V2 APIs will be removed from `production` on 8 August 2025. 
+
+
 ## Delivery partner endpoints and declarations are now available in production
 ### 19 May 2025
-
-**PRODUCTION**
+<strong class="govuk-tag govuk-tag--green">PRODUCTION</strong>
 
 The delivery partner API changes released in the sandbox environment on 14 April 2025 are now live in production.
 
@@ -19,7 +28,7 @@ This requirement does not apply to overseas applicants.
 ## Delivery partner endpoints and declarations added to sandbox for testing
 ### 14 April 2025
 
-**SANDBOX**
+<strong class="govuk-tag govuk-tag--yellow">SANDBOX</strong>
 
 We’ve made updates in the sandbox environment to improve how lead providers interact with the service.
 
@@ -34,7 +43,7 @@ Starting from 28 April 2025, the `delivery_partner_id` will be required for coho
 
 ## Standalone NPQ API now available in production
 ### 27 November 2024
-**PRODUCTION**
+<strong class="govuk-tag govuk-tag--green">PRODUCTION</strong>
 
 We've launched the live standalone National Professional Qualifications (NPQs) API following a 3-month test phase.
 
@@ -65,7 +74,7 @@ Providers can contact us via their dedicated DfE Slack channel if they’ve got 
 
 ## Standalone NPQ API added to sandbox for testing 
 ### 13 August 2024
-**SANDBOX**
+<strong class="govuk-tag govuk-tag--yellow">SANDBOX</strong>
 
 We’ve released a minimum viable product (MVP) version of the standalone National Professional Qualifications (NPQ) API for providers to test ahead of its full launch at the end of November 2024. 
 

--- a/app/views/api/guidance/release-notes.md
+++ b/app/views/api/guidance/release-notes.md
@@ -2,14 +2,14 @@
 
 If you have any questions or comments about these notes, please contact DfE via Slack or email.
 
-## V1 and V2 APIs are deactivated in sandbox
+## V1 and V2 APIs are removed from sandbox
 ### 28 July 2025
 
 <strong class="govuk-tag govuk-tag--yellow">SANDBOX</strong>
 
-The legacy V1 and V2 APIs have now been removed from `sandbox` ahead of removal from `production`.
+We've removed the legacy V1 and V2 APIs from the `sandbox` environment.
 
-V1 and V2 APIs will be removed from `production` on 8 August 2025. 
+These APIs will be removed from `production` on 8 August 2025. If you're still using them, you'll need to switch to the latest version before this date.
 
 
 ## Delivery partner endpoints and declarations are now available in production

--- a/config/application.rb
+++ b/config/application.rb
@@ -73,6 +73,6 @@ module NpqRegistration
                                                secure: !Rails.env.local?,
                                                expire_after: 2.weeks
 
-    config.x.disable_legacy_api = true
+    config.x.disable_legacy_api = false
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -72,5 +72,7 @@ module NpqRegistration
     config.session_store :active_record_store, key: "_npq_registration_session",
                                                secure: !Rails.env.local?,
                                                expire_after: 2.weeks
+
+    config.x.disable_legacy_api = true
   end
 end

--- a/config/environments/review.rb
+++ b/config/environments/review.rb
@@ -1,6 +1,8 @@
 require Rails.root.join("config/environments/production")
 
 Rails.application.configure do
+  config.x.disable_legacy_api = true
+
   config.after_initialize do
     Bullet.enable                       = true
     Bullet.bullet_logger                = false

--- a/config/environments/sandbox.rb
+++ b/config/environments/sandbox.rb
@@ -2,4 +2,5 @@ require Rails.root.join("config/environments/production")
 
 Rails.application.configure do
   config.log_level = :info
+  config.x.disable_legacy_api = true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,12 +65,14 @@ Rails.application.routes.draw do
     get "guidance/*page", to: "guidance#show", as: :guidance_page
     get "docs/:version", to: "documentation#index", as: :documentation
 
+    namespace :v1 do
+      namespace :get_an_identity do
+        resource :webhook_messages, only: %i[create]
+      end
+    end
+
     unless Rails.configuration.x.disable_legacy_api
       namespace :v1 do
-        namespace :get_an_identity do
-          resource :webhook_messages, only: %i[create]
-        end
-
         defaults format: :json do
           resources :applications, path: "npq-applications", only: %i[index show], param: :ecf_id do
             member do

--- a/lib/api/version.rb
+++ b/lib/api/version.rb
@@ -5,7 +5,7 @@ class API::Version
     end
 
     def all
-      %i[v1 v2 v3]
+      Rails.configuration.x.disable_legacy_api ? %i[v3] : %i[v1 v2 v3]
     end
   end
 end

--- a/spec/features/maintenance_banner_spec.rb
+++ b/spec/features/maintenance_banner_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "Maintenance banner" do
   end
 
   scenario "viewing an API docs path" do
-    visit api_documentation_path(version: "v1")
+    visit api_documentation_path(version: "v3")
     expect(page).to have_text(/This service will be unavailable from/)
   end
 
@@ -37,7 +37,7 @@ RSpec.feature "Maintenance banner" do
     end
 
     scenario "viewing the API docs" do
-      visit api_documentation_path(version: "v1")
+      visit api_documentation_path(version: "v3")
       expect(page).not_to have_text(/This service will be unavailable from/)
     end
   end

--- a/spec/lib/api/version_spec.rb
+++ b/spec/lib/api/version_spec.rb
@@ -5,7 +5,11 @@ RSpec.describe API::Version do
   describe ".all" do
     subject { described_class.all }
 
-    it { is_expected.to match_array(%i[v1 v2 v3]) }
+    if Rails.configuration.x.disable_legacy_api
+      it { is_expected.to match_array(%i[v3]) }
+    else
+      it { is_expected.to match_array(%i[v1 v2 v3]) }
+    end
   end
 
   describe ".exists?" do

--- a/spec/requests/api/docs/v1/applications_spec.rb
+++ b/spec/requests/api/docs/v1/applications_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "swagger_helper"
 
-RSpec.describe "NPQ Applications endpoint", :with_default_schedules, openapi_spec: "v1/swagger.yaml", type: :request do
+RSpec.describe "NPQ Applications endpoint", :with_default_schedules, openapi_spec: "v1/swagger.yaml", skip: Rails.configuration.x.disable_legacy_api, type: :request do
   include_context "with authorization for api doc request"
 
   let(:course_group) { CourseGroup.find_by(name: "leadership") || create(:course_group, name: "leadership") }

--- a/spec/requests/api/docs/v1/declarations_spec.rb
+++ b/spec/requests/api/docs/v1/declarations_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "swagger_helper"
 
-RSpec.describe "Declarations endpoints", openapi_spec: "v1/swagger.yaml", type: :request do
+RSpec.describe "Declarations endpoints", openapi_spec: "v1/swagger.yaml", skip: Rails.configuration.x.disable_legacy_api, type: :request do
   include_context "with authorization for api doc request"
 
   it_behaves_like "an API index Csv endpoint documentation",

--- a/spec/requests/api/docs/v1/participant_outcomes_spec.rb
+++ b/spec/requests/api/docs/v1/participant_outcomes_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "swagger_helper"
 
-RSpec.describe "NPQ Participant Outcomes endpoint", openapi_spec: "v1/swagger.yaml", type: :request do
+RSpec.describe "NPQ Participant Outcomes endpoint", openapi_spec: "v1/swagger.yaml", skip: Rails.configuration.x.disable_legacy_api, type: :request do
   include_context "with authorization for api doc request"
 
   let(:course_group) { CourseGroup.find_by(name: "leadership") || create(:course_group, name: "leadership") }

--- a/spec/requests/api/docs/v1/participants/outcomes_spec.rb
+++ b/spec/requests/api/docs/v1/participants/outcomes_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "swagger_helper"
 
-RSpec.describe "NPQ Participant Outcomes endpoint", openapi_spec: "v1/swagger.yaml", type: :request do
+RSpec.describe "NPQ Participant Outcomes endpoint", openapi_spec: "v1/swagger.yaml", skip: Rails.configuration.x.disable_legacy_api, type: :request do
   include_context "with authorization for api doc request"
 
   let(:course_group) { CourseGroup.find_by(name: "leadership") || create(:course_group, name: "leadership") }

--- a/spec/requests/api/docs/v1/participants_spec.rb
+++ b/spec/requests/api/docs/v1/participants_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "swagger_helper"
 
-RSpec.describe "NPQ Participants endpoint", openapi_spec: "v1/swagger.yaml", type: :request do
+RSpec.describe "NPQ Participants endpoint", openapi_spec: "v1/swagger.yaml", skip: Rails.configuration.x.disable_legacy_api, type: :request do
   include_context "with authorization for api doc request"
 
   let(:course) { create(:course, :early_headship_coaching_offer) }

--- a/spec/requests/api/docs/v2/applications_spec.rb
+++ b/spec/requests/api/docs/v2/applications_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "swagger_helper"
 
-RSpec.describe "NPQ Applications endpoint", :with_default_schedules, openapi_spec: "v2/swagger.yaml", type: :request do
+RSpec.describe "NPQ Applications endpoint", :with_default_schedules, openapi_spec: "v2/swagger.yaml", skip: Rails.configuration.x.disable_legacy_api, type: :request do
   include_context "with authorization for api doc request"
 
   let(:course_group) { CourseGroup.find_by(name: "leadership") || create(:course_group, name: "leadership") }

--- a/spec/requests/api/docs/v2/declarations_spec.rb
+++ b/spec/requests/api/docs/v2/declarations_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "swagger_helper"
 
-RSpec.describe "Declarations endpoints", openapi_spec: "v2/swagger.yaml", type: :request do
+RSpec.describe "Declarations endpoints", openapi_spec: "v2/swagger.yaml", skip: Rails.configuration.x.disable_legacy_api, type: :request do
   include_context "with authorization for api doc request"
 
   it_behaves_like "an API index Csv endpoint documentation",

--- a/spec/requests/api/docs/v2/enrolments_spec.rb
+++ b/spec/requests/api/docs/v2/enrolments_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "swagger_helper"
 
-RSpec.describe "NPQ enrolments endpoint", openapi_spec: "v2/swagger.yaml", type: :request do
+RSpec.describe "NPQ enrolments endpoint", openapi_spec: "v2/swagger.yaml", skip: Rails.configuration.x.disable_legacy_api, type: :request do
   include_context "with authorization for api doc request"
 
   it_behaves_like "an API index Csv endpoint documentation",

--- a/spec/requests/api/docs/v2/participant_outcomes_spec.rb
+++ b/spec/requests/api/docs/v2/participant_outcomes_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "swagger_helper"
 
-RSpec.describe "NPQ Participant Outcomes endpoint", openapi_spec: "v2/swagger.yaml", type: :request do
+RSpec.describe "NPQ Participant Outcomes endpoint", openapi_spec: "v2/swagger.yaml", skip: Rails.configuration.x.disable_legacy_api, type: :request do
   include_context "with authorization for api doc request"
 
   let(:course_group) { CourseGroup.find_by(name: "leadership") || create(:course_group, name: "leadership") }

--- a/spec/requests/api/docs/v2/participants/outcomes_spec.rb
+++ b/spec/requests/api/docs/v2/participants/outcomes_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "swagger_helper"
 
-RSpec.describe "NPQ Participant Outcomes endpoint", openapi_spec: "v2/swagger.yaml", type: :request do
+RSpec.describe "NPQ Participant Outcomes endpoint", openapi_spec: "v2/swagger.yaml", skip: Rails.configuration.x.disable_legacy_api, type: :request do
   include_context "with authorization for api doc request"
 
   let(:course_group) { CourseGroup.find_by(name: "leadership") || create(:course_group, name: "leadership") }

--- a/spec/requests/api/docs/v2/participants_spec.rb
+++ b/spec/requests/api/docs/v2/participants_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "swagger_helper"
 
-RSpec.describe "NPQ Participants endpoint", openapi_spec: "v2/swagger.yaml", type: :request do
+RSpec.describe "NPQ Participants endpoint", openapi_spec: "v2/swagger.yaml", skip: Rails.configuration.x.disable_legacy_api, type: :request do
   include_context "with authorization for api doc request"
 
   let(:course) { create(:course, :early_headship_coaching_offer) }

--- a/spec/requests/api/documentation_controller_spec.rb
+++ b/spec/requests/api/documentation_controller_spec.rb
@@ -5,14 +5,14 @@ require "rails_helper"
 RSpec.describe API::DocumentationController do
   subject { response }
 
-  context "with v1" do
+  context "with v1", skip: Rails.configuration.x.disable_legacy_api do
     before { get api_documentation_path(version: "v1") }
 
     it { is_expected.to have_http_status :success }
     it { expect(response.headers).to include "cache-control" => "no-store" }
   end
 
-  context "with v2" do
+  context "with v2", skip: Rails.configuration.x.disable_legacy_api do
     before { get api_documentation_path(version: "v2") }
 
     it { is_expected.to have_http_status :success }

--- a/spec/requests/api/errors_spec.rb
+++ b/spec/requests/api/errors_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Error responses", type: :request do
       expect(response.content_type).to match(/application\/json.*/)
     end
 
-    context "when the request is for a CSV" do
+    context "when the request is for a CSV", skip: Rails.configuration.x.disable_legacy_api do
       it "returns an plain text response" do
         api_get "/api/v2/npq-applications.csv"
         expect(response).to have_http_status(:internal_server_error)
@@ -55,7 +55,7 @@ RSpec.describe "Error responses", type: :request do
       expect(response.content_type).to match(/application\/json.*/)
     end
 
-    context "when the request is for a CSV" do
+    context "when the request is for a CSV", skip: Rails.configuration.x.disable_legacy_api do
       it "returns an plain text response" do
         api_get "/api/v2/npq-applications.csv"
         expect(response).to have_http_status(:unprocessable_entity)

--- a/spec/requests/api/v1/applications_spec.rb
+++ b/spec/requests/api/v1/applications_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Application endpoints", type: :request do
+RSpec.describe "Application endpoints", skip: Rails.configuration.x.disable_legacy_api, type: :request do
   let(:current_lead_provider) { create(:lead_provider) }
   let(:query) { Applications::Query }
   let(:serializer) { API::ApplicationSerializer }

--- a/spec/requests/api/v1/declarations_spec.rb
+++ b/spec/requests/api/v1/declarations_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Declaration endpoints", type: :request do
+RSpec.describe "Declaration endpoints", skip: Rails.configuration.x.disable_legacy_api, type: :request do
   let(:current_lead_provider) { create(:lead_provider) }
   let(:query) { Declarations::Query }
   let(:serializer) { API::DeclarationSerializer }

--- a/spec/requests/api/v1/participant_outcomes_spec.rb
+++ b/spec/requests/api/v1/participant_outcomes_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Participant outcome endpoints", type: :request do
+RSpec.describe "Participant outcome endpoints", skip: Rails.configuration.x.disable_legacy_api, type: :request do
   let(:current_lead_provider) { create(:lead_provider) }
   let(:query) { ParticipantOutcomes::Query }
   let(:serializer) { API::ParticipantOutcomeSerializer }

--- a/spec/requests/api/v1/participants/outcomes_spec.rb
+++ b/spec/requests/api/v1/participants/outcomes_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Participants outcome endpoints", type: :request do
+RSpec.describe "Participants outcome endpoints", skip: Rails.configuration.x.disable_legacy_api, type: :request do
   let(:current_lead_provider) { create(:lead_provider) }
   let(:query) { ParticipantOutcomes::Query }
   let(:serializer) { API::ParticipantOutcomeSerializer }

--- a/spec/requests/api/v1/participants_spec.rb
+++ b/spec/requests/api/v1/participants_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Participant endpoints", type: :request do
+RSpec.describe "Participant endpoints", skip: Rails.configuration.x.disable_legacy_api, type: :request do
   let(:current_lead_provider) { create(:lead_provider) }
   let(:query) { Participants::Query }
   let(:serializer) { API::ParticipantSerializer }

--- a/spec/requests/api/v2/applications_spec.rb
+++ b/spec/requests/api/v2/applications_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Application endpoints", type: :request do
+RSpec.describe "Application endpoints", skip: Rails.configuration.x.disable_legacy_api, type: :request do
   let(:current_lead_provider) { create(:lead_provider) }
   let(:query) { Applications::Query }
   let(:serializer) { API::ApplicationSerializer }

--- a/spec/requests/api/v2/declarations_spec.rb
+++ b/spec/requests/api/v2/declarations_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Declaration endpoints", type: :request do
+RSpec.describe "Declaration endpoints", skip: Rails.configuration.x.disable_legacy_api, type: :request do
   let(:current_lead_provider) { create(:lead_provider) }
   let(:query) { Declarations::Query }
   let(:serializer) { API::DeclarationSerializer }

--- a/spec/requests/api/v2/enrolments_spec.rb
+++ b/spec/requests/api/v2/enrolments_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Enrolment endpoints", type: :request do
+RSpec.describe "Enrolment endpoints", skip: Rails.configuration.x.disable_legacy_api, type: :request do
   let(:current_lead_provider) { create(:lead_provider) }
   let(:query) { Applications::Query }
 

--- a/spec/requests/api/v2/participant_outcomes_spec.rb
+++ b/spec/requests/api/v2/participant_outcomes_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Participant outcome endpoints", type: :request do
+RSpec.describe "Participant outcome endpoints", skip: Rails.configuration.x.disable_legacy_api, type: :request do
   let(:current_lead_provider) { create(:lead_provider) }
   let(:query) { ParticipantOutcomes::Query }
   let(:serializer) { API::ParticipantOutcomeSerializer }

--- a/spec/requests/api/v2/participants/outcomes_spec.rb
+++ b/spec/requests/api/v2/participants/outcomes_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Participants outcome endpoints", type: :request do
+RSpec.describe "Participants outcome endpoints", skip: Rails.configuration.x.disable_legacy_api, type: :request do
   let(:current_lead_provider) { create(:lead_provider) }
   let(:query) { ParticipantOutcomes::Query }
   let(:serializer) { API::ParticipantOutcomeSerializer }

--- a/spec/requests/api/v2/participants_spec.rb
+++ b/spec/requests/api/v2/participants_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Participant endpoints", type: :request do
+RSpec.describe "Participant endpoints", skip: Rails.configuration.x.disable_legacy_api, type: :request do
   let(:current_lead_provider) { create(:lead_provider) }
   let(:query) { Participants::Query }
   let(:serializer) { API::ParticipantSerializer }

--- a/spec/requests/rate_limiting_spec.rb
+++ b/spec/requests/rate_limiting_spec.rb
@@ -12,12 +12,19 @@ RSpec.describe "Rate limiting" do
     set_request_ip(ip)
   end
 
-  [
+  endpoints = [
     "/api/guidance",
-    "/api/docs/v1",
-    "/api/docs/v2",
     "/api/docs/v3",
-  ].each do |public_api_path|
+  ]
+
+  unless Rails.configuration.x.disable_legacy_api
+    endpoints += [
+      "/api/docs/v1",
+      "/api/docs/v2",
+    ]
+  end
+
+  endpoints.each do |public_api_path|
     context "when requesting the public API path #{public_api_path}" do
       let(:path) { public_api_path }
 

--- a/spec/routing/npq_separation_routes_spec.rb
+++ b/spec/routing/npq_separation_routes_spec.rb
@@ -1,8 +1,11 @@
 require "rails_helper"
 
 RSpec.describe "NPQ separation routes" do
-  it { expect(get(api_v1_applications_path)).to route_to("api/v1/applications#index", format: :json) }
-  it { expect(get(api_v2_applications_path)).to route_to("api/v2/applications#index", format: :json) }
+  context "with legacy api versions", skip: Rails.configuration.x.disable_legacy_api do
+    it { expect(get(api_v1_applications_path)).to route_to("api/v1/applications#index", format: :json) }
+    it { expect(get(api_v2_applications_path)).to route_to("api/v2/applications#index", format: :json) }
+  end
+
   it { expect(get(api_v3_applications_path)).to route_to("api/v3/applications#index", format: :json) }
 
   it { expect(get(npq_separation_admin_admins_path)).to route_to("npq_separation/admin/admins#index") }

--- a/spec/support/shared_examples/api_create_on_existing_resource_endpoint_documentation_support.rb
+++ b/spec/support/shared_examples/api_create_on_existing_resource_endpoint_documentation_support.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples "an API create on existing resource endpoint documentation", :exceptions_app do |url, tag, resource_description, response_description, response_schema_ref, request_schema_ref|
+  next if url =~ %r{/api/v[12]/} && Rails.configuration.x.disable_legacy_api
+
   path url do
     post resource_description do
       tags tag

--- a/spec/support/shared_examples/api_create_on_resource_endpoint_documentation_support.rb
+++ b/spec/support/shared_examples/api_create_on_resource_endpoint_documentation_support.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples "an API create on resource endpoint documentation", :exceptions_app do |url, tag, resource_description, response_description, response_schema_ref, request_schema_ref|
+  next if url =~ %r{/api/v[12]/} && Rails.configuration.x.disable_legacy_api
+
   path url do
     post resource_description do
       tags tag

--- a/spec/support/shared_examples/api_index_csv_endpoint_documentation_support.rb
+++ b/spec/support/shared_examples/api_index_csv_endpoint_documentation_support.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples "an API index Csv endpoint documentation" do |url, tag, resource_description, response_schema_ref, filter_schema_ref|
+  next if url =~ %r{/api/v[12]/} && Rails.configuration.x.disable_legacy_api
+
   path url do
     get "Retrieve all #{resource_description} in CSV format" do
       tags tag

--- a/spec/support/shared_examples/api_index_endpoint_documentation_support.rb
+++ b/spec/support/shared_examples/api_index_endpoint_documentation_support.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples "an API index endpoint documentation", :exceptions_app do |url, tag, resource_description, filter_schema_ref, response_schema_ref, default_sortable, sorting_schema_ref = nil|
+  next if url =~ %r{/api/v[12]/} && Rails.configuration.x.disable_legacy_api
+
   path url do
     get "Retrieve multiple #{resource_description}" do
       tags tag

--- a/spec/support/shared_examples/api_show_endpoint_documentation_support.rb
+++ b/spec/support/shared_examples/api_show_endpoint_documentation_support.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples "an API show endpoint documentation", :exceptions_app do |url, tag, resource_description, response_schema_ref|
+  next if url =~ %r{/api/v[12]/} && Rails.configuration.x.disable_legacy_api
+
   path url do
     get "Retrieve a single #{resource_description}" do
       tags tag

--- a/spec/support/shared_examples/api_update_endpoint_documentation_support.rb
+++ b/spec/support/shared_examples/api_update_endpoint_documentation_support.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples "an API update endpoint documentation", :exceptions_app do |url, tag, resource_description, response_description, response_schema_ref, request_schema_ref|
+  next if url =~ %r{/api/v[12]/} && Rails.configuration.x.disable_legacy_api
+
   path url do
     put resource_description do
       tags tag

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -98,14 +98,17 @@ RSpec.configure do |config|
       },
     }
   }.tap do |hash|
-    v1_v2_participant_declaration_requests = {
-      ParticipantDeclarationRequest: PARTICIPANT_DECLARATION_REQUEST,
-      ParticipantDeclarationStartedRequest: PARTICIPANT_DECLARATION_STARTED_REQUEST,
-      ParticipantDeclarationRetainedRequest: PARTICIPANT_DECLARATION_RETAINED_REQUEST,
-      ParticipantDeclarationCompletedRequest: PARTICIPANT_DECLARATION_COMPLETED_REQUEST,
-    }
-    hash["v1/swagger.yaml"][:components][:schemas].merge!(v1_v2_participant_declaration_requests)
-    hash["v2/swagger.yaml"][:components][:schemas].merge!(v1_v2_participant_declaration_requests)
+    unless Rails.configuration.x.disable_legacy_api
+      v1_v2_participant_declaration_requests = {
+        ParticipantDeclarationRequest: PARTICIPANT_DECLARATION_REQUEST,
+        ParticipantDeclarationStartedRequest: PARTICIPANT_DECLARATION_STARTED_REQUEST,
+        ParticipantDeclarationRetainedRequest: PARTICIPANT_DECLARATION_RETAINED_REQUEST,
+        ParticipantDeclarationCompletedRequest: PARTICIPANT_DECLARATION_COMPLETED_REQUEST,
+      }
+      hash["v1/swagger.yaml"][:components][:schemas].merge!(v1_v2_participant_declaration_requests)
+      hash["v2/swagger.yaml"][:components][:schemas].merge!(v1_v2_participant_declaration_requests)
+    end
+
     hash["v3/swagger.yaml"][:components][:schemas].merge!(
       ParticipantDeclarationRequest: V3_PARTICIPANT_DECLARATION_REQUEST,
       ParticipantDeclarationStartedRequest: V3_PARTICIPANT_DECLARATION_STARTED_REQUEST,

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -98,13 +98,14 @@ RSpec.configure do |config|
       },
     }
   }.tap do |hash|
+    v1_v2_participant_declaration_requests = {
+      ParticipantDeclarationRequest: PARTICIPANT_DECLARATION_REQUEST,
+      ParticipantDeclarationStartedRequest: PARTICIPANT_DECLARATION_STARTED_REQUEST,
+      ParticipantDeclarationRetainedRequest: PARTICIPANT_DECLARATION_RETAINED_REQUEST,
+      ParticipantDeclarationCompletedRequest: PARTICIPANT_DECLARATION_COMPLETED_REQUEST,
+    }
+
     unless Rails.configuration.x.disable_legacy_api
-      v1_v2_participant_declaration_requests = {
-        ParticipantDeclarationRequest: PARTICIPANT_DECLARATION_REQUEST,
-        ParticipantDeclarationStartedRequest: PARTICIPANT_DECLARATION_STARTED_REQUEST,
-        ParticipantDeclarationRetainedRequest: PARTICIPANT_DECLARATION_RETAINED_REQUEST,
-        ParticipantDeclarationCompletedRequest: PARTICIPANT_DECLARATION_COMPLETED_REQUEST,
-      }
       hash["v1/swagger.yaml"][:components][:schemas].merge!(v1_v2_participant_declaration_requests)
       hash["v2/swagger.yaml"][:components][:schemas].merge!(v1_v2_participant_declaration_requests)
     end

--- a/spec/swagger_schemas/requests/application_accept_request.rb
+++ b/spec/swagger_schemas/requests/application_accept_request.rb
@@ -1,5 +1,5 @@
 APPLICATION_ACCEPT_REQUEST = {
-  v1: {
+  v3: {
     description: "A NPQ application acceptance request",
     type: :object,
     required: %i[data],
@@ -33,8 +33,11 @@ APPLICATION_ACCEPT_REQUEST = {
     },
   },
 }.tap { |h|
-  h[:v2] = h[:v1].deep_dup
-  h[:v3] = h[:v2].deep_dup
+  unless Rails.configuration.x.disable_legacy_api
+    h[:v1] = h[:v3].deep_dup
+    h[:v2] = h[:v3].deep_dup
+  end
+
   h[:v3][:properties][:data][:properties][:attributes][:properties][:schedule_identifier] = {
     description: "The new schedule of the participant",
     nullable: false,


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-3098](https://dfedigital.atlassian.net/browse/CPDNPQ-3098)

We want to deactivate the legacy APIs so we need an easy way to activate/deactivate those APIs

### Changes proposed in this pull request

1. Added configuration flag to deactivate the APIs, defaulting to deactivated
2. Fixed up various specs to continue passing
3. Updated flag to re-activate those APIs

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/


[CPDNPQ-3098]: https://dfedigital.atlassian.net/browse/CPDNPQ-3098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ