### PR TITLE
[BAU] Remove old test environment links

### DIFF
--- a/app/views/api/guidance/test-environments.md
+++ b/app/views/api/guidance/test-environments.md
@@ -4,13 +4,7 @@ The test environments are used to test API integrations without affecting real d
 
 ## Test environment links
 
-We have test environments for each version of the API:
-
-* API v1:
-[https://npq-registration-sandbox-web.teacherservices.cloud/api/v1](https://npq-registration-sandbox-web.teacherservices.cloud/api/v1)
-
-* API v2:
-[https://npq-registration-sandbox-web.teacherservices.cloud/api/v2](https://npq-registration-sandbox-web.teacherservices.cloud/api/v2)
+We have a test environments for the API:
 
 * API v3:
 [https://npq-registration-sandbox-web.teacherservices.cloud/api/v3](https://npq-registration-sandbox-web.teacherservices.cloud/api/v3)

--- a/app/views/api/guidance/test-environments.md
+++ b/app/views/api/guidance/test-environments.md
@@ -4,7 +4,7 @@ The test environments are used to test API integrations without affecting real d
 
 ## Test environment links
 
-We have a test environments for the API:
+We have a test environment for the API:
 
 * API v3:
 [https://npq-registration-sandbox-web.teacherservices.cloud/api/v3](https://npq-registration-sandbox-web.teacherservices.cloud/api/v3)


### PR DESCRIPTION
### Context

Ticket: BAU

I've found a couple of links in the API guidance to the old versions of the API

### Changes proposed in this pull request

1. Remove those links