### PR TITLE
Configure containers to run as non-root user

### DIFF
--- a/global_config/review.sh
+++ b/global_config/review.sh
@@ -6,4 +6,4 @@ AZURE_RESOURCE_PREFIX=s189t01
 KV_PURGE_PROTECTION=false
 CONFIG_LONG=review
 NAMESPACE=cpd-development
-TERRAFORM_MODULES_TAG=main
+TERRAFORM_MODULES_TAG=2375-security-aks-containers-run-as-non-root-user-npq

--- a/terraform/application/application.tf
+++ b/terraform/application/application.tf
@@ -40,7 +40,7 @@ module "application_configuration" {
 }
 
 module "web_application" {
-  source = "./vendor/modules/aks//aks/application"
+  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/application?ref=2375-security-aks-containers-run-as-non-root-user-npq"
 
   is_web = true
 
@@ -66,7 +66,7 @@ module "web_application" {
 }
 
 module "worker_application" {
-  source = "./vendor/modules/aks//aks/application"
+  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/application?ref=2375-security-aks-containers-run-as-non-root-user-npq"
 
   is_web = false
 


### PR DESCRIPTION
### Context

Ticket: https://trello.com/c/ylAGk14G/2375-security-aks-containers-run-as-non-root-user-npq

To have non root user run within /app directory

### Changes proposed in this pull request

  - Added non-root user (appuser) with UID 10001 and group (appgroup)
  with GID 20001 to the production Docker image
  - Changed ownership of the entire /app directory and its contents to
  the non-root user to ensure proper read/write permissions
  - Configured the container to run as the non-root user (UID 10001)
  for improved security
  - All application processes now run under the non-root user context
  instead of root

<img width="835" height="801" alt="Screenshot 2025-07-16 at 10 15 19" src="https://github.com/user-attachments/assets/8539d04d-abc3-46ab-a808-52417e935a61" />

