### PR TITLE
[CPDNPQ-3069] Notify our alerts channel from StatusCake

### DIFF
--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -71,7 +71,7 @@ variable "external_url" {
   description = "Healthcheck URL for StatusCake monitoring"
 }
 variable "statuscake_contact_groups" {
-  default     = [291418,282453]
+  default     = [291418,282453,343307]
   description = "ID of the contact group in statuscake web UI"
 }
 variable "enable_monitoring" {


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-3069](https://dfedigital.atlassian.net/browse/CPDNPQ-3069)

Notify our internal alerts channel when Status Cake identifies an outage

### Changes proposed in this pull request

1. Added a new contact group to our status cake config

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/


[CPDNPQ-3069]: https://dfedigital.atlassian.net/browse/CPDNPQ-3069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ