### PR TITLE
[CPDNPQ-2722] add fuzzystrmatch to whitelist of postgres extensions

### DIFF
--- a/terraform/application/database.tf
+++ b/terraform/application/database.tf
@@ -36,7 +36,7 @@ module "postgres" {
   azure_enable_monitoring        = var.enable_monitoring
   azure_enable_backup_storage    = var.enable_postgres_backup_storage
   server_version                 = "14"
-  azure_extensions               = ["btree_gin", "citext", "pg_trgm"]
+  azure_extensions               = ["btree_gin", "citext", "fuzzystrmatch", "pg_trgm"]
   azure_enable_high_availability = var.postgres_enable_high_availability
   azure_sku_name                 = var.postgres_flexible_server_sku
   azure_maintenance_window       = var.azure_maintenance_window


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2722

### Changes proposed in this pull request

Need to add `fuzzystrmatch` to this list, otherwise deployments fail with:
```
PG::FeatureNotSupported: ERROR: extension "fuzzystrmatch" is not allow-listed for users in Azure Database for PostgreSQL (PG::FeatureNotSupported)
```