### PR TITLE
[CPDNPQ-2706] download contracts CSV

### DIFF
--- a/app/controllers/npq_separation/admin/cohorts_controller.rb
+++ b/app/controllers/npq_separation/admin/cohorts_controller.rb
@@ -48,6 +48,10 @@ class NpqSeparation::Admin::CohortsController < NpqSeparation::AdminController
     end
   end
 
+  def download_contracts
+    send_data Exporters::Contracts.new(cohort:).call, filename: "#{cohort.start_year}_cohort_contracts.csv", type: :csv
+  end
+
 private
 
   def cohort_params

--- a/app/controllers/npq_separation/admin/cohorts_controller.rb
+++ b/app/controllers/npq_separation/admin/cohorts_controller.rb
@@ -64,7 +64,8 @@ private
 
   def ensure_super_admin
     unless current_admin.super_admin?
-      flash[:error] = "You must be a super admin to change cohorts"
+      action = action_name == "download_contracts" ? "download contracts" : "change cohorts"
+      flash[:error] = "You must be a super admin to #{action}"
       redirect_to action: :index
     end
   end

--- a/app/services/exporters/contracts.rb
+++ b/app/services/exporters/contracts.rb
@@ -1,0 +1,46 @@
+class Exporters::Contracts
+  FIELD_NAMES =
+    %w[
+      lead_provider_name
+      course_identifier
+      recruitment_target
+      per_participant
+      service_fee_installments
+      special_course
+      monthly_service_fee
+    ].freeze
+  # technically service_fee_installments and monthly_service_fee are not used, but have been uploaded previously
+  # monthly_service_fee, output_payment_percentage, number_of_payment_periods, service_fee_installments and service_fee_percentage will be removed in CPDNPQ-2927
+
+  def initialize(cohort:)
+    @cohort = cohort
+  end
+
+  def call
+    CSV.generate(encoding: "utf-8") do |csv|
+      csv << FIELD_NAMES
+      query.each do |record|
+        csv << FIELD_NAMES.map { |field| record.attributes[field] }
+      end
+    end
+  end
+
+private
+
+  attr_reader :cohort
+
+  def query
+    ContractTemplate
+      .joins(contracts: [{ statement: :lead_provider }, :course])
+      .where(statements: { cohort: })
+      .select(
+        "lead_providers.name as lead_provider_name",
+        "courses.identifier as course_identifier",
+        :recruitment_target,
+        :per_participant,
+        :service_fee_installments,
+        :special_course,
+        :monthly_service_fee,
+      ).distinct
+  end
+end

--- a/app/services/one_off/update_contracts.rb
+++ b/app/services/one_off/update_contracts.rb
@@ -5,7 +5,7 @@ module OneOff
 
       ActiveRecord::Base.transaction do
         csv_file.each do |row|
-          lead_provider = LeadProvider.find_by!(name: row["provider_name"])
+          lead_provider = LeadProvider.find_by!(name: row["lead_provider_name"])
           cohort = Cohort.find_by!(start_year: cohort_year)
           course = Course.find_by!(identifier: row["course_identifier"])
 

--- a/app/services/statements/bulk_creator/contract_row.rb
+++ b/app/services/statements/bulk_creator/contract_row.rb
@@ -7,25 +7,25 @@ module Statements
       CONTRACT_TEMPLATE_ATTRIBUTES = %w[
         recruitment_target
         per_participant
+        service_fee_installments
         special_course
         monthly_service_fee
-        service_fee_installments
       ].freeze
 
       attribute :lead_provider_name, :string
       attribute :course_identifier, :string
       attribute :recruitment_target, :strict_integer
       attribute :per_participant, :strict_decimal, default: nil
+      attribute :service_fee_installments, :strict_integer, default: nil
       attribute :special_course, :boolean, default: false
       attribute :monthly_service_fee, :strict_decimal, default: nil
-      attribute :service_fee_installments, :strict_integer, default: nil
 
       validates :lead_provider_name, inclusion: { in: -> { LeadProvider.pluck(:name) } }
       validates :course_identifier, inclusion: { in: -> { Course.pluck(:identifier) } }
       validates :recruitment_target, numericality: { greater_than: 0 }
       validates :per_participant, numericality: { greater_than: 0 }
-      validates :monthly_service_fee, numericality: { greater_than_or_equal_to: 0 }
       validates :service_fee_installments, numericality: { greater_than_or_equal_to: 0 }
+      validates :monthly_service_fee, numericality: { greater_than_or_equal_to: 0 }
 
       def self.example_csv
         <<~CSV.strip

--- a/app/views/npq_separation/admin/cohorts/show.html.erb
+++ b/app/views/npq_separation/admin/cohorts/show.html.erb
@@ -23,6 +23,7 @@
   <%= govuk_button_link_to('Edit cohort details', edit_npq_separation_admin_cohort_path(@cohort)) %>
   <%= govuk_button_link_to('Delete cohort', npq_separation_admin_cohort_path(@cohort), method: :delete, warning: true) %>
   <%= govuk_button_link_to('Create statements', new_npq_separation_admin_cohort_statement_path(@cohort), secondary: true) %>
+  <%= govuk_button_link_to('Download contracts CSV', download_contracts_npq_separation_admin_cohort_path(@cohort), secondary: true) %>
 <% end %>
 
 <hr class="govuk-section-break govuk-section-break--l">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -245,6 +245,7 @@ Rails.application.routes.draw do
       resources :cohorts do
         resources :schedules, except: :index
         resources :statements, only: %i[new create show]
+        member { get :download_contracts, path: "download-contracts" }
       end
 
       resources :delivery_partners, path: "delivery-partners", except: %i[show destroy] do

--- a/spec/features/npq_separation/admin/creating_statements_spec.rb
+++ b/spec/features/npq_separation/admin/creating_statements_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Creating statements", type: :feature do
   include Helpers::AdminLogin
+  include Helpers::FileHelper
   include Helpers::StatementsHelper
 
   let(:cohort) { create(:cohort) }
@@ -72,10 +73,7 @@ RSpec.feature "Creating statements", type: :feature do
       click_on "Download empty statements template"
 
       csv_file = "#{Capybara.save_path}/statements.csv"
-      1.upto(50) do
-        sleep 0.1
-        break if File.exist?(csv_file)
-      end
+      wait_for_file_to_be_created(csv_file)
       csv = CSV.read(csv_file)
       expect(csv.count).to eq(1)
 
@@ -83,12 +81,14 @@ RSpec.feature "Creating statements", type: :feature do
       click_on "Download empty contracts template"
 
       csv_file = "#{Capybara.save_path}/contracts.csv"
-      1.upto(50) do
-        sleep 0.1
-        break if File.exist?(csv_file)
-      end
+      wait_for_file_to_be_created(csv_file)
       csv = CSV.read(csv_file)
       expect(csv.count).to eq(1)
+
+      visit npq_separation_admin_cohort_path(cohort)
+      click_on "Download contracts CSV"
+      csv_file = "#{Capybara.save_path}/contracts.csv"
+      wait_for_file_to_be_created(csv_file)
     end
   end
 end

--- a/spec/requests/npq_separation/admin/cohorts_controller_spec.rb
+++ b/spec/requests/npq_separation/admin/cohorts_controller_spec.rb
@@ -88,11 +88,11 @@ RSpec.describe NpqSeparation::Admin::CohortsController, :ecf_api_disabled, type:
   context "when logged in as normal admin" do
     before { sign_in_as_admin }
 
-    shared_examples "inaccessible to normal admins" do
+    shared_examples "inaccessible to normal admins" do |error_message: "You must be a super admin to change cohorts"|
       it { is_expected.to redirect_to npq_separation_admin_cohorts_path }
 
       it "flashes the correct error" do
-        expect(flash[:error]).to match(/You must be a super admin to change cohorts/i)
+        expect(flash[:error]).to match(/#{error_message}/i)
       end
     end
 
@@ -137,6 +137,12 @@ RSpec.describe NpqSeparation::Admin::CohortsController, :ecf_api_disabled, type:
 
       it_behaves_like "inaccessible to normal admins"
     end
+
+    describe "#download_contracts" do
+      before { get download_contracts_npq_separation_admin_cohort_path(cohort) }
+
+      it_behaves_like "inaccessible to normal admins", error_message: "You must be a super admin to download contracts"
+    end
   end
 
   context "when not logged in" do
@@ -178,6 +184,12 @@ RSpec.describe NpqSeparation::Admin::CohortsController, :ecf_api_disabled, type:
 
     describe "#destroy" do
       before { delete npq_separation_admin_cohort_path(cohort) }
+
+      it { is_expected.to redirect_to sign_in_path }
+    end
+
+    describe "#download_contracts" do
+      before { get download_contracts_npq_separation_admin_cohort_path(cohort) }
 
       it { is_expected.to redirect_to sign_in_path }
     end

--- a/spec/services/exporters/contracts_spec.rb
+++ b/spec/services/exporters/contracts_spec.rb
@@ -1,0 +1,72 @@
+require "rails_helper"
+
+RSpec.describe Exporters::Contracts do
+  subject { described_class.new(cohort:).call }
+
+  let(:lead_provider) { create(:lead_provider, name: "Some Lead Provider") }
+  let(:lead_provider_2) { create(:lead_provider, name: "Another Provider") }
+  let(:course) { create(:course, :early_years_leadership) }
+  let(:course_2) { create(:course, :senior_leadership) }
+
+  let(:cohort) { create(:cohort, :current) }
+  let(:statement) { create(:statement, cohort:, lead_provider:) }
+  let(:statement_2) { create(:statement, cohort:, lead_provider:) }
+  let(:statement_3_different_lead_provider) { create(:statement, cohort:, lead_provider: lead_provider_2) }
+
+  let(:other_cohort) { create(:cohort, :previous) }
+  let(:statement_other_cohort) { create(:statement, cohort: other_cohort) }
+
+  let(:contract_template) { create(:contract_template) }
+  let(:duplicate_contract_template) { create(:contract_template) } # yes, there are duplicate contracts templates in production
+  let(:contract_template_2) { create(:contract_template, per_participant: 801) }
+  let(:other_cohort_contract_template) { create(:contract_template, per_participant: 802) }
+
+  before do
+    create(:contract, statement:, course:, contract_template:)
+    create(:contract, statement: statement_2, course:, contract_template: duplicate_contract_template)
+    create(:contract, statement: statement_other_cohort, course:, contract_template: other_cohort_contract_template)
+    create(:contract, statement:, course: course_2, contract_template: contract_template_2)
+    create(:contract, statement: statement_3_different_lead_provider, course:, contract_template:)
+  end
+
+  it "generates a CSV with the correct header" do
+    expect(subject.lines[0]).to eq "#{Exporters::Contracts::FIELD_NAMES.join(",")}\n"
+  end
+
+  it "generates a CSV of contracts" do
+    expect(subject.lines.count).to eq(4) # header + contact_template for lead_provider + contract_template for lead_provider_2 + contract_template_2 for lead_provider_2
+
+    # contract_template_2 for lead_provider
+    expect(subject.lines[3].chomp).to eq [
+      "Some Lead Provider",
+      course_2.identifier,
+      contract_template_2.recruitment_target,
+      contract_template_2.per_participant,
+      contract_template_2.service_fee_installments,
+      contract_template_2.special_course,
+      contract_template_2.monthly_service_fee,
+    ].join(",")
+
+    # contact_template for lead_provider
+    expect(subject.lines[2].chomp).to eq [
+      "Some Lead Provider",
+      course.identifier,
+      contract_template.recruitment_target,
+      contract_template.per_participant,
+      contract_template.service_fee_installments,
+      contract_template.special_course,
+      contract_template.monthly_service_fee,
+    ].join(",")
+
+    # contract_template for lead_provider_2
+    expect(subject.lines[1].chomp).to eq [
+      "Another Provider",
+      course.identifier,
+      contract_template.recruitment_target,
+      contract_template.per_participant,
+      contract_template.service_fee_installments,
+      contract_template.special_course,
+      contract_template.monthly_service_fee,
+    ].join(",")
+  end
+end

--- a/spec/services/one_off/update_contracts_spec.rb
+++ b/spec/services/one_off/update_contracts_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe OneOff::UpdateContracts do
     let(:csv_path) { csv_file.path }
     let(:csv_content) do
       <<~CSV
-        provider_name,course_identifier,per_participant
+        lead_provider_name,course_identifier,per_participant
         Provider 1,#{Course::NPQ_SENCO},1000
         Provider 2,#{Course::NPQ_HEADSHIP},2000
       CSV
@@ -49,7 +49,7 @@ RSpec.describe OneOff::UpdateContracts do
       describe "logs" do
         let(:csv_content) do
           <<~CSV
-            provider_name,course_identifier,per_participant
+            lead_provider_name,course_identifier,per_participant
             Provider 1,#{Course::NPQ_SENCO},1000
           CSV
         end

--- a/spec/support/helpers/file_helper.rb
+++ b/spec/support/helpers/file_helper.rb
@@ -1,0 +1,11 @@
+module Helpers
+  module FileHelper
+    def wait_for_file_to_be_created(filename)
+      1.upto(50) do
+        sleep 0.1
+        break if File.exist?(filename)
+      end
+      fail "File #{filename} was not created" unless File.exist?(filename)
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2706

### Changes proposed in this pull request
* allow contracts CSV to be download via the admin console - via the cohort screens
* update our `OneOff::UpdateContracts` which is used in rake tasks to support the same CSV headers as we use for creating contracts via the admin console.
