### PR TITLE
[CPDNPQ-3277] Fix tests that break on 1st October

### DIFF
--- a/spec/services/contracts/change_per_participant_spec.rb
+++ b/spec/services/contracts/change_per_participant_spec.rb
@@ -42,7 +42,8 @@ RSpec.describe Contracts::ChangePerParticipant, type: :model do
 
     context "when a statement is paid" do
       before do
-        create(:statement, :paid, lead_provider:, month: Time.zone.today.month + 3, year: Time.zone.today.year)
+        date = Time.zone.today + 3.months
+        create(:statement, :paid, lead_provider:, month: date.month, year: date.year)
       end
 
       it "does not allow changes" do

--- a/spec/services/statements/summary_calculator_spec.rb
+++ b/spec/services/statements/summary_calculator_spec.rb
@@ -348,6 +348,7 @@ RSpec.describe Statements::SummaryCalculator do
 
     context "with declaration" do
       before do
+        application.schedule.update! applies_from: statement.deadline_date - 1.month
         earlier_statement = create(:statement, :next_output_fee, deadline_date: statement.deadline_date - 1.month, lead_provider:)
 
         awaiting_clawback = travel_to(earlier_statement.deadline_date) do
@@ -394,6 +395,7 @@ RSpec.describe Statements::SummaryCalculator do
     end
 
     before do
+      application.schedule.update! applies_from: statement.deadline_date - 1.month
       earlier_statement = create(:statement, :next_output_fee, deadline_date: statement.deadline_date - 1.month, lead_provider:)
 
       awaiting_clawback = travel_to(earlier_statement.deadline_date) do

--- a/spec/support/helpers/bulk_operations.rb
+++ b/spec/support/helpers/bulk_operations.rb
@@ -19,7 +19,7 @@ module Helpers
 
         lead_provider = create(:lead_provider)
         delivery_partner = create(:delivery_partner)
-        schedule = create(:schedule, cohort:, course_group: course.course_group, allowed_declaration_types: %w[started completed])
+        schedule = create(:schedule, cohort:, course_group: course.course_group, allowed_declaration_types: %w[started completed], applies_from: Date.yesterday)
 
         # Create required contracts and partnerships
         statement = create(:statement, cohort:, lead_provider:)


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-3277

Some automated tests have failed because of the date rolling over to 1st October, e.g. [this Actions run](https://github.com/DFE-Digital/npq-registration/actions/runs/18157787353/)  

They must pass regardless of today’s date, otherwise CI fails and we can’t ship changes