### PR TITLE
[CPDNPQ-3034] bugfix - cope with versions with no object_changes

### DIFF
--- a/app/components/npq_separation/admin/history_component.rb
+++ b/app/components/npq_separation/admin/history_component.rb
@@ -11,7 +11,7 @@ module NpqSeparation
     private
 
       def build_changes
-        record.versions.where(event: "update")
+        record.versions.where(event: "update").where.not(object_changes: nil)
           .select { |version| (version.object_changes.keys - %w[updated_at]).any? }
           .pluck(:created_at, :whodunnit, :object_changes)
           .map do |created_at, whodunnit, object_changes|


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-3034

application history doesn't work for some applications

### Changes proposed in this pull request

cope with application.versions that don't have any object_changes