### PR TITLE
Add optional application_id attribute to V3 api declaration create request

### DIFF
--- a/app/controllers/api/v3/declarations_controller.rb
+++ b/app/controllers/api/v3/declarations_controller.rb
@@ -68,7 +68,8 @@ module API
                   :course_identifier,
                   :has_passed,
                   :delivery_partner_id,
-                  :secondary_delivery_partner_id)
+                  :secondary_delivery_partner_id,
+                  :application_id)
           .merge(
             lead_provider: current_lead_provider,
           )

--- a/app/services/declarations/create.rb
+++ b/app/services/declarations/create.rb
@@ -13,6 +13,7 @@ module Declarations
     attribute :has_passed
     attribute :delivery_partner_id
     attribute :secondary_delivery_partner_id
+    attribute :application_id
 
     validates :lead_provider, presence: true
     validates :participant_id, presence: true, participant_id_change: true
@@ -33,6 +34,7 @@ module Declarations
     validate :delivery_partner_exists, if: :delivery_partner_id
     validate :secondary_delivery_partner_exists, if: :secondary_delivery_partner_id
     validate :declaration_valid
+    validate :application_exists
 
     attr_reader :raw_declaration_date, :declaration
 
@@ -61,12 +63,16 @@ module Declarations
     end
 
     def application
-      @application ||= participant
+      scope = participant
         &.applications
         &.accepted
         &.includes(:course)
         &.order(created_at: :desc, id: :desc)
-        &.find_by(lead_provider:, course: Course.find_by(identifier: course_identifier)&.rebranded_alternative_courses)
+      @application ||= if application_id.present?
+        scope&.find_by(ecf_id: application_id, lead_provider:, course: Course.find_by(identifier: course_identifier)&.rebranded_alternative_courses)
+      else
+        scope&.find_by(lead_provider:, course: Course.find_by(identifier: course_identifier)&.rebranded_alternative_courses)
+      end
     end
 
     def participant
@@ -222,6 +228,14 @@ module Declarations
       return if DeliveryPartner.exists?(ecf_id: secondary_delivery_partner_id)
 
       errors.add(:secondary_delivery_partner_id, :not_found)
+    end
+
+    def application_exists
+      return if application_id.nil?
+
+      if application.nil?
+        errors.add(:application_id, :application_not_found)
+      end
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -601,6 +601,8 @@ en:
               missing_contract_for_cohort_and_course: You cannot submit a declaration for this participant as you do not have a contract for the cohort and course. Contact the DfE for assistance.
             application:
               application_schedule_missing: The application is missing a schedule.
+            application_id:
+              application_not_found: "Your update cannot be made as an accepted application cannot be found for the given '#/application_id'."
             delivery_partner_id:
               not_found: The property '#/delivery_partner_id' does not exist
             secondary_delivery_partner_id:

--- a/public/api/docs/v3/swagger.yaml
+++ b/public/api/docs/v3/swagger.yaml
@@ -214,7 +214,7 @@ paths:
                         teacher_catchment_iso_country_code: GBR
                         itt_provider: University of Southampton
                         lead_mentor: true
-                        funded_place:
+                        funded_place: 
                         created_at: '2021-05-31T02:21:32.000Z'
                         updated_at: '2021-05-31T02:22:32.000Z'
                         schedule_identifier: npq-aso-march
@@ -451,9 +451,9 @@ paths:
                         course_identifier: npq-senior-leadership
                         declaration_date: '2021-05-31T02:22:32Z'
                         state: voided
-                        has_passed:
+                        has_passed: 
                         statement_id: cd3a12347-7308-4879-942a-c4a70ced400a
-                        clawback_statement_id:
+                        clawback_statement_id: 
                         uplift_paid: true
                         lead_provider_name: Example Institute
                         ineligible_for_funding_reason: duplicate_declaration
@@ -793,8 +793,8 @@ paths:
                           targeted_delivery_funding_eligibility: true
                           funded_place: true
                           email: isabelle.macdonald2@some-school.example.com
-                          withdrawal:
-                          deferral:
+                          withdrawal: 
+                          deferral: 
                           created_at: '2021-05-31T02:21:32.000Z'
                         participant_id_changes:
                         - from_participant_id: 23dd8d66-e11f-4139-9001-86b4f9abcb02
@@ -871,7 +871,7 @@ paths:
                           targeted_delivery_funding_eligibility: true
                           funded_place: true
                           email: isabelle.macdonald2@some-school.example.com
-                          withdrawal:
+                          withdrawal: 
                           deferral:
                             reason: bereavement
                             date: '2021-05-31T02:22:32.000Z'
@@ -954,7 +954,7 @@ paths:
                           withdrawal:
                             reason: insufficient-capacity-to-undertake-programme
                             date: '2021-05-31T02:22:32.000Z'
-                          deferral:
+                          deferral: 
                           created_at: '2021-05-31T02:21:32.000Z'
                         participant_id_changes:
                         - from_participant_id: 23dd8d66-e11f-4139-9001-86b4f9abcb02
@@ -1516,7 +1516,7 @@ components:
                 being funded by DfE
               nullable: true
               type: boolean
-              example:
+              example: 
             created_at:
               description: The date the application was created
               type: string
@@ -1787,7 +1787,7 @@ components:
                     required:
                     - reason
                     - date
-                    example:
+                    example: 
                     properties:
                       reason:
                         description: The reason a participant was withdrawn
@@ -1825,7 +1825,7 @@ components:
                     required:
                     - reason
                     - date
-                    example:
+                    example: 
                     properties:
                       reason:
                         description: The reason a participant was deferred
@@ -2430,7 +2430,7 @@ components:
             has_passed:
               description: Whether the participant has failed or passed
               type: string
-              example:
+              example: 
               nullable: true
             statement_id:
               description: Unique ID of the statement the declaration will be paid

--- a/spec/requests/api/v3/declarations_spec.rb
+++ b/spec/requests/api/v3/declarations_spec.rb
@@ -136,5 +136,22 @@ RSpec.describe "Declaration endpoints", type: :request do
     let(:resource_name) { :declaration }
 
     it_behaves_like "an API create endpoint"
+
+    context "when optional application_id param is included" do
+      let(:attributes) do
+        {
+          participant_id:,
+          declaration_type:,
+          declaration_date:,
+          course_identifier:,
+          has_passed:,
+          delivery_partner_id:,
+          secondary_delivery_partner_id:,
+          application_id: application.ecf_id,
+        }
+      end
+
+      it_behaves_like "an API create endpoint"
+    end
   end
 end

--- a/spec/services/declarations/create_spec.rb
+++ b/spec/services/declarations/create_spec.rb
@@ -431,6 +431,39 @@ RSpec.describe Declarations::Create, type: :model do
 
         expect(declaration.application).to eq(newer_application)
       end
+
+      context "when application id is provided" do
+        let(:application_id) { application.ecf_id }
+
+        let(:params_with_application_id) do
+          params.merge(application_id: )
+        end
+
+        subject { described_class.new(**params_with_application_id).create_declaration }
+
+        it "creates a declaration for the latest application" do
+          expect { subject }.to change(Declaration, :count).by(1)
+
+          expect(declaration.application).to eq(application)
+        end
+
+        context "when application_id is incorrect" do
+          subject { described_class.new(**params_with_application_id) }
+
+          context "when id does not exist" do
+            let(:application_id) { SecureRandom.uuid }
+
+            it { expect(subject).to have_error(:application_id, :application_not_found, "Your update cannot be made as an accepted application cannot be found for the given '#/application_id'.") }
+          end
+
+          context "when id does not belongs to participant" do
+            let(:other_application) { create(:application, :accepted, cohort:, course:, lead_provider:, schedule:) }
+            let(:application_id) { other_application.ecf_id }
+
+            it { expect(subject).to have_error(:application_id, :application_not_found, "Your update cannot be made as an accepted application cannot be found for the given '#/application_id'.") }
+          end
+        end
+      end
     end
 
     context "when there is already an older application with declarations" do

--- a/spec/swagger_schemas/requests/participant_declaration_completed_request.rb
+++ b/spec/swagger_schemas/requests/participant_declaration_completed_request.rb
@@ -51,6 +51,13 @@ PARTICIPANT_DECLARATION_COMPLETED_REQUEST = {
       nullable: false,
       example: true,
     },
+    application_id: {
+      description: "ID of application for declaration",
+      type: :string,
+      required: false,
+      nullable: true,
+      example: "f0de7abf-399b-4e68-83de-2c33b503810c",
+    }
   },
   example: {
     participant_id: "db3a7848-7308-4879-942a-c4a70ced400a",

--- a/spec/swagger_schemas/requests/participant_declaration_retained_request.rb
+++ b/spec/swagger_schemas/requests/participant_declaration_retained_request.rb
@@ -38,6 +38,13 @@ PARTICIPANT_DECLARATION_RETAINED_REQUEST = {
       enum: Course::IDENTIFIERS,
       example: Course::IDENTIFIERS.first,
     },
+    application_id: {
+      description: "ID of application for declaration",
+      type: :string,
+      required: false,
+      nullable: true,
+      example: "f0de7abf-399b-4e68-83de-2c33b503810c",
+    }
   },
   required: %i[
     participant_id

--- a/spec/swagger_schemas/requests/participant_declaration_started_request.rb
+++ b/spec/swagger_schemas/requests/participant_declaration_started_request.rb
@@ -37,6 +37,13 @@ PARTICIPANT_DECLARATION_STARTED_REQUEST = {
       enum: Course::IDENTIFIERS,
       example: Course::IDENTIFIERS.first,
     },
+    application_id: {
+      description: "ID of application for declaration",
+      type: :string,
+      required: false,
+      nullable: true,
+      example: "f0de7abf-399b-4e68-83de-2c33b503810c",
+    }
   },
   required: %i[
     participant_id


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-3144

### Changes proposed in this pull request

In some cases there could be 2 or more applications for given course. We would like to let LP choose an application in such case.