### PR TITLE
[BAU] Disable sonar scanner for now

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -142,7 +142,8 @@ jobs:
     name: Sonar Scanner
     runs-on: ubuntu-24.04
     needs: [ rspec, ruby_linting ]
-    if: github.ref != 'refs/heads/main' && github.actor != 'dependabot[bot]'
+    # if: github.ref != 'refs/heads/main' && github.actor != 'dependabot[bot]'
+    if: false
     environment:
       name: staging
     steps:


### PR DESCRIPTION
### Context

Ticket: BAU

Sonar scanner is currently broken and fixing it is going to require some investigation

### Changes proposed in this pull request

1. Temporarily disable it using the `if` clause in github actions