### PR TITLE
no need to check for EYL twice

### DIFF
--- a/app/services/funding_eligibility.rb
+++ b/app/services/funding_eligibility.rb
@@ -137,23 +137,17 @@ private
       return FUNDED_ELIGIBILITY_RESULT
     end
 
+    return EARLY_YEARS_INVALID_NPQ unless course.eyl?
+
     if childminder?
-      if course.eyl?
-        return FUNDED_ELIGIBILITY_RESULT if mandatory_institution.on_childminders_list?
+      return FUNDED_ELIGIBILITY_RESULT if mandatory_institution.on_childminders_list?
 
-        return NOT_ENTITLED_CHILDMINDER
-      end
-
-      return EARLY_YEARS_INVALID_NPQ
+      return NOT_ENTITLED_CHILDMINDER
     end
 
-    if course.eyl?
-      return FUNDED_ELIGIBILITY_RESULT if mandatory_institution.eyl_disadvantaged?
+    return FUNDED_ELIGIBILITY_RESULT if mandatory_institution.eyl_disadvantaged?
 
-      return NOT_ENTITLED_EY_INSTITUTION
-    end
-
-    EARLY_YEARS_INVALID_NPQ
+    NOT_ENTITLED_EY_INSTITUTION
   end
 
   def school_policy


### PR DESCRIPTION
### Context

Spotted this odd logic as a result of the funding eligibility diagram in https://dfedigital.atlassian.net/browse/NPQ-3483

### Changes proposed in this pull request

simplify the logic slightly

before:
<img width="1249" height="478" alt="Screenshot 2026-01-23 at 16 03 43" src="https://github.com/user-attachments/assets/7a7b3a40-8303-408c-8d67-5442535133a1" />

after:
<img width="1248" height="464" alt="Screenshot 2026-01-23 at 16 03 56" src="https://github.com/user-attachments/assets/53499f03-cb21-4dc4-9b60-b84ab480008b" />
