### PR TITLE
[CPDNPQ-3224] stop PII leaking into logs from webhook job logging

### DIFF
--- a/app/jobs/stream_api_requests_to_big_query_job.rb
+++ b/app/jobs/stream_api_requests_to_big_query_job.rb
@@ -3,6 +3,8 @@ require "google/cloud/bigquery"
 class StreamAPIRequestsToBigQueryJob < ApplicationJob
   include ActionController::HttpAuthentication::Token
 
+  self.log_arguments = false
+
   queue_as :low_priority
 
   def perform(request_data, response_data, status_code, created_at)


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-3224

### Changes proposed in this pull request
* stop logging the job arguments for `StreamAPIRequestsToBigQueryJob` - it seems redundant - the same parameters end up in BigQuery anyway
