### PR TITLE
[NPQ-3620] update course start date form with new options

### DIFF
--- a/app/forms/questionnaires/course_start_date.rb
+++ b/app/forms/questionnaires/course_start_date.rb
@@ -1,23 +1,17 @@
 module Questionnaires
   class CourseStartDate < Base
-    class Form < QuestionTypes::RadioButtonGroup
-      include ApplicationHelper
-      def type
-        "radio_button_group"
-      end
-
-      def question_text
-        "Do you want to start a course in #{application_course_start_date}?"
-      end
-    end
-
     include ApplicationHelper
 
     QUESTION_NAME = :course_start_date
 
+    OPTIONS = {
+      "2026a" => "Spring 2026",
+      "2026b" => "Autumn 2026",
+    }.freeze
+
     attribute QUESTION_NAME
 
-    validates QUESTION_NAME, presence: true, inclusion: { in: %w[yes no] }
+    validates QUESTION_NAME, presence: true, inclusion: { in: OPTIONS.keys }
 
     def self.permitted_params
       [QUESTION_NAME]
@@ -25,19 +19,15 @@ module Questionnaires
 
     def questions
       [
-        Form.new(
+        QuestionTypes::RadioButtonGroup.new(
           name: :course_start_date,
           options:,
-          style_options: { legend: { size: "m", tag: "h2" } },
         ),
       ]
     end
 
     def options
-      [
-        build_option_struct(value: "yes", link_errors: true, hint: I18n.t("helpers.hint.registration_wizard.course_start_date_hint")),
-        build_option_struct(value: "no"),
-      ]
+      OPTIONS.map { |value, label| build_option_struct(value:, label:) }
     end
 
     def requirements_met?
@@ -45,14 +35,7 @@ module Questionnaires
     end
 
     def next_step
-      if course_start_date == "yes"
-        wizard.store["course_start"] = "In #{application_course_start_date}"
-        wizard.current_user.update!(notify_user_for_future_reg: false)
-        :provider_check
-      else
-        wizard.current_user.update!(notify_user_for_future_reg: true)
-        :cannot_register_yet
-      end
+      :provider_check
     end
 
     def previous_step

--- a/app/forms/questionnaires/course_start_date.rb
+++ b/app/forms/questionnaires/course_start_date.rb
@@ -2,7 +2,7 @@ module Questionnaires
   class CourseStartDate < Base
     include ApplicationHelper
 
-    QUESTION_NAME = :course_start_date
+    QUESTION_NAME = :course_start_cohort
 
     OPTIONS = {
       "2026a" => "Spring 2026",
@@ -20,7 +20,7 @@ module Questionnaires
     def questions
       [
         QuestionTypes::RadioButtonGroup.new(
-          name: :course_start_date,
+          name: :course_start_cohort,
           options:,
         ),
       ]

--- a/app/forms/questionnaires/course_start_date.rb
+++ b/app/forms/questionnaires/course_start_date.rb
@@ -12,6 +12,7 @@ module Questionnaires
     attribute QUESTION_NAME
 
     validates QUESTION_NAME, presence: true, inclusion: { in: OPTIONS.keys }
+    validate :cohort_exists
 
     def self.permitted_params
       [QUESTION_NAME]
@@ -40,6 +41,13 @@ module Questionnaires
 
     def previous_step
       :start
+    end
+
+  private
+
+    def cohort_exists
+      cohort = Cohort.find_by(identifier: public_send(QUESTION_NAME))
+      errors.add(QUESTION_NAME, :invalid) unless cohort
     end
   end
 end

--- a/app/forms/questionnaires/course_start_date.rb
+++ b/app/forms/questionnaires/course_start_date.rb
@@ -46,8 +46,10 @@ module Questionnaires
   private
 
     def cohort_exists
-      cohort = Cohort.find_by(identifier: public_send(QUESTION_NAME))
+      cohort_identifier = course_start_cohort
+      cohort = Cohort.find_by(identifier: cohort_identifier)
       errors.add(QUESTION_NAME, :invalid) unless cohort
+      Sentry.capture_message("Cohort selected by user does not exist: #{cohort_identifier}")
     end
   end
 end

--- a/app/forms/questionnaires/course_start_date.rb
+++ b/app/forms/questionnaires/course_start_date.rb
@@ -5,8 +5,11 @@ module Questionnaires
     QUESTION_NAME = :course_start_cohort
 
     OPTIONS = {
-      "2026a" => "Spring 2026",
-      "2026b" => "Autumn 2026",
+      "2026b" => { label: "Yes",
+                   cohort_description: "Autumn 2026" },
+      "2026a" => { label: "No, I already started in Spring",
+                   hint: "DfE scholarship funding is not available",
+                   cohort_description: "Spring 2026" },
     }.freeze
 
     attribute QUESTION_NAME
@@ -28,7 +31,9 @@ module Questionnaires
     end
 
     def options
-      OPTIONS.map { |value, label| build_option_struct(value:, label:) }
+      OPTIONS.map do |cohort_identifier, label_options|
+        build_option_struct(value: cohort_identifier, label: label_options[:label], hint: label_options[:hint])
+      end
     end
 
     def requirements_met?

--- a/app/forms/questionnaires/ineligible_for_funding.rb
+++ b/app/forms/questionnaires/ineligible_for_funding.rb
@@ -3,6 +3,7 @@ module Questionnaires
     class UnexpectedEligibilityStatusCode < StandardError; end
 
     NOT_ELIGIBLE_FOR_SCHOLARSHIP_FUNDING = "not_eligible_for_scholarship_funding".freeze
+    UNFUNDED_COHORT = "unfunded_cohort".freeze
     NOT_IN_ENGLAND = "not_in_england".freeze
     EARLY_YEARS_INELIGIBLE_ESTABLISHMENT = "early_years/outside_catchment_or_not_on_early_years_register".freeze
     EARLY_YEARS_NOT_APPLYING_FOR_NPQEY = "early_years/not_applying_for_NPQEY".freeze
@@ -63,7 +64,7 @@ module Questionnaires
                                when FundingEligibility::INELIGIBLE_INSTITUTION_TYPE
                                  return NOT_ELIGIBLE_FOR_SCHOLARSHIP_FUNDING
                                when FundingEligibility::UNFUNDED_COHORT
-                                 return NOT_ELIGIBLE_FOR_SCHOLARSHIP_FUNDING
+                                 return UNFUNDED_COHORT
                                end
 
       raise UnexpectedEligibilityStatusCode, "Missing status code handling: #{funding_eligiblity_status_code}"

--- a/app/forms/questionnaires/ineligible_for_funding.rb
+++ b/app/forms/questionnaires/ineligible_for_funding.rb
@@ -62,6 +62,8 @@ module Questionnaires
                                  return NOT_ELIGIBLE_FOR_SCHOLARSHIP_FUNDING
                                when FundingEligibility::INELIGIBLE_INSTITUTION_TYPE
                                  return NOT_ELIGIBLE_FOR_SCHOLARSHIP_FUNDING
+                               when FundingEligibility::UNFUNDED_COHORT
+                                 return NOT_ELIGIBLE_FOR_SCHOLARSHIP_FUNDING
                                end
 
       raise UnexpectedEligibilityStatusCode, "Missing status code handling: #{funding_eligiblity_status_code}"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,7 +10,7 @@ module ApplicationHelper
       if Feature.trn_required? && current_user.trn.blank?
         registration_wizard_show_path(:teacher_reference_number)
       else
-        registration_wizard_show_path(:course_start_date)
+        registration_wizard_show_path("course-start-date")
       end
     else
       "/"
@@ -48,10 +48,6 @@ module ApplicationHelper
 
   def rejected?(application)
     application.rejected_lead_provider_approval_status?
-  end
-
-  def application_course_start_date
-    "autumn 2025"
   end
 
   def show_otp_code_in_ui(current_env, admin)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,18 +5,6 @@ module ApplicationHelper
     current_user.applications.size == 1 ? accounts_user_registration_path(current_user.applications.first) : account_path
   end
 
-  def npq_registration_link
-    if signed_in?
-      if Feature.trn_required? && current_user.trn.blank?
-        registration_wizard_show_path(:teacher_reference_number)
-      else
-        registration_wizard_show_path("course-start-date")
-      end
-    else
-      "/"
-    end
-  end
-
   def boolean_red_green_tag(bool, text = nil)
     text ||= bool ? "Yes" : "No"
     colour = bool ? "green" : "red"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,7 +39,7 @@ module ApplicationHelper
   end
 
   def application_cohort_description(application)
-    Questionnaires::CourseStartDate::OPTIONS[application.cohort.identifier]
+    Questionnaires::CourseStartDate::OPTIONS[application.cohort.identifier][:cohort_description]
   end
 
   def show_otp_code_in_ui(current_env, admin)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,6 +38,10 @@ module ApplicationHelper
     application.rejected_lead_provider_approval_status?
   end
 
+  def application_cohort_description(application)
+    Questionnaires::CourseStartDate::OPTIONS[application.cohort.identifier]
+  end
+
   def show_otp_code_in_ui(current_env, admin)
     return unless current_env.in?(%w[development review staging]) && admin.present?
 

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -141,7 +141,7 @@ class RegistrationWizard
       end
     end
 
-    array << Answer.new("Course start", store["course_start"], :course_start_date)
+    array << Answer.new("Course start", Questionnaires::CourseStartDate::OPTIONS[store["course_start_date"]], :course_start_date)
     array << Answer.new("Workplace in England", teacher_catchment_humanized, :teacher_catchment)
 
     if store["referred_by_return_to_teaching_adviser"]

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -141,7 +141,7 @@ class RegistrationWizard
       end
     end
 
-    array << Answer.new("Course start", Questionnaires::CourseStartDate::OPTIONS[store["course_start_date"]], :course_start_date)
+    array << Answer.new("Course start", Questionnaires::CourseStartDate::OPTIONS[store["course_start_cohort"]], :course_start_date)
     array << Answer.new("Workplace in England", teacher_catchment_humanized, :teacher_catchment)
 
     if store["referred_by_return_to_teaching_adviser"]

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -141,7 +141,7 @@ class RegistrationWizard
       end
     end
 
-    array << Answer.new("Course start", Questionnaires::CourseStartDate::OPTIONS[store["course_start_cohort"]], :course_start_date)
+    array << Answer.new("Course start", Questionnaires::CourseStartDate::OPTIONS[store["course_start_cohort"]][:cohort_description], :course_start_date)
     array << Answer.new("Workplace in England", teacher_catchment_humanized, :teacher_catchment)
 
     if store["referred_by_return_to_teaching_adviser"]

--- a/app/services/funding_eligibility.rb
+++ b/app/services/funding_eligibility.rb
@@ -25,10 +25,12 @@ class FundingEligibility
   # Lead Mentor
   NOT_LEAD_MENTOR_COURSE = :not_lead_mentor_course
 
+  UNFUNDED_COHORT = :unfunded_cohort
   NOT_IN_ENGLAND = :not_in_england
 
   FUNDING_STATUS_CODE_DESCRIPTIONS = {
     FUNDED_ELIGIBILITY_RESULT => :scholarship_eligibility,
+    UNFUNDED_COHORT => :unfunded_cohort,
     NOT_IN_ENGLAND => :outside_catchment,
     INELIGIBLE_INSTITUTION_TYPE => :ineligible_setting,
     EARLY_YEARS_INVALID_NPQ => :ineligible_setting,
@@ -44,7 +46,8 @@ class FundingEligibility
     SUBJECT_TO_REVIEW => :subject_to_review,
   }.freeze
 
-  attr_reader :institution,
+  attr_reader :cohort,
+              :institution,
               :course,
               :trn,
               :approved_itt_provider,
@@ -64,7 +67,10 @@ class FundingEligibility
                              get_an_identity_id:,
                              approved_itt_provider: false,
                              query_store: nil)
-      new(institution:,
+      cohort = Cohort.find_by(identifier: query_store.course_start_cohort)
+
+      new(cohort:,
+          institution:,
           course:,
           inside_catchment:,
           trn:,
@@ -78,7 +84,9 @@ class FundingEligibility
     end
   end
 
-  def initialize(institution:,
+  # FundingEligibilty.new is not actually called outside of this class - only the specs call it directly
+  def initialize(cohort:,
+                 institution:,
                  course:,
                  inside_catchment:,
                  trn:,
@@ -89,6 +97,7 @@ class FundingEligibility
                  childminder:,
                  referred_by_return_to_teaching_adviser:,
                  work_setting:)
+    @cohort = cohort
     @institution = institution
     @course = course
     @inside_catchment = inside_catchment
@@ -116,6 +125,7 @@ class FundingEligibility
 
   def funding_eligiblity_status_code
     @funding_eligiblity_status_code ||= begin
+      return UNFUNDED_COHORT unless cohort.funded?
       return NOT_IN_ENGLAND unless inside_catchment
       return PREVIOUSLY_FUNDED if previously_funded?
 

--- a/app/services/handle_submission_for_store.rb
+++ b/app/services/handle_submission_for_store.rb
@@ -39,15 +39,20 @@ class HandleSubmissionForStore
         on_submission_trn: store["trn"],
         teacher_catchment_country:,
         teacher_catchment_iso_country_code:,
-        cohort: Cohort.current,
+        cohort:,
         lead_provider_approval_status: Application.lead_provider_approval_statuses[:pending],
         review_status: funding_eligibility_service.subject_to_review? ? "needs_review" : nil,
+        **({ funded_place: false } unless cohort.funded?),
       )
       enqueue_send_application_submission_email_job(application)
     end
   end
 
 private
+
+  def cohort
+    Cohort.find_by(identifier: store["course_start_cohort"])
+  end
 
   def raw_application_data
     # Cutting out confirmation keys since that is not application related data
@@ -202,6 +207,7 @@ private
   end
 
   def user
+    # TODO: remove current_user - this is legacy behaviour
     @user ||= store["current_user"].presence || User.find(store["current_user_id"])
   end
 

--- a/app/services/handle_submission_for_store.rb
+++ b/app/services/handle_submission_for_store.rb
@@ -207,8 +207,7 @@ private
   end
 
   def user
-    # TODO: remove current_user - this is legacy behaviour
-    @user ||= store["current_user"].presence || User.find(store["current_user_id"])
+    @user ||= User.find(store["current_user_id"])
   end
 
   def uk_country

--- a/app/services/handle_submission_for_store.rb
+++ b/app/services/handle_submission_for_store.rb
@@ -42,7 +42,7 @@ class HandleSubmissionForStore
         cohort:,
         lead_provider_approval_status: Application.lead_provider_approval_statuses[:pending],
         review_status: funding_eligibility_service.subject_to_review? ? "needs_review" : nil,
-        **({ funded_place: false } unless cohort.funded?),
+        funded_place:,
       )
       enqueue_send_application_submission_email_job(application)
     end
@@ -51,7 +51,7 @@ class HandleSubmissionForStore
 private
 
   def cohort
-    Cohort.find_by(identifier: store["course_start_cohort"])
+    Cohort.find_by!(identifier: store["course_start_cohort"])
   end
 
   def raw_application_data
@@ -238,5 +238,9 @@ private
       Sentry.capture_message("Could not find the ISO3166 alpha3 code for #{teacher_catchment_country}.", level: :warning)
       nil
     end
+  end
+
+  def funded_place
+    false unless cohort.funded?
   end
 end

--- a/app/services/registration_query_store.rb
+++ b/app/services/registration_query_store.rb
@@ -195,6 +195,6 @@ class RegistrationQueryStore
   end
 
   def course_start_cohort
-    store["course_start_date"]
+    store["course_start_cohort"]
   end
 end

--- a/app/services/registration_query_store.rb
+++ b/app/services/registration_query_store.rb
@@ -193,4 +193,8 @@ class RegistrationQueryStore
         end
       end
   end
+
+  def course_start_cohort
+    store["course_start_date"]
+  end
 end

--- a/app/views/accounts/user_registrations/_course_details.html.erb
+++ b/app/views/accounts/user_registrations/_course_details.html.erb
@@ -60,22 +60,6 @@
         </dd>
       </div>
 
-      <% if application.lead_provider_approval_status.blank? || pending?(application) %>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Course start
-          </dt>
-          <dd class="govuk-summary-list__value">
-            <%= application_course_start_date.titleize %>
-            <% if application.eligible_for_funding %>
-              <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= I18n.t("course_start_details.eligible_for_funding", date: application_course_start_date) %></p>
-            <% else %>
-              <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-0"><%= I18n.t("course_start_details.not_eligible_for_funding", date: application_course_start_date) %></p>
-            <% end %>
-          </dd>
-        </div>
-      <% end %>
-
       <% if application.latest_participant_outcome_state.present? && accepted?(application) %>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">

--- a/app/views/accounts/user_registrations/_course_details.html.erb
+++ b/app/views/accounts/user_registrations/_course_details.html.erb
@@ -60,6 +60,17 @@
         </dd>
       </div>
 
+      <% if application.lead_provider_approval_status.blank? || pending?(application) %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Course start
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= application_cohort_description(application) %>
+          </dd>
+        </div>
+      <% end %>
+
       <% if application.latest_participant_outcome_state.present? && accepted?(application) %>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">

--- a/app/views/registration_wizard/change_your_course_or_provider.html.erb
+++ b/app/views/registration_wizard/change_your_course_or_provider.html.erb
@@ -20,8 +20,7 @@
     <% if Feature.trn_required? && current_user.trn.blank? %>
       <%= govuk_start_button(text: "Submit a new registration", href: registration_wizard_show_path(:teacher_reference_number)) %>
     <% else %>
-      <%= govuk_start_button(text: "Submit a new registration", href: registration_wizard_show_path(:course_start_date)) %>
+      <%= govuk_start_button(text: "Submit a new registration", href: registration_wizard_show_path("course-start-date")) %>
     <% end %>
   </div>
 </div>
-  

--- a/app/views/registration_wizard/course_start_date.html.erb
+++ b/app/views/registration_wizard/course_start_date.html.erb
@@ -1,33 +1,3 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl"><%= t("helpers.title.registration_wizard.course_start_date", date: application_course_start_date) %></h1>
-  </div>
-</div>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body govuk-!-margin-bottom-4">
-      <%= t("helpers.hint.registration_wizard.course_start_date_one") %>
-    </p>
-  </div>
-</div>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body govuk-!-margin-bottom-4">
-      <%= t("helpers.hint.registration_wizard.course_start_date_two") %>
-    </p>
-  </div>
-</div>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body govuk-!-margin-bottom-4">
-      <%= t("helpers.hint.registration_wizard.course_start_date_three", date: application_course_start_date) %>
-    </p>
-  </div>
-</div>
-
 <%=
   render(
     'registration_wizard/shared/questions_page',

--- a/app/views/registration_wizard/ineligible_for_funding.erb
+++ b/app/views/registration_wizard/ineligible_for_funding.erb
@@ -6,7 +6,11 @@
     ) do
 %>
 
-  <%= render "registration_wizard/ineligible_for_funding/#{@form.ineligible_template}", course: @form.course, lead_provider: @form.lead_provider.try(:name) %>
+  <%= render "registration_wizard/ineligible_for_funding/#{@form.ineligible_template}",
+    course: @form.course,
+    lead_provider: @form.lead_provider.try(:name),
+    chosen_cohort: Questionnaires::CourseStartDate::OPTIONS[@wizard.query_store.course_start_cohort]
+  %>
 
   <%= govuk_button_link_to "Continue", registration_wizard_show_path(@wizard.next_step_path) %>
 

--- a/app/views/registration_wizard/ineligible_for_funding.erb
+++ b/app/views/registration_wizard/ineligible_for_funding.erb
@@ -9,7 +9,7 @@
   <%= render "registration_wizard/ineligible_for_funding/#{@form.ineligible_template}",
     course: @form.course,
     lead_provider: @form.lead_provider.try(:name),
-    chosen_cohort: Questionnaires::CourseStartDate::OPTIONS[@wizard.query_store.course_start_cohort]
+    chosen_cohort: Questionnaires::CourseStartDate::OPTIONS[@wizard.query_store.course_start_cohort][:cohort_description]
   %>
 
   <%= govuk_button_link_to "Continue", registration_wizard_show_path(@wizard.next_step_path) %>

--- a/app/views/registration_wizard/ineligible_for_funding/_unfunded_cohort.html.erb
+++ b/app/views/registration_wizard/ineligible_for_funding/_unfunded_cohort.html.erb
@@ -1,0 +1,18 @@
+<h1 class="govuk-heading-xl">Funding</h1>
+
+<p class="govuk-body">
+You’re not eligible for scholarship funding for <%= localise_sentence_embedded_course_name(course) %> course as
+you have selected the <%= chosen_cohort %> cohort.
+</p>
+
+<p class="govuk-body">
+  This means that you would need to pay for the course another way.
+  For example, you could pay for the course fees yourself or ask your workplace or trust to:
+</p>
+
+<p class="govuk-body">
+  <ul class="govuk-list govuk-list--bullet">
+    <li>cover the full cost of the course</li>
+    <li>share the cost of the course with you</li>
+  </ul>
+</p>

--- a/app/views/registration_wizard/shared/_register_for_an_npq.html.erb
+++ b/app/views/registration_wizard/shared/_register_for_an_npq.html.erb
@@ -28,7 +28,7 @@
     <% if !current_user.teacher_auth_provider? && Feature.trn_required? && current_user.trn.blank? %>
       <%= govuk_start_button(text: "Register for another NPQ", href: registration_wizard_show_path(:teacher_reference_number)) %>
     <% else %>
-      <%= govuk_start_button(text: "Register for another NPQ", href: registration_wizard_show_path(:course_start_date)) %>
+      <%= govuk_start_button(text: "Register for another NPQ", href: registration_wizard_show_path("course-start-date")) %>
     <% end %>
   </div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1035,7 +1035,7 @@ en:
         course_identifier: "Which NPQ do you want to do?"
         maths_eligibility_teaching_for_mastery: "Have you taken at least one year of the primary maths Teaching for Mastery programme?"
         maths_understanding_of_approach: "How can you show your understanding of mastery approaches to teaching maths?"
-        course_start_date: "Do you want to start a course before April 2024?"
+        course_start_date: Choose when you want to start your course
         funding_eligibility_maths: "Funding Eligibility"
         ehco_funding_choice: "How are you funding the Early headship coaching offer?"
         itt_provider: "Enter the name of the ITT provider you are working with"
@@ -1058,9 +1058,6 @@ en:
         choose_your_npq_html: "To register for an NPQ and the <a href=\"https://professional-development-for-teachers-leaders.education.gov.uk/early-headship-coaching-offer\" class=\"govuk-link\">Early headship coaching offer</a>, submit 2 separate registrations."
         maths_eligibility_teaching_for_mastery_html_one: "You need to be able to demonstrate that you have an understanding of mastery approaches to teaching maths."
         maths_eligibility_teaching_for_mastery_two_html: "You can demonstrate this if you’ve taken at least one year of the <a href=\"https://www.gov.uk/guidance/join-the-maths-teaching-for-mastery-programme\" class=\"govuk-link\">primary maths Teaching for Mastery programme</a>."
-        course_start_date_one: "NPQ courses start once a year every autumn."
-        course_start_date_two: "Registrations are currently open for courses starting in autumn 2025."
-        course_start_date_three: "Early headship coaching offer start dates vary by provider and are throughout the year."
         maths_understanding_of_approach_html: "Your provider will ask you for details."
         work_setting_options:
           a_16_to_19_educational_setting_html: "Includes:<ul class=\"question-hint-list\"><li>sixth form colleges</li><li>further education colleges</li><li>schools that also teach ages 16 to 19</li></ul>"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1036,7 +1036,7 @@ en:
         course_identifier: "Which NPQ do you want to do?"
         maths_eligibility_teaching_for_mastery: "Have you taken at least one year of the primary maths Teaching for Mastery programme?"
         maths_understanding_of_approach: "How can you show your understanding of mastery approaches to teaching maths?"
-        course_start_date: Choose when you want to start your course
+        course_start_cohort: Choose when you want to start your course
         funding_eligibility_maths: "Funding Eligibility"
         ehco_funding_choice: "How are you funding the Early headship coaching offer?"
         itt_provider: "Enter the name of the ITT provider you are working with"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -928,6 +928,7 @@ en:
 
   funding_details:
     ineligible_setting: "You’re not eligible for scholarship funding as you do not work in one of the eligible settings, such as state-funded schools."
+    unfunded_cohort: "You’re not eligible for scholarship funding."
     outside_catchment: "You’re not eligible for scholarship funding as you do not work in England."
     no_ofsted: "You’re not eligible for schools funding as you or your employer is not registered on the Ofsted Early Years Register or with a registered Childminder Agency."
     previously_funded: "You have already been allocated scholarship funding for %{course_name}."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1036,7 +1036,7 @@ en:
         course_identifier: "Which NPQ do you want to do?"
         maths_eligibility_teaching_for_mastery: "Have you taken at least one year of the primary maths Teaching for Mastery programme?"
         maths_understanding_of_approach: "How can you show your understanding of mastery approaches to teaching maths?"
-        course_start_cohort: Choose when you want to start your course
+        course_start_cohort: Are you starting a course in Autumn 2026?
         funding_eligibility_maths: "Funding Eligibility"
         ehco_funding_choice: "How are you funding the Early headship coaching offer?"
         itt_provider: "Enter the name of the ITT provider you are working with"

--- a/db/seeds/base/add_applications.rb
+++ b/db/seeds/base/add_applications.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 all_courses = Course.all.to_a
-all_cohorts = Cohort.where.not(funding: "unfunded").to_a
+funded_cohorts = Cohort.capped_funding.or(Cohort.full_funding).to_a
 
 LeadProvider.find_each do |lead_provider|
   quantity = { "review" => 4, "development" => 1 }.fetch(Rails.env, 0)
@@ -17,7 +17,7 @@ LeadProvider.find_each do |lead_provider|
       lead_provider:,
       course: all_courses.sample,
       lead_provider_approval_status: "pending",
-      cohort: all_cohorts.sample,
+      cohort: funded_cohorts.sample,
     )
 
     # users with 3 applications each
@@ -31,7 +31,7 @@ LeadProvider.find_each do |lead_provider|
       user:,
       lead_provider:,
       course: all_courses.sample,
-      cohort: all_cohorts.sample,
+      cohort: funded_cohorts.sample,
     )
 
     FactoryBot.create_list(
@@ -43,7 +43,7 @@ LeadProvider.find_each do |lead_provider|
       user:,
       lead_provider:,
       course: all_courses.sample,
-      cohort: all_cohorts.sample,
+      cohort: funded_cohorts.sample,
     )
 
     # users with one accepted application each
@@ -56,7 +56,7 @@ LeadProvider.find_each do |lead_provider|
       lead_provider:,
       course: all_courses.sample,
       participant_outcome_state: "passed",
-      cohort: all_cohorts.sample,
+      cohort: funded_cohorts.sample,
     )
 
     # users with one rejected application each
@@ -69,7 +69,7 @@ LeadProvider.find_each do |lead_provider|
       lead_provider:,
       course: all_courses.sample,
       participant_outcome_state: "failed",
-      cohort: all_cohorts.sample,
+      cohort: funded_cohorts.sample,
     )
 
     # users with one deferred application each
@@ -83,7 +83,7 @@ LeadProvider.find_each do |lead_provider|
       :with_random_participant_outcome_state,
       lead_provider:,
       course: all_courses.sample,
-      cohort: all_cohorts.sample,
+      cohort: funded_cohorts.sample,
     )
 
     # users with one withdrawn application each
@@ -97,7 +97,7 @@ LeadProvider.find_each do |lead_provider|
       :with_random_participant_outcome_state,
       lead_provider:,
       course: all_courses.sample,
-      cohort: all_cohorts.sample,
+      cohort: funded_cohorts.sample,
     )
 
     # users with one eligible for funded place application each (cohort funding_cap true)

--- a/db/seeds/base/add_applications.rb
+++ b/db/seeds/base/add_applications.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 all_courses = Course.all.to_a
-all_cohorts = Cohort.all.to_a
+all_cohorts = Cohort.where.not(funding: "unfunded").to_a
 
 LeadProvider.find_each do |lead_provider|
   quantity = { "review" => 4, "development" => 1 }.fetch(Rails.env, 0)

--- a/db/seeds/base/add_cohorts.rb
+++ b/db/seeds/base/add_cohorts.rb
@@ -1,16 +1,14 @@
+# create older cohorts without funding cap
 (2021..2023).each do |start_year|
   FactoryBot.create(:cohort, :without_funding_cap, start_year:)
 end
 
-# Ensure Cohort.next is always created
-registration_start_month = Cohort.find_by(start_year: 2021).registration_start_date.month
-next_cohort_start_year = Date.current.year + (Date.current.month < registration_start_month ? 0 : 1)
-
-(2024..next_cohort_start_year).each do |start_year|
+# create newer cohorts with funding cap
+current_cohort_start_year = Date.current.month < 9 ? (Date.current.year - 1) : Date.current.year
+(2024..current_cohort_start_year).each do |start_year|
   FactoryBot.create(:cohort, :with_funding_cap, start_year:)
 end
 
-# Add suffixed cohort
-FactoryBot.create(:cohort, :with_funding_cap, start_year: 2025,
-                                              suffix: "b",
-                                              description: "Autumn 2025")
+# create next cohorts
+FactoryBot.create(:cohort, :next, :unfunded, description: "Unfunded cohort")
+FactoryBot.create(:cohort, :next, :with_funding_cap, suffix: "b")

--- a/db/seeds/base/add_declarations.rb
+++ b/db/seeds/base/add_declarations.rb
@@ -8,11 +8,13 @@ lead_providers.each do |lead_provider|
   Schedule.find_each do |schedule|
     schedule.courses.each do |course|
       application_count.times do
+        eligible_for_funding = schedule.cohort.funding != "unfunded"
         application = FactoryBot.create(
           :application,
-          :eligible_for_funded_place,
+          :accepted,
           :with_random_user,
           :with_random_work_setting,
+          eligible_for_funding:,
           cohort: schedule.cohort,
           lead_provider:,
           course:,

--- a/spec/controllers/registration_wizard_controller_spec.rb
+++ b/spec/controllers/registration_wizard_controller_spec.rb
@@ -53,14 +53,14 @@ RSpec.describe RegistrationWizardController do
   end
 
   describe "#update" do
-    let(:wizard_params) { { course_start_date: "yes" } }
+    let(:wizard_params) { { course_start_date: "2026a" } }
     let(:make_request) { patch :update, params: { step: "course-start-date", registration_wizard: wizard_params } }
 
     it_behaves_like "it redirects on missing mandatory institution"
 
     it "persists data to session" do
       make_request
-      expect(session["registration_store"]["course_start_date"]).to eql("yes")
+      expect(session["registration_store"]["course_start_date"]).to eql("2026a")
     end
 
     context "when step is being skipped" do

--- a/spec/controllers/registration_wizard_controller_spec.rb
+++ b/spec/controllers/registration_wizard_controller_spec.rb
@@ -56,6 +56,8 @@ RSpec.describe RegistrationWizardController do
     let(:wizard_params) { { course_start_cohort: "2026a" } }
     let(:make_request) { patch :update, params: { step: "course-start-date", registration_wizard: wizard_params } }
 
+    before { create(:cohort, start_year: 2026) }
+
     it_behaves_like "it redirects on missing mandatory institution"
 
     it "persists data to session" do

--- a/spec/controllers/registration_wizard_controller_spec.rb
+++ b/spec/controllers/registration_wizard_controller_spec.rb
@@ -53,14 +53,14 @@ RSpec.describe RegistrationWizardController do
   end
 
   describe "#update" do
-    let(:wizard_params) { { course_start_date: "2026a" } }
+    let(:wizard_params) { { course_start_cohort: "2026a" } }
     let(:make_request) { patch :update, params: { step: "course-start-date", registration_wizard: wizard_params } }
 
     it_behaves_like "it redirects on missing mandatory institution"
 
     it "persists data to session" do
       make_request
-      expect(session["registration_store"]["course_start_date"]).to eql("2026a")
+      expect(session["registration_store"]["course_start_cohort"]).to eql("2026a")
     end
 
     context "when step is being skipped" do

--- a/spec/factories/registration_wizard_store.rb
+++ b/spec/factories/registration_wizard_store.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     end
 
     current_user { create(:user) }
+    course_start_cohort { Cohort.current.identifier }
     course_identifier { course.identifier }
     institution_identifier { "School-#{school.urn}" }
     lead_provider_id { lead_provider.id }

--- a/spec/factories/registration_wizard_store.rb
+++ b/spec/factories/registration_wizard_store.rb
@@ -6,9 +6,10 @@ FactoryBot.define do
       course { create(Course::IDENTIFIERS.first.to_sym) }
       school { create(:school, :funding_eligible_establishment_type_code) }
       lead_provider { LeadProvider.first }
+      user { create(:user) }
     end
 
-    current_user { create(:user) }
+    current_user_id { user.id }
     course_start_cohort { Cohort.current.identifier }
     course_identifier { course.identifier }
     institution_identifier { "School-#{school.urn}" }
@@ -19,6 +20,6 @@ FactoryBot.define do
     referred_by_return_to_teaching_adviser { "no" }
     senco_in_role { "yes" }
     senco_start_date { "2024-12-12" }
-    trn { current_user.trn }
+    trn { user.trn }
   end
 end

--- a/spec/features/back_links_spec.rb
+++ b/spec/features/back_links_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Back links", type: :feature do
   include Helpers::JourneyAssertionHelper
+  include Helpers::JourneyStepHelper
 
   include_context "Stub Get An Identity Omniauth Responses"
 
@@ -15,15 +16,13 @@ RSpec.feature "Back links", type: :feature do
 
     expect(page).not_to have_content("Before you start")
 
-    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: false, axe_check: false)
     page.click_link("Back")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: false, axe_check: false)
 
-    expect(page).to have_checked_field("Yes", visible: :all)
+    expect(page).to have_checked_field(course_start_date_description, visible: :all)
   end
 end

--- a/spec/features/back_links_spec.rb
+++ b/spec/features/back_links_spec.rb
@@ -23,6 +23,6 @@ RSpec.feature "Back links", type: :feature do
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: false, axe_check: false)
 
-    expect(page).to have_checked_field(course_start_date_description, visible: :all)
+    expect(page).to have_checked_field(course_start_cohort_description, visible: :all)
   end
 end

--- a/spec/features/back_links_spec.rb
+++ b/spec/features/back_links_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Back links", type: :feature do
+RSpec.feature "Back links", :with_default_schedules, type: :feature do
   include Helpers::JourneyAssertionHelper
   include Helpers::JourneyStepHelper
 

--- a/spec/features/back_links_spec.rb
+++ b/spec/features/back_links_spec.rb
@@ -23,6 +23,6 @@ RSpec.feature "Back links", :with_default_schedules, type: :feature do
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: false, axe_check: false)
 
-    expect(page).to have_checked_field(course_start_cohort_description, visible: :all)
+    expect(page).to have_checked_field(course_start_cohort_label, visible: :all)
   end
 end

--- a/spec/features/course_start_date_spec.rb
+++ b/spec/features/course_start_date_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Happy journeys", type: :feature do
+RSpec.feature "Happy journeys", :no_js, type: :feature do
   include Helpers::JourneyAssertionHelper
   include Helpers::JourneyStepHelper
   include ApplicationHelper
@@ -18,8 +18,7 @@ RSpec.feature "Happy journeys", type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
-      expect(page).to have_text("Do you want to start a course in autumn 2025?")
+      expect(page).to have_text("Choose when you want to start your course")
     end
   end
 end

--- a/spec/features/course_start_date_spec.rb
+++ b/spec/features/course_start_date_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Happy journeys", :no_js, type: :feature do
     expect(page).not_to have_content("Before you start")
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text("Choose when you want to start your course")
+      expect(page).to have_text("Are you starting a course in Autumn 2026?")
     end
   end
 end

--- a/spec/features/journeys/happy_paths/able_to_receive_targeted_delivery_funding_spec.rb
+++ b/spec/features/journeys/happy_paths/able_to_receive_targeted_delivery_funding_spec.rb
@@ -78,7 +78,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_eligibility_list_
     expect_page_to_have(path: "/registration/check-answers", submit_form: true, submit_button_text: "Submit") do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_date_description,
+          "Course start" => course_start_cohort_description,
           "Workplace in England" => "Yes",
           "Work setting" => "A school",
           "Course" => "Senior leadership",
@@ -150,7 +150,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_eligibility_list_
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start_date" => course_start_date_value,
+        "course_start_cohort" => course_start_cohort_value,
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "eligible_scholarship_funding_not_tsf",
         "funding_eligiblity_status_code" => "funded",

--- a/spec/features/journeys/happy_paths/able_to_receive_targeted_delivery_funding_spec.rb
+++ b/spec/features/journeys/happy_paths/able_to_receive_targeted_delivery_funding_spec.rb
@@ -26,10 +26,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_eligibility_list_
 
     expect(page).not_to have_content("Before you start")
 
-    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
       expect(page).to have_text("Have you chosen an NPQ and provider?")
@@ -81,7 +78,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_eligibility_list_
     expect_page_to_have(path: "/registration/check-answers", submit_form: true, submit_button_text: "Submit") do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "In #{application_course_start_date}",
+          "Course start" => course_start_date_description,
           "Workplace in England" => "Yes",
           "Work setting" => "A school",
           "Course" => "Senior leadership",
@@ -153,8 +150,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_eligibility_list_
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "In #{application_course_start_date}",
-        "course_start_date" => "yes",
+        "course_start_date" => course_start_date_value,
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "eligible_scholarship_funding_not_tsf",
         "funding_eligiblity_status_code" => "funded",

--- a/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
@@ -183,7 +183,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_default_school, t
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start_date" => "2026b",
+        "course_start_cohort" => "2026b",
         "course_identifier" => "npq-headship",
         "email_template" => "not_eligible_scholarship_funding_not_tsf",
         "funding" => "trust",

--- a/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
@@ -26,10 +26,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_default_school, t
 
     expect(page).not_to have_content("Before you start")
 
-    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
       expect(page).to have_text("Have you chosen an NPQ and provider?")
@@ -81,7 +78,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_default_school, t
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "In #{application_course_start_date}",
+          "Course start" => "Autumn 2026",
           "Course" => "Headship",
           "Provider" => "Teach First",
           "Workplace" => "open manchester school – street 1, manchester",
@@ -186,8 +183,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_default_school, t
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "In #{application_course_start_date}",
-        "course_start_date" => "yes",
+        "course_start_date" => "2026b",
         "course_identifier" => "npq-headship",
         "email_template" => "not_eligible_scholarship_funding_not_tsf",
         "funding" => "trust",

--- a/spec/features/journeys/happy_paths/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
@@ -81,7 +81,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_form: false) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_date_description,
+          "Course start" => course_start_cohort_description,
           "Course" => "Senior leadership",
           "Course funding" => "I am paying",
           "Employment type" => "In an independent hospital education organisation",
@@ -132,7 +132,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_form: true, submit_button_text: "Submit") do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_date_description,
+          "Course start" => course_start_cohort_description,
           "Course" => "Senior leadership",
           "Course funding" => "My workplace is covering the cost",
           "Work setting" => "A school",
@@ -204,7 +204,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start_date" => course_start_date_value,
+        "course_start_cohort" => course_start_cohort_value,
         "course_identifier" => "npq-senior-leadership",
         "employer_name" => "Big company",
         "employment_type" => "hospital_school",

--- a/spec/features/journeys/happy_paths/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
@@ -26,10 +26,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
 
     expect(page).not_to have_content("Before you start")
 
-    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
       expect(page).to have_text("Have you chosen an NPQ and provider?")
@@ -84,7 +81,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_form: false) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "In #{application_course_start_date}",
+          "Course start" => course_start_date_description,
           "Course" => "Senior leadership",
           "Course funding" => "I am paying",
           "Employment type" => "In an independent hospital education organisation",
@@ -135,7 +132,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_form: true, submit_button_text: "Submit") do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "In #{application_course_start_date}",
+          "Course start" => course_start_date_description,
           "Course" => "Senior leadership",
           "Course funding" => "My workplace is covering the cost",
           "Work setting" => "A school",
@@ -207,8 +204,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "In #{application_course_start_date}",
-        "course_start_date" => "yes",
+        "course_start_date" => course_start_date_value,
         "course_identifier" => "npq-senior-leadership",
         "employer_name" => "Big company",
         "employment_type" => "hospital_school",

--- a/spec/features/journeys/happy_paths/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
@@ -85,7 +85,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_form: false) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_date_description,
+          "Course start" => course_start_cohort_description,
           "Course" => "Senior leadership",
           "Course funding" => "My workplace is covering the cost",
           "Work setting" => "Early years or childcare",
@@ -140,7 +140,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_date_description,
+          "Course start" => course_start_cohort_description,
           "Course" => "Senior leadership",
           "Course funding" => "I am paying",
           "Employment type" => "In an independent hospital education organisation",
@@ -213,7 +213,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start_date" => course_start_date_value,
+        "course_start_cohort" => course_start_cohort_value,
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "not_eligible_scholarship_funding_not_tsf",
         "funding" => "self",

--- a/spec/features/journeys/happy_paths/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
@@ -26,10 +26,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
 
     expect(page).not_to have_content("Before you start")
 
-    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
       expect(page).to have_text("Have you chosen an NPQ and provider?")
@@ -88,7 +85,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_form: false) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "In #{application_course_start_date}",
+          "Course start" => course_start_date_description,
           "Course" => "Senior leadership",
           "Course funding" => "My workplace is covering the cost",
           "Work setting" => "Early years or childcare",
@@ -143,7 +140,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "In #{application_course_start_date}",
+          "Course start" => course_start_date_description,
           "Course" => "Senior leadership",
           "Course funding" => "I am paying",
           "Employment type" => "In an independent hospital education organisation",
@@ -216,8 +213,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "In #{application_course_start_date}",
-        "course_start_date" => "yes",
+        "course_start_date" => course_start_date_value,
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "not_eligible_scholarship_funding_not_tsf",
         "funding" => "self",

--- a/spec/features/journeys/happy_paths/changing_from_outside_of_catchment_area_to_inside_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_from_outside_of_catchment_area_to_inside_spec.rb
@@ -73,7 +73,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_form: false) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_date_description,
+          "Course start" => course_start_cohort_description,
           "Course" => "Senior leadership",
           "Course funding" => "I am paying",
           "Work setting" => "A school",
@@ -127,7 +127,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_date_description,
+          "Course start" => course_start_cohort_description,
           "Course" => "Senior leadership",
           "Workplace" => "open manchester school – street 1, manchester",
           "Course funding" => "My workplace is covering the cost",
@@ -199,7 +199,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start_date" => course_start_date_value,
+        "course_start_cohort" => course_start_cohort_value,
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "not_eligible_scholarship_funding_not_tsf",
         "funding" => "school",

--- a/spec/features/journeys/happy_paths/changing_from_outside_of_catchment_area_to_inside_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_from_outside_of_catchment_area_to_inside_spec.rb
@@ -26,10 +26,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
 
     expect(page).not_to have_content("Before you start")
 
-    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
       expect(page).to have_text("Have you chosen an NPQ and provider?")
@@ -76,7 +73,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_form: false) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "In #{application_course_start_date}",
+          "Course start" => course_start_date_description,
           "Course" => "Senior leadership",
           "Course funding" => "I am paying",
           "Work setting" => "A school",
@@ -130,7 +127,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "In #{application_course_start_date}",
+          "Course start" => course_start_date_description,
           "Course" => "Senior leadership",
           "Workplace" => "open manchester school – street 1, manchester",
           "Course funding" => "My workplace is covering the cost",
@@ -202,8 +199,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "In #{application_course_start_date}",
-        "course_start_date" => "yes",
+        "course_start_date" => course_start_date_value,
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "not_eligible_scholarship_funding_not_tsf",
         "funding" => "school",

--- a/spec/features/journeys/happy_paths/changing_npq_to_one_leadprovider_no_longer_supports_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_npq_to_one_leadprovider_no_longer_supports_spec.rb
@@ -85,7 +85,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_form: false) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_date_description,
+          "Course start" => course_start_cohort_description,
           "Course" => "Senior leadership",
           "Course funding" => "My workplace is covering the cost",
           "Provider" => "Best Practice Network",
@@ -131,7 +131,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_date_description,
+          "Course start" => course_start_cohort_description,
           "Course" => "Early years leadership",
           "Course funding" => "My workplace is covering the cost",
           "Provider" => "National Institute of Teaching",
@@ -204,7 +204,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start_date" => course_start_date_value,
+        "course_start_cohort" => course_start_cohort_value,
         "course_identifier" => "npq-early-years-leadership",
         "email_template" => "not_on_ofsted_register",
         "funding" => "school",

--- a/spec/features/journeys/happy_paths/changing_npq_to_one_leadprovider_no_longer_supports_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_npq_to_one_leadprovider_no_longer_supports_spec.rb
@@ -26,10 +26,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
 
     expect(page).not_to have_content("Before you start")
 
-    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
       expect(page).to have_text("Have you chosen an NPQ and provider?")
@@ -88,7 +85,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_form: false) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "In #{application_course_start_date}",
+          "Course start" => course_start_date_description,
           "Course" => "Senior leadership",
           "Course funding" => "My workplace is covering the cost",
           "Provider" => "Best Practice Network",
@@ -134,7 +131,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "In #{application_course_start_date}",
+          "Course start" => course_start_date_description,
           "Course" => "Early years leadership",
           "Course funding" => "My workplace is covering the cost",
           "Provider" => "National Institute of Teaching",
@@ -207,8 +204,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "In #{application_course_start_date}",
-        "course_start_date" => "yes",
+        "course_start_date" => course_start_date_value,
         "course_identifier" => "npq-early-years-leadership",
         "email_template" => "not_on_ofsted_register",
         "funding" => "school",

--- a/spec/features/journeys/happy_paths/choose_a_childcare_provider_spec.rb
+++ b/spec/features/journeys/happy_paths/choose_a_childcare_provider_spec.rb
@@ -18,9 +18,7 @@ RSpec.feature "Choose a childcare provider page", :with_default_schedules, type:
       page.click_button("Start now")
     end
 
-    navigate_to_page(path: "/registration/course-start-date", submit_form: true) do
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     navigate_to_page(path: "/registration/provider-check", submit_form: true) do
       page.choose("Yes", visible: :all)

--- a/spec/features/journeys/happy_paths/choose_a_school_spec.rb
+++ b/spec/features/journeys/happy_paths/choose_a_school_spec.rb
@@ -18,9 +18,7 @@ RSpec.feature "Choose a school page", :with_default_schedules, type: :feature do
       page.click_button("Start now")
     end
 
-    navigate_to_page(path: "/registration/course-start-date", submit_form: true) do
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     navigate_to_page(path: "/registration/provider-check", submit_form: true) do
       page.choose("Yes", visible: :all)

--- a/spec/features/journeys/happy_paths/funded_ehco_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/funded_ehco_registration_journey_spec.rb
@@ -93,7 +93,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
     expect_page_to_have(path: "/registration/check-answers", submit_form: true, submit_button_text: "Submit") do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_date_description,
+          "Course start" => course_start_cohort_description,
           "Workplace in England" => "Yes",
           "Work setting" => "A school",
           "Course" => "Early headship coaching offer",
@@ -182,7 +182,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start_date" => course_start_date_value,
+        "course_start_cohort" => course_start_cohort_value,
         "course_identifier" => "npq-early-headship-coaching-offer",
         "ehco_headteacher" => "yes",
         "ehco_new_headteacher" => "yes",

--- a/spec/features/journeys/happy_paths/funded_ehco_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/funded_ehco_registration_journey_spec.rb
@@ -26,10 +26,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
 
     expect(page).not_to have_content("Before you start")
 
-    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
       expect(page).to have_text("Have you chosen an NPQ and provider?")
@@ -96,7 +93,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
     expect_page_to_have(path: "/registration/check-answers", submit_form: true, submit_button_text: "Submit") do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "In #{application_course_start_date}",
+          "Course start" => course_start_date_description,
           "Workplace in England" => "Yes",
           "Work setting" => "A school",
           "Course" => "Early headship coaching offer",
@@ -185,8 +182,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "In #{application_course_start_date}",
-        "course_start_date" => "yes",
+        "course_start_date" => course_start_date_value,
         "course_identifier" => "npq-early-headship-coaching-offer",
         "ehco_headteacher" => "yes",
         "ehco_new_headteacher" => "yes",

--- a/spec/features/journeys/happy_paths/international_teacher_npqh_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/international_teacher_npqh_journey_spec.rb
@@ -22,10 +22,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
 
     expect(page).not_to have_content("Before you start")
 
-    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
       expect(page).to have_text("Have you chosen an NPQ and provider?")
@@ -72,7 +69,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "In #{application_course_start_date}",
+          "Course start" => course_start_date_description,
           "Workplace in England" => "No",
           "Work setting" => "A school",
           "Course" => "Headship",
@@ -164,8 +161,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
         "work_setting" => "a_school",
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "In #{application_course_start_date}",
-        "course_start_date" => "yes",
+        "course_start_date" => course_start_date_value,
         "course_identifier" => "npq-headship",
         "funding" => "school",
         "teacher_catchment" => "another",

--- a/spec/features/journeys/happy_paths/international_teacher_npqh_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/international_teacher_npqh_journey_spec.rb
@@ -69,7 +69,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_date_description,
+          "Course start" => course_start_cohort_description,
           "Workplace in England" => "No",
           "Work setting" => "A school",
           "Course" => "Headship",
@@ -161,7 +161,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
         "work_setting" => "a_school",
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start_date" => course_start_date_value,
+        "course_start_cohort" => course_start_cohort_value,
         "course_identifier" => "npq-headship",
         "funding" => "school",
         "teacher_catchment" => "another",

--- a/spec/features/journeys/happy_paths/other_funded_ehco_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/other_funded_ehco_registration_journey_spec.rb
@@ -92,7 +92,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_date_description,
+          "Course start" => course_start_cohort_description,
           "Workplace in England" => "Yes",
           "Work setting" => "A school",
           "Course" => "Early headship coaching offer",
@@ -181,7 +181,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start_date" => course_start_date_value,
+        "course_start_cohort" => course_start_cohort_value,
         "course_identifier" => "npq-early-headship-coaching-offer",
         "ehco_funding_choice" => "self",
         "ehco_headteacher" => "no",

--- a/spec/features/journeys/happy_paths/other_funded_ehco_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/other_funded_ehco_registration_journey_spec.rb
@@ -25,10 +25,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
 
     expect(page).not_to have_content("Before you start")
 
-    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
       expect(page).to have_text("Have you chosen an NPQ and provider?")
@@ -95,7 +92,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "In #{application_course_start_date}",
+          "Course start" => course_start_date_description,
           "Workplace in England" => "Yes",
           "Work setting" => "A school",
           "Course" => "Early headship coaching offer",
@@ -184,8 +181,7 @@ RSpec.feature "Happy journeys", :rack_test_driver, :with_default_schedules, type
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "In #{application_course_start_date}",
-        "course_start_date" => "yes",
+        "course_start_date" => course_start_date_value,
         "course_identifier" => "npq-early-headship-coaching-offer",
         "ehco_funding_choice" => "self",
         "ehco_headteacher" => "no",

--- a/spec/features/journeys/happy_paths/previously_received_targeted_delivery_funding_spec.rb
+++ b/spec/features/journeys/happy_paths/previously_received_targeted_delivery_funding_spec.rb
@@ -78,7 +78,7 @@ RSpec.feature "Happy journeys", :no_js, :with_default_schedules, :with_eligibili
     expect_page_to_have(path: "/registration/check-answers", submit_form: true, submit_button_text: "Submit") do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_date_description,
+          "Course start" => course_start_cohort_description,
           "Workplace in England" => "Yes",
           "Work setting" => "A school",
           "Course" => "Senior leadership",
@@ -150,7 +150,7 @@ RSpec.feature "Happy journeys", :no_js, :with_default_schedules, :with_eligibili
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start_date" => course_start_date_value,
+        "course_start_cohort" => course_start_cohort_value,
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "eligible_scholarship_funding_not_tsf",
         "funding_eligiblity_status_code" => "funded",

--- a/spec/features/journeys/happy_paths/previously_received_targeted_delivery_funding_spec.rb
+++ b/spec/features/journeys/happy_paths/previously_received_targeted_delivery_funding_spec.rb
@@ -26,10 +26,7 @@ RSpec.feature "Happy journeys", :no_js, :with_default_schedules, :with_eligibili
 
     expect(page).not_to have_content("Before you start")
 
-    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
       expect(page).to have_text("Have you chosen an NPQ and provider?")
@@ -81,7 +78,7 @@ RSpec.feature "Happy journeys", :no_js, :with_default_schedules, :with_eligibili
     expect_page_to_have(path: "/registration/check-answers", submit_form: true, submit_button_text: "Submit") do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "In #{application_course_start_date}",
+          "Course start" => course_start_date_description,
           "Workplace in England" => "Yes",
           "Work setting" => "A school",
           "Course" => "Senior leadership",
@@ -153,8 +150,7 @@ RSpec.feature "Happy journeys", :no_js, :with_default_schedules, :with_eligibili
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "In #{application_course_start_date}",
-        "course_start_date" => "yes",
+        "course_start_date" => course_start_date_value,
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "eligible_scholarship_funding_not_tsf",
         "funding_eligiblity_status_code" => "funded",

--- a/spec/features/journeys/happy_paths/teacher_auth_login_spec.rb
+++ b/spec/features/journeys/happy_paths/teacher_auth_login_spec.rb
@@ -14,10 +14,8 @@ RSpec.feature "Happy journeys", :no_js, :with_default_schedules, :with_default_s
       page.click_button("Start now with Teacher Auth")
     end
 
-    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(User.last.attributes).to include(user_attributes_from_stubbed_callback_response)
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
+    expect(User.last.attributes).to include(user_attributes_from_stubbed_callback_response)
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
       page.choose("Yes", visible: :all)
@@ -56,7 +54,7 @@ RSpec.feature "Happy journeys", :no_js, :with_default_schedules, :with_default_s
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "In #{application_course_start_date}",
+          "Course start" => course_start_date_description,
           "Course" => "Headship",
           "Provider" => "Teach First",
           "Workplace" => "open manchester school – street 1, manchester",

--- a/spec/features/journeys/happy_paths/teacher_auth_login_spec.rb
+++ b/spec/features/journeys/happy_paths/teacher_auth_login_spec.rb
@@ -54,7 +54,7 @@ RSpec.feature "Happy journeys", :no_js, :with_default_schedules, :with_default_s
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_date_description,
+          "Course start" => course_start_cohort_description,
           "Course" => "Headship",
           "Provider" => "Teach First",
           "Workplace" => "open manchester school – street 1, manchester",

--- a/spec/features/journeys/happy_paths/unfunded_cohort_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/unfunded_cohort_registration_journey_spec.rb
@@ -38,6 +38,7 @@ RSpec.feature "Happy journeys", :no_js, :with_default_schedules, :with_default_s
     end
 
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
+      expect(page).to have_content("You’re not eligible for scholarship funding for the Headship NPQ course as you have selected the Spring 2026 cohort.")
       page.click_link("Continue")
     end
 

--- a/spec/features/journeys/happy_paths/unfunded_cohort_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/unfunded_cohort_registration_journey_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+RSpec.feature "Happy journeys", :no_js, :with_default_schedules, :with_default_school, type: :feature do
+  include Helpers::JourneyAssertionHelper
+  include Helpers::JourneyStepHelper
+  include ApplicationHelper
+
+  # include_context "retrieve latest application data"
+  include_context "Stub Get An Identity Omniauth Responses"
+
+  scenario "unfunded cohort registration journey" do
+    stub_participant_validation_request
+
+    navigate_to_page(path: "/", submit_form: false, axe_check: false) do
+      page.click_button("Start now")
+    end
+
+    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
+      page.choose("Spring 2026", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
+      page.choose("Yes", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/teacher-catchment", axe_check: false, submit_form: true) do
+      page.choose("Yes", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/work-setting", submit_form: true) do
+      page.choose("A school", visible: :all)
+    end
+
+    choose_a_school(js: false, name: "open")
+
+    expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do
+      page.choose("Headship", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
+      page.click_link("Continue")
+    end
+
+    expect_page_to_have(path: "/registration/funding-your-npq", submit_form: true) do
+      page.choose "My trust is paying", visible: :all
+    end
+
+    expect_page_to_have(path: "/registration/choose-your-provider", submit_form: true) do
+      page.choose("Ambition Institute", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/share-provider", submit_form: true) do
+      page.check("Yes, I agree to share my information", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
+      expect_check_answers_page_to_have_answers(
+        {
+          "Course start" => "Spring 2026",
+          "Course" => "Headship",
+          "Provider" => "Ambition Institute",
+          "Workplace" => "open manchester school – street 1, manchester",
+          "Course funding" => "My trust is paying",
+          "Work setting" => "A school",
+          "Workplace in England" => "Yes",
+        },
+      )
+    end
+
+    expect_applicant_reached_end_of_journey
+
+    application = Application.last
+    expect(application.funded_place).to be(false)
+    expect(application.eligible_for_funding).to be(false)
+    expect(application.cohort.funding).to eq "unfunded"
+  end
+end

--- a/spec/features/journeys/happy_paths/unfunded_cohort_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/unfunded_cohort_registration_journey_spec.rb
@@ -72,6 +72,6 @@ RSpec.feature "Happy journeys", :no_js, :with_default_schedules, :with_default_s
     application = Application.last
     expect(application.funded_place).to be(false)
     expect(application.eligible_for_funding).to be(false)
-    expect(application.cohort.funding).to eq "unfunded"
+    expect(application.cohort.funding).to eq "zero"
   end
 end

--- a/spec/features/journeys/happy_paths/unfunded_cohort_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/unfunded_cohort_registration_journey_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Happy journeys", :no_js, :with_default_schedules, :with_default_s
     end
 
     expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      page.choose("Spring 2026", visible: :all)
+      page.choose("No, I already started in Spring", visible: :all)
     end
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do

--- a/spec/features/journeys/happy_paths/unfunded_cohort_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/unfunded_cohort_registration_journey_spec.rb
@@ -68,7 +68,7 @@ RSpec.feature "Happy journeys", :no_js, :with_default_schedules, :with_default_s
       )
     end
 
-    expect_applicant_reached_end_of_journey
+    expect_applicant_reached_end_of_journey(course_start: "Spring 2026")
 
     application = Application.last
     expect(application.funded_place).to be(false)

--- a/spec/features/journeys/happy_paths/via_using_old_name_and_not_headship_spec.rb
+++ b/spec/features/journeys/happy_paths/via_using_old_name_and_not_headship_spec.rb
@@ -26,10 +26,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_default_school, t
 
     expect(page).not_to have_content("Before you start")
 
-    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
       expect(page).to have_text("Have you chosen an NPQ and provider?")
@@ -78,7 +75,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_default_school, t
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "In #{application_course_start_date}",
+          "Course start" => course_start_date_description,
           "Course" => "Senior leadership",
           "Workplace" => "open manchester school – street 1, manchester",
           "Course funding" => "My workplace is covering the cost",
@@ -150,8 +147,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_default_school, t
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "In #{application_course_start_date}",
-        "course_start_date" => "yes",
+        "course_start_date" => course_start_date_value,
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "not_eligible_scholarship_funding_not_tsf",
         "funding" => "school",

--- a/spec/features/journeys/happy_paths/via_using_old_name_and_not_headship_spec.rb
+++ b/spec/features/journeys/happy_paths/via_using_old_name_and_not_headship_spec.rb
@@ -75,7 +75,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_default_school, t
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_date_description,
+          "Course start" => course_start_cohort_description,
           "Course" => "Senior leadership",
           "Workplace" => "open manchester school – street 1, manchester",
           "Course funding" => "My workplace is covering the cost",
@@ -147,7 +147,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_default_school, t
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start_date" => course_start_date_value,
+        "course_start_cohort" => course_start_cohort_value,
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "not_eligible_scholarship_funding_not_tsf",
         "funding" => "school",

--- a/spec/features/journeys/happy_paths/when_choose_lead_mentor_course_spec.rb
+++ b/spec/features/journeys/happy_paths/when_choose_lead_mentor_course_spec.rb
@@ -26,10 +26,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
 
     expect(page).not_to have_content("Before you start")
 
-    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
       expect(page).to have_text("Have you chosen an NPQ and provider?")
@@ -77,7 +74,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       expect_check_answers_page_to_have_answers(
         {
 
-          "Course start" => "In #{application_course_start_date}",
+          "Course start" => course_start_date_description,
           "Course" => "Leading teacher development",
           "Employment type" => "As a lead mentor for an accredited initial teacher training (ITT) provider",
           "ITT provider" => approved_itt_provider_legal_name,
@@ -188,8 +185,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
         "funding_eligiblity_status_code" => "funded",
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "In #{application_course_start_date}",
-        "course_start_date" => "yes",
+        "course_start_date" => course_start_date_value,
         "course_identifier" => "npq-leading-teaching-development",
         "employment_type" => "lead_mentor_for_accredited_itt_provider",
         "itt_provider" => approved_itt_provider_legal_name,

--- a/spec/features/journeys/happy_paths/when_choose_lead_mentor_course_spec.rb
+++ b/spec/features/journeys/happy_paths/when_choose_lead_mentor_course_spec.rb
@@ -74,7 +74,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       expect_check_answers_page_to_have_answers(
         {
 
-          "Course start" => course_start_date_description,
+          "Course start" => course_start_cohort_description,
           "Course" => "Leading teacher development",
           "Employment type" => "As a lead mentor for an accredited initial teacher training (ITT) provider",
           "ITT provider" => approved_itt_provider_legal_name,
@@ -185,7 +185,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
         "funding_eligiblity_status_code" => "funded",
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start_date" => course_start_date_value,
+        "course_start_cohort" => course_start_cohort_value,
         "course_identifier" => "npq-leading-teaching-development",
         "employment_type" => "lead_mentor_for_accredited_itt_provider",
         "itt_provider" => approved_itt_provider_legal_name,

--- a/spec/features/journeys/happy_paths/when_choose_maths_course_spec.rb
+++ b/spec/features/journeys/happy_paths/when_choose_maths_course_spec.rb
@@ -86,7 +86,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_eligibility_list_
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_date_description,
+          "Course start" => course_start_cohort_description,
           "Workplace in England" => "Yes",
           "Work setting" => "A school",
           "Workplace" => "open manchester school – street 1, manchester",
@@ -187,7 +187,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_eligibility_list_
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start_date" => course_start_date_value,
+        "course_start_cohort" => course_start_cohort_value,
         "course_identifier" => "npq-leading-primary-mathematics",
         "email_template" => "eligible_scholarship_funding_not_tsf",
         "funding_eligiblity_status_code" => "funded",

--- a/spec/features/journeys/happy_paths/when_choose_maths_course_spec.rb
+++ b/spec/features/journeys/happy_paths/when_choose_maths_course_spec.rb
@@ -22,10 +22,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_eligibility_list_
 
     expect(page).not_to have_content("Before you start")
 
-    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
       expect(page).to have_text("Have you chosen an NPQ and provider?")
@@ -89,7 +86,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_eligibility_list_
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "In #{application_course_start_date}",
+          "Course start" => course_start_date_description,
           "Workplace in England" => "Yes",
           "Work setting" => "A school",
           "Workplace" => "open manchester school – street 1, manchester",
@@ -190,8 +187,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_eligibility_list_
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "In #{application_course_start_date}",
-        "course_start_date" => "yes",
+        "course_start_date" => course_start_date_value,
         "course_identifier" => "npq-leading-primary-mathematics",
         "email_template" => "eligible_scholarship_funding_not_tsf",
         "funding_eligiblity_status_code" => "funded",

--- a/spec/features/journeys/happy_paths/when_get_an_identity_returns_no_trn_spec.rb
+++ b/spec/features/journeys/happy_paths/when_get_an_identity_returns_no_trn_spec.rb
@@ -55,10 +55,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_default_school, t
       page.fill_in "National Insurance number", with: "AB123456C"
     end
 
-    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
       expect(page).to have_text("Have you chosen an NPQ and provider?")
@@ -107,7 +104,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_default_school, t
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "In #{application_course_start_date}",
+          "Course start" => course_start_date_description,
           "Full name" => "Jane Smith",
           "Teacher reference number (TRN)" => manually_entered_trn,
           "Date of birth" => "13 December 1980",
@@ -221,8 +218,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_default_school, t
         "active_alert" => false,
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "In #{application_course_start_date}",
-        "course_start_date" => "yes",
+        "course_start_date" => course_start_date_value,
         "course_identifier" => "npq-headship",
         "date_of_birth" => "1980-12-13",
         "email_template" => "not_eligible_scholarship_funding_not_tsf",

--- a/spec/features/journeys/happy_paths/when_get_an_identity_returns_no_trn_spec.rb
+++ b/spec/features/journeys/happy_paths/when_get_an_identity_returns_no_trn_spec.rb
@@ -104,7 +104,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_default_school, t
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_date_description,
+          "Course start" => course_start_cohort_description,
           "Full name" => "Jane Smith",
           "Teacher reference number (TRN)" => manually_entered_trn,
           "Date of birth" => "13 December 1980",
@@ -218,7 +218,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_default_school, t
         "active_alert" => false,
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start_date" => course_start_date_value,
+        "course_start_cohort" => course_start_cohort_value,
         "course_identifier" => "npq-headship",
         "date_of_birth" => "1980-12-13",
         "email_template" => "not_eligible_scholarship_funding_not_tsf",

--- a/spec/features/journeys/happy_paths/when_outside_of_catchment_area_crown_dependencies_spec.rb
+++ b/spec/features/journeys/happy_paths/when_outside_of_catchment_area_crown_dependencies_spec.rb
@@ -75,7 +75,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_date_description,
+          "Course start" => course_start_cohort_description,
           "Course" => "Senior leadership",
           "Course funding" => "I am paying",
           "Work setting" => "A school",
@@ -146,7 +146,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start_date" => course_start_date_value,
+        "course_start_cohort" => course_start_cohort_value,
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "not_england_wrong_catchment",
         "funding" => "self",

--- a/spec/features/journeys/happy_paths/when_outside_of_catchment_area_crown_dependencies_spec.rb
+++ b/spec/features/journeys/happy_paths/when_outside_of_catchment_area_crown_dependencies_spec.rb
@@ -26,10 +26,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
 
     expect(page).not_to have_content("Before you start")
 
-    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
       expect(page).to have_text("Have you chosen an NPQ and provider?")
@@ -78,7 +75,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "In #{application_course_start_date}",
+          "Course start" => course_start_date_description,
           "Course" => "Senior leadership",
           "Course funding" => "I am paying",
           "Work setting" => "A school",
@@ -149,8 +146,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "In #{application_course_start_date}",
-        "course_start_date" => "yes",
+        "course_start_date" => course_start_date_value,
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "not_england_wrong_catchment",
         "funding" => "self",

--- a/spec/features/journeys/happy_paths/when_outside_of_catchment_area_spec.rb
+++ b/spec/features/journeys/happy_paths/when_outside_of_catchment_area_spec.rb
@@ -26,10 +26,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
 
     expect(page).not_to have_content("Before you start")
 
-    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
       expect(page).to have_text("Have you chosen an NPQ and provider?")
@@ -75,7 +72,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "In #{application_course_start_date}",
+          "Course start" => course_start_date_description,
           "Course" => "Senior leadership",
           "Course funding" => "I am paying",
           "Work setting" => "A school",
@@ -144,8 +141,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "In #{application_course_start_date}",
-        "course_start_date" => "yes",
+        "course_start_date" => course_start_date_value,
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "not_england_wrong_catchment",
         "funding" => "self",

--- a/spec/features/journeys/happy_paths/when_outside_of_catchment_area_spec.rb
+++ b/spec/features/journeys/happy_paths/when_outside_of_catchment_area_spec.rb
@@ -72,7 +72,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_date_description,
+          "Course start" => course_start_cohort_description,
           "Course" => "Senior leadership",
           "Course funding" => "I am paying",
           "Work setting" => "A school",
@@ -141,7 +141,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start_date" => course_start_date_value,
+        "course_start_cohort" => course_start_cohort_value,
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "not_england_wrong_catchment",
         "funding" => "self",

--- a/spec/features/journeys/happy_paths/when_previously_funded_spec.rb
+++ b/spec/features/journeys/happy_paths/when_previously_funded_spec.rb
@@ -120,7 +120,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_date_description,
+          "Course start" => course_start_cohort_description,
           "Course" => "Early headship coaching offer",
           "Course funding" => "I am paying",
           "Headship NPQ stage" => "I’ve completed it",
@@ -198,7 +198,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
         "course_identifier" => "npq-early-headship-coaching-offer",
-        "course_start_date" => course_start_date_value,
+        "course_start_cohort" => course_start_cohort_value,
         "email_template" => "already_funded_not_elgible_ehco_funding",
         "ehco_funding_choice" => "self",
         "ehco_headteacher" => "yes",

--- a/spec/features/journeys/happy_paths/when_previously_funded_spec.rb
+++ b/spec/features/journeys/happy_paths/when_previously_funded_spec.rb
@@ -34,10 +34,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       page.click_link("Register for another NPQ")
     end
 
-    expect_page_to_have(path: "/registration/course_start_date", submit_form: true) do
-      expect(page).to have_text("Do you want to start a course in autumn 2025?")
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
       expect(page).to have_text("Have you chosen an NPQ and provider?")
@@ -123,7 +120,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "In autumn 2025",
+          "Course start" => course_start_date_description,
           "Course" => "Early headship coaching offer",
           "Course funding" => "I am paying",
           "Headship NPQ stage" => "I’ve completed it",
@@ -201,8 +198,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
         "course_identifier" => "npq-early-headship-coaching-offer",
-        "course_start_date" => "yes",
-        "course_start" => "In autumn 2025",
+        "course_start_date" => course_start_date_value,
         "email_template" => "already_funded_not_elgible_ehco_funding",
         "ehco_funding_choice" => "self",
         "ehco_headteacher" => "yes",

--- a/spec/features/journeys/happy_paths/when_referred_by_return_to_teaching_adviser_spec.rb
+++ b/spec/features/journeys/happy_paths/when_referred_by_return_to_teaching_adviser_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
   include Helpers::JourneyAssertionHelper
+  include Helpers::JourneyStepHelper
   include ApplicationHelper
 
   include_context "retrieve latest application data"
@@ -21,10 +22,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
 
     expect(page).not_to have_content("Before you start")
 
-    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
       expect(page).to have_text("Have you chosen an NPQ and provider?")
@@ -69,7 +67,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "In #{application_course_start_date}",
+          "Course start" => course_start_date_description,
           "Course" => "Senior leadership",
           "Work setting" => "Other",
           "Referred by return to teaching adviser" => "Yes",
@@ -140,8 +138,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "In #{application_course_start_date}",
-        "course_start_date" => "yes",
+        "course_start_date" => course_start_date_value,
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "not_eligible_scholarship_funding_not_tsf",
         "employer_name" => "Return to teaching adviser referral",

--- a/spec/features/journeys/happy_paths/when_referred_by_return_to_teaching_adviser_spec.rb
+++ b/spec/features/journeys/happy_paths/when_referred_by_return_to_teaching_adviser_spec.rb
@@ -67,7 +67,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_date_description,
+          "Course start" => course_start_cohort_description,
           "Course" => "Senior leadership",
           "Work setting" => "Other",
           "Referred by return to teaching adviser" => "Yes",
@@ -138,7 +138,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start_date" => course_start_date_value,
+        "course_start_cohort" => course_start_cohort_value,
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "not_eligible_scholarship_funding_not_tsf",
         "employer_name" => "Return to teaching adviser referral",

--- a/spec/features/journeys/happy_paths/when_working_at_an_eligible_primary_school_spec.rb
+++ b/spec/features/journeys/happy_paths/when_working_at_an_eligible_primary_school_spec.rb
@@ -74,7 +74,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_date_description,
+          "Course start" => course_start_cohort_description,
           "Course" => "Headship",
           "Provider" => "Teach First",
           "Workplace" => "open manchester school – street 1, manchester",
@@ -179,7 +179,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
         "course_identifier" => "npq-headship",
-        "course_start_date" => course_start_date_value,
+        "course_start_cohort" => course_start_cohort_value,
         "email_template" => "eligible_scholarship_funding_not_tsf",
         "funding_eligiblity_status_code" => "funded",
         "institution_identifier" => "School-100000",

--- a/spec/features/journeys/happy_paths/when_working_at_an_eligible_primary_school_spec.rb
+++ b/spec/features/journeys/happy_paths/when_working_at_an_eligible_primary_school_spec.rb
@@ -26,10 +26,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
 
     expect(page).not_to have_content("Before you start")
 
-    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
       expect(page).to have_text("Have you chosen an NPQ and provider?")
@@ -77,7 +74,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "In #{application_course_start_date}",
+          "Course start" => course_start_date_description,
           "Course" => "Headship",
           "Provider" => "Teach First",
           "Workplace" => "open manchester school – street 1, manchester",
@@ -182,8 +179,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
         "course_identifier" => "npq-headship",
-        "course_start" => "In #{application_course_start_date}",
-        "course_start_date" => "yes",
+        "course_start_date" => course_start_date_value,
         "email_template" => "eligible_scholarship_funding_not_tsf",
         "funding_eligiblity_status_code" => "funded",
         "institution_identifier" => "School-100000",

--- a/spec/features/journeys/happy_paths/when_working_in_other_spec.rb
+++ b/spec/features/journeys/happy_paths/when_working_in_other_spec.rb
@@ -76,7 +76,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       expect_check_answers_page_to_have_answers(
         {
           "Course funding" => "My workplace is covering the cost",
-          "Course start" => course_start_date_description,
+          "Course start" => course_start_cohort_description,
           "Course" => "Senior leadership",
           "Work setting" => "Other",
           "Referred by return to teaching adviser" => "No",
@@ -147,7 +147,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start_date" => course_start_date_value,
+        "course_start_cohort" => course_start_cohort_value,
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "not_eligible_scholarship_funding_not_tsf",
         "funding" => "school",

--- a/spec/features/journeys/happy_paths/when_working_in_other_spec.rb
+++ b/spec/features/journeys/happy_paths/when_working_in_other_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
   include Helpers::JourneyAssertionHelper
+  include Helpers::JourneyStepHelper
   include ApplicationHelper
 
   include_context "retrieve latest application data"
@@ -21,10 +22,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
 
     expect(page).not_to have_content("Before you start")
 
-    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
       expect(page).to have_text("Have you chosen an NPQ and provider?")
@@ -78,7 +76,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       expect_check_answers_page_to_have_answers(
         {
           "Course funding" => "My workplace is covering the cost",
-          "Course start" => "In #{application_course_start_date}",
+          "Course start" => course_start_date_description,
           "Course" => "Senior leadership",
           "Work setting" => "Other",
           "Referred by return to teaching adviser" => "No",
@@ -149,8 +147,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "In #{application_course_start_date}",
-        "course_start_date" => "yes",
+        "course_start_date" => course_start_date_value,
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "not_eligible_scholarship_funding_not_tsf",
         "funding" => "school",

--- a/spec/features/journeys/happy_paths/while_not_currently_working_at_school_spec.rb
+++ b/spec/features/journeys/happy_paths/while_not_currently_working_at_school_spec.rb
@@ -77,7 +77,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_date_description,
+          "Course start" => course_start_cohort_description,
           "Course" => "Senior leadership",
           "Course funding" => "I am paying",
           "Work setting" => "Another setting",
@@ -150,7 +150,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start_date" => course_start_date_value,
+        "course_start_cohort" => course_start_cohort_value,
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "not_eligible_scholarship_funding_not_tsf",
         "employer_name" => "Big company",

--- a/spec/features/journeys/happy_paths/while_not_currently_working_at_school_spec.rb
+++ b/spec/features/journeys/happy_paths/while_not_currently_working_at_school_spec.rb
@@ -1,9 +1,8 @@
 require "rails_helper"
 
-RSpec.feature "Happy journeys",
-              :with_default_schedules,
-              type: :feature do
+RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
   include Helpers::JourneyAssertionHelper
+  include Helpers::JourneyStepHelper
   include ApplicationHelper
 
   include_context "retrieve latest application data"
@@ -23,10 +22,7 @@ RSpec.feature "Happy journeys",
 
     expect(page).not_to have_content("Before you start")
 
-    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
       expect(page).to have_text("Have you chosen an NPQ and provider?")
@@ -81,7 +77,7 @@ RSpec.feature "Happy journeys",
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "In #{application_course_start_date}",
+          "Course start" => course_start_date_description,
           "Course" => "Senior leadership",
           "Course funding" => "I am paying",
           "Work setting" => "Another setting",
@@ -154,8 +150,7 @@ RSpec.feature "Happy journeys",
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "In #{application_course_start_date}",
-        "course_start_date" => "yes",
+        "course_start_date" => course_start_date_value,
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "not_eligible_scholarship_funding_not_tsf",
         "employer_name" => "Big company",

--- a/spec/features/journeys/happy_paths/while_working_at_private_childcare_provider_but_not_a_nursery_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_at_private_childcare_provider_but_not_a_nursery_spec.rb
@@ -26,10 +26,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_eligibility_list_
 
     expect(page).not_to have_content("Before you start")
 
-    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
       expect(page).to have_text("Have you chosen an NPQ and provider?")
@@ -106,7 +103,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_eligibility_list_
     expect_page_to_have(path: "/registration/check-answers", submit_form: true, submit_button_text: "Submit") do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "In #{application_course_start_date}",
+          "Course start" => course_start_date_description,
           "Course" => "Early years leadership",
           "Work setting" => "Early years or childcare",
           "Provider" => "Teach First",
@@ -180,8 +177,8 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_eligibility_list_
         "funding_eligiblity_status_code" => "funded",
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "In #{application_course_start_date}",
-        "course_start_date" => "yes",
+        "course_start_date" => course_start_date_value,
+        "funding_amount" => nil,
         "course_identifier" => "npq-early-years-leadership",
         "has_ofsted_urn" => "yes",
         "private_childcare_identifier" => "PrivateChildcareProvider-EY487263",

--- a/spec/features/journeys/happy_paths/while_working_at_private_childcare_provider_but_not_a_nursery_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_at_private_childcare_provider_but_not_a_nursery_spec.rb
@@ -103,7 +103,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_eligibility_list_
     expect_page_to_have(path: "/registration/check-answers", submit_form: true, submit_button_text: "Submit") do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_date_description,
+          "Course start" => course_start_cohort_description,
           "Course" => "Early years leadership",
           "Work setting" => "Early years or childcare",
           "Provider" => "Teach First",
@@ -177,7 +177,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_eligibility_list_
         "funding_eligiblity_status_code" => "funded",
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start_date" => course_start_date_value,
+        "course_start_cohort" => course_start_cohort_value,
         "funding_amount" => nil,
         "course_identifier" => "npq-early-years-leadership",
         "has_ofsted_urn" => "yes",

--- a/spec/features/journeys/happy_paths/while_working_at_private_childcare_provider_but_not_a_nursery_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_at_private_childcare_provider_but_not_a_nursery_spec.rb
@@ -178,7 +178,6 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_eligibility_list_
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
         "course_start_cohort" => course_start_cohort_value,
-        "funding_amount" => nil,
         "course_identifier" => "npq-early-years-leadership",
         "has_ofsted_urn" => "yes",
         "private_childcare_identifier" => "PrivateChildcareProvider-EY487263",

--- a/spec/features/journeys/happy_paths/while_working_at_private_nursery_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_at_private_nursery_spec.rb
@@ -26,10 +26,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_eligibility_list_
 
     expect(page).not_to have_content("Before you start")
 
-    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
       expect(page).to have_text("Have you chosen an NPQ and provider?")
@@ -104,7 +101,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_eligibility_list_
     expect_page_to_have(path: "/registration/check-answers", submit_form: true, submit_button_text: "Submit") do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "In #{application_course_start_date}",
+          "Course start" => course_start_date_description,
           "Course" => "Early years leadership",
           "Work setting" => "Early years or childcare",
           "Provider" => "Teach First",
@@ -178,8 +175,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_eligibility_list_
         "funding_eligiblity_status_code" => "funded",
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "In #{application_course_start_date}",
-        "course_start_date" => "yes",
+        "course_start_date" => course_start_date_value,
         "course_identifier" => "npq-early-years-leadership",
         "has_ofsted_urn" => "yes",
         "private_childcare_identifier" => "PrivateChildcareProvider-EY487263",

--- a/spec/features/journeys/happy_paths/while_working_at_private_nursery_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_at_private_nursery_spec.rb
@@ -101,7 +101,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_eligibility_list_
     expect_page_to_have(path: "/registration/check-answers", submit_form: true, submit_button_text: "Submit") do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_date_description,
+          "Course start" => course_start_cohort_description,
           "Course" => "Early years leadership",
           "Work setting" => "Early years or childcare",
           "Provider" => "Teach First",
@@ -175,7 +175,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, :with_eligibility_list_
         "funding_eligiblity_status_code" => "funded",
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start_date" => course_start_date_value,
+        "course_start_cohort" => course_start_cohort_value,
         "course_identifier" => "npq-early-years-leadership",
         "has_ofsted_urn" => "yes",
         "private_childcare_identifier" => "PrivateChildcareProvider-EY487263",

--- a/spec/features/journeys/happy_paths/while_working_at_public_nursery_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_at_public_nursery_spec.rb
@@ -86,7 +86,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_date_description,
+          "Course start" => course_start_cohort_description,
           "Course" => "Senior leadership",
           "Course funding" => "My workplace is covering the cost",
           "Work setting" => "Early years or childcare",
@@ -159,7 +159,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start_date" => course_start_date_value,
+        "course_start_cohort" => course_start_cohort_value,
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "not_eligible_scholarship_funding_not_tsf",
         "funding" => "school",

--- a/spec/features/journeys/happy_paths/while_working_at_public_nursery_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_at_public_nursery_spec.rb
@@ -26,10 +26,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
 
     expect(page).not_to have_content("Before you start")
 
-    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
       expect(page).to have_text("Have you chosen an NPQ and provider?")
@@ -89,7 +86,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "In #{application_course_start_date}",
+          "Course start" => course_start_date_description,
           "Course" => "Senior leadership",
           "Course funding" => "My workplace is covering the cost",
           "Work setting" => "Early years or childcare",
@@ -162,8 +159,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "In #{application_course_start_date}",
-        "course_start_date" => "yes",
+        "course_start_date" => course_start_date_value,
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "not_eligible_scholarship_funding_not_tsf",
         "funding" => "school",

--- a/spec/features/journeys/happy_paths/while_working_in_neither_a_school_nor_childcare_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_in_neither_a_school_nor_childcare_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
   include Helpers::JourneyAssertionHelper
+  include Helpers::JourneyStepHelper
   include ApplicationHelper
 
   include_context "retrieve latest application data"
@@ -21,10 +22,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
 
     expect(page).not_to have_content("Before you start")
 
-    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
       expect(page).to have_text("Have you chosen an NPQ and provider?")
@@ -80,7 +78,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       expect_check_answers_page_to_have_answers(
         {
           "Course funding" => "I am paying",
-          "Course start" => "In #{application_course_start_date}",
+          "Course start" => course_start_date_description,
           "Course" => "Early years leadership",
           "Employment type" => "In an independent hospital education organisation",
           "Employer" => "Big company",
@@ -152,8 +150,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "In #{application_course_start_date}",
-        "course_start_date" => "yes",
+        "course_start_date" => course_start_date_value,
         "course_identifier" => "npq-early-years-leadership",
         "email_template" => "not_on_ofsted_register",
         "employer_name" => "Big company",

--- a/spec/features/journeys/happy_paths/while_working_in_neither_a_school_nor_childcare_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_in_neither_a_school_nor_childcare_spec.rb
@@ -78,7 +78,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       expect_check_answers_page_to_have_answers(
         {
           "Course funding" => "I am paying",
-          "Course start" => course_start_date_description,
+          "Course start" => course_start_cohort_description,
           "Course" => "Early years leadership",
           "Employment type" => "In an independent hospital education organisation",
           "Employer" => "Big company",
@@ -150,7 +150,7 @@ RSpec.feature "Happy journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start_date" => course_start_date_value,
+        "course_start_cohort" => course_start_cohort_value,
         "course_identifier" => "npq-early-years-leadership",
         "email_template" => "not_on_ofsted_register",
         "employer_name" => "Big company",

--- a/spec/features/journeys/sad_paths/applying_for_ehco_but_not_new_headteacher_spec.rb
+++ b/spec/features/journeys/sad_paths/applying_for_ehco_but_not_new_headteacher_spec.rb
@@ -100,7 +100,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, :with_default_school, typ
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_date_description,
+          "Course start" => course_start_cohort_description,
           "Workplace in England" => "Yes",
           "Work setting" => "A school",
           "Course" => "Early headship coaching offer",
@@ -175,7 +175,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, :with_default_school, typ
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start_date" => course_start_date_value,
+        "course_start_cohort" => course_start_cohort_value,
         "course_identifier" => "npq-early-headship-coaching-offer",
         "ehco_funding_choice" => "self",
         "ehco_headteacher" => "yes",

--- a/spec/features/journeys/sad_paths/applying_for_ehco_but_not_new_headteacher_spec.rb
+++ b/spec/features/journeys/sad_paths/applying_for_ehco_but_not_new_headteacher_spec.rb
@@ -26,10 +26,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, :with_default_school, typ
 
     expect(page).not_to have_content("Before you start")
 
-    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
       expect(page).to have_text("Have you chosen an NPQ and provider?")
@@ -103,7 +100,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, :with_default_school, typ
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "In #{application_course_start_date}",
+          "Course start" => course_start_date_description,
           "Workplace in England" => "Yes",
           "Work setting" => "A school",
           "Course" => "Early headship coaching offer",
@@ -178,8 +175,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, :with_default_school, typ
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "In #{application_course_start_date}",
-        "course_start_date" => "yes",
+        "course_start_date" => course_start_date_value,
         "course_identifier" => "npq-early-headship-coaching-offer",
         "ehco_funding_choice" => "self",
         "ehco_headteacher" => "yes",

--- a/spec/features/journeys/sad_paths/dfe_sign_in_spec.rb
+++ b/spec/features/journeys/sad_paths/dfe_sign_in_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "DfE sign in", type: :feature do
+RSpec.feature "DfE sign in", :no_js, type: :feature do
   include Helpers::JourneyAssertionHelper
 
   let(:user) { User.find_by(email: "user@example.com") }

--- a/spec/features/journeys/sad_paths/going_back_and_changing_referred_by_return_to_teaching_adviser_spec.rb
+++ b/spec/features/journeys/sad_paths/going_back_and_changing_referred_by_return_to_teaching_adviser_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 # The fix put in was just a quick fix - making the back steps correct will also fix the issue, but it's a larger piece of work (see CPDNPQ-3053).
 RSpec.feature "Sad journey", :with_default_schedules, type: :feature do
   include Helpers::JourneyAssertionHelper
+  include Helpers::JourneyStepHelper
   include ApplicationHelper
 
   include_context "Stub Get An Identity Omniauth Responses"
@@ -20,9 +21,7 @@ RSpec.feature "Sad journey", :with_default_schedules, type: :feature do
       page.click_button("Start now")
     end
 
-    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
       page.choose("Yes", visible: :all)

--- a/spec/features/journeys/sad_paths/lead_mentor_journey_with_incorrect_course_spec.rb
+++ b/spec/features/journeys/sad_paths/lead_mentor_journey_with_incorrect_course_spec.rb
@@ -30,10 +30,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, type: :feature do
 
     expect(page).not_to have_content("Before you start")
 
-    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
       expect(page).to have_text("Have you chosen an NPQ and provider?")
@@ -88,7 +85,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "In #{application_course_start_date}",
+          "Course start" => course_start_date_description,
           "Course" => "Senior leadership",
           "Employment type" => "As a lead mentor for an accredited initial teacher training (ITT) provider",
           "ITT provider" => approved_itt_provider_legal_name,
@@ -198,8 +195,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "In #{application_course_start_date}",
-        "course_start_date" => "yes",
+        "course_start_date" => course_start_date_value,
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "itt_leader_wrong_course",
         "employment_type" => "lead_mentor_for_accredited_itt_provider",

--- a/spec/features/journeys/sad_paths/lead_mentor_journey_with_incorrect_course_spec.rb
+++ b/spec/features/journeys/sad_paths/lead_mentor_journey_with_incorrect_course_spec.rb
@@ -85,7 +85,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_date_description,
+          "Course start" => course_start_cohort_description,
           "Course" => "Senior leadership",
           "Employment type" => "As a lead mentor for an accredited initial teacher training (ITT) provider",
           "ITT provider" => approved_itt_provider_legal_name,
@@ -195,7 +195,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start_date" => course_start_date_value,
+        "course_start_cohort" => course_start_cohort_value,
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "itt_leader_wrong_course",
         "employment_type" => "lead_mentor_for_accredited_itt_provider",

--- a/spec/features/journeys/sad_paths/missing_mandatory_institution_spec.rb
+++ b/spec/features/journeys/sad_paths/missing_mandatory_institution_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Sad journeys", type: :feature do
+RSpec.feature "Sad journeys", :no_js, :with_default_schedules, type: :feature do
   include Helpers::JourneyAssertionHelper
   include Helpers::JourneyStepHelper
 

--- a/spec/features/journeys/sad_paths/missing_mandatory_institution_spec.rb
+++ b/spec/features/journeys/sad_paths/missing_mandatory_institution_spec.rb
@@ -14,9 +14,7 @@ RSpec.feature "Sad journeys", type: :feature do
       page.click_button("Start now")
     end
 
-    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
       page.choose("Yes", visible: :all)

--- a/spec/features/journeys/sad_paths/not_chosen_dqt_or_provider_spec.rb
+++ b/spec/features/journeys/sad_paths/not_chosen_dqt_or_provider_spec.rb
@@ -25,10 +25,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, type: :feature do
 
     expect(page).not_to have_content("Before you start")
 
-    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
       expect(page).to have_text("Have you chosen an NPQ and provider?")

--- a/spec/features/journeys/sad_paths/school_not_in_england_spec.rb
+++ b/spec/features/journeys/sad_paths/school_not_in_england_spec.rb
@@ -25,10 +25,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, type: :feature do
 
     expect(page).not_to have_content("Before you start")
 
-    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
       expect(page).to have_text("Have you chosen an NPQ and provider?")

--- a/spec/features/journeys/sad_paths/when_teacher_auth_returns_no_trn_spec.rb
+++ b/spec/features/journeys/sad_paths/when_teacher_auth_returns_no_trn_spec.rb
@@ -17,11 +17,10 @@ RSpec.feature "Sad journeys", :no_js, :with_default_schedules, :with_default_sch
         page.click_button("Start now with Teacher Auth")
       end
 
-      expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-        expect(User.last.trn).to be_nil
-        expect(User.last.attributes).to include(user_attributes_from_stubbed_callback_response)
-        page.choose("Yes", visible: :all)
-      end
+      choose_course_start_date
+
+      expect(User.last.trn).to be_nil
+      expect(User.last.attributes).to include(user_attributes_from_stubbed_callback_response)
 
       expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
         page.choose("Yes", visible: :all)
@@ -60,7 +59,7 @@ RSpec.feature "Sad journeys", :no_js, :with_default_schedules, :with_default_sch
       expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
         expect_check_answers_page_to_have_answers(
           {
-            "Course start" => "In #{application_course_start_date}",
+            "Course start" => course_start_date_description,
             "Course" => "Headship",
             "Provider" => "Teach First",
             "Workplace" => "open manchester school – street 1, manchester",

--- a/spec/features/journeys/sad_paths/when_teacher_auth_returns_no_trn_spec.rb
+++ b/spec/features/journeys/sad_paths/when_teacher_auth_returns_no_trn_spec.rb
@@ -59,7 +59,7 @@ RSpec.feature "Sad journeys", :no_js, :with_default_schedules, :with_default_sch
       expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
         expect_check_answers_page_to_have_answers(
           {
-            "Course start" => course_start_date_description,
+            "Course start" => course_start_cohort_description,
             "Course" => "Headship",
             "Provider" => "Teach First",
             "Workplace" => "open manchester school – street 1, manchester",

--- a/spec/features/journeys/sad_paths/working_at_private_nursery_with_no_ofsted_urn_spec.rb
+++ b/spec/features/journeys/sad_paths/working_at_private_nursery_with_no_ofsted_urn_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.feature "Sad journeys", :no_js, :with_default_schedules, :with_eligibility_list_entries, type: :feature do
+  include Helpers::JourneyAssertionHelper
+  include Helpers::JourneyStepHelper
+  include ApplicationHelper
+
+  include_context "Stub Get An Identity Omniauth Responses"
+
+  scenario "infinite loop scenario" do
+    navigate_to_page(path: "/", submit_form: false, axe_check: false) do
+      expect(page).to have_text("Before you start")
+      page.click_button("Start now")
+    end
+
+    expect(page).not_to have_content("Before you start")
+
+    choose_course_start_date
+
+    expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
+      expect(page).to have_text("Have you chosen an NPQ and provider?")
+      page.choose("Yes", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/teacher-catchment", axe_check: false, submit_form: true) do
+      page.choose("Yes", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/work-setting", submit_form: true) do
+      page.choose("Early years or childcare", visible: :all)
+    end
+
+    School.create!(urn: 100_000, name: "open manchester school", address_1: "street 1", town: "manchester", establishment_status_code: "1")
+
+    expect_page_to_have(path: "/registration/kind-of-nursery", submit_form: true) do
+      expect(page).to have_text("Which early years setting do you work in?")
+      page.choose("Private nursery", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/have-ofsted-urn", submit_form: true) do
+      expect(page).to have_text("Do you or your employer have an Ofsted unique reference number (URN)?")
+      page.choose("No", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do
+      expect(page).to have_text("Which NPQ do you want to do?")
+      page.choose("Early years leadership", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/have-ofsted-urn", submit_form: true) do
+      expect(page).to have_text("Do you or your employer have an Ofsted unique reference number (URN)?")
+      expect(page).to have_text("Your application requires details of your nursery.")
+      page.click_button("Continue")
+    end
+
+    expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do
+      expect(page).to have_text("Which NPQ do you want to do?")
+      page.choose("Early years leadership", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/have-ofsted-urn", submit_form: true) do
+      expect(page).to have_text("Do you or your employer have an Ofsted unique reference number (URN)?")
+      expect(page).to have_text("Your application requires details of your nursery.")
+    end
+
+    # this is an infinite loop - the user gets bounced to choose-your-npq and have-ofsted-urn indefinitely
+  end
+end

--- a/spec/features/journeys/sad_paths/works_in_childcare_but_not_in_england_spec.rb
+++ b/spec/features/journeys/sad_paths/works_in_childcare_but_not_in_england_spec.rb
@@ -26,10 +26,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, type: :feature do
 
     expect(page).not_to have_content("Before you start")
 
-    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-      expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
-      page.choose("Yes", visible: :all)
-    end
+    choose_course_start_date
 
     expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
       expect(page).to have_text("Have you chosen an NPQ and provider?")
@@ -77,7 +74,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "In #{application_course_start_date}",
+          "Course start" => course_start_date_description,
           "Course" => "Senior leadership",
           "Course funding" => "My workplace is covering the cost",
           "Work setting" => "Early years or childcare",
@@ -148,8 +145,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start" => "In #{application_course_start_date}",
-        "course_start_date" => "yes",
+        "course_start_date" => course_start_date_value,
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "not_england_wrong_catchment",
         "funding" => "school",

--- a/spec/features/journeys/sad_paths/works_in_childcare_but_not_in_england_spec.rb
+++ b/spec/features/journeys/sad_paths/works_in_childcare_but_not_in_england_spec.rb
@@ -74,7 +74,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_date_description,
+          "Course start" => course_start_cohort_description,
           "Course" => "Senior leadership",
           "Course funding" => "My workplace is covering the cost",
           "Work setting" => "Early years or childcare",
@@ -145,7 +145,7 @@ RSpec.feature "Sad journeys", :with_default_schedules, type: :feature do
       "raw_application_data" => {
         "can_share_choices" => "1",
         "chosen_provider" => "yes",
-        "course_start_date" => course_start_date_value,
+        "course_start_cohort" => course_start_cohort_value,
         "course_identifier" => "npq-senior-leadership",
         "email_template" => "not_england_wrong_catchment",
         "funding" => "school",

--- a/spec/features/service_closed_spec.rb
+++ b/spec/features/service_closed_spec.rb
@@ -28,8 +28,7 @@ RSpec.feature "Service is closed", type: :feature do
     expect(page).to have_text("Before you start")
     page.click_button("Start now")
 
-    expect(page).to have_text("Course start")
-    page.choose("Yes", visible: :all)
+    choose_course_start_date
 
     # Registration is now closed
     close_registration!
@@ -73,9 +72,7 @@ RSpec.feature "Service is closed", type: :feature do
       visit "/closed_registration_exception"
       click_on("Start now")
 
-      expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-        expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
-      end
+      choose_course_start_date
     end
 
     scenario "When user is deleted" do
@@ -97,9 +94,7 @@ RSpec.feature "Service is closed", type: :feature do
 
       click_on("Start now")
 
-      expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-        expect(page).to have_text(I18n.t("helpers.hint.registration_wizard.course_start_date_one"))
-      end
+      choose_course_start_date
 
       visit "/npq-separation/admin/registration-closed/closed-registration-users"
 

--- a/spec/forms/questionnaires/choose_your_npq_spec.rb
+++ b/spec/forms/questionnaires/choose_your_npq_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe Questionnaires::ChooseYourNpq, type: :model do
     let(:instance) { described_class.new(course_identifier: course.identifier) }
     let(:course) { create(:course, :leading_behaviour_culture) }
     let(:lead_provider) { LeadProvider.for(course:).first }
+    let(:cohort) { create(:cohort, :current) }
+
     let(:store) do
       {
         course_identifier: course.identifier,
@@ -56,6 +58,7 @@ RSpec.describe Questionnaires::ChooseYourNpq, type: :model do
         let(:previous_course) { create(:course, :headship) }
         let(:store) do
           {
+            course_start_cohort: cohort.identifier,
             course_identifier: previous_course.identifier,
             institution_identifier: "School-#{school.urn}",
             works_in_school: "yes",

--- a/spec/forms/questionnaires/course_start_date_spec.rb
+++ b/spec/forms/questionnaires/course_start_date_spec.rb
@@ -11,6 +11,19 @@ RSpec.describe Questionnaires::CourseStartDate, type: :model do
   describe "validations" do
     it { is_expected.to validate_presence_of(:course_start_cohort) }
     it { is_expected.to validate_inclusion_of(:course_start_cohort).in_array(described_class::OPTIONS.keys) }
+
+    context "when the course_start_cohort does not correspond to an existing cohort" do
+      it { is_expected.to have_error(:course_start_cohort, :invalid) }
+    end
+
+    context "when the course_start_cohort corresponds to an existing cohort" do
+      before do
+        instance.course_start_cohort = described_class::OPTIONS.keys.first
+        create(:cohort, start_year: 2026)
+      end
+
+      it { is_expected.to be_valid }
+    end
   end
 
   describe "#next_step" do

--- a/spec/forms/questionnaires/course_start_date_spec.rb
+++ b/spec/forms/questionnaires/course_start_date_spec.rb
@@ -1,16 +1,16 @@
 require "rails_helper"
 
 RSpec.describe Questionnaires::CourseStartDate, type: :model do
-  subject(:instance) { described_class.new(wizard:, course_start_date:) }
+  subject(:instance) { described_class.new(wizard:, course_start_cohort:) }
 
   let(:current_step) { :course_start_date }
   let(:user) { create(:user) }
   let(:wizard) { RegistrationWizard.new(current_step:, store: {}, request: nil, current_user: user) }
-  let(:course_start_date) { "" }
+  let(:course_start_cohort) { "" }
 
   describe "validations" do
-    it { is_expected.to validate_presence_of(:course_start_date) }
-    it { is_expected.to validate_inclusion_of(:course_start_date).in_array(described_class::OPTIONS.keys) }
+    it { is_expected.to validate_presence_of(:course_start_cohort) }
+    it { is_expected.to validate_inclusion_of(:course_start_cohort).in_array(described_class::OPTIONS.keys) }
   end
 
   describe "#next_step" do

--- a/spec/forms/questionnaires/course_start_date_spec.rb
+++ b/spec/forms/questionnaires/course_start_date_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe Questionnaires::CourseStartDate, type: :model do
+  subject(:instance) { described_class.new(wizard:, course_start_date:) }
+
+  let(:current_step) { :course_start_date }
+  let(:user) { create(:user) }
+  let(:wizard) { RegistrationWizard.new(current_step:, store: {}, request: nil, current_user: user) }
+  let(:course_start_date) { "" }
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:course_start_date) }
+    it { is_expected.to validate_inclusion_of(:course_start_date).in_array(described_class::OPTIONS.keys) }
+  end
+
+  describe "#next_step" do
+    subject { instance.next_step }
+
+    it { is_expected.to eq(:provider_check) }
+  end
+
+  describe "#previous_step" do
+    subject { instance.previous_step }
+
+    it { is_expected.to eq(:start) }
+  end
+end

--- a/spec/forms/questionnaires/course_start_date_spec.rb
+++ b/spec/forms/questionnaires/course_start_date_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Questionnaires::CourseStartDate, type: :model do
 
     context "when the course_start_cohort corresponds to an existing cohort" do
       before do
-        instance.course_start_cohort = described_class::OPTIONS.keys.first
+        instance.course_start_cohort = described_class::OPTIONS.keys.last
         create(:cohort, start_year: 2026)
       end
 

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -226,4 +226,28 @@ RSpec.describe Cohort, type: :model do
       it { is_expected.to be false }
     end
   end
+
+  describe "#funded?" do
+    subject { cohort.funded? }
+
+    let(:cohort) { create(:cohort, funding:) }
+
+    context "when funding is 'funded'" do
+      let(:funding) { "funded" }
+
+      it { is_expected.to be true }
+    end
+
+    context "when funding is 'capped'" do
+      let(:funding) { "capped" }
+
+      it { is_expected.to be true }
+    end
+
+    context "when funding is 'unfunded'" do
+      let(:funding) { "unfunded" }
+
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -226,28 +226,4 @@ RSpec.describe Cohort, type: :model do
       it { is_expected.to be false }
     end
   end
-
-  describe "#funded?" do
-    subject { cohort.funded? }
-
-    let(:cohort) { create(:cohort, funding:) }
-
-    context "when funding is 'funded'" do
-      let(:funding) { "funded" }
-
-      it { is_expected.to be true }
-    end
-
-    context "when funding is 'capped'" do
-      let(:funding) { "capped" }
-
-      it { is_expected.to be true }
-    end
-
-    context "when funding is 'unfunded'" do
-      let(:funding) { "unfunded" }
-
-      it { is_expected.to be false }
-    end
-  end
 end

--- a/spec/models/registration_wizard_spec.rb
+++ b/spec/models/registration_wizard_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe RegistrationWizard do
   let(:request) { ActionController::TestRequest.new({}, session, ApplicationController) }
   let(:user) { create(:user) }
   let(:current_step) { "share_provider" }
+  let(:cohort) { create(:cohort, :current) }
 
   before { create(:course, :additional_support_offer) }
 
@@ -33,6 +34,7 @@ RSpec.describe RegistrationWizard do
     context "when working in Local authority maintained nursery" do
       let(:store) do
         {
+          "course_start_cohort" => cohort.identifier,
           "chosen_provider" => "yes",
           "teacher_catchment" => "england",
           "teacher_catchment_country" => "",
@@ -64,6 +66,7 @@ RSpec.describe RegistrationWizard do
       let(:private_childcare_provider) { create(:private_childcare_provider) }
       let(:store) do
         {
+          "course_start_cohort" => cohort.identifier,
           "chosen_provider" => "yes",
           "course_identifier" => "npq-additional-support-offer",
           "date_of_birth" => 30.years.ago,

--- a/spec/models/registration_wizard_spec.rb
+++ b/spec/models/registration_wizard_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RegistrationWizard do
   let(:request) { ActionController::TestRequest.new({}, session, ApplicationController) }
   let(:user) { create(:user) }
   let(:current_step) { "share_provider" }
-  let(:cohort) { create(:cohort, :current) }
+  let(:cohort) { create(:cohort, :next) }
 
   before { create(:course, :additional_support_offer) }
 

--- a/spec/services/funding_eligibility_spec.rb
+++ b/spec/services/funding_eligibility_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe FundingEligibility do
 
   let(:store) do
     {
-      course_start_date: course_start_cohort,
+      course_start_cohort: course_start_cohort,
       work_setting:,
       kind_of_nursery:,
       employment_type:,
@@ -75,13 +75,13 @@ RSpec.describe FundingEligibility do
     it { is_expected.not_to respond_to :lead_mentor_for_accredited_itt_provider }
     it { is_expected.not_to respond_to :query_store }
 
-    context "when the course_start_date is in an unfunded cohort" do
+    context "when the course_start_cohort is in an unfunded cohort" do
       let(:course_start_cohort) { unfunded_cohort.identifier }
 
       it { is_expected.to have_attributes cohort: unfunded_cohort }
     end
 
-    context "when the course_start_date is a funded cohort" do
+    context "when the course_start_cohort is a funded cohort" do
       let(:course_start_cohort) { cohort.identifier }
 
       it { is_expected.to have_attributes cohort: cohort }

--- a/spec/services/funding_eligibility_spec.rb
+++ b/spec/services/funding_eligibility_spec.rb
@@ -2,7 +2,8 @@ require "rails_helper"
 
 RSpec.describe FundingEligibility do
   subject(:funding_eligibility) do
-    described_class.new(institution:,
+    described_class.new(cohort:,
+                        institution:,
                         course:,
                         inside_catchment:,
                         trn: "1234567",
@@ -17,6 +18,7 @@ RSpec.describe FundingEligibility do
 
   let(:store) do
     {
+      course_start_date: course_start_cohort,
       work_setting:,
       kind_of_nursery:,
       employment_type:,
@@ -26,6 +28,9 @@ RSpec.describe FundingEligibility do
     }.stringify_keys
   end
 
+  let(:unfunded_cohort) { create(:cohort, :current, :unfunded) }
+  let(:cohort) { create(:cohort, :current, suffix: "b", registration_start_date: (unfunded_cohort.registration_start_date + 2.months)) }
+  let(:course_start_cohort) { cohort.identifier }
   let(:inside_catchment) { true }
   let(:approved_itt_provider) { nil }
   let(:institution) { nil }
@@ -35,6 +40,11 @@ RSpec.describe FundingEligibility do
   let(:referred_by_return_to_teaching_adviser) { nil }
   let(:new_headteacher) { "no" }
   let(:query_store) { RegistrationQueryStore.new(store:) }
+
+  before do
+    unfunded_cohort
+    cohort
+  end
 
   describe ".new_from_query_store" do
     subject do
@@ -65,6 +75,18 @@ RSpec.describe FundingEligibility do
     it { is_expected.not_to respond_to :lead_mentor_for_accredited_itt_provider }
     it { is_expected.not_to respond_to :query_store }
 
+    context "when the course_start_date is in an unfunded cohort" do
+      let(:course_start_cohort) { unfunded_cohort.identifier }
+
+      it { is_expected.to have_attributes cohort: unfunded_cohort }
+    end
+
+    context "when the course_start_date is a funded cohort" do
+      let(:course_start_cohort) { cohort.identifier }
+
+      it { is_expected.to have_attributes cohort: cohort }
+    end
+
     context "with childminder" do
       before { store["kind_of_nursery"] = "childminder" }
 
@@ -91,6 +113,12 @@ RSpec.describe FundingEligibility do
   end
 
   RSpec.shared_examples "general rules" do
+    context "and the cohort chosen is in an unfunded cohort" do
+      let(:cohort) { create(:cohort, :current, :unfunded) }
+
+      include_examples "funding eligibility", :unfunded_cohort
+    end
+
     context "and the applicant is outside England" do
       let(:inside_catchment) { false }
 

--- a/spec/services/handle_submission_for_store_spec.rb
+++ b/spec/services/handle_submission_for_store_spec.rb
@@ -11,10 +11,12 @@ RSpec.describe HandleSubmissionForStore do
   let(:courses) { Course.where(identifier: "npq-leading-primary-mathematics") }
   let(:course) { courses.sample }
   let(:lead_provider) { LeadProvider.all.sample }
+  let(:last_application) { user.applications.last }
 
   let(:store) do
     {
       "current_user_id" => user.id,
+      "course_start_cohort" => cohort.identifier,
       "course_identifier" => course.identifier,
       "private_childcare_identifier" => "PrivateChildcareProvider-#{private_childcare_provider.provider_urn}",
       "lead_provider_id" => lead_provider.id,
@@ -64,6 +66,7 @@ RSpec.describe HandleSubmissionForStore do
       let(:store) do
         {
           "current_user" => user,
+          "course_start_cohort" => cohort.identifier,
           "course_identifier" => course.identifier,
           "lead_provider_id" => lead_provider.id,
         }
@@ -75,10 +78,28 @@ RSpec.describe HandleSubmissionForStore do
       end
     end
 
-    context "when store includes information from the school path" do
+    context "when there are multiple cohorts" do
+      let(:cohort) { create(:cohort, :current, :unfunded) }
+      let(:newer_cohort) { create(:cohort, :current, suffix: "b") }
+
+      let(:store) { super().merge("course_start_cohort" => cohort.identifier) }
+
+      before do
+        cohort
+        newer_cohort
+      end
+
+      it "chooses the cohort specified in the store" do
+        subject.call
+        expect(last_application.cohort).to eq(cohort)
+      end
+    end
+
+    context "when the store includes information from the school path" do
       let(:store) do
         {
           "current_user_id" => user.id,
+          "course_start_cohort" => cohort.identifier,
           "course_identifier" => course.identifier,
           "institution_identifier" => "School-#{school.urn}",
           "lead_provider_id" => lead_provider.id,
@@ -101,7 +122,6 @@ RSpec.describe HandleSubmissionForStore do
 
         expect(stable_as_json(user.reload)).to match(expected_user_attributes)
         expect(user.applications.reload.count).to eq 1
-        last_application = user.applications.last
         expect(stable_as_json(last_application)).to match({
           "course_id" => course.id,
           "schedule_id" => nil,
@@ -155,7 +175,7 @@ RSpec.describe HandleSubmissionForStore do
       end
     end
 
-    context "when store includes information from the early years path" do
+    context "when the store includes information from the early years path" do
       let(:courses) { [Course.ehco] }
       let(:store) do
         {
@@ -173,7 +193,7 @@ RSpec.describe HandleSubmissionForStore do
           "senco_in_role" => nil,
           "senco_start_date" => nil,
           "on_submission_trn" => nil,
-        }
+        )
       end
 
       it "stores data from store" do
@@ -185,7 +205,6 @@ RSpec.describe HandleSubmissionForStore do
 
         expect(stable_as_json(user.reload)).to match(expected_user_attributes)
         expect(user.applications.reload.count).to eq 1
-        last_application = user.applications.last
         expect(stable_as_json(last_application)).to match({
           "course_id" => course.id,
           "schedule_id" => nil,
@@ -292,14 +311,12 @@ RSpec.describe HandleSubmissionForStore do
     context "when applying for EHCO" do
       context "happy path" do
         let(:store) do
-          {
-            "current_user_id" => user.id,
+          super().merge(
             "course_identifier" => ehco_course.identifier,
             "institution_identifier" => "School-#{school.urn}",
-            "lead_provider_id" => LeadProvider.all.sample.id,
             "ehco_headteacher" => "yes",
-            "ehco_new_headteacher" => "no",
-          }
+            "ehco_new_headteacher" => "yes",
+          )
         end
 
         let(:ehco_course) { Course.ehco }
@@ -308,18 +325,21 @@ RSpec.describe HandleSubmissionForStore do
           subject.call
           expect(user.applications.first.course).to eq(ehco_course)
         end
+
+        it "returns headteacher_status as yes_in_first_five_years" do
+          subject.call
+          expect(user.applications.first.reload.headteacher_status).to eq "yes_in_first_five_years"
+        end
       end
 
       context "a headteacher for over five years" do
         let(:store) do
-          {
-            "current_user_id" => user.id,
+          super().merge(
             "course_identifier" => Course.ehco.identifier,
             "institution_identifier" => "School-#{school.urn}",
-            "lead_provider_id" => LeadProvider.all.sample.id,
             "ehco_headteacher" => "yes",
             "ehco_new_headteacher" => "no",
-          }
+          )
         end
 
         it "returns headteacher_status as yes_over_five_years" do
@@ -335,14 +355,7 @@ RSpec.describe HandleSubmissionForStore do
 
     context "when teacher catchment is not in the UK catchment area" do
       let(:store) do
-        {
-          "current_user_id" => user.id,
-          "course_identifier" => course.identifier,
-          "institution_identifier" => "PrivateChildcareProvider-#{private_childcare_provider.provider_urn}",
-          "lead_provider_id" => lead_provider.id,
-          "works_in_childcare" => "yes",
-          "works_in_school" => "no",
-          "kind_of_nursery" => "private_nursery",
+        super().merge(
           "teacher_catchment" => "another",
           "teacher_catchment_country" => "spain",
           "work_setting" => "early_years_or_childcare",
@@ -350,7 +363,7 @@ RSpec.describe HandleSubmissionForStore do
           "senco_in_role" => nil,
           "senco_start_date" => nil,
           "on_submission_trn" => nil,
-        }
+        )
       end
 
       it "stores data from store" do
@@ -411,14 +424,7 @@ RSpec.describe HandleSubmissionForStore do
 
     context "when teacher catchment is empty" do
       let(:store) do
-        {
-          "current_user_id" => user.id,
-          "course_identifier" => course.identifier,
-          "institution_identifier" => "PrivateChildcareProvider-#{private_childcare_provider.provider_urn}",
-          "lead_provider_id" => lead_provider.id,
-          "works_in_childcare" => "yes",
-          "works_in_school" => "no",
-          "kind_of_nursery" => "private_nursery",
+        super().merge(
           "teacher_catchment" => nil,
           "teacher_catchment_country" => nil,
           "work_setting" => "early_years_or_childcare",
@@ -426,7 +432,7 @@ RSpec.describe HandleSubmissionForStore do
           "senco_in_role" => nil,
           "senco_start_date" => nil,
           "on_submission_trn" => nil,
-        }
+        )
       end
 
       it "stores data from store" do
@@ -491,14 +497,7 @@ RSpec.describe HandleSubmissionForStore do
       end
 
       let(:store) do
-        {
-          "current_user_id" => user.id,
-          "course_identifier" => course.identifier,
-          "institution_identifier" => "PrivateChildcareProvider-#{private_childcare_provider.provider_urn}",
-          "lead_provider_id" => lead_provider.id,
-          "works_in_childcare" => "yes",
-          "works_in_school" => "no",
-          "kind_of_nursery" => "private_nursery",
+        super().merge(
           "teacher_catchment" => "another",
           "teacher_catchment_country" => "wonderland",
           "work_setting" => "early_years_or_childcare",
@@ -506,7 +505,7 @@ RSpec.describe HandleSubmissionForStore do
           "senco_in_role" => nil,
           "senco_start_date" => nil,
           "on_submission_trn" => nil,
-        }
+        )
       end
 
       it "logs an error" do

--- a/spec/services/handle_submission_for_store_spec.rb
+++ b/spec/services/handle_submission_for_store_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe HandleSubmissionForStore do
           "senco_in_role" => nil,
           "senco_start_date" => nil,
           "on_submission_trn" => nil,
-        )
+        }
       end
 
       it "stores data from store" do

--- a/spec/services/handle_submission_for_store_spec.rb
+++ b/spec/services/handle_submission_for_store_spec.rb
@@ -164,6 +164,7 @@ RSpec.describe HandleSubmissionForStore do
       let(:store) do
         {
           "current_user_id" => user.id,
+          "course_start_cohort" => cohort.identifier,
           "course_identifier" => course.identifier,
           "has_ofsted_urn" => "yes",
           "private_childcare_identifier" => "PrivateChildcareProvider-#{private_childcare_provider.provider_urn}",

--- a/spec/services/handle_submission_for_store_spec.rb
+++ b/spec/services/handle_submission_for_store_spec.rb
@@ -62,22 +62,6 @@ RSpec.describe HandleSubmissionForStore do
       record.as_json(except: %i[id created_at updated_at significantly_updated_at updated_from_tra_at DEPRECATED_school_urn email_updates_status email_updates_unsubscribe_key])
     end
 
-    context "when the store includes a user object (legacy behaviour)" do
-      let(:store) do
-        {
-          "current_user" => user,
-          "course_start_cohort" => cohort.identifier,
-          "course_identifier" => course.identifier,
-          "lead_provider_id" => lead_provider.id,
-        }
-      end
-
-      it "creates an application for the user" do
-        subject.call
-        expect(user.applications.reload.count).to eq 1
-      end
-    end
-
     context "when there are multiple cohorts" do
       let(:cohort) { create(:cohort, :current, :unfunded) }
       let(:newer_cohort) { create(:cohort, :current, suffix: "b") }

--- a/spec/support/helpers/journey_assertion_helper.rb
+++ b/spec/support/helpers/journey_assertion_helper.rb
@@ -38,7 +38,7 @@ module Helpers
       expect_page_to_have(path: "/accounts/user_registrations/#{latest_application.reload.id}?success=true", submit_form: false) do
         expect(page).to have_text("Registration successfully submitted")
         expect(page).to have_text("Application ID: #{latest_application.ecf_id}")
-        expect(page).to have_link("Register for another NPQ", href: /\/registration\/course_start_date/)
+        expect(page).to have_link("Register for another NPQ", href: registration_wizard_show_path("course-start-date"))
       end
 
       expect(User.count).to be(1)

--- a/spec/support/helpers/journey_assertion_helper.rb
+++ b/spec/support/helpers/journey_assertion_helper.rb
@@ -34,10 +34,11 @@ module Helpers
       expect(summary_data).to eql(values)
     end
 
-    def expect_applicant_reached_end_of_journey(total_number_of_created_applications: 1)
+    def expect_applicant_reached_end_of_journey(total_number_of_created_applications: 1, course_start: "Autumn 2026")
       expect_page_to_have(path: "/accounts/user_registrations/#{latest_application.reload.id}?success=true", submit_form: false) do
         expect(page).to have_text("Registration successfully submitted")
         expect(page).to have_text("Application ID: #{latest_application.ecf_id}")
+        expect(page).to have_summary_item("Course start", course_start)
         expect(page).to have_link("Register for another NPQ", href: registration_wizard_show_path("course-start-date"))
       end
 

--- a/spec/support/helpers/journey_step_helper.rb
+++ b/spec/support/helpers/journey_step_helper.rb
@@ -108,5 +108,20 @@ module Helpers
         end
       end
     end
+
+    def course_start_date_value
+      "2026b"
+    end
+
+    def course_start_date_description
+      "Autumn 2026"
+    end
+
+    def choose_course_start_date
+      expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
+        expect(page).to have_text(I18n.t("helpers.legend.registration_wizard.course_start_date"))
+        page.choose(course_start_date_description, visible: :all)
+      end
+    end
   end
 end

--- a/spec/support/helpers/journey_step_helper.rb
+++ b/spec/support/helpers/journey_step_helper.rb
@@ -109,18 +109,18 @@ module Helpers
       end
     end
 
-    def course_start_date_value
+    def course_start_cohort_value
       "2026b"
     end
 
-    def course_start_date_description
+    def course_start_cohort_description
       "Autumn 2026"
     end
 
     def choose_course_start_date
       expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
-        expect(page).to have_text(I18n.t("helpers.legend.registration_wizard.course_start_date"))
-        page.choose(course_start_date_description, visible: :all)
+        expect(page).to have_text(I18n.t("helpers.legend.registration_wizard.course_start_cohort"))
+        page.choose(course_start_cohort_description, visible: :all)
       end
     end
   end

--- a/spec/support/helpers/journey_step_helper.rb
+++ b/spec/support/helpers/journey_step_helper.rb
@@ -110,11 +110,11 @@ module Helpers
     end
 
     def course_start_cohort_value
-      "2026b"
+      Questionnaires::CourseStartDate::OPTIONS.keys.last
     end
 
     def course_start_cohort_description
-      "Autumn 2026"
+      Questionnaires::CourseStartDate::OPTIONS.values.last
     end
 
     def choose_course_start_date

--- a/spec/support/helpers/journey_step_helper.rb
+++ b/spec/support/helpers/journey_step_helper.rb
@@ -110,17 +110,21 @@ module Helpers
     end
 
     def course_start_cohort_value
-      Questionnaires::CourseStartDate::OPTIONS.keys.last
+      Questionnaires::CourseStartDate::OPTIONS.keys.first
+    end
+
+    def course_start_cohort_label
+      Questionnaires::CourseStartDate::OPTIONS.values.first[:label]
     end
 
     def course_start_cohort_description
-      Questionnaires::CourseStartDate::OPTIONS.values.last
+      Questionnaires::CourseStartDate::OPTIONS.values.first[:cohort_description]
     end
 
     def choose_course_start_date
       expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
         expect(page).to have_text(I18n.t("helpers.legend.registration_wizard.course_start_cohort"))
-        page.choose(course_start_cohort_description, visible: :all)
+        page.choose(course_start_cohort_label, visible: :all)
       end
     end
   end

--- a/spec/support/with_default_schedules.rb
+++ b/spec/support/with_default_schedules.rb
@@ -2,24 +2,36 @@
 
 RSpec.shared_context "with default schedules", shared_context: :metadata do
   before do
-    # create cohorts since 2021 with default schedule
+    default_schedules = %i[
+      npq_aso_december
+      npq_aso_june
+      npq_aso_march
+      npq_aso_november
+      npq_ehco_june
+      npq_ehco_march
+      npq_ehco_november
+      npq_ehco_december
+      npq_leadership_spring
+      npq_leadership_autumn
+      npq_specialist_spring
+      npq_specialist_autumn
+    ]
+
+    # create cohorts since 2021
     end_year = Date.current.month < 9 ? Date.current.year : Date.current.year.succ
-    (2021..end_year).each do |start_year|
-      cohort = FactoryBot.create(:cohort, start_year:)
-      %i[
-        npq_aso_december
-        npq_aso_june
-        npq_aso_march
-        npq_aso_november
-        npq_ehco_june
-        npq_ehco_march
-        npq_ehco_november
-        npq_ehco_december
-        npq_leadership_spring
-        npq_leadership_autumn
-        npq_specialist_spring
-        npq_specialist_autumn
-      ].each do |schedule_identifier|
+    (2021..(end_year - 1)).each do |start_year|
+      FactoryBot.create(:cohort, start_year:)
+    end
+
+    # create an unfunded cohort for the end year
+    FactoryBot.create(:cohort, :unfunded, start_year: end_year)
+
+    # create a funded 'b' cohort for the end year
+    FactoryBot.create(:cohort, start_year: end_year, suffix: "b")
+
+    # create default schedules for all cohorts
+    Cohort.find_each do |cohort|
+      default_schedules.each do |schedule_identifier|
         FactoryBot.create(:schedule, schedule_identifier, cohort:, change_applies_dates: false)
       end
     end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/NPQ-3620

### Changes proposed in this pull request
* update options on `course-start-date` page: now answering 'yes' or 'no' to starting in Autumn 2026
* new ineligible messaging if it's because the user chose 'no' (i.e. the Spring 2026 cohort)
* update specs to work with new choice
* update funding eligibility checker to return unfunded if the cohort is unfunded
* remove 'Course start' section on account page, because this was using a hardcoded single value for the course start date
* update seeds to include an unfunded cohort

