### PR TITLE
[CPDNPQ-2604] Remove PR trigger from verify external links

### DIFF
--- a/.github/workflows/verify_external_links.yml
+++ b/.github/workflows/verify_external_links.yml
@@ -4,11 +4,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 4 * * *" # 4am every day
-  # remove below after PR approval: it's needed to show up as a
-  # workflow_dispatch action before merging, but in practice external service
-  # status should not fail/block our PRs
-  pull_request:
-    branches: [ main ]
 
 env:
   RAILS_ENV: staging


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2604

Now that this branch has been merged, we no longer need the `pull_request` workflow trigger (and in fact we don't want this to block PRs).