### PR TITLE
[CPDNPQ-2980] Change spring 2025 to autumn 2025

### DIFF
--- a/app/forms/questionnaires/course_start_date.rb
+++ b/app/forms/questionnaires/course_start_date.rb
@@ -47,7 +47,7 @@ module Questionnaires
 
     def next_step
       if course_start_date == "yes"
-        wizard.store["course_start"] = "Before #{application_course_start_date}"
+        wizard.store["course_start"] = "In #{application_course_start_date}"
         wizard.current_user.update!(notify_user_for_future_reg: false)
         :provider_check
       else

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -51,7 +51,7 @@ module ApplicationHelper
   end
 
   def application_course_start_date
-    "spring 2025"
+    "autumn 2025"
   end
 
   def show_otp_code_in_ui(current_env, admin)

--- a/app/views/registration_wizard/start.html.erb
+++ b/app/views/registration_wizard/start.html.erb
@@ -5,7 +5,7 @@
     <p class="govuk-body">Use this service to:</p>
 
       <ul class="govuk-list govuk-list--bullet">
-        <li>register for an NPQ or <%= localise_sentence_embedded_course_name(Course.ehco) %> starting before <%= application_course_start_date %></li>
+        <li>register for an NPQ or <%= localise_sentence_embedded_course_name(Course.ehco) %> starting in <%= application_course_start_date.titleize %></li>
         <li>check your registration details, if you already registered</li>
         <li>check your course outcome, if you have completed your course</li>
       </ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1013,9 +1013,9 @@ en:
         choose_your_npq_html: "To register for an NPQ and the <a href=\"https://professional-development-for-teachers-leaders.education.gov.uk/early-headship-coaching-offer\" class=\"govuk-link\">Early headship coaching offer</a>, submit 2 separate registrations."
         maths_eligibility_teaching_for_mastery_html_one: "You need to be able to demonstrate that you have an understanding of mastery approaches to teaching maths."
         maths_eligibility_teaching_for_mastery_two_html: "You can demonstrate this if you’ve taken at least one year of the <a href=\"https://www.gov.uk/guidance/join-the-maths-teaching-for-mastery-programme\" class=\"govuk-link\">primary maths Teaching for Mastery programme</a>."
-        course_start_date_one: "NPQs usually start every spring and autumn."
+        course_start_date_one: "NPQs usually start every autumn."
         course_start_date_two: "The early headship coaching offer starts at different times throughout the year depending on the provider."
-        course_start_date_three: "Registrations are currently open for courses starting in spring 2025."
+        course_start_date_three: "Registrations are currently open for courses starting in autumn 2025."
         maths_understanding_of_approach_html: "Your provider will ask you for details."
         work_setting_options:
           a_school_html: "Includes:<ul><li>local authority maintained schools (some may provide hospital education, for example pupil referral units, alternative provision or special schools)</li><li>secure children’s homes and secure training centres</li></ul>"

--- a/spec/features/course_start_date_spec.rb
+++ b/spec/features/course_start_date_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "Happy journeys", type: :feature do
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
       expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
-      expect(page).to have_text("Do you want to start a course in spring 2025?")
+      expect(page).to have_text("Do you want to start a course in autumn 2025?")
     end
   end
 end

--- a/spec/features/journeys/happy_paths/able_to_receive_targeted_delivery_funding_spec.rb
+++ b/spec/features/journeys/happy_paths/able_to_receive_targeted_delivery_funding_spec.rb
@@ -82,7 +82,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
     expect_page_to_have(path: "/registration/check-answers", submit_form: true, submit_button_text: "Submit") do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "Before #{application_course_start_date}",
+          "Course start" => "In #{application_course_start_date}",
           "Workplace in England" => "Yes",
           "Work setting" => "A school",
           "Course" => "Senior leadership",
@@ -162,7 +162,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "Before #{application_course_start_date}",
+        "course_start" => "In #{application_course_start_date}",
         "course_start_date" => "yes",
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "eligible_scholarship_funding_not_tsf",

--- a/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
@@ -82,7 +82,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "Before #{application_course_start_date}",
+          "Course start" => "In #{application_course_start_date}",
           "Course" => "Headship",
           "Provider" => "Teach First",
           "Workplace" => "open manchester school – street 1, manchester",
@@ -195,7 +195,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "Before #{application_course_start_date}",
+        "course_start" => "In #{application_course_start_date}",
         "course_start_date" => "yes",
         "course_identifier" => "npq-headship",
         "email_template" => "not_eligible_scholarship_funding_not_tsf",

--- a/spec/features/journeys/happy_paths/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
@@ -85,7 +85,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_form: false) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "Before #{application_course_start_date}",
+          "Course start" => "In #{application_course_start_date}",
           "Course" => "Senior leadership",
           "Course funding" => "I am paying",
           "Employment type" => "In an independent hospital education organisation",
@@ -136,7 +136,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_form: true, submit_button_text: "Submit") do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "Before #{application_course_start_date}",
+          "Course start" => "In #{application_course_start_date}",
           "Course" => "Senior leadership",
           "Course funding" => "My workplace is covering the cost",
           "Work setting" => "A school",
@@ -216,7 +216,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "Before #{application_course_start_date}",
+        "course_start" => "In #{application_course_start_date}",
         "course_start_date" => "yes",
         "course_identifier" => "npq-senior-leadership",
         "employer_name" => "Big company",

--- a/spec/features/journeys/happy_paths/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
@@ -94,7 +94,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_form: false) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "Before #{application_course_start_date}",
+          "Course start" => "In #{application_course_start_date}",
           "Course" => "Senior leadership",
           "Course funding" => "My workplace is covering the cost",
           "Work setting" => "Early years or childcare",
@@ -149,7 +149,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "Before #{application_course_start_date}",
+          "Course start" => "In #{application_course_start_date}",
           "Course" => "Senior leadership",
           "Course funding" => "I am paying",
           "Employment type" => "In an independent hospital education organisation",
@@ -230,7 +230,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "Before #{application_course_start_date}",
+        "course_start" => "In #{application_course_start_date}",
         "course_start_date" => "yes",
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "not_eligible_scholarship_funding_not_tsf",

--- a/spec/features/journeys/happy_paths/changing_from_outside_of_catchment_area_to_inside_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_from_outside_of_catchment_area_to_inside_spec.rb
@@ -77,7 +77,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_form: false) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "Before #{application_course_start_date}",
+          "Course start" => "In #{application_course_start_date}",
           "Course" => "Senior leadership",
           "Course funding" => "I am paying",
           "Work setting" => "A school",
@@ -131,7 +131,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "Before #{application_course_start_date}",
+          "Course start" => "In #{application_course_start_date}",
           "Course" => "Senior leadership",
           "Workplace" => "open manchester school – street 1, manchester",
           "Course funding" => "My workplace is covering the cost",
@@ -211,7 +211,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "Before #{application_course_start_date}",
+        "course_start" => "In #{application_course_start_date}",
         "course_start_date" => "yes",
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "not_eligible_scholarship_funding_not_tsf",

--- a/spec/features/journeys/happy_paths/changing_npq_to_one_leadprovider_no_longer_supports_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_npq_to_one_leadprovider_no_longer_supports_spec.rb
@@ -99,7 +99,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_form: false) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "Before #{application_course_start_date}",
+          "Course start" => "In #{application_course_start_date}",
           "Course" => "Senior leadership",
           "Course funding" => "My workplace is covering the cost",
           "Provider" => "Best Practice Network",
@@ -145,7 +145,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "Before #{application_course_start_date}",
+          "Course start" => "In #{application_course_start_date}",
           "Course" => "Early years leadership",
           "Course funding" => "My workplace is covering the cost",
           "Provider" => "National Institute of Teaching",
@@ -226,7 +226,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "Before #{application_course_start_date}",
+        "course_start" => "In #{application_course_start_date}",
         "course_start_date" => "yes",
         "course_identifier" => "npq-early-years-leadership",
         "email_template" => "not_on_ofsted_register",

--- a/spec/features/journeys/happy_paths/funded_ehco_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/funded_ehco_registration_journey_spec.rb
@@ -99,7 +99,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
     expect_page_to_have(path: "/registration/check-answers", submit_form: true, submit_button_text: "Submit") do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "Before #{application_course_start_date}",
+          "Course start" => "In #{application_course_start_date}",
           "Workplace in England" => "Yes",
           "Work setting" => "A school",
           "Course" => "Early headship coaching offer",
@@ -196,7 +196,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "Before #{application_course_start_date}",
+        "course_start" => "In #{application_course_start_date}",
         "course_start_date" => "yes",
         "course_identifier" => "npq-early-headship-coaching-offer",
         "ehco_headteacher" => "yes",

--- a/spec/features/journeys/happy_paths/international_teacher_npqh_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/international_teacher_npqh_journey_spec.rb
@@ -73,7 +73,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "Before #{application_course_start_date}",
+          "Course start" => "In #{application_course_start_date}",
           "Workplace in England" => "No",
           "Work setting" => "A school",
           "Course" => "Headship",
@@ -172,7 +172,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
         "work_setting" => "a_school",
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "Before #{application_course_start_date}",
+        "course_start" => "In #{application_course_start_date}",
         "course_start_date" => "yes",
         "course_identifier" => "npq-headship",
         "funding" => "school",

--- a/spec/features/journeys/happy_paths/other_funded_ehco_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/other_funded_ehco_registration_journey_spec.rb
@@ -97,7 +97,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "Before #{application_course_start_date}",
+          "Course start" => "In #{application_course_start_date}",
           "Workplace in England" => "Yes",
           "Work setting" => "A school",
           "Course" => "Early headship coaching offer",
@@ -194,7 +194,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "Before #{application_course_start_date}",
+        "course_start" => "In #{application_course_start_date}",
         "course_start_date" => "yes",
         "course_identifier" => "npq-early-headship-coaching-offer",
         "ehco_funding_choice" => "self",

--- a/spec/features/journeys/happy_paths/previously_received_targeted_delivery_funding_spec.rb
+++ b/spec/features/journeys/happy_paths/previously_received_targeted_delivery_funding_spec.rb
@@ -82,7 +82,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
     expect_page_to_have(path: "/registration/check-answers", submit_form: true, submit_button_text: "Submit") do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "Before #{application_course_start_date}",
+          "Course start" => "In #{application_course_start_date}",
           "Workplace in England" => "Yes",
           "Work setting" => "A school",
           "Course" => "Senior leadership",
@@ -162,7 +162,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "Before #{application_course_start_date}",
+        "course_start" => "In #{application_course_start_date}",
         "course_start_date" => "yes",
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "eligible_scholarship_funding_not_tsf",

--- a/spec/features/journeys/happy_paths/via_using_old_name_and_not_headship_spec.rb
+++ b/spec/features/journeys/happy_paths/via_using_old_name_and_not_headship_spec.rb
@@ -79,7 +79,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "Before #{application_course_start_date}",
+          "Course start" => "In #{application_course_start_date}",
           "Course" => "Senior leadership",
           "Workplace" => "open manchester school – street 1, manchester",
           "Course funding" => "My workplace is covering the cost",
@@ -159,7 +159,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "Before #{application_course_start_date}",
+        "course_start" => "In #{application_course_start_date}",
         "course_start_date" => "yes",
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "not_eligible_scholarship_funding_not_tsf",

--- a/spec/features/journeys/happy_paths/via_using_same_name_spec.rb
+++ b/spec/features/journeys/happy_paths/via_using_same_name_spec.rb
@@ -82,7 +82,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "Before #{application_course_start_date}",
+          "Course start" => "In #{application_course_start_date}",
           "Workplace in England" => "Yes",
           "Work setting" => "A school",
           "Course" => "Headship",
@@ -177,7 +177,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "Before #{application_course_start_date}",
+        "course_start" => "In #{application_course_start_date}",
         "course_start_date" => "yes",
         "course_identifier" => "npq-headship",
         "funding" => "trust",

--- a/spec/features/journeys/happy_paths/when_choose_lead_mentor_course_spec.rb
+++ b/spec/features/journeys/happy_paths/when_choose_lead_mentor_course_spec.rb
@@ -78,7 +78,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       expect_check_answers_page_to_have_answers(
         {
 
-          "Course start" => "Before #{application_course_start_date}",
+          "Course start" => "In #{application_course_start_date}",
           "Course" => "Leading teacher development",
           "Employment type" => "As a lead mentor for an accredited initial teacher training (ITT) provider",
           "ITT provider" => approved_itt_provider_legal_name,
@@ -201,7 +201,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
         "tsf_primary_plus_eligibility" => false,
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "Before #{application_course_start_date}",
+        "course_start" => "In #{application_course_start_date}",
         "course_start_date" => "yes",
         "course_identifier" => "npq-leading-teaching-development",
         "employment_type" => "lead_mentor_for_accredited_itt_provider",

--- a/spec/features/journeys/happy_paths/when_choose_maths_course_spec.rb
+++ b/spec/features/journeys/happy_paths/when_choose_maths_course_spec.rb
@@ -96,7 +96,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "Before #{application_course_start_date}",
+          "Course start" => "In #{application_course_start_date}",
           "Workplace in England" => "Yes",
           "Work setting" => "A school",
           "Workplace" => "open manchester school – street 1, manchester",
@@ -205,7 +205,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "Before #{application_course_start_date}",
+        "course_start" => "In #{application_course_start_date}",
         "course_start_date" => "yes",
         "course_identifier" => "npq-leading-primary-mathematics",
         "email_template" => "eligible_scholarship_funding_not_tsf",

--- a/spec/features/journeys/happy_paths/when_get_an_identity_returns_no_trn_spec.rb
+++ b/spec/features/journeys/happy_paths/when_get_an_identity_returns_no_trn_spec.rb
@@ -107,7 +107,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "Before #{application_course_start_date}",
+          "Course start" => "In #{application_course_start_date}",
           "Full name" => "Jane Smith",
           "Teacher reference number (TRN)" => manually_entered_trn,
           "Date of birth" => "13 December 1980",
@@ -226,7 +226,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
         "active_alert" => false,
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "Before #{application_course_start_date}",
+        "course_start" => "In #{application_course_start_date}",
         "course_start_date" => "yes",
         "course_identifier" => "npq-headship",
         "date_of_birth" => "1980-12-13",

--- a/spec/features/journeys/happy_paths/when_outside_of_catchment_area_crown_dependencies_spec.rb
+++ b/spec/features/journeys/happy_paths/when_outside_of_catchment_area_crown_dependencies_spec.rb
@@ -79,7 +79,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "Before #{application_course_start_date}",
+          "Course start" => "In #{application_course_start_date}",
           "Course" => "Senior leadership",
           "Course funding" => "I am paying",
           "Work setting" => "A school",
@@ -158,7 +158,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "Before #{application_course_start_date}",
+        "course_start" => "In #{application_course_start_date}",
         "course_start_date" => "yes",
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "not_england_wrong_catchment",

--- a/spec/features/journeys/happy_paths/when_outside_of_catchment_area_spec.rb
+++ b/spec/features/journeys/happy_paths/when_outside_of_catchment_area_spec.rb
@@ -76,7 +76,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "Before #{application_course_start_date}",
+          "Course start" => "In #{application_course_start_date}",
           "Course" => "Senior leadership",
           "Course funding" => "I am paying",
           "Work setting" => "A school",
@@ -153,7 +153,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "Before #{application_course_start_date}",
+        "course_start" => "In #{application_course_start_date}",
         "course_start_date" => "yes",
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "not_england_wrong_catchment",

--- a/spec/features/journeys/happy_paths/when_referred_by_return_to_teaching_adviser_spec.rb
+++ b/spec/features/journeys/happy_paths/when_referred_by_return_to_teaching_adviser_spec.rb
@@ -70,7 +70,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "Before #{application_course_start_date}",
+          "Course start" => "In #{application_course_start_date}",
           "Course" => "Senior leadership",
           "Work setting" => "Other",
           "Referred by return to teaching adviser" => "Yes",
@@ -149,7 +149,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "Before #{application_course_start_date}",
+        "course_start" => "In #{application_course_start_date}",
         "course_start_date" => "yes",
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "not_eligible_scholarship_funding_not_tsf",

--- a/spec/features/journeys/happy_paths/when_working_at_an_eligible_primary_school_spec.rb
+++ b/spec/features/journeys/happy_paths/when_working_at_an_eligible_primary_school_spec.rb
@@ -80,7 +80,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "Before #{application_course_start_date}",
+          "Course start" => "In #{application_course_start_date}",
           "Course" => "Headship",
           "Provider" => "Teach First",
           "Workplace" => "open manchester school – street 1, manchester",
@@ -193,7 +193,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
         "course_identifier" => "npq-headship",
-        "course_start" => "Before #{application_course_start_date}",
+        "course_start" => "In #{application_course_start_date}",
         "course_start_date" => "yes",
         "email_template" => "eligible_scholarship_funding_not_tsf",
         "funding_eligiblity_status_code" => "funded",

--- a/spec/features/journeys/happy_paths/when_working_in_other_spec.rb
+++ b/spec/features/journeys/happy_paths/when_working_in_other_spec.rb
@@ -79,7 +79,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       expect_check_answers_page_to_have_answers(
         {
           "Course funding" => "My workplace is covering the cost",
-          "Course start" => "Before #{application_course_start_date}",
+          "Course start" => "In #{application_course_start_date}",
           "Course" => "Senior leadership",
           "Work setting" => "Other",
           "Referred by return to teaching adviser" => "No",
@@ -158,7 +158,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "Before #{application_course_start_date}",
+        "course_start" => "In #{application_course_start_date}",
         "course_start_date" => "yes",
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "not_eligible_scholarship_funding_not_tsf",

--- a/spec/features/journeys/happy_paths/while_not_currently_working_at_school_spec.rb
+++ b/spec/features/journeys/happy_paths/while_not_currently_working_at_school_spec.rb
@@ -82,7 +82,7 @@ RSpec.feature "Happy journeys",
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "Before #{application_course_start_date}",
+          "Course start" => "In #{application_course_start_date}",
           "Course" => "Senior leadership",
           "Course funding" => "I am paying",
           "Work setting" => "Another setting",
@@ -163,7 +163,7 @@ RSpec.feature "Happy journeys",
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "Before #{application_course_start_date}",
+        "course_start" => "In #{application_course_start_date}",
         "course_start_date" => "yes",
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "not_eligible_scholarship_funding_not_tsf",

--- a/spec/features/journeys/happy_paths/while_working_at_private_childcare_provider_but_not_a_nursery_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_at_private_childcare_provider_but_not_a_nursery_spec.rb
@@ -107,7 +107,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_form: true, submit_button_text: "Submit") do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "Before #{application_course_start_date}",
+          "Course start" => "In #{application_course_start_date}",
           "Course" => "Early years leadership",
           "Work setting" => "Early years or childcare",
           "Provider" => "Teach First",
@@ -191,7 +191,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
         "tsf_primary_plus_eligibility" => false,
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "Before #{application_course_start_date}",
+        "course_start" => "In #{application_course_start_date}",
         "course_start_date" => "yes",
         "funding_amount" => nil,
         "course_identifier" => "npq-early-years-leadership",

--- a/spec/features/journeys/happy_paths/while_working_at_private_nursery_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_at_private_nursery_spec.rb
@@ -105,7 +105,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_form: true, submit_button_text: "Submit") do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "Before #{application_course_start_date}",
+          "Course start" => "In #{application_course_start_date}",
           "Course" => "Early years leadership",
           "Work setting" => "Early years or childcare",
           "Provider" => "Teach First",
@@ -190,7 +190,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
         "tsf_primary_plus_eligibility" => false,
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "Before #{application_course_start_date}",
+        "course_start" => "In #{application_course_start_date}",
         "course_start_date" => "yes",
         "course_identifier" => "npq-early-years-leadership",
         "has_ofsted_urn" => "yes",

--- a/spec/features/journeys/happy_paths/while_working_at_public_nursery_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_at_public_nursery_spec.rb
@@ -95,7 +95,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "Before #{application_course_start_date}",
+          "Course start" => "In #{application_course_start_date}",
           "Course" => "Senior leadership",
           "Course funding" => "My workplace is covering the cost",
           "Work setting" => "Early years or childcare",
@@ -176,7 +176,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "Before #{application_course_start_date}",
+        "course_start" => "In #{application_course_start_date}",
         "course_start_date" => "yes",
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "not_eligible_scholarship_funding_not_tsf",

--- a/spec/features/journeys/happy_paths/while_working_in_neither_a_school_nor_childcare_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_in_neither_a_school_nor_childcare_spec.rb
@@ -81,7 +81,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       expect_check_answers_page_to_have_answers(
         {
           "Course funding" => "I am paying",
-          "Course start" => "Before #{application_course_start_date}",
+          "Course start" => "In #{application_course_start_date}",
           "Course" => "Early years leadership",
           "Employment type" => "In an independent hospital education organisation",
           "Employer" => "Big company",
@@ -161,7 +161,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "Before #{application_course_start_date}",
+        "course_start" => "In #{application_course_start_date}",
         "course_start_date" => "yes",
         "course_identifier" => "npq-early-years-leadership",
         "email_template" => "not_on_ofsted_register",

--- a/spec/features/journeys/sad_paths/applying_for_ehco_but_not_new_headteacher_spec.rb
+++ b/spec/features/journeys/sad_paths/applying_for_ehco_but_not_new_headteacher_spec.rb
@@ -103,7 +103,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "Before #{application_course_start_date}",
+          "Course start" => "In #{application_course_start_date}",
           "Workplace in England" => "Yes",
           "Work setting" => "A school",
           "Course" => "Early headship coaching offer",
@@ -186,7 +186,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "Before #{application_course_start_date}",
+        "course_start" => "In #{application_course_start_date}",
         "course_start_date" => "yes",
         "course_identifier" => "npq-early-headship-coaching-offer",
         "ehco_funding_choice" => "self",

--- a/spec/features/journeys/sad_paths/lead_mentor_journey_with_incorrect_course_spec.rb
+++ b/spec/features/journeys/sad_paths/lead_mentor_journey_with_incorrect_course_spec.rb
@@ -88,7 +88,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "Before #{application_course_start_date}",
+          "Course start" => "In #{application_course_start_date}",
           "Course" => "Senior leadership",
           "Employment type" => "As a lead mentor for an accredited initial teacher training (ITT) provider",
           "ITT provider" => approved_itt_provider_legal_name,
@@ -206,7 +206,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "Before #{application_course_start_date}",
+        "course_start" => "In #{application_course_start_date}",
         "course_start_date" => "yes",
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "itt_leader_wrong_course",

--- a/spec/features/journeys/sad_paths/works_in_childcare_but_not_in_england_spec.rb
+++ b/spec/features/journeys/sad_paths/works_in_childcare_but_not_in_england_spec.rb
@@ -77,7 +77,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "Before #{application_course_start_date}",
+          "Course start" => "In #{application_course_start_date}",
           "Course" => "Senior leadership",
           "Course funding" => "My workplace is covering the cost",
           "Work setting" => "Early years or childcare",
@@ -156,7 +156,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "Before #{application_course_start_date}",
+        "course_start" => "In #{application_course_start_date}",
         "course_start_date" => "yes",
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "not_england_wrong_catchment",


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-2980](https://dfedigital.atlassian.net/browse/CPDNPQ-2980)

The course selector page currently refers to spring 2025 and should refer to autumn 2025

### Changes proposed in this pull request

1. Change all references to "spring 2025" to "autumn 2025"

[CPDNPQ-2980]: https://dfedigital.atlassian.net/browse/CPDNPQ-2980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ