### PR TITLE
[CPDNPQ-2722] delivery partner name similarity matching

### DIFF
--- a/app/controllers/npq_separation/admin/delivery_partners_controller.rb
+++ b/app/controllers/npq_separation/admin/delivery_partners_controller.rb
@@ -1,4 +1,9 @@
 class NpqSeparation::Admin::DeliveryPartnersController < NpqSeparation::AdminController
+  before_action :set_similarly_named_delivery_partners, only: %i[create continue]
+  before_action :set_existing_delivery_partner, only: %i[edit update]
+  before_action :set_new_delivery_partner, only: %i[create continue]
+  before_action :set_continue_form, only: %i[create continue]
+
   def index
     @pagy, @delivery_partners = pagy(scope, limit: 10)
   end
@@ -7,11 +12,19 @@ class NpqSeparation::Admin::DeliveryPartnersController < NpqSeparation::AdminCon
     @delivery_partner = DeliveryPartner.new
   end
 
-  def create
-    @delivery_partner = DeliveryPartner.new(delivery_partners_params)
+  def continue
+    if @continue_form.valid?
+      save_delivery_partner if @continue_form.continue?
+      redirect_to action: :index
+    else
+      render :similar, status: :unprocessable_entity
+    end
+  end
 
-    if @delivery_partner.save
-      flash[:success] = "Delivery partner created"
+  def create
+    if @delivery_partner.name.present? && DeliveryPartner.name_similar_to(@delivery_partner.name).any?
+      render :similar
+    elsif save_delivery_partner
       redirect_to action: :index
     else
       render :new
@@ -19,12 +32,10 @@ class NpqSeparation::Admin::DeliveryPartnersController < NpqSeparation::AdminCon
   end
 
   def edit
-    @delivery_partner = DeliveryPartner.find(params[:id])
+    # empty method, because rubocop will complain in the before_action otherwise
   end
 
   def update
-    @delivery_partner = DeliveryPartner.find(params[:id])
-
     if @delivery_partner.update(delivery_partners_params)
       flash[:success] = "Delivery partner updated"
       redirect_to action: :index
@@ -34,6 +45,12 @@ class NpqSeparation::Admin::DeliveryPartnersController < NpqSeparation::AdminCon
   end
 
 private
+
+  def save_delivery_partner
+    @delivery_partner.save.tap do |success| # rubocop:disable Rails/SaveBang - result of save is used by caller
+      flash[:success] = "Delivery partner created" if success
+    end
+  end
 
   def delivery_partners_params
     params.require(:delivery_partner).permit(
@@ -47,7 +64,29 @@ private
     )
   end
 
+  def continue_params
+    params.permit(continue_form: [:continue])[:continue_form] || {}
+  end
+
   def scope
     AdminService::DeliveryPartnersSearch.new(q: params[:q]).call
+  end
+
+  def set_existing_delivery_partner
+    @delivery_partner = DeliveryPartner.find(params[:id])
+  end
+
+  def set_new_delivery_partner
+    @delivery_partner = DeliveryPartner.new(delivery_partners_params)
+  end
+
+  def set_similarly_named_delivery_partners
+    return [] if params.dig(:delivery_partner, :name).blank?
+
+    @similarly_named_delivery_partners = DeliveryPartner.name_similar_to(params.dig(:delivery_partner, :name))
+  end
+
+  def set_continue_form
+    @continue_form = Admin::DeliveryPartners::ContinueForm.new(continue_params)
   end
 end

--- a/app/forms/admin/delivery_partners/continue_form.rb
+++ b/app/forms/admin/delivery_partners/continue_form.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Admin::DeliveryPartners
+  class ContinueForm
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :continue
+    attribute :delivery_partner
+
+    validates_inclusion_of :continue, in: %w[yes no]
+
+    def continue?
+      continue == "yes"
+    end
+  end
+end

--- a/app/models/delivery_partner.rb
+++ b/app/models/delivery_partner.rb
@@ -1,4 +1,9 @@
 class DeliveryPartner < ApplicationRecord
+  scope :name_similar_to, ->(name) { wildcard_search(name).or(levenshtein_name_search(name)).where.not(name:) }
+  scope :levenshtein_name_search, ->(name) { where("levenshtein(name, ?) <= 4", name) }
+  scope :contains, ->(name) { where("name ILIKE ?", "%#{name}%") }
+  scope :begins_with, ->(name) { where("name ILIKE ?", "#{name}%") }
+
   has_many :delivery_partnerships
   has_many :lead_providers, through: :delivery_partnerships
   has_many :cohorts, through: :delivery_partnerships
@@ -7,6 +12,16 @@ class DeliveryPartner < ApplicationRecord
 
   validates :ecf_id, uniqueness: { case_sensitive: false }
   validates :name, presence: true, uniqueness: { case_sensitive: false }
+
+  def self.wildcard_search(name)
+    name_begins_with_the = name.match(/^The (.*)/)
+    scope = if name_begins_with_the
+              begins_with("The #{name.split.second}").or(begins_with(name_begins_with_the[1].split.first))
+            else
+              begins_with(name.split.first).or(begins_with("The #{name.split.first}"))
+            end
+    scope.or(contains(name))
+  end
 
   def declarations
     Declaration.for_delivery_partners(self)

--- a/app/services/admin_service/delivery_partners_search.rb
+++ b/app/services/admin_service/delivery_partners_search.rb
@@ -6,7 +6,7 @@ class AdminService::DeliveryPartnersSearch
   end
 
   def call
-    default_scope.where("name ILIKE ?", "%#{q}%")
+    default_scope.contains(q)
   end
 
 private

--- a/app/views/npq_separation/admin/delivery_partners/similar.html.erb
+++ b/app/views/npq_separation/admin/delivery_partners/similar.html.erb
@@ -1,0 +1,22 @@
+<%= govuk_back_link href: new_npq_separation_admin_delivery_partner_path %>
+
+<h1 class="govuk-heading-l govuk-!-margin-top-6">We found similar delivery partners</h1>
+
+<p class="govuk-body">The following delivery partners have similar names to <strong><%= @delivery_partner.name %></strong>:</p>
+
+<%= govuk_list @similarly_named_delivery_partners.map(&:name), type: :bullet %>
+
+<%= form_for @continue_form, url: continue_npq_separation_admin_delivery_partners_path(@delivery_partner), as: :continue_form do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= f.govuk_radio_buttons_fieldset :continue, legend: { text: "Are you sure you want to add '#{@delivery_partner.name}'?", tag: 'h1', size: 'm' } do %>
+    <%= f.govuk_radio_button :continue, "yes", label: { text: "Yes" }, link_errors: true %>
+    <%= f.govuk_radio_button :continue, "no", label: { text: "No" } %>
+  <% end %>
+  <%= hidden_field_tag "delivery_partner[name]",  @delivery_partner.name %>
+
+  <div class="govuk-button-group">
+    <%= f.govuk_submit %>
+    <%= govuk_link_to "Cancel", npq_separation_admin_delivery_partners_path %>
+  </div>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -308,6 +308,10 @@ en:
           attributes:
             add_another:
               inclusion: Select if you need to add another adjustment
+        admin/delivery_partners/continue_form:
+          attributes:
+            continue:
+              inclusion: Select ‘Yes’ or ‘No’ to continue
         applications/change_training_status:
           attributes:
             training_status:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -250,6 +250,9 @@ Rails.application.routes.draw do
 
       resources :delivery_partners, path: "delivery-partners", except: %i[show destroy] do
         resource :delivery_partnerships, path: "delivery-partnerships", only: :edit
+        collection do
+          post :continue
+        end
       end
 
       resources :schools, only: %i[index show]

--- a/db/migrate/20250910144739_install_fuzzy_str_match_extension.rb
+++ b/db/migrate/20250910144739_install_fuzzy_str_match_extension.rb
@@ -1,0 +1,5 @@
+class InstallFuzzyStrMatchExtension < ActiveRecord::Migration[7.2]
+  def change
+    enable_extension "fuzzystrmatch"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_08_162110) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_10_144739) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
+  enable_extension "fuzzystrmatch"
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
 

--- a/spec/forms/admin/delivery_partners/continue_form_spec.rb
+++ b/spec/forms/admin/delivery_partners/continue_form_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::DeliveryPartners::ContinueForm, type: :model do
+  subject(:form) { described_class.new(delivery_partner:, continue:) }
+
+  let(:delivery_partner) { create(:delivery_partner) }
+  let(:continue) { "no" }
+
+  describe "validations" do
+    it { is_expected.to validate_inclusion_of(:continue).in_array(%w[yes no]) }
+  end
+
+  describe "#continue?" do
+    subject(:continue) { form.continue? }
+
+    context "when continue is 'yes'" do
+      let(:continue) { "yes" }
+
+      it { is_expected.to be true }
+    end
+
+    context "when continue is 'no'" do
+      let(:continue) { "no" }
+
+      it { is_expected.to be false }
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2722

### Changes proposed in this pull request
* when creating a delivery partner, check for similar matching names
* methods used to match:
  * wildcard match using first word (with and without any leading 'The')
  * wildcard match using '%name%' - same method used in delivery partner search
  * levenshtein match - for any typos
