### PR TITLE
WIP - Allow delivery partner search by ID

### DIFF
--- a/app/controllers/npq_separation/admin/delivery_partners_controller.rb
+++ b/app/controllers/npq_separation/admin/delivery_partners_controller.rb
@@ -83,8 +83,11 @@ private
   def set_similarly_named_delivery_partners
     return [] if params.dig(:delivery_partner, :name).blank?
 
-    @similarly_named_delivery_partners = DeliveryPartner.name_similar_to(params.dig(:delivery_partner, :name))
+    @similarly_named_delivery_partners = DeliveryPartner.name_or_ecf_id_similar_to(
+      params.dig(:delivery_partner, :name)
+    )
   end
+
 
   def set_continue_form
     @continue_form = Admin::DeliveryPartners::ContinueForm.new(continue_params)

--- a/app/services/admin_service/delivery_partners_search.rb
+++ b/app/services/admin_service/delivery_partners_search.rb
@@ -1,17 +1,10 @@
 class AdminService::DeliveryPartnersSearch
-  attr_reader :q
-
   def initialize(q:)
-    @q = q
+    @q = q.to_s.strip
   end
 
   def call
-    default_scope.contains(q)
-  end
-
-private
-
-  def default_scope
-    DeliveryPartner.order(name: :asc)
+    return DeliveryPartner.all if @q.blank?
+    DeliveryPartner.name_or_ecf_id_similar_to(@q)
   end
 end

--- a/db/seeds/base/add_delivery_partners.rb
+++ b/db/seeds/base/add_delivery_partners.rb
@@ -1,13 +1,42 @@
-# first lead provider will have 100 delivery partners - useful for showing what production volume will get up to
+first_lead_provider = LeadProvider.first
+raise "No lead providers found!" unless first_lead_provider
+
+EDU_NAMES = [
+  "Bright Futures Academy",
+  "The Learning Hub",
+  "NextGen Education",
+  "Aspire Teaching Institute",
+  "Pathway Scholars",
+  "The Knowledge Centre",
+  "Elevate Academy",
+  "Inspire Teaching Hub",
+  "Pioneer Learning",
+  "The Growth Academy"
+].freeze
+
 100.times do
-  FactoryBot.create(:delivery_partner, lead_providers: Cohort.all.index_with { LeadProvider.first })
+  FactoryBot.create(
+    :delivery_partner,
+    name: EDU_NAMES.sample + " #{Faker::Number.unique.number(digits: 3)}",
+    lead_providers: [first_lead_provider]
+  )
 end
 
-# other lead providers will have 10 delivery partners, each with a random sample of 3 cohorts
-LeadProvider.excluding(LeadProvider.first).find_each do |lead_provider|
-  DeliveryPartner.limit(10).find_each do |delivery_partner|
+LeadProvider.where.not(id: first_lead_provider.id).find_each do |lead_provider|
+  10.times do
+    delivery_partner = FactoryBot.create(
+      :delivery_partner,
+      name: EDU_NAMES.sample + " #{Faker::Number.unique.number(digits: 3)}",
+      lead_providers: [lead_provider]
+    )
+
     Cohort.all.sample(3).each do |cohort|
-      FactoryBot.create(:delivery_partnership, delivery_partner: delivery_partner, lead_provider: lead_provider, cohort: cohort)
+      FactoryBot.create(
+        :delivery_partnership,
+        delivery_partner: delivery_partner,
+        lead_provider: lead_provider,
+        cohort: cohort
+      )
     end
   end
 end


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-3148

On the delivery partner page in the admin console, you can currently search for delivery partners by their name. We want to extend this so that you can search by ID as well.

Questions not answered by ticket:

- Do we want to allow users to search both with and without the hyphens? 
- Do we want to insist on searching by the entire ID, or is only a few characters enough?