### PR TITLE
[CPDNPQ-3166] Show declaration delivery partners in admin

### DIFF
--- a/app/controllers/npq_separation/admin/applications_controller.rb
+++ b/app/controllers/npq_separation/admin/applications_controller.rb
@@ -11,7 +11,7 @@ class NpqSeparation::Admin::ApplicationsController < NpqSeparation::AdminControl
   def show
     @application = Application.find(params[:id])
     @declarations = @application.declarations
-                                .includes(:lead_provider, :cohort, :participant_outcomes, :statements)
+                                .includes(:lead_provider, :cohort, :participant_outcomes, :statements, :delivery_partner, :secondary_delivery_partner)
                                 .order(created_at: :asc, id: :asc)
   end
 

--- a/app/views/npq_separation/admin/applications/show.html.erb
+++ b/app/views/npq_separation/admin/applications/show.html.erb
@@ -169,6 +169,16 @@
         end
 
         sl.with_row do |row|
+          row.with_key(text: "Delivery partner")
+          row.with_value(text: declaration.delivery_partner.name)
+        end
+
+        sl.with_row do |row|
+          row.with_key(text: "Secondary delivery partner")
+          row.with_value(text: declaration.secondary_delivery_partner.try(:name))
+        end
+
+        sl.with_row do |row|
           row.with_key(text: "Created at")
           row.with_value(text: declaration.created_at.to_fs(:govuk_short))
         end

--- a/spec/factories/declarations.rb
+++ b/spec/factories/declarations.rb
@@ -73,5 +73,9 @@ FactoryBot.define do
     trait :with_delivery_partner do
       delivery_partner { create(:delivery_partner, lead_providers: { cohort => lead_provider }) }
     end
+
+    trait :with_secondary_delivery_partner do
+      secondary_delivery_partner { create(:delivery_partner, lead_providers: { cohort => lead_provider }) }
+    end
   end
 end

--- a/spec/features/npq_separation/admin/applications/applications_spec.rb
+++ b/spec/features/npq_separation/admin/applications/applications_spec.rb
@@ -206,7 +206,7 @@ RSpec.feature "Listing and viewing applications", type: :feature do
     visit(npq_separation_admin_applications_path)
 
     application = Application.order(created_at: :asc, id: :asc).first
-    started_declaration = create(:declaration, :from_ecf, application:)
+    started_declaration = create(:declaration, :from_ecf, :with_secondary_delivery_partner, application:)
     completed_declaration = create(:declaration, :completed, application:)
     payable_statement = create(:statement, :payable)
     payable_declaration = create(:declaration, :payable, application:, statement: payable_statement)
@@ -229,6 +229,8 @@ RSpec.feature "Listing and viewing applications", type: :feature do
         expect(summary_list).to have_summary_item("Declaration date", started_declaration.declaration_date.to_fs(:govuk_short))
         expect(summary_list).to have_summary_item("Declaration cohort", started_declaration.cohort.start_year)
         expect(summary_list).to have_summary_item("Provider", started_declaration.lead_provider.name)
+        expect(summary_list).to have_summary_item("Delivery partner", started_declaration.delivery_partner.name)
+        expect(summary_list).to have_summary_item("Secondary delivery partner", started_declaration.secondary_delivery_partner.name)
         expect(summary_list).to have_summary_item("Created at", started_declaration.created_at.to_fs(:govuk_short))
         expect(summary_list).to have_summary_item("Updated at", started_declaration.updated_at.to_fs(:govuk_short))
         expect(summary_list).to have_summary_item("Statements", "")
@@ -243,6 +245,8 @@ RSpec.feature "Listing and viewing applications", type: :feature do
         expect(summary_list).to have_summary_item("Declaration date", completed_declaration.declaration_date.to_fs(:govuk_short))
         expect(summary_list).to have_summary_item("Declaration cohort", completed_declaration.cohort.start_year)
         expect(summary_list).to have_summary_item("Provider", completed_declaration.lead_provider.name)
+        expect(summary_list).to have_summary_item("Delivery partner", completed_declaration.delivery_partner.name)
+        expect(summary_list).to have_summary_item("Secondary delivery partner", "")
         expect(summary_list).to have_summary_item("Created at", completed_declaration.created_at.to_fs(:govuk_short))
         expect(summary_list).to have_summary_item("Updated at", completed_declaration.updated_at.to_fs(:govuk_short))
         expect(summary_list).to have_summary_item("Statements", "")


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-3166

Show the delivery partner (and secondary delivery partner) when viewing an application's declarations in the admin console