### PR TITLE
CPDNPQ-3168 Remove links to legacy API documentation

### DIFF
--- a/app/views/api/guidance/get-started.md
+++ b/app/views/api/guidance/get-started.md
@@ -54,10 +54,8 @@ Providers can also create ‘dummy’ applications in the sandbox environment. T
 
 ## Access YAML format API specs
 
-Provider development teams can also access the OpenAPI spec in YAML formats:
+Provider development teams can also access the OpenAPI spec in YAML format:
 
-* [view the OpenAPI version 1 spec](/api/docs/v1/swagger.yaml)
-* [view the OpenAPI version 2 spec](/api/docs/v2/swagger.yaml)
 * [view the OpenAPI version 3 spec](/api/docs/v3/swagger.yaml)
 
 Providers can use API testing tools such as Postman to make test API calls. Providers can import the API as a collection by using [Postman’s](https://www.postman.com/) import feature and copying in the YAML URL of the API spec.

--- a/app/views/api/guidance/index.html.erb
+++ b/app/views/api/guidance/index.html.erb
@@ -104,6 +104,7 @@
   </div>
 </div>
 
+<%- unless Rails.configuration.x.disable_legacy_api -%>
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full-from-desktop">
@@ -119,6 +120,7 @@
     </div>
   </div>
 </div>
+<%- end -%>
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-3168](https://dfedigital.atlassian.net/browse/CPDNPQ-3168)

We've deactivated the legacy APIs, the documentation has gone away which leaves the links from the Guidance as dead links

### Changes proposed in this pull request

1. Remove dead links to legacy APIs from API Guidance pages

### Failed feature specs screenshots

If any of the feature specs would fail, there will be page on the wiki with all
failures:

https://github.com/DFE-Digital/npq-registration/wiki/


[CPDNPQ-3168]: https://dfedigital.atlassian.net/browse/CPDNPQ-3168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ