### PR TITLE
[CPDNPQ-3124] Fix nil User#date_of_birth error

### DIFF
--- a/app/views/npq_separation/admin/applications/_user.html.erb
+++ b/app/views/npq_separation/admin/applications/_user.html.erb
@@ -12,7 +12,7 @@
 
 <p class="govuk-body govuk-!-margin-bottom-2">
   <strong>Date of birth:</strong>
-  <%= user.date_of_birth.to_fs(:govuk_short) %>
+  <%= user.date_of_birth.try(:to_fs, :govuk_short) || 'Not provided' %>
   |
   <strong>National Insurance:</strong>
   <%= user.national_insurance_number.presence || 'Not provided' %>

--- a/spec/views/npq_separation/admin/applications/show.html.erb_spec.rb
+++ b/spec/views/npq_separation/admin/applications/show.html.erb_spec.rb
@@ -50,6 +50,8 @@ RSpec.describe "npq_separation/admin/applications/show.html.erb", type: :view do
       build_stubbed :application, cohort: nil, itt_provider: nil, school: nil
     end
 
+    before { application.user.date_of_birth = nil }
+
     it { is_expected.to have_css "h1", text: application.user.full_name }
     it { is_expected.to have_text "TRN: #{application.user.trn}", normalize_ws: true }
     it { is_expected.to have_summary_item "Application ID", application.ecf_id }


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-3124

As per [this Sentry error](https://dfe-teacher-services.sentry.io/issues/6725183117/?alert_rule_id=14507801&alert_type=issue&environment=production&notification_uuid=ab8763a4-abcd-4908-9635-5319c497cc43&project=5817541) if a `User`’s `date_of_birth` is `nil`, the `app/views/npq_separation/admin/applications/_user.html.erb` template blows up because it is assumed that it will always be set.

### Changes proposed in this pull request

Handle `nil` values