### PR TITLE
[CPDNPQ-3140] admin console statements page - add filter for output_fee

### DIFF
--- a/app/components/npq_separation/admin/statement_selector_component.html.erb
+++ b/app/components/npq_separation/admin/statement_selector_component.html.erb
@@ -47,5 +47,17 @@
     </div>
   </div>
 
+  <div class="govuk-grid-row">
+    <% unless format_for_sidebar %>
+      <div class="<%= grid_column_class %>">
+        <%= f.govuk_select :output_fee,
+          options_for_select({ "Yes" => true, "No" => false }, output_fee),
+          options: { include_blank: 'All' },
+          label: { text: "Payment run", size: "s" }
+        %>
+      </div>
+    <% end %>
+  </div>
+
   <%= f.govuk_submit submit_button_text %>
 <% end %>

--- a/app/components/npq_separation/admin/statement_selector_component.html.erb
+++ b/app/components/npq_separation/admin/statement_selector_component.html.erb
@@ -47,8 +47,8 @@
     </div>
   </div>
 
-  <div class="govuk-grid-row">
-    <% unless format_for_sidebar %>
+  <% unless format_for_sidebar %>
+    <div class="govuk-grid-row">
       <div class="<%= grid_column_class %>">
         <%= f.govuk_select :output_fee,
           options_for_select({ "Yes" => true, "No" => false }, output_fee),
@@ -56,8 +56,8 @@
           label: { text: "Payment run", size: "s" }
         %>
       </div>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 
   <%= f.govuk_submit submit_button_text %>
 <% end %>

--- a/app/components/npq_separation/admin/statement_selector_component.rb
+++ b/app/components/npq_separation/admin/statement_selector_component.rb
@@ -27,6 +27,10 @@ module NpqSeparation
         selection[:payment_status].presence
       end
 
+      def output_fee
+        selection[:output_fee]
+      end
+
       def lead_providers
         LeadProvider.all.alphabetical
       end
@@ -45,7 +49,7 @@ module NpqSeparation
       end
 
       def selected_statement
-        selection[:statement].presence || selection.values_at(:year, :month).join("-")
+        selection[:statement].presence
       end
     end
   end

--- a/app/components/npq_separation/admin/statements_table_component.rb
+++ b/app/components/npq_separation/admin/statements_table_component.rb
@@ -27,6 +27,7 @@ module NpqSeparation
           "Cohort",
           "Statement date",
           "Status",
+          "Payment run",
           "Actions",
         ].compact
       end
@@ -38,6 +39,7 @@ module NpqSeparation
             cohort_link(statement),
             helpers.statement_name(statement),
             statement_tag(statement),
+            payment_run_tag(statement),
             view_link(statement),
           ].compact
         end
@@ -65,10 +67,14 @@ module NpqSeparation
       end
 
       def statement_tag(statement)
-        govuk_tag(
+        helpers.govuk_tag(
           text: statement.state.capitalize,
           classes: STATE_COLOURS[statement.state.to_sym],
         )
+      end
+
+      def payment_run_tag(statement)
+        helpers.boolean_red_green_tag(statement.output_fee)
       end
 
       def metadata_link_arguments

--- a/app/controllers/npq_separation/admin/finance/statements_controller.rb
+++ b/app/controllers/npq_separation/admin/finance/statements_controller.rb
@@ -32,7 +32,7 @@ class NpqSeparation::Admin::Finance::StatementsController < NpqSeparation::Admin
 private
 
   def statement_params
-    params.permit(:lead_provider_id, :cohort_id, :payment_status, :statement)
+    params.permit(:lead_provider_id, :cohort_id, :payment_status, :statement, :output_fee)
           .tap { extract_period _1 }
           .tap { extract_state _1 }
           .compact_blank

--- a/app/views/npq_separation/admin/finance/statements/show.html.erb
+++ b/app/views/npq_separation/admin/finance/statements/show.html.erb
@@ -15,6 +15,10 @@
       <strong>Status:</strong>
       <%= @statement.state.humanize %>
     </p>
+    <p class="govuk-body govuk-!-margin-bottom-2">
+      <strong>Payment run:</strong>
+      <%= boolean_tag(@statement.output_fee) %>
+    </p>
     <%= govuk_details(summary_text: "Statement ID", id: "statement-id") do
           @statement.ecf_id
         end %>

--- a/app/views/npq_separation/admin/finance/statements/show.html.erb
+++ b/app/views/npq_separation/admin/finance/statements/show.html.erb
@@ -17,7 +17,7 @@
     </p>
     <p class="govuk-body govuk-!-margin-bottom-2">
       <strong>Payment run:</strong>
-      <%= boolean_tag(@statement.output_fee) %>
+      <%= boolean_red_green_tag(@statement.output_fee) %>
     </p>
     <%= govuk_details(summary_text: "Statement ID", id: "statement-id") do
           @statement.ecf_id

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -144,6 +144,8 @@ en:
       application:
         lead_provider: Provider
         funding_eligiblity_status_code: Funding eligibility status code
+      statement:
+        output_fee: Payment run
     errors:
       models:
         adjustment:

--- a/spec/components/npq_separation/admin/statement_selector_component_spec.rb
+++ b/spec/components/npq_separation/admin/statement_selector_component_spec.rb
@@ -5,19 +5,34 @@ require "rails_helper"
 RSpec.describe NpqSeparation::Admin::StatementSelectorComponent, type: :component do
   include StatementHelper
 
-  let(:lead_provider)    { create :lead_provider }
-  let!(:statement)       { create(:statement, lead_provider:) }
-  let(:cohort)           { statement.cohort }
-  let(:instance)         { described_class.new(statement) }
-
+  let(:lead_provider) { create :lead_provider }
+  let!(:statement) { create(:statement, lead_provider:) }
+  let!(:statement_other_cohort) { create(:statement, lead_provider:, cohort: other_cohort) }
+  let!(:statement_other_lead_provider) { create(:statement, lead_provider: create(:lead_provider)) }
+  let(:other_cohort) { create(:cohort, :previous) }
+  let(:cohort) { statement.cohort }
+  let(:instance) { described_class.new(statement_params) }
+  let(:lead_provider_param) { nil }
+  let(:cohort_param) { nil }
+  let(:statement_param) { nil }
+  let(:payment_status_param) { nil }
+  let(:output_fee_param) { nil }
   let(:rendered) { render_inline instance }
   let(:payment_status_selector) { "select#payment-status-field" }
+
+  let(:statement_params) do
+    { lead_provider_id: lead_provider_param,
+      cohort_id: cohort_param,
+      payment_status: payment_status_param,
+      statement: statement_param,
+      output_fee: output_fee_param }
+  end
 
   it "has a form that GETs to correct action" do
     expect(rendered).to have_selector("form[method=get][action='/npq-separation/admin/finance/statements']")
   end
 
-  it "has dropdown with state" do
+  it "has dropdown with status" do
     expect(rendered).to have_selector(payment_status_selector)
     expect(rendered).to have_selector("#{payment_status_selector} option[value='']", text: "All")
     expect(rendered).to have_selector("#{payment_status_selector} option[value='paid']", text: "Paid")
@@ -34,25 +49,91 @@ RSpec.describe NpqSeparation::Admin::StatementSelectorComponent, type: :componen
     expect(rendered).to have_selector("select#cohort-id-field option[value='#{cohort.id}']", text: cohort.start_year)
   end
 
-  it "has dropdown with statement" do
+  it "has dropdown with statement dates" do
     expect(rendered).to have_selector("select#statement-field")
     expect(rendered).to have_selector("select#statement-field option[value='#{statement_period(statement)}']", text: statement_name(statement))
+    expect(rendered).to have_selector("select#statement-field option[value='#{statement_period(statement_other_cohort)}']", text: statement_name(statement_other_cohort))
+    expect(rendered).to have_selector("select#statement-field option[value='#{statement_period(statement_other_lead_provider)}']", text: statement_name(statement_other_lead_provider))
+  end
+
+  context "when a lead provider has been selected" do
+    let(:lead_provider_param) { lead_provider.id }
+
+    it "only shows statements for that lead provider" do
+      expect(rendered).to have_selector("select#statement-field option[value='#{statement_period(statement)}']", text: statement_name(statement))
+      expect(rendered).to have_selector("select#statement-field option[value='#{statement_period(statement_other_cohort)}']", text: statement_name(statement_other_cohort))
+      expect(rendered).not_to have_selector("select#statement-field option[value='#{statement_period(statement_other_lead_provider)}']", text: statement_name(statement_other_lead_provider))
+    end
+
+    context "and a cohort has been selected" do
+      let(:cohort_param) { other_cohort.id }
+
+      it "only shows statements for that lead provider and cohort" do
+        expect(rendered).to have_selector("select#statement-field option[value='#{statement_period(statement_other_cohort)}']", text: statement_name(statement_other_cohort))
+        expect(rendered).not_to have_selector("select#statement-field option[value='#{statement_period(statement)}']", text: statement_name(statement))
+      end
+    end
+  end
+
+  context "when a cohort has been selected" do
+    let(:cohort_param) { cohort.id }
+
+    it "only shows statements for that cohort" do
+      expect(rendered).to have_selector("select#statement-field option[value='#{statement_period(statement)}']", text: statement_name(statement))
+      expect(rendered).to have_selector("select#statement-field option[value='#{statement_period(statement_other_lead_provider)}']", text: statement_name(statement_other_lead_provider))
+      expect(rendered).not_to have_selector("select#statement-field option[value='#{statement_period(statement_other_cohort)}']", text: statement_name(statement_other_cohort))
+    end
+  end
+
+  it "has a dropdown with payment run" do
+    expect(rendered).to have_selector("select#output-fee-field")
+    expect(rendered).to have_selector("select#output-fee-field option[value='']", text: "All")
+    expect(rendered).to have_selector("select#output-fee-field option[value='true']", text: "Yes")
+    expect(rendered).to have_selector("select#output-fee-field option[value='false']", text: "No")
   end
 
   it "has submit button" do
     expect(rendered).to have_selector("button[type=submit]", text: "Search")
   end
 
-  it "defaults to selected lead provider" do
-    expect(rendered).to have_selector("select#lead-provider-id-field option[selected]", text: statement.lead_provider.name, visible: :all)
+  context "when the statement param is present" do
+    let(:statement_param) { statement_period(statement) }
+
+    it "defaults to selected statement" do
+      expect(rendered).to have_selector("select#statement-field option[selected]", text: statement_name(statement), visible: :all)
+    end
   end
 
-  it "defaults to selected cohort" do
-    expect(rendered).to have_selector("select#cohort-id-field option[selected]", text: statement.cohort.start_year, visible: :all)
+  context "when the lead provider param is present" do
+    let(:lead_provider_param) { lead_provider.id }
+
+    it "defaults to selected lead provider" do
+      expect(rendered).to have_selector("select#lead-provider-id-field option[selected]", text: statement.lead_provider.name, visible: :all)
+    end
   end
 
-  it "defaults to selected statement" do
-    expect(rendered).to have_selector("select#statement-field option[selected]", text: statement_name(statement), visible: :all)
+  context "when the context param is present" do
+    let(:cohort_param) { cohort.id }
+
+    it "defaults to selected cohort" do
+      expect(rendered).to have_selector("select#cohort-id-field option[selected]", text: statement.cohort.start_year, visible: :all)
+    end
+  end
+
+  context "when the payment status param is present" do
+    let(:payment_status_param) { "paid" }
+
+    it "defaults to selected payment status" do
+      expect(rendered).to have_selector("#{payment_status_selector} option[selected]", text: "Paid", visible: :all)
+    end
+  end
+
+  context "when the output fee param is present" do
+    let(:output_fee_param) { "true" }
+
+    it "defaults to selected output fee" do
+      expect(rendered).to have_selector("select#output-fee-field option[selected]", text: "Yes", visible: :all)
+    end
   end
 
   context "when sidebar mode is enabled" do

--- a/spec/components/npq_separation/admin/statement_selector_component_spec.rb
+++ b/spec/components/npq_separation/admin/statement_selector_component_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe NpqSeparation::Admin::StatementSelectorComponent, type: :componen
     end
   end
 
-  context "when the context param is present" do
+  context "when the cohort param is present" do
     let(:cohort_param) { cohort.id }
 
     it "defaults to selected cohort" do

--- a/spec/requests/npq_separation/admin/finance/statements_controller_spec.rb
+++ b/spec/requests/npq_separation/admin/finance/statements_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe NpqSeparation::Admin::Finance::StatementsController, type: :reque
     [
       create(:statement, cohort:, lead_provider:, year: 2024, month: 10),
       create(:statement, cohort:, lead_provider:, year: 2024, month: 11),
-      create(:statement, cohort:, lead_provider:, year: 2024, month: 12),
+      create(:statement, cohort:, lead_provider:, year: 2024, month: 12, output_fee: false),
     ]
   end
 
@@ -52,6 +52,18 @@ RSpec.describe NpqSeparation::Admin::Finance::StatementsController, type: :reque
       end
 
       it { is_expected.to have_http_status(:ok) }
+    end
+
+    context "with params matching multiple statements using output fee" do
+      let(:params) do
+        {
+          output_fee: "true",
+        }
+      end
+
+      it { is_expected.to have_attributes body: %r{October 2024</td>} }
+      it { is_expected.to have_attributes body: %r{November 2024</td>} }
+      it { is_expected.not_to have_attributes body: %r{December 2024</td>} }
     end
 
     context "with params matching no statement statement" do


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-3140

### Changes proposed in this pull request

* show `output_fee` on the statements page, as "Payment run"
* add a filter for Payment run
* increased test coverage on `StatementSelectorComponent` to 100%
* show Payment run on the statement page
