### PR TITLE
bau-tighten-write-access-to-swagger-docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ COPY --from=builder /app /app
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 
 # Change ownership only for directories that need write access
-RUN chown -R appuser:appgroup /app/tmp /app/public/api/docs
+RUN chown -R appuser:appgroup /app/tmp /app/public/api/docs/**/swagger.yaml
 
 ARG COMMIT_SHA
 ENV AUTHORISED_HOSTS=127.0.0.1 \


### PR DESCRIPTION
### Context

Ticket: BAU

We want our containers to limit write access to the greatest extent possible

### Changes proposed in this pull request

1. Change the write access from directory level to specific files since the files should already exist at `docker build` time

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
