### PR TITLE
[CPDNPQ-3198] Qualifications API endpoint performance

### DIFF
--- a/db/migrate/20251002110536_index_users_on_trn.rb
+++ b/db/migrate/20251002110536_index_users_on_trn.rb
@@ -1,0 +1,7 @@
+class IndexUsersOnTrn < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :users, :trn, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_30_132614) do
+ActiveRecord::Schema[7.2].define(version: 2025_10_02_110536) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -600,6 +600,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_30_132614) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["provider"], name: "index_users_on_provider"
     t.index ["significantly_updated_at"], name: "index_users_on_significantly_updated_at"
+    t.index ["trn"], name: "index_users_on_trn"
     t.index ["uid"], name: "index_users_on_uid", unique: true
   end
 


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-3198

The majority of calls to our Qualifications API endpoint take longer than they ought to. I profiled this with `stackprof` and found that, beyond the database queries themselves, a big chunk of wall time is spent in Ruby wrangling the two different ActiveRecord models into a compatible form.

By removing the need for ActiveRecord instances and having a single SQL query return all the data we need, plus an index, I got quite a significant speed-up on my machine:

```
ruby 3.4.6 (2025-09-16 revision dbd83256b1) +YJIT +PRISM [aarch64-linux-musl]
Warming up --------------------------------------
            existing     1.000 i/100ms
           sql union     2.000 i/100ms
Calculating -------------------------------------
            existing      6.517 (±15.3%) i/s  (153.44 ms/i) -     31.000 in   5.087401s
           sql union     45.632 (±11.0%) i/s   (21.91 ms/i) -    226.000 in   5.040502s
```

That's ~7X faster against the snapshot database via konduit; the production results will vary a bit, but in any case, a big enough margin to feel confident this should make a significant difference to the response time.

I also dropped the serializer since I couldn't see the value in the extra layer, which should also shave off a little bit more time.