### PR TITLE
[CPDNPQ-3260] Fix Admin::Applications#show not handling blank delivery partner

### DIFF
--- a/app/views/npq_separation/admin/applications/show.html.erb
+++ b/app/views/npq_separation/admin/applications/show.html.erb
@@ -170,12 +170,12 @@
 
         sl.with_row do |row|
           row.with_key(text: "Delivery partner")
-          row.with_value(text: declaration.delivery_partner.name)
+          row.with_value { declaration.delivery_partner&.name || tag.em("-") }
         end
 
         sl.with_row do |row|
           row.with_key(text: "Secondary delivery partner")
-          row.with_value(text: declaration.secondary_delivery_partner.try(:name))
+          row.with_value { declaration.secondary_delivery_partner&.name || tag.em("-") }
         end
 
         sl.with_row do |row|

--- a/spec/views/npq_separation/admin/applications/show.html.erb_spec.rb
+++ b/spec/views/npq_separation/admin/applications/show.html.erb_spec.rb
@@ -10,14 +10,21 @@ RSpec.describe "npq_separation/admin/applications/show.html.erb", type: :view do
     assign(:declarations, declarations)
   end
 
-  describe "a row for a full application" do
+  describe "a summary card for a full application" do
     let :application do
       build_stubbed :application, :accepted, :with_school
     end
 
     let :declarations do
-      build_stubbed_pair :declaration, application_id: application.id,
-                                       lead_provider: application.lead_provider
+      [
+        build_stubbed(:declaration, application_id: application.id,
+                                    lead_provider: application.lead_provider,
+                                    declaration_type: "started",
+                                    delivery_partner: nil),
+        build_stubbed(:declaration, application_id: application.id,
+                                    lead_provider: application.lead_provider,
+                                    declaration_type: "retained-1"),
+      ]
     end
 
     it { is_expected.to have_css(".govuk-caption-m", text: "#{application.user.full_name}, #{application.course.name}, #{application.created_at.to_date.to_fs(:govuk_short)}", normalize_ws: true) }
@@ -43,7 +50,7 @@ RSpec.describe "npq_separation/admin/applications/show.html.erb", type: :view do
     it { is_expected.not_to have_link(application.employer_name_to_display) }
   end
 
-  describe "a row for a minimal application" do
+  describe "a summary card for a minimal application" do
     let :application do
       build_stubbed :application, cohort: nil, itt_provider: nil, school: nil
     end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-3260

Delivery partner will not always be set and we shouldn't be assuming that it is

### Changes proposed in this pull request

1. Handle when delivery partner is nil
2. Generate declarations of both types in view specs