### PR TITLE
Add tasks to remove circular dependency

### DIFF
--- a/lib/tasks/one_off/fix_circular_dependencies_3081.rake
+++ b/lib/tasks/one_off/fix_circular_dependencies_3081.rake
@@ -23,13 +23,16 @@ namespace :one_off do
 
         next unless to_user.trn == from_user.trn
 
-        ParticipantIdChange.where(from_participant_id: change.to_participant_id, to_participant_id: from_user.ecf_id).destroy_all
-        change.destroy!
-
-        if to_user.significantly_updated_at > from_user.significantly_updated_at
-          Users::MergeAndArchive.new(user_to_merge: from_user, user_to_keep: to_user).call(dry_run: false)
+        if to_user.archived?
+          change.destroy!
         else
-          Users::MergeAndArchive.new(user_to_merge: to_user, user_to_keep: from_user).call(dry_run: false)
+          ParticipantIdChange.where(from_participant_id: change.to_participant_id, to_participant_id: from_user.ecf_id).destroy_all
+          change.destroy!
+          if to_user.significantly_updated_at > from_user.significantly_updated_at
+            Users::MergeAndArchive.new(user_to_merge: from_user, user_to_keep: to_user).call(dry_run: false)
+          else
+            Users::MergeAndArchive.new(user_to_merge: to_user, user_to_keep: from_user).call(dry_run: false)
+          end
         end
       end
     end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-3081

Adds 2 tasks to remove circular dependency records:

#### `delete_empty_participant_id_changes`

Some of the `uuid` are not associated with any records, in that case the `ParticipantIdChange` will be deleted.

#### `fix_participant_id_changes_circular_dependencies`

This task is removing ParticipantIdChanges and is using `MergeAndArchive`. The user to merge to is based on `significantly_updated_at`.

When the `to_user` is already archived, the script will remove only redundant relation.