### PR TITLE
Hold a reference to declarations tempfile

### DIFF
--- a/spec/models/bulk_operation/submit_declarations_spec.rb
+++ b/spec/models/bulk_operation/submit_declarations_spec.rb
@@ -71,11 +71,13 @@ RSpec.describe BulkOperation::SubmitDeclarations do
   describe "#run!" do
     subject(:run) { bulk_operation.run! }
 
+    let(:csv_file) { tempfile(csv) }
+
     before do
       create(:contract, statement:, course:)
       create(:delivery_partnership, cohort:, delivery_partner:, lead_provider:)
 
-      bulk_operation.file.attach(tempfile(csv).open)
+      bulk_operation.file.attach(csv_file.open)
       bulk_operation.save!
     end
 


### PR DESCRIPTION
(No ticket)

There is an [intermittent test failure](https://github.com/DFE-Digital/npq-registration/actions/runs/16717947019/job/47315422900) on the line that attaches the tempfile:

```
  1) BulkOperation::SubmitDeclarations#run! when the entire CSV is valid creates declarations for all rows
     Failure/Error: bulk_operation.file.attach(tempfile(csv).open)

     IOError:
       closed stream
     # ./spec/models/bulk_operation/submit_declarations_spec.rb:78:in 'block (3 levels) in <top (required)>'
```

It is suspected that this could be down to the tempfile being garbage collected too early, so this change assigns the tempfile to a variable so that it will not be garbage collected until after the spec has finished