### PR TITLE
Record job as the actor in PaperTrail versions

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -6,7 +6,7 @@ class ApplicationJob < ActiveJob::Base
   end
 
   around_perform do |job, actual_job_code|
-    PaperTrail.request(whodunnit: "Background Job #{job.class.name}") do
+    PaperTrail.request(whodunnit: "Background job: #{job.class.name}") do
       actual_job_code.call
     end
   end

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ApplicationJob, type: :job do
     end
 
     it "sets whodunnit to the job class name" do
-      expect(PaperTrail::Version.last.whodunnit).to eq("SimpleJob")
+      expect(PaperTrail::Version.last.whodunnit).to eq("Background job: SimpleJob")
     end
   end
 end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-3209

If data is changed in a background job, then we do not record the actor in the whodunnit field. This is useful information which we'd like to retain.

### Changes proposed in this pull request

Set the whodunnit for all background jobs, with the name of the Job making the changes.