### PR TITLE
[CPDNPQ-3126] Extend admin declarations upload for 'completed' declarations

### DIFF
--- a/app/models/bulk_operation/submit_declarations.rb
+++ b/app/models/bulk_operation/submit_declarations.rb
@@ -1,6 +1,6 @@
 class BulkOperation::SubmitDeclarations < BulkOperation
   HEADERS = true
-  FILE_HEADERS = %w[participant_id declaration_type declaration_date course_identifier delivery_partner_id lead_provider_name].freeze
+  FILE_HEADERS = %w[participant_id declaration_type declaration_date course_identifier delivery_partner_id lead_provider_name has_passed].freeze
 
   def run!
     result = {}
@@ -47,6 +47,7 @@ private
       declaration_date: row["declaration_date"],
       course_identifier: row["course_identifier"],
       delivery_partner_id: row["delivery_partner_id"],
+      has_passed: row["has_passed"].presence.try(:downcase),
     )
 
     if service.create_declaration

--- a/app/views/npq_separation/admin/bulk_operations/submit_declarations/index.html.erb
+++ b/app/views/npq_separation/admin/bulk_operations/submit_declarations/index.html.erb
@@ -22,13 +22,15 @@
     <li>course_identifier</li>
     <li>delivery_partner_id</li>
     <li>lead_provider_name</li>
+    <li>has_passed (TRUE or FALSE for "completed" declarations, otherwise blank)</li>
   </ul>
 
   <p class="govuk-body">
     For example:
     <pre>
-      participant_id,declaration_type,declaration_date,course_identifier,delivery_partner_id,lead_provider_name
-      1234567890,declaration_type,2021-01-01T00:00:00Z,course_identifier,1234567890,"Lead provider name"
+      participant_id,declaration_type,declaration_date,course_identifier,delivery_partner_id,lead_provider_name,has_passed
+      1234567890,started,2021-01-01T00:00:00Z,course_identifier,1234567890,"Lead provider name",
+      1234567891,completed,2021-01-01T00:00:00Z,course_identifier,1234567890,"Lead provider name",TRUE
     </pre>
   </p>
 

--- a/spec/features/admin/bulk_operations/submit_declarations_spec.rb
+++ b/spec/features/admin/bulk_operations/submit_declarations_spec.rb
@@ -56,6 +56,14 @@ RSpec.feature "submit declarations", :rack_test_driver, type: :feature do
       expect(page).to have_content "Declaration created successfully"
       expect(page).not_to have_button("Submit declarations")
       expect(Declaration.count).to eq(2)
+      expect(ParticipantOutcome.count).to eq(1)
+
+      declaration = Declaration.last
+      expect(declaration.declaration_type).to eq("completed")
+
+      outcome = ParticipantOutcome.last
+      expect(outcome.state).to eq("passed")
+      expect(outcome.declaration).to eq(declaration)
     end
 
     scenario "when the bulk operation has started but not finished" do
@@ -100,9 +108,9 @@ RSpec.feature "submit declarations", :rack_test_driver, type: :feature do
       create(:delivery_partnership, cohort: cohort, delivery_partner: delivery_partner, lead_provider: lead_provider)
 
       mixed_csv_content = <<~CSV
-        participant_id,declaration_type,declaration_date,course_identifier,delivery_partner_id,lead_provider_name
-        #{participant.ecf_id},started,#{schedule.applies_from.rfc3339},#{course.identifier},#{delivery_partner.ecf_id},"#{lead_provider.name}"
-        nonexistent-participant-id,started,#{(schedule.applies_from + 1.day).rfc3339},#{course.identifier},#{delivery_partner.ecf_id},"#{lead_provider.name}"
+        participant_id,declaration_type,declaration_date,course_identifier,delivery_partner_id,lead_provider_name,has_passed
+        #{participant.ecf_id},started,#{schedule.applies_from.rfc3339},#{course.identifier},#{delivery_partner.ecf_id},"#{lead_provider.name}",
+        nonexistent-participant-id,started,#{(schedule.applies_from + 1.day).rfc3339},#{course.identifier},#{delivery_partner.ecf_id},"#{lead_provider.name}",
       CSV
 
       mixed_file = tempfile_with_bom(mixed_csv_content)

--- a/spec/models/bulk_operation/submit_declarations_spec.rb
+++ b/spec/models/bulk_operation/submit_declarations_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe BulkOperation::SubmitDeclarations do
     context "with valid CSV file" do
       let(:valid_csv_file) do
         tempfile <<~CSV
-          participant_id,declaration_type,declaration_date,course_identifier,delivery_partner_id,lead_provider_name
-          #{participant.ecf_id},started,2023-01-01T00:00:00Z,#{course.identifier},#{delivery_partner.ecf_id},"#{lead_provider.name}"
+          participant_id,declaration_type,declaration_date,course_identifier,delivery_partner_id,lead_provider_name,has_passed
+          #{participant.ecf_id},started,2023-01-01T00:00:00Z,#{course.identifier},#{delivery_partner.ecf_id},"#{lead_provider.name}",
         CSV
       end
 
@@ -53,7 +53,7 @@ RSpec.describe BulkOperation::SubmitDeclarations do
     context "with empty CSV file" do
       let(:empty_csv_file) do
         tempfile <<~CSV
-          participant_id,declaration_type,declaration_date,course_identifier,delivery_partner_id,lead_provider_name
+          participant_id,declaration_type,declaration_date,course_identifier,delivery_partner_id,lead_provider_name,has_passed
         CSV
       end
 
@@ -85,9 +85,9 @@ RSpec.describe BulkOperation::SubmitDeclarations do
 
       let(:csv) do
         <<~CSV
-          participant_id,declaration_type,declaration_date,course_identifier,delivery_partner_id,lead_provider_name
-          #{participant.ecf_id},started,#{schedule.applies_from.rfc3339},#{course.identifier},#{delivery_partner.ecf_id},"#{lead_provider.name}"
-          #{participant2.ecf_id},started,#{(schedule.applies_from + 1.day).rfc3339},#{course.identifier},#{delivery_partner.ecf_id},"#{lead_provider.name}"
+          participant_id,declaration_type,declaration_date,course_identifier,delivery_partner_id,lead_provider_name,has_passed
+          #{participant.ecf_id},started,#{schedule.applies_from.rfc3339},#{course.identifier},#{delivery_partner.ecf_id},"#{lead_provider.name}",
+          #{participant2.ecf_id},started,#{(schedule.applies_from + 1.day).rfc3339},#{course.identifier},#{delivery_partner.ecf_id},"#{lead_provider.name}",
         CSV
       end
 
@@ -117,9 +117,9 @@ RSpec.describe BulkOperation::SubmitDeclarations do
     context "when some rows are invalid" do
       let(:csv) do
         <<~CSV
-          participant_id,declaration_type,declaration_date,course_identifier,delivery_partner_id,lead_provider_name
-          #{participant.ecf_id},started,#{schedule.applies_from.rfc3339},#{course.identifier},#{delivery_partner.ecf_id},"#{lead_provider.name}"
-          nonexistent-participant-id,started,#{(schedule.applies_from + 1.day).rfc3339},#{course.identifier},#{delivery_partner.ecf_id},"#{lead_provider.name}"
+          participant_id,declaration_type,declaration_date,course_identifier,delivery_partner_id,lead_provider_name,has_passed
+          #{participant.ecf_id},started,#{schedule.applies_from.rfc3339},#{course.identifier},#{delivery_partner.ecf_id},"#{lead_provider.name}",
+          nonexistent-participant-id,started,#{(schedule.applies_from + 1.day).rfc3339},#{course.identifier},#{delivery_partner.ecf_id},"#{lead_provider.name}",
         CSV
       end
 
@@ -144,8 +144,8 @@ RSpec.describe BulkOperation::SubmitDeclarations do
       context "when participant does not exist" do
         let(:csv) do
           <<~CSV
-            participant_id,declaration_type,declaration_date,course_identifier,delivery_partner_id,lead_provider_name
-            nonexistent-participant-id,started,2023-01-01T00:00:00Z,#{course.identifier},#{delivery_partner.ecf_id},"#{lead_provider.name}"
+            participant_id,declaration_type,declaration_date,course_identifier,delivery_partner_id,lead_provider_name,has_passed
+            nonexistent-participant-id,started,2023-01-01T00:00:00Z,#{course.identifier},#{delivery_partner.ecf_id},"#{lead_provider.name}",
           CSV
         end
 
@@ -161,8 +161,8 @@ RSpec.describe BulkOperation::SubmitDeclarations do
 
         let(:csv) do
           <<~CSV
-            participant_id,declaration_type,declaration_date,course_identifier,delivery_partner_id,lead_provider_name
-            #{participant_without_app.ecf_id},started,#{schedule.applies_from.rfc3339},#{course.identifier},#{delivery_partner.ecf_id},"#{lead_provider.name}"
+            participant_id,declaration_type,declaration_date,course_identifier,delivery_partner_id,lead_provider_name,has_passed
+            #{participant_without_app.ecf_id},started,#{schedule.applies_from.rfc3339},#{course.identifier},#{delivery_partner.ecf_id},"#{lead_provider.name}",
           CSV
         end
 
@@ -176,8 +176,8 @@ RSpec.describe BulkOperation::SubmitDeclarations do
       context "when lead provider does not exist" do
         let(:csv) do
           <<~CSV
-            participant_id,declaration_type,declaration_date,course_identifier,delivery_partner_id,lead_provider_name
-            #{participant.ecf_id},started,#{schedule.applies_from.rfc3339},#{course.identifier},#{delivery_partner.ecf_id},NonExistentProvider
+            participant_id,declaration_type,declaration_date,course_identifier,delivery_partner_id,lead_provider_name,has_passed
+            #{participant.ecf_id},started,#{schedule.applies_from.rfc3339},#{course.identifier},#{delivery_partner.ecf_id},NonExistentProvider,
           CSV
         end
 
@@ -191,8 +191,8 @@ RSpec.describe BulkOperation::SubmitDeclarations do
       context "when declaration service validation fails" do
         let(:csv) do
           <<~CSV
-            participant_id,declaration_type,declaration_date,course_identifier,delivery_partner_id,lead_provider_name
-            #{participant.ecf_id},invalid_type,2023-01-01T00:00:00Z,#{course.identifier},#{delivery_partner.ecf_id},"#{lead_provider.name}"
+            participant_id,declaration_type,declaration_date,course_identifier,delivery_partner_id,lead_provider_name,has_passed
+            #{participant.ecf_id},invalid_type,2023-01-01T00:00:00Z,#{course.identifier},#{delivery_partner.ecf_id},"#{lead_provider.name}",
           CSV
         end
 

--- a/spec/support/helpers/bulk_operations.rb
+++ b/spec/support/helpers/bulk_operations.rb
@@ -15,10 +15,11 @@ module Helpers
     def declarations_file
       @declarations_file ||= begin
         cohort = Cohort.current
-        course = create(:course, identifier: "leadership-development")
+        course = create(:course, :senior_leadership)
+
         lead_provider = create(:lead_provider)
         delivery_partner = create(:delivery_partner)
-        schedule = create(:schedule, cohort:, course_group: course.course_group, allowed_declaration_types: %w[started])
+        schedule = create(:schedule, cohort:, course_group: course.course_group, allowed_declaration_types: %w[started completed])
 
         # Create required contracts and partnerships
         statement = create(:statement, cohort:, lead_provider:)
@@ -32,9 +33,9 @@ module Helpers
         create(:application, :accepted, user: participant2, cohort:, course:, lead_provider:, schedule:)
 
         tempfile_with_bom <<~CSV
-          participant_id,declaration_type,declaration_date,course_identifier,delivery_partner_id,lead_provider_name
-          #{participant1.ecf_id},started,#{schedule.applies_from.rfc3339},#{course.identifier},#{delivery_partner.ecf_id},"#{lead_provider.name}"
-          #{participant2.ecf_id},started,#{(schedule.applies_from + 1.day).rfc3339},#{course.identifier},#{delivery_partner.ecf_id},"#{lead_provider.name}"
+          participant_id,declaration_type,declaration_date,course_identifier,delivery_partner_id,lead_provider_name,has_passed
+          #{participant1.ecf_id},started,#{schedule.applies_from.rfc3339},#{course.identifier},#{delivery_partner.ecf_id},"#{lead_provider.name}",
+          #{participant2.ecf_id},completed,#{(schedule.applies_from + 1.day).rfc3339},#{course.identifier},#{delivery_partner.ecf_id},"#{lead_provider.name}",TRUE
         CSV
       end
     end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-3126

An extra parameter is required when creating "completed" declarations in order to create a participant outcome: `has_passed`

This PR adds the extra column to the existing functionality