### PR TITLE
Prevent line break between minus sign and pound symbol in currency formatting

### DIFF
--- a/app/components/npq_separation/admin/adjustments_table_component.html.erb
+++ b/app/components/npq_separation/admin/adjustments_table_component.html.erb
@@ -15,7 +15,7 @@
         adjustments.each do |adjustment|
           body.with_row do |row|
             row.with_cell(text: adjustment.description)
-            row.with_cell(text: number_to_currency(adjustment.amount), numeric: true)
+            row.with_cell(text: number_to_currency(adjustment.amount, negative_format: "\u2011%u%n"), numeric: true)
             row.with_cell do
               if show_actions
                 govuk_link_to(t(".edit"), edit_npq_separation_admin_finance_statement_adjustment_path(adjustment.statement, adjustment, show_all_adjustments:)) +
@@ -29,7 +29,7 @@
         if show_total
           body.with_row do |row|
             row.with_cell(text: t(".total"), header: true)
-            row.with_cell(text: number_to_currency(adjustments.sum(&:amount)), numeric: true, header: true)
+            row.with_cell(text: number_to_currency(adjustments.sum(&:amount), negative_format: "\u2011%u%n"), numeric: true, header: true)
             row.with_cell
           end
         end

--- a/spec/components/npq_separation/admin/adjustments_table_component_spec.rb
+++ b/spec/components/npq_separation/admin/adjustments_table_component_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe NpqSeparation::Admin::AdjustmentsTableComponent, type: :component
   let(:statement) { create(:statement) }
   let(:adjustment_1) { create(:adjustment, statement:, amount: 100) }
   let(:adjustment_2) { create(:adjustment, statement:, amount: 200) }
-  let(:adjustment_3) { create(:adjustment, statement:, amount: -300) }
+  let(:adjustment_3) { create(:adjustment, statement:, amount: -250) }
   let(:adjustments) { [adjustment_1, adjustment_2, adjustment_3] }
   let(:show_total) { nil }
   let(:show_actions) { nil }
@@ -21,7 +21,7 @@ RSpec.describe NpqSeparation::Admin::AdjustmentsTableComponent, type: :component
     it { is_expected.to have_css "tbody td", text: adjustment_2.description }
     it { is_expected.to have_css "tbody td", text: "£#{adjustment_2.amount}" }
     it { is_expected.to have_css "tbody td", text: adjustment_3.description }
-    it { is_expected.to have_css "tbody td", text: "‑£300" }
+    it { is_expected.to have_css "tbody td", text: "‑£250" }
 
     context "when show_actions is true" do
       let(:show_actions) { true }
@@ -39,14 +39,14 @@ RSpec.describe NpqSeparation::Admin::AdjustmentsTableComponent, type: :component
   describe "adjustment total" do
     context "when show_total is false" do
       it { is_expected.not_to have_css "tbody th", text: t(".total") }
-      it { is_expected.not_to have_css "tbody td", text: "£0.00" }
+      it { is_expected.not_to have_css "tbody td", text: "£50.00" }
     end
 
     context "when show_total is true" do
       let(:show_total) { true }
 
       it { is_expected.to have_css "tbody th", text: t(".total") }
-      it { is_expected.to have_css "tbody th", text: "£0.00" }
+      it { is_expected.to have_css "tbody th", text: "£50.00" }
     end
   end
 end

--- a/spec/components/npq_separation/admin/adjustments_table_component_spec.rb
+++ b/spec/components/npq_separation/admin/adjustments_table_component_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe NpqSeparation::Admin::AdjustmentsTableComponent, type: :component
   let(:statement) { create(:statement) }
   let(:adjustment_1) { create(:adjustment, statement:, amount: 100) }
   let(:adjustment_2) { create(:adjustment, statement:, amount: 200) }
-  let(:adjustment_3) { create(:adjustment, statement:, amount: 300) }
+  let(:adjustment_3) { create(:adjustment, statement:, amount: -300) }
   let(:adjustments) { [adjustment_1, adjustment_2, adjustment_3] }
   let(:show_total) { nil }
   let(:show_actions) { nil }
@@ -21,7 +21,7 @@ RSpec.describe NpqSeparation::Admin::AdjustmentsTableComponent, type: :component
     it { is_expected.to have_css "tbody td", text: adjustment_2.description }
     it { is_expected.to have_css "tbody td", text: "£#{adjustment_2.amount}" }
     it { is_expected.to have_css "tbody td", text: adjustment_3.description }
-    it { is_expected.to have_css "tbody td", text: "£#{adjustment_3.amount}" }
+    it { is_expected.to have_css "tbody td", text: "‑£300" }
 
     context "when show_actions is true" do
       let(:show_actions) { true }
@@ -39,14 +39,14 @@ RSpec.describe NpqSeparation::Admin::AdjustmentsTableComponent, type: :component
   describe "adjustment total" do
     context "when show_total is false" do
       it { is_expected.not_to have_css "tbody th", text: t(".total") }
-      it { is_expected.not_to have_css "tbody td", text: "£600" }
+      it { is_expected.not_to have_css "tbody td", text: "£0.00" }
     end
 
     context "when show_total is true" do
       let(:show_total) { true }
 
       it { is_expected.to have_css "tbody th", text: t(".total") }
-      it { is_expected.to have_css "tbody th", text: "£600" }
+      it { is_expected.to have_css "tbody th", text: "£0.00" }
     end
   end
 end


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-3097

We do not want minus numbers to wrap over two lines. Resolving this by using a non-breaking hyphen.

# Before

<img width="598" height="275" alt="image" src="https://github.com/user-attachments/assets/96ccec8f-c506-4c94-85e6-e9802656fbf2" />

# After

<img width="820" height="426" alt="Screenshot 2025-08-04 at 13 58 28" src="https://github.com/user-attachments/assets/d4afd91d-b651-441e-87d0-ecba96214a79" />

