### PR TITLE
[BAU] Avoid sending analytics requests for monitoring

### DIFF
--- a/app/controllers/monitoring_controller.rb
+++ b/app/controllers/monitoring_controller.rb
@@ -1,6 +1,4 @@
-class MonitoringController < PublicPagesController
-  skip_before_action :set_sentry_user, :initialize_store
-
+class MonitoringController < ActionController::Base
   def healthcheck
     render status:, json: {
       git_commit_sha: ENV["COMMIT_SHA"],


### PR DESCRIPTION
### Context

Ticket: BAU

We are getting errors from our `staging` and `sandbox` apps when redis gets replaced by Azure

I believe this is a caused by the dfe-analytics gem injecting itself into the `/up` endpoint and it shouldn't be

### Changes proposed in this pull request

1. Inherit directly from ActionController::Base

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
