### PR TITLE
[BAU] Handle users without date of birth present

### DIFF
--- a/app/views/npq_separation/admin/applications/_user.html.erb
+++ b/app/views/npq_separation/admin/applications/_user.html.erb
@@ -12,10 +12,10 @@
 
 <p class="govuk-body govuk-!-margin-bottom-2">
   <strong>Date of birth:</strong>
-  <%= user.date_of_birth.to_fs(:govuk_short) %>
+  <%= user.date_of_birth&.to_fs(:govuk_short) || "Not provided" %>
   |
   <strong>National Insurance:</strong>
-  <%= user.national_insurance_number.presence || 'Not provided' %>
+  <%= user.national_insurance_number.presence || "Not provided" %>
 </p>
 
 <p class="govuk-body govuk-!-margin-bottom-2">

--- a/spec/views/npq_separation/admin/applications/show.html.erb_spec.rb
+++ b/spec/views/npq_separation/admin/applications/show.html.erb_spec.rb
@@ -59,4 +59,11 @@ RSpec.describe "npq_separation/admin/applications/show.html.erb", type: :view do
     it { is_expected.to have_summary_item "UK Provider Reference Number (UKPRN)", "" }
     it { is_expected.to have_summary_item "Schedule identifier", "-" }
   end
+
+  describe "a row for a user without a date of birth" do
+    let(:application) { build_stubbed :application, user: }
+    let(:user) { build_stubbed :user, date_of_birth: nil }
+
+    it { is_expected.to have_text "Date of birth: Not provided", normalize_ws: true }
+  end
 end


### PR DESCRIPTION
### Context

Ticket: BAU

Currently if a user account is lacking a date of birth the show page for their application produces and error

### Changes proposed in this pull request

1. Fall back to showing 'Not provided'
2. Added spec for scenario

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/
