### PR TITLE
Search for delivery partners by ecf_id as well as name

### DIFF
--- a/app/services/admin_service/delivery_partners_search.rb
+++ b/app/services/admin_service/delivery_partners_search.rb
@@ -6,7 +6,7 @@ class AdminService::DeliveryPartnersSearch
   end
 
   def call
-    default_scope.contains(q).or(DeliveryPartner.where(ecf_id: q))
+    default_scope.contains(q).or(default_scope.where(ecf_id: q))
   end
 
 private

--- a/app/services/admin_service/delivery_partners_search.rb
+++ b/app/services/admin_service/delivery_partners_search.rb
@@ -6,7 +6,7 @@ class AdminService::DeliveryPartnersSearch
   end
 
   def call
-    default_scope.contains(q)
+    default_scope.contains(q).or(DeliveryPartner.where(ecf_id: q))
   end
 
 private

--- a/app/views/npq_separation/admin/delivery_partners/index.html.erb
+++ b/app/views/npq_separation/admin/delivery_partners/index.html.erb
@@ -13,7 +13,7 @@
         :q,
         value: params[:q],
         label: { text: "Find a delivery partner", size: "m" },
-        hint: { text: "Enter part or all of the delivery partner’s name.", size: "s" },
+        hint: { text: "Enter part or all of the delivery partner’s name, or the entire ID with or without hyphens.", size: "s" },
       )
     %>
     <%= f.govuk_submit "Search" %>

--- a/spec/services/admin_service/delivery_partners_search_spec.rb
+++ b/spec/services/admin_service/delivery_partners_search_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe AdminService::DeliveryPartnersSearch do
 
   describe "#call" do
     context "when partial name match with different capitalisation" do
-      let(:q) { "DEL" }
+      let(:q) { delivery_partner.name.first(3).upcase }
 
       it "returns the match" do
         expect(subject.call).to include(delivery_partner)
@@ -29,6 +29,46 @@ RSpec.describe AdminService::DeliveryPartnersSearch do
 
       it "returns results ordered by name" do
         expect(subject.call).to eq([a_delivery_partner, delivery_partner, z_delivery_partner])
+      end
+    end
+
+    context "with a matching ECF ID" do
+      let(:q) { delivery_partner.ecf_id }
+
+      it "returns the match" do
+        expect(subject.call).to include(delivery_partner)
+      end
+    end
+
+    context "with a random ECF ID" do
+      let(:q) { SecureRandom.uuid }
+
+      it "does not return a match" do
+        expect(subject.call).to be_empty
+      end
+    end
+
+    context "with an ECF ID without hyphens" do
+      let(:q) { delivery_partner.ecf_id.gsub(/-/, '') }
+
+      it "returns the match" do
+        expect(subject.call).to include(delivery_partner)
+      end
+    end
+
+    context "with an uppercase ECF ID" do
+      let(:q) { delivery_partner.ecf_id.upcase }
+
+      it "returns the match" do
+        expect(subject.call).to include(delivery_partner)
+      end
+    end
+
+    context "with an uppercase ECF ID without hyphens" do
+      let(:q) { delivery_partner.ecf_id.upcase.gsub(/-/, '') }
+
+      it "returns the match" do
+        expect(subject.call).to include(delivery_partner)
       end
     end
   end

--- a/spec/services/admin_service/delivery_partners_search_spec.rb
+++ b/spec/services/admin_service/delivery_partners_search_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe AdminService::DeliveryPartnersSearch do
     end
 
     context "with an ECF ID without hyphens" do
-      let(:q) { delivery_partner.ecf_id.gsub(/-/, '') }
+      let(:q) { delivery_partner.ecf_id.delete("-") }
 
       it "returns the match" do
         expect(subject.call).to include(delivery_partner)
@@ -65,7 +65,7 @@ RSpec.describe AdminService::DeliveryPartnersSearch do
     end
 
     context "with an uppercase ECF ID without hyphens" do
-      let(:q) { delivery_partner.ecf_id.upcase.gsub(/-/, '') }
+      let(:q) { delivery_partner.ecf_id.upcase.delete("-") }
 
       it "returns the match" do
         expect(subject.call).to include(delivery_partner)


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/CPDNPQ-3148

Admin users need to search for delivery partners by ID.

### Changes proposed in this pull request

- Expanded the existing delivery partner search scope so that you can search by ecf_id as well as name. 
- Added tests to check for different scenarios when searching by ecf_id, such as searching in uppercase or without hyphens.
- Updated the hint text copy to reflect the change in how you can search.

