### PR TITLE
Remove bundler jobs limit (use default nproc)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN bundler -v && \
     bundle config set no-cache 'true' && \
     bundle config set no-binstubs 'true' && \
     bundle config without ${BUNDLE_WITHOUT} && \
-    bundle install --retry=5 --jobs=4 && \
+    bundle install --retry=5 && \
     rm -rf /usr/local/bundle/cache
 
 # Install node packages defined in package.json, including webpack


### PR DESCRIPTION
### Context

https://dfedigital.atlassian.net/browse/CPDNPQ-3222

Bundler docs:

> --jobs=<number>, -j=<number>
> The maximum number of parallel download and install jobs. The default is the number of available processors.

There's no reason to cap this at 4. Using all available cores should speed up `docker build`, especially for native extensions.