### PR TITLE
[CPDNPQ-3170] Fix email signup

### DIFF
--- a/app/controllers/email_updates_controller.rb
+++ b/app/controllers/email_updates_controller.rb
@@ -1,6 +1,6 @@
 class EmailUpdatesController < PublicPagesController
   before_action only: %i[new create] do
-    redirect_to root_path unless current_user.persisted?
+    redirect_to root_path unless current_user&.persisted?
   end
 
   def new

--- a/spec/requests/email_updates_controller_spec.rb
+++ b/spec/requests/email_updates_controller_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe EmailUpdatesController, type: :request do
+  let(:user) { create :user }
+
+  describe "#new" do
+    subject { get(new_email_update_path) && response }
+
+    context "when logged in" do
+      before { allow(User).to receive(:find_by).and_return user }
+
+      it { is_expected.to have_http_status :success }
+    end
+
+    context "when not logged in" do
+      it { is_expected.to redirect_to root_path }
+    end
+  end
+
+  describe "#create" do
+    subject(:do_request) { post(email_updates_path, params:) && response }
+
+    let(:params) { { email_updates: { email_updates_status: :senco } } }
+
+    context "when logged in" do
+      before { allow(User).to receive(:find_by).and_return user }
+
+      context "with valid request" do
+        it "saves email update" do
+          expect {
+            do_request
+          }.to change(user, :email_updates_status).to("senco")
+
+          expect(do_request).to have_http_status(:success)
+        end
+      end
+
+      context "with invalid request" do
+        let(:params) { {} }
+
+        it "does not save email update" do
+          expect { do_request }.not_to change(user, :email_updates_status)
+
+          expect(do_request).to have_http_status(:success)
+        end
+      end
+    end
+
+    context "when not logged in" do
+      it { is_expected.to redirect_to root_path }
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-3170](https://dfedigital.atlassian.net/browse/CPDNPQ-3170)

Its not immediately clear how users are managing to trigger this error, they are visiting a link which the home page does not redirect to unless they are logged in _but_ we should be correctly checking they are logged in anyway

### Changes proposed in this pull request

1. Added a request spec to verify the behaviour of the controller and fixed the controllers behaviour when the user is not logged in