### PR TITLE
[CPDNPQ-3193] fix failing specs

### DIFF
--- a/spec/factories/declarations.rb
+++ b/spec/factories/declarations.rb
@@ -70,7 +70,7 @@ FactoryBot.define do
     end
 
     trait :with_delivery_partner do
-      delivery_partner { create(:delivery_partner, lead_provider:) }
+      delivery_partner { create(:delivery_partner, lead_providers: { cohort => lead_provider }) }
     end
   end
 end

--- a/spec/factories/schedules.rb
+++ b/spec/factories/schedules.rb
@@ -151,7 +151,7 @@ FactoryBot.define do
     # setting it to false
     before(:create) do |schedule, evaluator|
       if schedule.applies_from.future? && evaluator.change_applies_dates
-        schedule.applies_from = Date.current - 1.week
+        schedule.applies_from = Date.current - 1.month
         schedule.applies_to = Date.current + 1.month
       end
     end

--- a/spec/features/npq_separation/admin/applications/applications_spec.rb
+++ b/spec/features/npq_separation/admin/applications/applications_spec.rb
@@ -441,9 +441,10 @@ RSpec.feature "Listing and viewing applications", type: :feature do
   end
 
   scenario "changing schedule cohort" do
+    future_cohort = create(:cohort, start_year: 3.years.from_now.year)
     application = create(:application, cohort: Cohort.first)
     create(:schedule, :npq_leadership_autumn, cohort: application.cohort)
-    create(:schedule, :npq_leadership_spring, cohort: create(:cohort, start_year: 2025))
+    create(:schedule, :npq_leadership_spring, cohort: future_cohort)
 
     visit npq_separation_admin_application_path(application)
 
@@ -456,11 +457,11 @@ RSpec.feature "Listing and viewing applications", type: :feature do
     click_button "Continue"
     expect(page).to have_css(".govuk-error-message", text: "Choose a cohort")
 
-    choose "2025", visible: :all
+    choose future_cohort.start_year.to_s, visible: :all
     click_button "Continue"
 
     within(".govuk-summary-list__row", text: "Schedule cohort") do |row|
-      expect(row).to have_text("2025")
+      expect(row).to have_text(future_cohort.start_year.to_s)
     end
   end
 

--- a/spec/lib/tasks/update_application_spec.rb
+++ b/spec/lib/tasks/update_application_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "update_application" do
   include_context "with default schedules"
 
-  let(:cohort) { create(:cohort, :current, :without_funding_cap) }
+  let(:cohort) { create(:cohort, :previous, :without_funding_cap) }
 
   shared_examples "outputting an error" do
     it "outputs an error message" do
@@ -69,7 +69,7 @@ RSpec.describe "update_application" do
     after { Rake::Task["update_application:withdraw"].reenable }
 
     let(:participant) { create(:user) }
-    let(:application) { create(:application, :with_declaration, user: participant) }
+    let(:application) { create(:application, :with_declaration, user: participant, cohort:) }
 
     it "withdraws the application" do
       run_task
@@ -126,7 +126,7 @@ RSpec.describe "update_application" do
     end
 
     context "when the application has declarations" do
-      let(:application) { create(:application, :with_declaration) }
+      let(:application) { create(:application, :with_declaration, cohort:) }
 
       it "raises an error" do
         expect { run_task }.to raise_error(RuntimeError, "Cannot change cohort for an application with declarations")
@@ -165,7 +165,7 @@ RSpec.describe "update_application" do
     end
 
     context "when the application has declarations" do
-      let(:application) { create(:application, :with_declaration) }
+      let(:application) { create(:application, :with_declaration, cohort:) }
 
       it "raises an error" do
         expect { run_task }.to raise_error(RuntimeError, "Cannot change schedule for an application with declarations")

--- a/spec/services/declarations/create_spec.rb
+++ b/spec/services/declarations/create_spec.rb
@@ -7,16 +7,16 @@ RSpec.describe Declarations::Create, type: :model do
   let(:cohort) { create(:cohort, :current) }
   let(:course_group) { CourseGroup.find_by(name: "leadership") || create(:course_group, name: "leadership") }
   let(:course) { create(:course, :senior_leadership, course_group:) }
-  let!(:schedule) { create(:schedule, :npq_leadership_autumn, course_group:, cohort:) }
-  let(:application) { create(:application, :accepted, cohort:, course:, lead_provider:) }
+  let(:schedule) { create(:schedule, :npq_leadership_autumn, course_group:, cohort:) }
+  let(:application) { create(:application, :accepted, cohort:, course:, lead_provider:, schedule:) }
   let(:participant) { application.user }
   let(:participant_id) { participant.ecf_id }
   let(:declaration_type) { "started" }
   let(:declaration_date) { schedule.applies_from + 1.hour }
   let(:course_identifier) { course.identifier }
   let(:has_passed) { true }
-  let!(:delivery_partner_id) { create(:delivery_partner, lead_providers: { cohort => lead_provider }).ecf_id }
-  let!(:secondary_delivery_partner_id) { create(:delivery_partner, lead_providers: { cohort => lead_provider }).ecf_id }
+  let(:delivery_partner_id) { create(:delivery_partner, lead_providers: { cohort => lead_provider }).ecf_id }
+  let(:secondary_delivery_partner_id) { create(:delivery_partner, lead_providers: { cohort => lead_provider }).ecf_id }
   let(:params) do
     {
       lead_provider:,
@@ -463,10 +463,10 @@ RSpec.describe Declarations::Create, type: :model do
       before do
         travel_to(1.month.ago) do
           application
-          create(:declaration, application:, declaration_type:, declaration_date: 1.month.ago)
-          create(:declaration, application:, declaration_type: "retained-1", declaration_date: 1.month.ago)
-          create(:declaration, application:, declaration_type: "retained-2", declaration_date: 1.month.ago)
-          create(:declaration, application:, declaration_type: "completed", declaration_date: 1.month.ago)
+          create(:declaration, application:, declaration_type: "started")
+          create(:declaration, application:, declaration_type: "retained-1")
+          create(:declaration, application:, declaration_type: "retained-2")
+          create(:declaration, application:, declaration_type: "completed")
         end
         newer_application
       end

--- a/spec/services/statements/summary_calculator_spec.rb
+++ b/spec/services/statements/summary_calculator_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Statements::SummaryCalculator do
   let(:cohort) { create(:cohort, :current) }
   let(:lead_provider) { create :lead_provider }
-  let(:statement) { create(:statement, lead_provider:, reconcile_amount: 0) }
-  let(:application) { create(:application, :accepted, :eligible_for_funding, course:, lead_provider:) }
+  let(:statement) { create(:statement, :next_output_fee, lead_provider:, reconcile_amount: 0, cohort:) }
+  let(:application) { create(:application, :accepted, :eligible_for_funding, course:, lead_provider:, cohort:) }
   let(:declaration_type) { "started" }
 
   let!(:course) { create(:course, :leading_teaching) }
@@ -143,17 +143,22 @@ RSpec.describe Statements::SummaryCalculator do
     end
 
     context "when there are clawbacks" do
-      let!(:declaration) do
-        travel_to(1.month.ago) { create(:declaration, :paid, lead_provider:, statement: paid_statement) }
-      end
-      let(:paid_statement)     { create(:statement, :paid, lead_provider:) }
-
-      let!(:statement)         { create(:statement, :next_output_fee, deadline_date: paid_statement.deadline_date + 1.month, lead_provider:) }
-
       before do
-        travel_to statement.deadline_date do
-          Declarations::Void.new(declaration:).void
+        declaration = travel_to(1.month.ago) do
+          create(:declaration, :paid, lead_provider:, statement: paid_statement, cohort:)
         end
+
+        statement
+
+        travel_to statement.deadline_date do
+          Declarations::Void.new(declaration:).void || raise("Could not void")
+        end
+      end
+
+      let(:paid_statement) { create(:statement, :paid, lead_provider:) }
+
+      let :statement do
+        create(:statement, :next_output_fee, deadline_date: paid_statement.deadline_date + 1.month, lead_provider:, cohort:)
       end
 
       it "does not count them" do
@@ -342,6 +347,18 @@ RSpec.describe Statements::SummaryCalculator do
     end
 
     context "with declaration" do
+      before do
+        earlier_statement = create(:statement, :next_output_fee, deadline_date: statement.deadline_date - 1.month, lead_provider:)
+
+        awaiting_clawback = travel_to(earlier_statement.deadline_date) do
+          create(:declaration, :paid, declaration_type:, application:, lead_provider:, statement: earlier_statement)
+        end
+
+        travel_to statement.deadline_date do
+          Declarations::Void.new(declaration: awaiting_clawback).void || raise("Could not void")
+        end
+      end
+
       let(:declaration_type) { "started" }
 
       let(:application) do
@@ -352,19 +369,8 @@ RSpec.describe Statements::SummaryCalculator do
           course:,
           lead_provider:,
           targeted_delivery_funding_eligibility: true,
+          cohort:,
         )
-      end
-
-      let!(:to_be_awaiting_clawed_back) do
-        travel_to create(:statement, :next_output_fee, deadline_date: statement.deadline_date - 1.month, lead_provider:).deadline_date do
-          create(:declaration, :paid, declaration_type:, application:, lead_provider:)
-        end
-      end
-
-      before do
-        travel_to statement.deadline_date do
-          Declarations::Void.new(declaration: to_be_awaiting_clawed_back).void
-        end
       end
 
       it "returns total targeted delivery funding refundable" do
@@ -383,18 +389,19 @@ RSpec.describe Statements::SummaryCalculator do
         lead_provider:,
         eligible_for_funding: true,
         targeted_delivery_funding_eligibility: true,
+        cohort:,
       )
     end
 
-    let!(:to_be_awaiting_clawed_back) do
-      travel_to create(:statement, :next_output_fee, deadline_date: statement.deadline_date - 1.month, lead_provider:).deadline_date do
+    before do
+      earlier_statement = create(:statement, :next_output_fee, deadline_date: statement.deadline_date - 1.month, lead_provider:)
+
+      awaiting_clawback = travel_to(earlier_statement.deadline_date) do
         create(:declaration, :paid, declaration_type:, application:, lead_provider:, statement:)
       end
-    end
 
-    before do
       travel_to statement.deadline_date do
-        Declarations::Void.new(declaration: to_be_awaiting_clawed_back).void
+        Declarations::Void.new(declaration: awaiting_clawback).void || raise("Could not void")
       end
     end
 

--- a/spec/services/statements/summary_calculator_spec.rb
+++ b/spec/services/statements/summary_calculator_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Statements::SummaryCalculator do
 
         travel_to 1.month.from_now do
           create(:statement, :next_output_fee, lead_provider:, cohort: application.cohort)
-          Declarations::Void.new(declaration: awaiting_clawback).void || raise("Failed to void")
+          Declarations::Void.new(declaration: awaiting_clawback).void || raise("Could not void")
         end
       end
 


### PR DESCRIPTION
### Context

Ticket: [CPDNPQ-3193](https://dfedigital.atlassian.net/browse/CPDNPQ-3193)

Our specs are failing on `main`

### Changes proposed in this pull request

1. Fixes to various specs which were relying on `create(:cohort, :current)` to always return the same value which isn't true if things like `travel_to` are used
2. Refactored some of the specs to improve readability and clarify why some specs were failing
3. Explicitly fail if the `void` service silently with invalid data

[CPDNPQ-3193]: https://dfedigital.atlassian.net/browse/CPDNPQ-3193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ