### PR TITLE
[CPDNPQ-3025] enable GAI syncing - update message format and fix admin console

### DIFF
--- a/app/controllers/api/v1/get_an_identity/webhook_messages_controller.rb
+++ b/app/controllers/api/v1/get_an_identity/webhook_messages_controller.rb
@@ -3,7 +3,6 @@ module API
     module GetAnIdentity
       class WebhookMessagesController < ActionController::API
         before_action :set_cache_headers
-        before_action :log_incoming_message
         before_action :verify_signature!, only: :create
 
         def create
@@ -28,10 +27,6 @@ module API
           return if signature_valid?
 
           head :unauthorized
-        end
-
-        def log_incoming_message
-          Sentry.capture_message("GetAnIdentity webhook message received")
         end
 
         def signature_valid?

--- a/app/controllers/npq_separation/admin/webhook_messages/processing_jobs_controller.rb
+++ b/app/controllers/npq_separation/admin/webhook_messages/processing_jobs_controller.rb
@@ -4,6 +4,6 @@ class NpqSeparation::Admin::WebhookMessages::ProcessingJobsController < NpqSepar
     @webhook_message.update!(status: :pending)
     @webhook_message.enqueue_processing_job
 
-    redirect_to admin_webhook_message_path(@webhook_message)
+    redirect_to npq_separation_admin_webhook_message_path(@webhook_message)
   end
 end

--- a/app/decorators/get_an_identity/webhook_messages/user_updated_decorator.rb
+++ b/app/decorators/get_an_identity/webhook_messages/user_updated_decorator.rb
@@ -12,30 +12,30 @@ module GetAnIdentity
       end
 
       def uid
-        message_json["userId"]
+        message_json.fetch("userId")
       end
 
       def email
-        message_json["emailAddress"]
+        message_json.fetch("emailAddress")
       end
 
       def full_name
-        message_json["preferredName"]
+        message_json.fetch("preferredName")
       end
 
       def date_of_birth
-        raw_dob = message_json["dateOfBirth"]
+        raw_dob = message_json.fetch("dateOfBirth")
         return if raw_dob.blank?
 
         Date.parse(raw_dob, "%Y-%m-%d")
       end
 
       def trn
-        message_json["trn"]
+        message_json.fetch("trn")
       end
 
       def trn_lookup_status
-        message_json["trnLookupStatus"]
+        message_json.fetch("trnLookupStatus")
       end
 
       def sent_at

--- a/app/decorators/get_an_identity/webhook_messages/user_updated_decorator.rb
+++ b/app/decorators/get_an_identity/webhook_messages/user_updated_decorator.rb
@@ -38,10 +38,6 @@ module GetAnIdentity
         message_json["trnLookupStatus"]
       end
 
-      def trn_verified
-        trn_lookup_status == "Found"
-      end
-
       def sent_at
         webhook_message.sent_at
       end

--- a/app/decorators/get_an_identity/webhook_messages/user_updated_decorator.rb
+++ b/app/decorators/get_an_identity/webhook_messages/user_updated_decorator.rb
@@ -12,7 +12,7 @@ module GetAnIdentity
       end
 
       def uid
-        message_json["uid"]
+        message_json["userId"]
       end
 
       def email
@@ -20,10 +20,7 @@ module GetAnIdentity
       end
 
       def full_name
-        [
-          message_json["firstName"],
-          message_json["lastName"],
-        ].join(" ")
+        message_json["preferredName"]
       end
 
       def date_of_birth
@@ -52,7 +49,7 @@ module GetAnIdentity
     private
 
       def message_json
-        webhook_message.message
+        webhook_message.message["user"]
       end
     end
   end

--- a/app/helpers/webhook_messages_helper.rb
+++ b/app/helpers/webhook_messages_helper.rb
@@ -2,12 +2,10 @@ module WebhookMessagesHelper
   def webhook_message_status_tag(webhook_message)
     text = webhook_message.status
 
-    colour = case status
-             when "pending"
-               "grey"
+    colour = case text
              when "processed"
                "green"
-             when "unhandled_message_type", "error"
+             when "unhandled_message_type", "error", "failed"
                "red"
              else
                "grey"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -112,17 +112,17 @@ class User < ApplicationRecord
     self.updated_from_tra_at = Time.zone.now
   end
 
-  def trn_update_params(trn:, trn_lookup_status:)
+  def set_trn_from_provider_data(trn:, trn_lookup_status:)
     trn_lookup_status_found = (trn_lookup_status == "Found")
     trn_unchanged = (self.trn == trn)
 
-    return {} if trn.blank? || (trn_verified? && trn_unchanged && !trn_lookup_status_found)
+    return if trn.blank? || (trn_verified? && trn_unchanged && !trn_lookup_status_found)
 
-    {
+    assign_attributes(
       trn:,
       trn_verified: trn_lookup_status_found,
       trn_lookup_status:,
-    }
+    )
   end
 
 private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -112,6 +112,29 @@ class User < ApplicationRecord
     self.updated_from_tra_at = Time.zone.now
   end
 
+  def trn_update_params(trn:, trn_lookup_status:)
+    return {} if trn.blank?
+
+    if self.trn != trn
+      {
+        trn: trn,
+        trn_verified: trn_lookup_status == "Found",
+        trn_lookup_status:,
+      }
+    elsif !trn_verified? && trn_lookup_status == "Found"
+      {
+        trn_verified: true,
+        trn_lookup_status:,
+      }
+    elsif !trn_verified? || trn_lookup_status == "Found"
+      {
+        trn_lookup_status:,
+      }
+    else
+      {}
+    end
+  end
+
 private
 
   def touch_significantly_updated_at

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -113,26 +113,16 @@ class User < ApplicationRecord
   end
 
   def trn_update_params(trn:, trn_lookup_status:)
-    return {} if trn.blank?
+    trn_lookup_status_found = (trn_lookup_status == "Found")
+    trn_unchanged = (self.trn == trn)
 
-    if self.trn != trn
-      {
-        trn: trn,
-        trn_verified: trn_lookup_status == "Found",
-        trn_lookup_status:,
-      }
-    elsif !trn_verified? && trn_lookup_status == "Found"
-      {
-        trn_verified: true,
-        trn_lookup_status:,
-      }
-    elsif !trn_verified? || trn_lookup_status == "Found"
-      {
-        trn_lookup_status:,
-      }
-    else
-      {}
-    end
+    return {} if trn.blank? || (trn_verified? && trn_unchanged && !trn_lookup_status_found)
+
+    {
+      trn:,
+      trn_verified: trn_lookup_status_found,
+      trn_lookup_status:,
+    }
   end
 
 private

--- a/app/services/get_an_identity_service/webhooks/user_updated_processor.rb
+++ b/app/services/get_an_identity_service/webhooks/user_updated_processor.rb
@@ -73,12 +73,11 @@ module GetAnIdentityService
         {
           full_name: decorated_message.full_name,
           date_of_birth: decorated_message.date_of_birth,
-          trn: decorated_message.trn,
-          trn_verified: decorated_message.trn_verified,
-          trn_lookup_status: decorated_message.trn_lookup_status,
           email: decorated_message.email,
           updated_from_tra_at: decorated_message.sent_at,
-        }
+        }.tap do |params|
+          params.merge!(user.trn_update_params(trn: decorated_message.trn, trn_lookup_status: decorated_message.trn_lookup_status))
+        end
       end
     end
   end

--- a/app/services/get_an_identity_service/webhooks/user_updated_processor.rb
+++ b/app/services/get_an_identity_service/webhooks/user_updated_processor.rb
@@ -36,12 +36,13 @@ module GetAnIdentityService
       delegate :trn, :trn_lookup_status, to: :decorated_message
       delegate :decorated_message, to: :webhook_message
 
-      def record_error(message)
+      def record_error(message, send_to_sentry: true)
         webhook_message.update!(
           status: :failed,
           status_comment: message,
           processed_at: Time.zone.now,
         )
+        Sentry.capture_message("[GAI webhook] #{message}") if send_to_sentry
         false
       end
 
@@ -50,7 +51,7 @@ module GetAnIdentityService
       end
 
       def no_user_found_failure
-        record_error("No user found with get_an_identity_id: #{decorated_message.uid}")
+        record_error("No user found with get_an_identity_id: #{decorated_message.uid}", send_to_sentry: false)
       end
 
       def incorrect_format_failure

--- a/app/services/participants/change_trn.rb
+++ b/app/services/participants/change_trn.rb
@@ -17,7 +17,7 @@ module Participants
     def change_trn
       return false if invalid?
 
-      user.update(trn:, trn_verified: true) # rubocop:disable Rails/SaveBang - return value is used by caller
+      user.update(trn:, trn_verified: true, trn_lookup_status: nil) # rubocop:disable Rails/SaveBang - return value is used by caller
     end
 
   private

--- a/app/services/users/find_or_create_from_provider_data.rb
+++ b/app/services/users/find_or_create_from_provider_data.rb
@@ -57,13 +57,7 @@ module Users
         user.date_of_birth = Date.parse(extra_info.birthdate, "%Y-%m-%d")
       end
 
-      # The user's TRN should remain unchanged if the TRA returns an empty TRN
-      if extra_info&.trn.present?
-        user.trn = extra_info.trn
-        user.trn_verified = true
-        user.trn_lookup_status = extra_info.trn_lookup_status
-      end
-
+      user.assign_attributes(user.trn_update_params(trn: extra_info&.trn, trn_lookup_status: extra_info&.trn_lookup_status))
       user.set_updated_from_tra_at
     end
   end

--- a/app/services/users/find_or_create_from_provider_data.rb
+++ b/app/services/users/find_or_create_from_provider_data.rb
@@ -57,7 +57,7 @@ module Users
         user.date_of_birth = Date.parse(extra_info.birthdate, "%Y-%m-%d")
       end
 
-      user.assign_attributes(user.trn_update_params(trn: extra_info&.trn, trn_lookup_status: extra_info&.trn_lookup_status))
+      user.set_trn_from_provider_data(trn: extra_info&.trn, trn_lookup_status: extra_info&.trn_lookup_status)
       user.set_updated_from_tra_at
     end
   end

--- a/app/views/npq_separation/admin/webhook_messages/index.html.erb
+++ b/app/views/npq_separation/admin/webhook_messages/index.html.erb
@@ -23,12 +23,12 @@
                 row.with_cell(text: webhook_message.message_id)
                 row.with_cell(text: webhook_message_status_tag(webhook_message))
                 row.with_cell(text: webhook_message.sent_at.to_fs(:govuk_short))
-                row.with_cell(text: govuk_link_to("View", admin_webhook_message_path(webhook_message)))
+                row.with_cell(text: govuk_link_to("View", npq_separation_admin_webhook_message_path(webhook_message)))
               end
             end
           else
             body.with_row do |row|
-              row.with_cell(text: "No Webhook Messages received yet")
+              row.with_cell(text: "No Webhook messages received yet")
               row.with_cell
               row.with_cell
               row.with_cell

--- a/app/views/npq_separation/admin/webhook_messages/show.html.erb
+++ b/app/views/npq_separation/admin/webhook_messages/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :before_content do %>
   <%= render GovukComponent::BackLinkComponent.new(
     text: "Back",
-    href: admin_webhook_messages_path
+    href: npq_separation_admin_webhook_messages_path
   ) %>
 <% end %>
 
@@ -9,7 +9,7 @@
 
 <% if @webhook_message.retryable? %>
   <%=
-    link_to("Queue retry", admin_webhook_message_processing_jobs_path(webhook_message_id: @webhook_message.id), class: "govuk-button", method: :post)
+    link_to("Queue retry", npq_separation_admin_webhook_message_processing_jobs_path(webhook_message_id: @webhook_message.id), class: "govuk-button", method: :post)
   %>
 <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -742,17 +742,6 @@ en:
         sync_log: "ECF Sync Log"
         tabs: "Tabs"
         applications: "Applications"
-    webhook_messages:
-      show:
-        title: "Webhook Message"
-        message_id: "Message ID"
-        message_type: "Message Type"
-        status: "Status"
-        sent_at: "Sent at"
-        created_at: "Received at"
-        processed_at: "Processed at"
-        status_comment: "Status Comment"
-        message: "Message"
 
   course:
     embedded_sentence:
@@ -880,6 +869,17 @@ en:
             banner:
               title: "Authorising for payment"
               content: "Requested at %{statement_marked_as_paid_at}. This may take up to 15 minutes. Refresh to see the updated statement."
+      webhook_messages:
+        show:
+          title: "Webhook message"
+          message_id: "Message ID"
+          message_type: "Message Type"
+          status: "Status"
+          sent_at: "Sent at"
+          created_at: "Received at"
+          processed_at: "Processed at"
+          status_comment: "Status Comment"
+          message: "Message"
 
   funding_details:
     ineligible_setting: "You’re not eligible for scholarship funding as you do not work in one of the eligible settings, such as state-funded schools."

--- a/spec/factories/get_an_identity_webhook_messages.rb
+++ b/spec/factories/get_an_identity_webhook_messages.rb
@@ -1,0 +1,33 @@
+FactoryBot.define do
+  factory :get_an_identity_webhook_message, class: "GetAnIdentity::WebhookMessage" do
+    message_id { SecureRandom.uuid }
+    message_type { "UserUpdated" }
+    status { "failed" }
+    status_comment { "Invalid message format" }
+    sent_at { Time.zone.now }
+    processed_at { Time.zone.now }
+    raw do
+      {
+        "message" => {
+          "user" => {
+            "trn" => "1234567",
+            "userId" => SecureRandom.uuid,
+            "lastName" => "Doe",
+            "firstName" => "John",
+            "middleName" => nil,
+            "dateOfBirth" => "1995-01-01",
+            "emailAddress" => Faker::Internet.email(name: "John Doe"),
+            "mobileNumber" => nil,
+            "preferredName" => "John Doe",
+            "trnLookupStatus" => "Pending",
+          },
+          "changes" => { "preferredName" => "John Doe" },
+        },
+        "timeUtc" => Time.zone.now.as_json,
+        "messageType" => "UserUpdated",
+        "notificationId" => SecureRandom.uuid,
+      }
+    end
+    message { raw["message"] }
+  end
+end

--- a/spec/features/npq_separation/admin/webhook_messages_spec.rb
+++ b/spec/features/npq_separation/admin/webhook_messages_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Webhook messages", type: :feature do
+RSpec.feature "Webhook messages", :no_js, type: :feature do
   include Helpers::AdminLogin
 
   let!(:webhook_message) { create(:get_an_identity_webhook_message) }
@@ -24,5 +24,13 @@ RSpec.feature "Webhook messages", type: :feature do
 
     expect(page).to have_css("h1", text: "Webhook message")
     expect(page).to have_content('"preferredName": "John Doe"')
+  end
+
+  scenario "enqueueing a webhook message for retrying processing" do
+    visit(npq_separation_admin_webhook_messages_path)
+    click_link "View"
+    expect {
+      click_link "Queue retry"
+    }.to have_enqueued_job(::GetAnIdentity::ProcessWebhookMessageJob)
   end
 end

--- a/spec/features/npq_separation/admin/webhook_messages_spec.rb
+++ b/spec/features/npq_separation/admin/webhook_messages_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.feature "Webhook messages", type: :feature do
+  include Helpers::AdminLogin
+
+  let!(:webhook_message) { create(:get_an_identity_webhook_message) }
+
+  before do
+    sign_in_as(create(:admin))
+  end
+
+  scenario "listing webhook messages" do
+    visit(npq_separation_admin_webhook_messages_path)
+
+    expect(page).to have_css("h1", text: "Webhook messages")
+    expect(page).to have_content(webhook_message.message_type)
+    expect(page).to have_content(webhook_message.message_id)
+    expect(page).to have_content(webhook_message.status)
+  end
+
+  scenario "viewing a webhook message" do
+    visit(npq_separation_admin_webhook_messages_path)
+    click_link "View"
+
+    expect(page).to have_css("h1", text: "Webhook message")
+    expect(page).to have_content('"preferredName": "John Doe"')
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -451,8 +451,14 @@ RSpec.describe User do
           context "when the new trn_lookup_status is Found" do
             let(:new_trn_lookup_status) { "Found" }
 
-            it "returns the TRN lookup status only" do # this updates manually verified TRNs with the latest lookup status
-              expect(subject).to eq({ trn_lookup_status: new_trn_lookup_status })
+            it "returns the TRN parameters" do # this updates manually verified TRNs with the latest lookup status
+              expect(subject).to eq(
+                {
+                  trn:,
+                  trn_verified: true,
+                  trn_lookup_status: new_trn_lookup_status,
+                },
+              )
             end
           end
         end
@@ -460,21 +466,14 @@ RSpec.describe User do
         context "when the user's TRN is not verified" do
           let(:trn_verified) { false }
 
-          it "returns the TRN lookup status only" do
-            expect(subject).to eq({ trn_lookup_status: new_trn_lookup_status })
-          end
-
-          context "when the new trn_lookup_status is Found" do
-            let(:new_trn_lookup_status) { "Found" }
-
-            it "returns the trn_verified and trn_lookup_status" do
-              expect(subject).to eq(
-                {
-                  trn_verified: true,
-                  trn_lookup_status: new_trn_lookup_status,
-                },
-              )
-            end
+          it "returns the TRN parameters" do
+            expect(subject).to eq(
+              {
+                trn:,
+                trn_verified: false,
+                trn_lookup_status: new_trn_lookup_status,
+              },
+            )
           end
         end
       end
@@ -483,7 +482,7 @@ RSpec.describe User do
         let(:new_trn) { "2345678" }
         let(:new_trn_lookup_status) { "None" }
 
-        it "returns all parameters" do
+        it "returns the TRN parameters" do
           expect(subject).to eq(
             {
               trn: new_trn,
@@ -493,20 +492,22 @@ RSpec.describe User do
           )
         end
 
-        context "when the new trn_lookup_status is Found" do
-          let(:new_trn_lookup_status) { "Found" }
+        context "with different trn_lookup_statuses" do
+          context "when the new trn_lookup_status is Found" do
+            let(:new_trn_lookup_status) { "Found" }
 
-          it "returns the TRN as verified" do
-            expect(subject[:trn_verified]).to be(true)
+            it "returns the TRN as verified" do
+              expect(subject[:trn_verified]).to be(true)
+            end
           end
-        end
 
-        %w[None Pending Failed].each do |status|
-          context "when the new trn_lookup_status is #{status}" do
-            let(:new_trn_lookup_status) { status }
+          %w[None Pending Failed].each do |status|
+            context "when the new trn_lookup_status is #{status}" do
+              let(:new_trn_lookup_status) { status }
 
-            it "returns the TRN as not verified" do
-              expect(subject[:trn_verified]).to be(false)
+              it "returns the TRN as not verified" do
+                expect(subject[:trn_verified]).to be(false)
+              end
             end
           end
         end

--- a/spec/services/get_an_identity_service/webhooks/user_updated_processor_spec.rb
+++ b/spec/services/get_an_identity_service/webhooks/user_updated_processor_spec.rb
@@ -29,6 +29,8 @@ RSpec.describe GetAnIdentityService::Webhooks::UserUpdatedProcessor do
 
   subject { described_class.call(webhook_message:) }
 
+  before { freeze_time }
+
   context "when passed the correct message_type" do
     let(:message_type) { "UserUpdated" }
     let(:message) do

--- a/spec/services/get_an_identity_service/webhooks/user_updated_processor_spec.rb
+++ b/spec/services/get_an_identity_service/webhooks/user_updated_processor_spec.rb
@@ -14,8 +14,20 @@ RSpec.describe GetAnIdentityService::Webhooks::UserUpdatedProcessor do
   let(:sent_at) { Time.zone.now }
   let(:old_email) { "mail@example.com" }
   let(:old_date_of_birth) { 30.years.ago.to_date }
+  let(:old_trn) { "1234567" }
+  let(:old_trn_verified) { false }
 
-  let(:user) { create(:user, :with_get_an_identity_id, email: old_email, date_of_birth: old_date_of_birth, full_name: "John Doe") }
+  let(:user) do
+    create(:user,
+           :with_get_an_identity_id,
+           email: old_email,
+           date_of_birth: old_date_of_birth,
+           full_name: "John Doe",
+           trn: old_trn,
+           trn_verified: old_trn_verified)
+  end
+
+  subject { described_class.call(webhook_message:) }
 
   context "when passed the correct message_type" do
     let(:message_type) { "UserUpdated" }
@@ -37,28 +49,34 @@ RSpec.describe GetAnIdentityService::Webhooks::UserUpdatedProcessor do
 
     let(:new_email) { "#{SecureRandom.uuid}@example.com" }
     let(:new_name) { "#{Faker::Name.first_name} #{Faker::Name.last_name}" }
-    let(:new_date_of_birth) { 20.years.ago.to_date.as_json }
+    let(:new_date_of_birth) { 20.years.ago.to_date }
     let(:new_trn) { rand(1_000_000..9_999_999).to_s }
     let(:new_trn_status) { "Found" }
 
     it "updates user data" do
       expect {
-        described_class.call(webhook_message:)
-      }.to change {
-        user.reload.slice(:email, :trn, :full_name, :date_of_birth, :updated_from_tra_at).as_json
-      }.from(
-        "email" => old_email,
-        "trn" => user.trn,
-        "full_name" => "John Doe",
-        "date_of_birth" => old_date_of_birth.as_json,
-        "updated_from_tra_at" => nil,
-      ).to({
-        "email" => new_email,
-        "trn" => new_trn,
-        "full_name" => new_name,
-        "date_of_birth" => new_date_of_birth,
-        "updated_from_tra_at" => sent_at.as_json,
-      })
+        subject
+      }.to change { user.reload.dup }.from(
+        an_object_having_attributes(
+          email: old_email,
+          trn: old_trn,
+          trn_verified: false,
+          trn_lookup_status: nil,
+          full_name: "John Doe",
+          date_of_birth: old_date_of_birth,
+          updated_from_tra_at: nil,
+        ),
+      ).to(
+        an_object_having_attributes(
+          email: new_email,
+          trn: new_trn,
+          trn_verified: true,
+          trn_lookup_status: new_trn_status,
+          full_name: new_name,
+          date_of_birth: new_date_of_birth,
+          updated_from_tra_at: sent_at,
+        ),
+      )
     end
 
     context "when the new email is already in use" do
@@ -68,7 +86,7 @@ RSpec.describe GetAnIdentityService::Webhooks::UserUpdatedProcessor do
 
       it "marks the webhook_message as failed" do
         expect {
-          described_class.call(webhook_message:)
+          subject
         }.to change {
           webhook_message.reload.slice(:status, :status_comment)
         }.from(
@@ -81,28 +99,82 @@ RSpec.describe GetAnIdentityService::Webhooks::UserUpdatedProcessor do
       end
     end
 
-    context "when the trn is not present" do
+    context "when the TRN is not present" do
       let(:new_trn) { nil }
       let(:new_trn_status) { "None" }
 
-      it "stores the data without the TRN" do
+      it "stores the data without changing the TRN" do
         expect {
-          described_class.call(webhook_message:)
-        }.to change {
-          user.reload.slice(:email, :trn, :full_name, :date_of_birth, :updated_from_tra_at).as_json
-        }.from(
-          "email" => old_email,
-          "trn" => user.trn,
-          "full_name" => "John Doe",
-          "date_of_birth" => old_date_of_birth.as_json,
-          "updated_from_tra_at" => nil,
-        ).to({
-          "email" => new_email,
-          "trn" => nil,
-          "full_name" => new_name,
-          "date_of_birth" => new_date_of_birth,
-          "updated_from_tra_at" => sent_at.as_json,
-        })
+          subject
+        }.to change { user.reload.dup }.from(
+          an_object_having_attributes(
+            email: old_email,
+            trn: old_trn,
+            trn_verified: false,
+            trn_lookup_status: nil,
+            full_name: "John Doe",
+            date_of_birth: old_date_of_birth,
+            updated_from_tra_at: nil,
+          ),
+        ).to(
+          an_object_having_attributes(
+            email: new_email,
+            trn: old_trn,
+            trn_verified: false,
+            trn_lookup_status: nil,
+            full_name: new_name,
+            date_of_birth: new_date_of_birth,
+            updated_from_tra_at: sent_at,
+          ),
+        )
+      end
+    end
+
+    context "when the user already has a verified TRN" do
+      let(:old_trn_verified) { true }
+
+      context "when the new TRN is the same as the user's current TRN" do
+        let(:new_trn) { old_trn }
+
+        context "when the new trn_lookup_status is Found" do
+          let(:new_trn_status) { "Found" }
+
+          it "updates the trn_lookup_status to Found" do
+            subject
+            expect(user.reload.trn_lookup_status).to eq("Found")
+          end
+        end
+
+        context "when the new trn_lookup_status is not Found" do
+          let(:new_trn_status) { "None" }
+
+          it "does not change trn_verified" do
+            subject
+            expect(user.reload.trn_verified).to be true
+          end
+
+          it "does not change trn_lookup_status" do
+            subject
+            expect(user.reload.trn_lookup_status).to be_nil
+          end
+        end
+      end
+
+      context "when the provider data has a TRN that is different from the user's current TRN" do
+        let(:new_trn) { "2345678" }
+        let(:new_trn_status) { "None" }
+
+        it "updates the TRN" do
+          expect { subject }.to change { user.reload.trn }.from(old_trn).to(new_trn)
+        end
+
+        it "updates trn_verified" do
+          expect { subject }.to change { user.reload.trn_verified }.from(true).to(false)
+        end
+
+        it "updates trn_lookup_status" do
+          expect { subject }.to change { user.reload.trn_lookup_status }.from(nil).to("None")
+        end
       end
     end
 
@@ -111,7 +183,7 @@ RSpec.describe GetAnIdentityService::Webhooks::UserUpdatedProcessor do
 
       it "stores the data without the TRN" do
         expect {
-          described_class.call(webhook_message:)
+          subject
         }.to change {
           webhook_message.reload.slice(:status, :status_comment, :raw, :message)
         }.from(
@@ -135,7 +207,7 @@ RSpec.describe GetAnIdentityService::Webhooks::UserUpdatedProcessor do
 
     it "marks the webhook_message as failed" do
       expect {
-        described_class.call(webhook_message:)
+        subject
       }.to change {
         webhook_message.reload.slice(:status, :status_comment)
       }.from(

--- a/spec/services/participants/change_trn_spec.rb
+++ b/spec/services/participants/change_trn_spec.rb
@@ -71,10 +71,14 @@ RSpec.describe Participants::ChangeTrn, type: :model do
     end
 
     context "when trn_verified is false" do
-      let(:user) { create(:user, trn: original_trn) }
+      let(:user) { create(:user, trn: original_trn, trn_lookup_status: "Failed") }
 
       it "updates trn_verified to true" do
         expect { subject }.to change(user, :trn_verified).from(false).to(true)
+      end
+
+      it "updates trn_lookup_status to nil" do
+        expect { subject }.to change(user, :trn_lookup_status).to(nil)
       end
     end
   end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-3025

### Changes proposed in this pull request

* the message format of the webhook message has changed
* we did not used to use the preferred name (we do when the user first logs in) - this has been fixed
* the admin console webhook messages pages had the wrong path names
* make GAI syncing and login code use same logic when updating TRN/trn_verified/trn_lookup_status - this logic is now in the `User` model
* add missing specs for webhook messages pages on admin console