### PR TITLE
[CPDNPQ-3171] Session restore error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
+  before_action :clear_null_user_sessions
   before_action :set_cache_headers
   before_action :authenticate_user!
   before_action :set_sentry_user
@@ -60,5 +61,13 @@ private
 
   def set_cache_headers
     no_store
+  end
+
+  def clear_null_user_sessions
+    if session.key?(:registration_store) &&
+        session[:registration_store][:current_user].is_a?(NullUser)
+      reset_session
+      redirect_to root_path
+    end
   end
 end

--- a/app/models/null_user.rb
+++ b/app/models/null_user.rb
@@ -1,0 +1,15 @@
+class NullUser < User
+  def null_user?
+    true
+  end
+
+  def actual_user?
+    false
+  end
+
+  def flipper_id
+    "User;#{feature_flag_id}"
+  end
+
+  attr_accessor :feature_flag_id
+end

--- a/spec/controllers/controllers_spec.rb
+++ b/spec/controllers/controllers_spec.rb
@@ -99,4 +99,38 @@ RSpec.describe "choosing the correct controller to inherit from" do
     it_behaves_like "allowing an authenticated user access"
     it_behaves_like "allowing an admin access"
   end
+
+  describe "sessions with NullUser in" do
+    controller(PublicPagesController) do
+      def index
+        head :ok
+      end
+    end
+
+    context "with a NullUser set" do
+      before do
+        session[:user_id] = 1
+        session[:registration_store] = { current_user: NullUser.new }
+      end
+
+      it "clears out the session" do
+        get :index
+        expect(session[:user_id]).to be_nil
+        expect(session[:registration_store]).to be_nil
+      end
+    end
+
+    context "without a NullUser set" do
+      before do
+        session[:user_id] = user.id
+        session[:registration_store] = { current_user: user }
+      end
+
+      it "does not clear out the session" do
+        get :index
+        expect(session[:user_id]).to eq user.id
+        expect(session[:registration_store][:current_user]).to eq user
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-3171](https://dfedigital.atlassian.net/browse/CPDNPQ-3171]

We have had a user in Staging unable to restore an old session because they have a NullUser persisted in the :registration_store key

### Changes proposed in this pull request

1. Restore the `NullUser` to allow sessions to be successfully restored
2. Clear out the old bad session and redirect the user to the homepage

[CPDNPQ-3171]: https://dfedigital.atlassian.net/browse/CPDNPQ-3171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ