### PR TITLE
H2 'Applications' is getting repeated with each summary card 

### DIFF
--- a/app/views/npq_separation/admin/users/_application.html.erb
+++ b/app/views/npq_separation/admin/users/_application.html.erb
@@ -1,5 +1,3 @@
-<h2 class="govuk-heading-m">Applications</h2>
-
 <%- title = "#{application.course.name}" -%>
 <%- actions = [govuk_link_to("View full application", npq_separation_admin_application_path(application))] -%>
 

--- a/app/views/npq_separation/admin/users/show.html.erb
+++ b/app/views/npq_separation/admin/users/show.html.erb
@@ -66,6 +66,8 @@
   </div>
 </div>
 
+<h2 class="govuk-heading-m">Applications</h2>
+
 <% if @applications.none? %>
   <p class="govuk-body">This user has no applications.</p>
 <% else %>

--- a/spec/features/npq_separation/admin/users_spec.rb
+++ b/spec/features/npq_separation/admin/users_spec.rb
@@ -88,6 +88,7 @@ RSpec.feature "User administration", type: :feature do
       visit npq_separation_admin_user_path(user)
 
       expect(page).to have_css("h1", text: user.full_name)
+      expect(page).to have_css("h2", text: "Applications", count: 1)
       applications.each do |application|
         within(".govuk-summary-card", text: application.course.name.to_s) do |summary_card|
           expect(summary_card).to have_summary_item("NPQ course", application.course.name)


### PR DESCRIPTION
Bug fix to stop the H2 'Applications' getting repeated above each summary card on the users show page.
