### PR TITLE
Add new row for schedule identifier to the application show page

### DIFF
--- a/app/views/npq_separation/admin/applications/show.html.erb
+++ b/app/views/npq_separation/admin/applications/show.html.erb
@@ -68,7 +68,7 @@
     end
     sl.with_row do |row|
       row.with_key(text: "Schedule identifier")
-      row.with_value(text: @application.schedule_id)
+      row.with_value(text: @application.schedule_id.presence || "-" )
     end
     sl.with_row do |row|
       row.with_key(text: "Funding choice")

--- a/app/views/npq_separation/admin/applications/show.html.erb
+++ b/app/views/npq_separation/admin/applications/show.html.erb
@@ -67,6 +67,10 @@
       row.with_action(text: "Change", href: npq_separation_admin_applications_change_cohort_path(@application))
     end
     sl.with_row do |row|
+      row.with_key(text: "Schedule identifier")
+      row.with_value(text: @application.schedule_id)
+    end
+    sl.with_row do |row|
       row.with_key(text: "Funding choice")
       row.with_value(text: @application.funding_choice.try(:humanize))
     end

--- a/app/views/npq_separation/admin/applications/show.html.erb
+++ b/app/views/npq_separation/admin/applications/show.html.erb
@@ -68,7 +68,7 @@
     end
     sl.with_row do |row|
       row.with_key(text: "Schedule identifier")
-      row.with_value(text: @application.schedule_id.presence || "-" )
+      row.with_value(text: @application.schedule&.identifier || "-" )
     end
     sl.with_row do |row|
       row.with_key(text: "Funding choice")

--- a/spec/features/npq_separation/admin/applications_spec.rb
+++ b/spec/features/npq_separation/admin/applications_spec.rb
@@ -179,7 +179,7 @@ RSpec.feature "Listing and viewing applications", type: :feature do
       expect(summary_list).to have_summary_item("Funded place", "")
       expect(summary_list).to have_summary_item("Status code", application.funding_eligiblity_status_code.humanize)
       expect(summary_list).to have_summary_item("Schedule cohort", application.cohort.start_year)
-      expect(summary_list).to have_summary_item("Schedule identifier", application.schedule_id)
+      expect(summary_list).to have_summary_item("Schedule identifier", application.schedule&.identifier || "-")
       expect(summary_list).to have_summary_item("Funding choice", application.funding_choice&.capitalize)
       expect(summary_list).to have_summary_item("Notes", "No notes")
     end

--- a/spec/features/npq_separation/admin/applications_spec.rb
+++ b/spec/features/npq_separation/admin/applications_spec.rb
@@ -179,7 +179,7 @@ RSpec.feature "Listing and viewing applications", type: :feature do
       expect(summary_list).to have_summary_item("Funded place", "")
       expect(summary_list).to have_summary_item("Status code", application.funding_eligiblity_status_code.humanize)
       expect(summary_list).to have_summary_item("Schedule cohort", application.cohort.start_year)
-      expect(summary_list).to have_summary_item("Schedule identifier", application.schedule&.identifier || "-")
+      expect(summary_list).to have_summary_item("Schedule identifier", "-")
       expect(summary_list).to have_summary_item("Funding choice", application.funding_choice&.capitalize)
       expect(summary_list).to have_summary_item("Notes", "No notes")
     end

--- a/spec/features/npq_separation/admin/applications_spec.rb
+++ b/spec/features/npq_separation/admin/applications_spec.rb
@@ -179,6 +179,7 @@ RSpec.feature "Listing and viewing applications", type: :feature do
       expect(summary_list).to have_summary_item("Funded place", "")
       expect(summary_list).to have_summary_item("Status code", application.funding_eligiblity_status_code.humanize)
       expect(summary_list).to have_summary_item("Schedule cohort", application.cohort.start_year)
+      expect(summary_list).to have_summary_item("Schedule identifier", application.schedule_id)
       expect(summary_list).to have_summary_item("Funding choice", application.funding_choice&.capitalize)
       expect(summary_list).to have_summary_item("Notes", "No notes")
     end

--- a/spec/views/npq_separation/admin/applications/show.html.erb_spec.rb
+++ b/spec/views/npq_separation/admin/applications/show.html.erb_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe "npq_separation/admin/applications/show.html.erb", type: :view do
     it { is_expected.to have_link(application.employer_name_to_display, href: npq_separation_admin_schools_path(q: application.school.urn)) }
     it { is_expected.to have_summary_item "Unique reference number (URN)", application.school.urn }
     it { is_expected.to have_summary_item "UK Provider Reference Number (UKPRN)", application.school.ukprn }
+    it { is_expected.to have_summary_item "Schedule identifier", application.schedule.identifier }
 
     context "with application overview summary card" do
       subject { Capybara.string(render).find(".govuk-summary-card", text: "Application overview") }
@@ -56,5 +57,6 @@ RSpec.describe "npq_separation/admin/applications/show.html.erb", type: :view do
     it { is_expected.to have_summary_item "Course", application.course.name }
     it { is_expected.to have_summary_item "Unique reference number (URN)", "" }
     it { is_expected.to have_summary_item "UK Provider Reference Number (UKPRN)", "" }
+    it { is_expected.to have_summary_item "Schedule identifier", "-" }
   end
 end


### PR DESCRIPTION
Add schedule identifier row to the funding eligibility section on the application show page.

Admins need this info when investigating queries and bugs.

<img width="1058" height="506" alt="Screenshot 2025-07-16 at 13 55 14" src="https://github.com/user-attachments/assets/84f8207f-b523-4b27-b3f3-1fe663bbe8ca" />

ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-3071
