### PR TITLE
[CPDNPQ-3238] Prevent possible funding #previous_step exception

### DIFF
--- a/app/forms/questionnaires/possible_funding.rb
+++ b/app/forms/questionnaires/possible_funding.rb
@@ -7,7 +7,7 @@ module Questionnaires
     end
 
     def previous_step
-      if course.npqlpm?
+      if course.try(:npqlpm?)
         if maths_understanding?
           :maths_eligibility_teaching_for_mastery
         else


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-3238

As per https://dfe-teacher-services.sentry.io/issues/6883382844/?alert_rule_id=14507801&alert_type=issue&notification_uuid=3811b956-9fa7-4472-b207-8308fda8bcfd&project=5817541 if you visit the `possible-funding` registration step without having set `course_identifier` in your store, an exception will be raised in `#previous_step`.

This PR prevents that exception and adds test coverage of the `previous_step` method.