### PR TITLE
Ensure that training status cannot be set when provider approval status is pending

### DIFF
--- a/app/services/applications/change_training_status.rb
+++ b/app/services/applications/change_training_status.rb
@@ -93,6 +93,8 @@ module Applications
     end
 
     def do_not_change_status_of_pending_application
+      return if errors.any?
+
       if application.lead_provider_approval_status == "pending"
         errors.add(:training_status, :pending_lead_provider_approval_status)
       end

--- a/app/services/applications/change_training_status.rb
+++ b/app/services/applications/change_training_status.rb
@@ -21,7 +21,7 @@ module Applications
     validates :training_status, inclusion: Application.training_statuses.values
     validates :reason, inclusion: { in: :valid_reasons }, if: :reason_required?
     validate :do_not_defer_if_without_declarations, if: :application
-    validate :do_not_change_status_of_pending_application
+    validate :do_not_change_status_of_pending_application, if: :application
 
     before_validation(unless: :reason_required?) { self.reason = nil }
 
@@ -97,6 +97,5 @@ module Applications
         errors.add(:training_status, :pending_lead_provider_approval_status)
       end
     end
-
   end
 end

--- a/app/services/applications/change_training_status.rb
+++ b/app/services/applications/change_training_status.rb
@@ -21,6 +21,7 @@ module Applications
     validates :training_status, inclusion: Application.training_statuses.values
     validates :reason, inclusion: { in: :valid_reasons }, if: :reason_required?
     validate :do_not_defer_if_without_declarations, if: :application
+    validate :do_not_change_status_of_pending_application
 
     before_validation(unless: :reason_required?) { self.reason = nil }
 
@@ -90,5 +91,12 @@ module Applications
         errors.add(:training_status, :invalid_deferral_no_declarations)
       end
     end
+
+    def do_not_change_status_of_pending_application
+      if application.lead_provider_approval_status == "pending"
+        errors.add(:training_status, :pending_lead_provider_approval_status)
+      end
+    end
+
   end
 end

--- a/app/views/npq_separation/admin/applications/change_training_statuses/new.html.erb
+++ b/app/views/npq_separation/admin/applications/change_training_statuses/new.html.erb
@@ -15,7 +15,7 @@
       <p class="govuk-body">
         <strong>Training status</strong>
         <br/>
-        <%= @application.training_status&.humanize %>
+        <%= @application.training_status&.humanize || "-" %>
       </p>
     </div>
 

--- a/app/views/npq_separation/admin/applications/change_training_statuses/new.html.erb
+++ b/app/views/npq_separation/admin/applications/change_training_statuses/new.html.erb
@@ -15,7 +15,7 @@
       <p class="govuk-body">
         <strong>Training status</strong>
         <br/>
-        <%= @application.training_status&.humanize || "- not set - " %>
+        <%= @application.training_status&.humanize %>
       </p>
     </div>
 

--- a/app/views/npq_separation/admin/applications/show.html.erb
+++ b/app/views/npq_separation/admin/applications/show.html.erb
@@ -32,8 +32,10 @@
     end
     sl.with_row do |row|
       row.with_key(text: "Training status")
-      row.with_value(text: @application.training_status.try(:humanize))
-      row.with_action(text: "Change", href: new_npq_separation_admin_applications_change_training_status_path(@application))
+      row.with_value(text: @application.lead_provider_approval_status == 'pending' ? '-' : @application.training_status.try(:humanize))
+      unless @application.lead_provider_approval_status == 'pending'
+        row.with_action(text: "Change", href: new_npq_separation_admin_applications_change_training_status_path(@application))
+      end
     end
     sl.with_row do |row|
       row.with_key(text: "Created")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -327,7 +327,7 @@ en:
             training_status:
               inclusion: Choose a valid training status
               invalid_deferral_no_declarations: You cannot defer an NPQ participant that has no declarations
-              pending_lead_provider_approval_status: You cannot change the training status of an application which is in a pending state.
+              pending_lead_provider_approval_status: You cannot change the training status of an application which is in a pending state
             reason:
               inclusion: Choose a valid reason for the training status change
         applications/change_funding_eligibility:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -327,6 +327,7 @@ en:
             training_status:
               inclusion: Choose a valid training status
               invalid_deferral_no_declarations: You cannot defer an NPQ participant that has no declarations
+              pending_lead_provider_approval_status: You cannot change the training status of an application which is in a pending state.
             reason:
               inclusion: Choose a valid reason for the training status change
         applications/change_funding_eligibility:

--- a/spec/services/applications/change_training_status_spec.rb
+++ b/spec/services/applications/change_training_status_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Applications::ChangeTrainingStatus, type: :model do
 
     describe "#training_status" do
       context "when application is pending" do
+        let(:training_status) { "active" }
         let(:application) { create(:application, :pending) }
 
         it { is_expected.not_to be_valid }

--- a/spec/services/applications/change_training_status_spec.rb
+++ b/spec/services/applications/change_training_status_spec.rb
@@ -14,10 +14,24 @@ RSpec.describe Applications::ChangeTrainingStatus, type: :model do
     it { is_expected.to validate_inclusion_of(:training_status).in_array(%w[active deferred withdrawn]) }
 
     context "when provider approval status pending, training_status cannot be set" do
-      let(:training_status) { "active" }
       let(:application) { create(:application, :pending) }
 
-      it { is_expected.not_to be_valid }
+      context "when training status is nil" do
+
+        it "returns an error message" do
+          expect(service).to have_error(:training_status, :inclusion, "Choose a valid training status")
+          expect(service).to have_error_count(1)
+        end
+      end
+
+      context "when training status is set" do
+        let(:training_status) { "active" }
+
+        it "returns an error message" do
+          expect(service).to have_error(:training_status, :pending_lead_provider_approval_status, "You cannot change the training status of an application which is in a pending state")
+          expect(service).to have_error_count(1)
+        end
+      end
     end
 
     context "when checking whether a reason is required based on training status" do

--- a/spec/services/applications/change_training_status_spec.rb
+++ b/spec/services/applications/change_training_status_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Applications::ChangeTrainingStatus, type: :model do
     it { is_expected.to validate_presence_of :application }
     it { is_expected.to validate_inclusion_of(:training_status).in_array(%w[active deferred withdrawn]) }
 
-    context "when provider approval status pending, training_status cannot be set" do
+    context "when provider approval status pending" do
       let(:application) { create(:application, :pending) }
 
       context "when training status is nil" do

--- a/spec/services/applications/change_training_status_spec.rb
+++ b/spec/services/applications/change_training_status_spec.rb
@@ -13,6 +13,14 @@ RSpec.describe Applications::ChangeTrainingStatus, type: :model do
     it { is_expected.to validate_presence_of :application }
     it { is_expected.to validate_inclusion_of(:training_status).in_array(%w[active deferred withdrawn]) }
 
+    describe "#training_status" do
+      context "when application is pending" do
+        let(:application) { create(:application, :pending) }
+
+        it { is_expected.not_to be_valid }
+      end
+    end
+
     describe "#reason" do
       context "with training_status set to blank" do
         let(:training_status) { nil }

--- a/spec/services/applications/change_training_status_spec.rb
+++ b/spec/services/applications/change_training_status_spec.rb
@@ -13,16 +13,14 @@ RSpec.describe Applications::ChangeTrainingStatus, type: :model do
     it { is_expected.to validate_presence_of :application }
     it { is_expected.to validate_inclusion_of(:training_status).in_array(%w[active deferred withdrawn]) }
 
-    describe "#training_status" do
-      context "when application is pending" do
-        let(:training_status) { "active" }
-        let(:application) { create(:application, :pending) }
+    context "when provider approval status pending, training_status cannot be set" do
+      let(:training_status) { "active" }
+      let(:application) { create(:application, :pending) }
 
-        it { is_expected.not_to be_valid }
-      end
+      it { is_expected.not_to be_valid }
     end
 
-    describe "#reason" do
+    context "when checking whether a reason is required based on training status" do
       context "with training_status set to blank" do
         let(:training_status) { nil }
 

--- a/spec/services/applications/change_training_status_spec.rb
+++ b/spec/services/applications/change_training_status_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe Applications::ChangeTrainingStatus, type: :model do
       let(:application) { create(:application, :pending) }
 
       context "when training status is nil" do
-
         it "returns an error message" do
           expect(service).to have_error(:training_status, :inclusion, "Choose a valid training status")
           expect(service).to have_error_count(1)


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-3119

When the provider approvial status is in pending, i.e. it has not yet been set:
- do not show change link next to 'Training status' - people should not be able to change the training status in this scenario
- add a dash next to 'Training status' - we use a dash throughout the admin console when a status is not yet set

| Before    | After |
| -------- | ------- |
| <img width="878" height="91" alt="Screenshot 2025-08-05 at 17 05 58" src="https://github.com/user-attachments/assets/fb31e6db-c5b4-4e2f-9ec9-296bea42f6c4" />  | <img width="969" height="101" alt="Screenshot 2025-08-05 at 17 04 06" src="https://github.com/user-attachments/assets/f9d30a79-e3a9-4269-b656-94e1594df0b3" />    |

Account for the scenario where you could still reach this page with a better error message and consistent use of the dash in the inset text:

| Before    | After |
| -------- | ------- |
| <img width="680" height="986" alt="Screenshot 2025-08-05 at 17 08 23" src="https://github.com/user-attachments/assets/29e6777a-1786-4afb-be22-79c16ac1203c" /> | <img width="712" height="1112" alt="Screenshot 2025-08-05 at 17 16 12" src="https://github.com/user-attachments/assets/c4a5dfaf-4121-4dd0-86d1-24c73ea399ca" />     |





