### PR TITLE
[CPDNPQ-3136] Fix bin/dev: add foreman to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,6 +80,7 @@ end
 
 group :development do
   gem "brakeman"
+  gem "foreman", "~> 0.90.0"
   gem "i18n-debug"
   gem "listen", ">= 3.0.5", "< 3.10"
   gem "rails-erd"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,6 +240,8 @@ GEM
       rack-protection (>= 1.5.3, < 5.0.0)
       rack-session (>= 1.0.2, < 3.0.0)
       sanitize (< 8)
+    foreman (0.90.0)
+      thor (~> 1.4)
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -770,6 +772,7 @@ DEPENDENCIES
   flipper (~> 1.3)
   flipper-active_record (~> 1.3)
   flipper-ui (~> 1.3)
+  foreman (~> 0.90.0)
   google-cloud-bigquery
   govuk-components (~> 5.10)
   govuk_design_system_formbuilder (~> 5.8)


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-3136

36fbf66 changed runtime permissions in the container such that `gem install` doesn't work.

This means that running `bin/dev` in a container will fail if the `foreman` gem is not already installed.

By adding it to `Gemfile` in the development group, it'll be installed when the image is built, so there's no need to install it at runtime, and the permissions issue is avoided.