### PR TITLE
fix flaky spec

### DIFF
--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
-  sequence(:urn) { |n| sprintf("1%05d", n % 100_000) }
-  sequence(:ukprn) { |n| sprintf("%08d", n % 100_000_000) }
+  sequence(:urn) { |n| sprintf("1TEST%05d", n % 100_000) }
+  sequence(:ukprn) { |n| sprintf("TEST%08d", n % 100_000_000) }
 
   factory :school do
     sequence(:name) { |n| Faker::Educator.primary_school + " #{n}" }

--- a/spec/services/funding_eligibility_spec.rb
+++ b/spec/services/funding_eligibility_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe FundingEligibility do
     end
 
     context "when school is LA nursery" do
-      let(:institution) { build(:school, :non_pp50, establishment_type_code: "15", urn: "900000") }
+      let(:institution) { build(:school, :non_pp50, establishment_type_code: "15") }
 
       context "when LA disadvantaged nursery" do
         before do

--- a/spec/services/funding_eligibility_spec.rb
+++ b/spec/services/funding_eligibility_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe FundingEligibility do
     end
 
     context "when school is LA nursery" do
-      let(:institution) { build(:school, :non_pp50, establishment_type_code: "15") }
+      let(:institution) { build(:school, :non_pp50, establishment_type_code: "15", urn: "900000") }
 
       context "when LA disadvantaged nursery" do
         before do


### PR DESCRIPTION
### Context

occasional failure in funding_eligibility_spec:

`rspec ./spec/services/funding_eligibility_spec.rb[1:15:38:2:5:1:2]` # FundingEligibility when institution is a School when school is LA nursery when not LA disadvantaged nursery when user has selected the early_years_leadership course behaves like funding eligibility returns funding_eligiblity_status_code not_entitled_ey_institution

The URN was previously just a number, and occasionally it would match a URN from LA_DISADVANTAGED_NURSERIES.
This PR changes the factory so URNs and UKPRNs start with 'TEST', so they will never match a URN from the PP50 lists.
