### PR TITLE
[CPDNPQ-2910] raise RoutingError when no template found

### DIFF
--- a/app/controllers/api/guidance_controller.rb
+++ b/app/controllers/api/guidance_controller.rb
@@ -11,6 +11,8 @@ module API
       @page = Guidance::GuidancePage.new(params[:page])
 
       render template: @page.template
+    rescue ActionView::MissingTemplate
+      raise ActionController::RoutingError, "Not Found"
     end
   end
 end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -30,6 +30,6 @@ class ErrorsController < PublicPagesController
 private
 
   def set_format
-    request.format = :json if request.original_fullpath =~ /^\/api\/v\d+/ && request.format.html?
+    request.format = :json if request.original_fullpath =~ %r{^/api/(?!docs|guidance)} && request.format.html?
   end
 end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -30,6 +30,6 @@ class ErrorsController < PublicPagesController
 private
 
   def set_format
-    request.format = :json if request.original_fullpath.start_with?("/api/") && request.format.html?
+    request.format = :json if request.original_fullpath =~ /^\/api\/v\d+/ && request.format.html?
   end
 end

--- a/spec/requests/api/errors_spec.rb
+++ b/spec/requests/api/errors_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Error responses", type: :request do
     end
 
     context "when the request is for a CSV" do
-      it "returns an plain text response" do
+      it "returns a plain text response" do
         api_get "/api/v2/thisdoesnotexist.csv"
         expect(response).to have_http_status(:not_found)
         expect(response.body).to be_empty
@@ -52,7 +52,7 @@ RSpec.describe "Error responses", type: :request do
     end
 
     context "when the request is for a CSV", skip: Rails.configuration.x.disable_legacy_api do
-      it "returns an plain text response" do
+      it "returns a plain text response" do
         api_get "/api/v2/npq-applications.csv"
         expect(response).to have_http_status(:internal_server_error)
         expect(response.body).to be_empty
@@ -74,7 +74,7 @@ RSpec.describe "Error responses", type: :request do
     end
 
     context "when the request is for a CSV", skip: Rails.configuration.x.disable_legacy_api do
-      it "returns an plain text response" do
+      it "returns a plain text response" do
         api_get "/api/v2/npq-applications.csv"
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.body).to be_empty

--- a/spec/requests/api/errors_spec.rb
+++ b/spec/requests/api/errors_spec.rb
@@ -19,6 +19,24 @@ RSpec.describe "Error responses", type: :request do
         expect(response.content_type).to match(/text\/plain.*/)
       end
     end
+
+    context "when the request is for API guidance docs" do
+      it "returns an HTML response" do
+        api_get "/api/guidance/thisdoesnotexist"
+        expect(response).to have_http_status(:not_found)
+        expect(response.body).to include "The page you were looking for doesn’t exist."
+        expect(response.content_type).to match(/text\/html.*/)
+      end
+    end
+
+    context "when the request is for API swagger docs" do
+      it "returns an HTML response" do
+        api_get "/api/docs/thisdoesnotexist"
+        expect(response).to have_http_status(:not_found)
+        expect(response.body).to include "The page you were looking for doesn’t exist."
+        expect(response.content_type).to match(/text\/html.*/)
+      end
+    end
   end
 
   describe "internal server error" do

--- a/spec/requests/api/guidance_controller_spec.rb
+++ b/spec/requests/api/guidance_controller_spec.rb
@@ -21,15 +21,15 @@ RSpec.describe API::GuidanceController do
     end
 
     context "with unknown page" do
-      let(:get_page) { get api_guidance_page_path(page: "unknown") }
+      before { get api_guidance_page_path(page: "unknown") }
 
-      it { expect { get_page }.to raise_exception ActionView::MissingTemplate }
+      it { is_expected.to have_http_status :missing }
     end
 
     context "with non-guidance page" do
-      let(:get_page) { get api_guidance_page_path(page: "../../errors/not_found") }
+      before { get api_guidance_page_path(page: "../../errors/not_found") }
 
-      it { expect { get_page }.to raise_exception ActionView::MissingTemplate }
+      it { is_expected.to have_http_status :missing }
     end
   end
 end

--- a/spec/requests/api/teacher_record_service/qualifications_spec.rb
+++ b/spec/requests/api/teacher_record_service/qualifications_spec.rb
@@ -44,6 +44,21 @@ RSpec.describe "Qualifications endpoint", type: :request do
           expect(response.content_type).to eql("application/json")
         end
       end
+
+      context "when there is an internal server error and the request was for HTML" do
+        include_context "when errors are rendered"
+
+        before do
+          allow(Qualifications::Query).to receive(:new).and_raise(StandardError)
+        end
+
+        it "returns a JSON error response" do
+          api_get("#{path}.html", token: "trs_token")
+          expect(response).to have_http_status(:internal_server_error)
+          expect(response.body).to eq %({"error":"Internal server error"})
+          expect(response.content_type).to eql("application/json")
+        end
+      end
     end
 
     context "when the TRN does not exist" do


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-2910

### Changes proposed in this pull request

- catch the `ActionView::MissingTemplate` for the `API::GuidanceController#show` and raise a `ActionController::RoutingError`, which results in a 404 response.
- make sure error pages for `/api/guidance/` and `/api/docs/` are in HTML not JSON.

