### PR TITLE
Enforce run_as_non_root

### DIFF
--- a/terraform/application/application.tf
+++ b/terraform/application/application.tf
@@ -63,6 +63,7 @@ module "web_application" {
 
   enable_logit = var.enable_logit
   send_traffic_to_maintenance_page = var.send_traffic_to_maintenance_page
+  run_as_non_root = true
 }
 
 module "worker_application" {
@@ -89,6 +90,7 @@ module "worker_application" {
 
   enable_logit = var.enable_logit
   enable_gcp_wif = true
+  run_as_non_root = true
 
   depends_on = [time_sleep.wait_15_seconds]
 }


### PR DESCRIPTION
### Context

Ticket: https://trello.com/c/ylAGk14G/2375-security-aks-containers-run-as-non-root-user-npq

### Changes proposed in this pull request

Setting the run_as_non_root flag to true
