### PR TITLE
Handle cased emails from GAI properly

### DIFF
--- a/app/services/users/find_or_create_from_provider_data.rb
+++ b/app/services/users/find_or_create_from_provider_data.rb
@@ -11,14 +11,15 @@ module Users
 
     def call
       user = User.find_by(provider: provider_data.provider, uid: provider_data.uid, archived_at: nil)
+      provider_email = provider_data.info.email.downcase
 
       if user
-        check_and_archive_clashing_user(provider_data.info.email, user)
-        user.assign_attributes(email: provider_data.info.email)
+        check_and_archive_clashing_user(provider_email, user)
+        user.assign_attributes(email: provider_email)
       else
         Rails.logger.info("[GAI] User not found using UID, UID=#{provider_data.uid}, using email to find user")
         check_if_supplied_uid_matches_archived_account # CPDNPQ-2647
-        user = User.find_or_initialize_by(email: provider_data.info.email, archived_at: nil)
+        user = User.find_or_initialize_by(email: provider_email, archived_at: nil)
         user.assign_attributes(provider: provider_data.provider, uid: provider_data.uid)
       end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -406,4 +406,16 @@ RSpec.describe User do
       end
     end
   end
+
+  context "when email has upcase characters" do
+    let(:user) { build(:user, email: "Foo@example.com") }
+
+    before do
+      user.save
+    end
+
+    it "downcases email during saving" do
+      expect(user.reload.email).to eq("foo@example.com")
+    end
+  end
 end

--- a/spec/services/users/find_or_create_from_provider_data_spec.rb
+++ b/spec/services/users/find_or_create_from_provider_data_spec.rb
@@ -161,6 +161,7 @@ RSpec.describe Users::FindOrCreateFromProviderData do
 
     context "when there is a clashing user with the same email" do
       let(:existing_user) { create(:user, :with_get_an_identity_id, uid: provider_data_uid, trn: "0000000") }
+
       let!(:clashing_user) { create(:user, email: provider_data_email) }
 
       it "archives the clashing user" do
@@ -243,6 +244,17 @@ RSpec.describe Users::FindOrCreateFromProviderData do
 
         it_behaves_like "a saved valid user with provider data assigned"
       end
+    end
+  end
+
+  context "when the provider email is cased differently but the same otherwise" do
+    let(:provider_data_email) { "Foo@example.com" }
+    let(:clashing_downcase_email) { "foo@example.com" }
+
+    let!(:existing_user) { create(:user, email: clashing_downcase_email, trn: "0000000") }
+
+    it "returns existing user" do
+      expect(subject).to eq(existing_user)
     end
   end
 end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2984

### Changes proposed in this pull request

In very rare cases, GAI user can have cased email that clashes with an existing user, eg GAI returns `FOO@example.com` and our database already have `foo@example.com`. This results in a validation error.
The proposed code fixes the issue. Please note that device gem is downcasing all our emails before saving them - hence regression spec in `user_spec.rb`.