### PR TITLE
[NPQ-3548] email notifications when application status and course outcome changes

### DIFF
--- a/app/mailers/application_accepted_mailer.rb
+++ b/app/mailers/application_accepted_mailer.rb
@@ -1,0 +1,14 @@
+class ApplicationAcceptedMailer < ApplicationMailer
+  TEMPLATE_ID = "3ccfcf63-f2bd-498b-a1d2-7814bb8bede8".freeze
+
+  def application_accepted_mail(to:, full_name:, provider_name:, course_name:, ecf_id:)
+    template_mail(TEMPLATE_ID,
+                  to:,
+                  personalisation: {
+                    full_name:,
+                    provider_name:,
+                    course_name:,
+                    ecf_id:,
+                  })
+  end
+end

--- a/app/mailers/application_deferred_mailer.rb
+++ b/app/mailers/application_deferred_mailer.rb
@@ -1,0 +1,14 @@
+class ApplicationDeferredMailer < ApplicationMailer
+  TEMPLATE_ID = "6e29f6f2-5c9d-4106-baa7-7fd9aeed63d6".freeze
+
+  def application_deferred_mail(to:, full_name:, provider_name:, course_name:, ecf_id:)
+    template_mail(TEMPLATE_ID,
+                  to:,
+                  personalisation: {
+                    full_name:,
+                    provider_name:,
+                    course_name:,
+                    ecf_id:,
+                  })
+  end
+end

--- a/app/mailers/application_rejected_mailer.rb
+++ b/app/mailers/application_rejected_mailer.rb
@@ -1,0 +1,14 @@
+class ApplicationRejectedMailer < ApplicationMailer
+  TEMPLATE_ID = "76a5eb0d-4510-4e26-87ca-dc375e4bf972".freeze
+
+  def application_rejected_mail(to:, full_name:, provider_name:, course_name:, ecf_id:)
+    template_mail(TEMPLATE_ID,
+                  to:,
+                  personalisation: {
+                    full_name:,
+                    provider_name:,
+                    course_name:,
+                    ecf_id:,
+                  })
+  end
+end

--- a/app/mailers/application_resumed_mailer.rb
+++ b/app/mailers/application_resumed_mailer.rb
@@ -1,0 +1,14 @@
+class ApplicationResumedMailer < ApplicationMailer
+  TEMPLATE_ID = "5c648930-42e0-4b4a-9fc0-73617a9d6bdd".freeze
+
+  def application_resumed_mail(to:, full_name:, provider_name:, course_name:, ecf_id:)
+    template_mail(TEMPLATE_ID,
+                  to:,
+                  personalisation: {
+                    full_name:,
+                    provider_name:,
+                    course_name:,
+                    ecf_id:,
+                  })
+  end
+end

--- a/app/mailers/application_withdrawn_mailer.rb
+++ b/app/mailers/application_withdrawn_mailer.rb
@@ -1,0 +1,14 @@
+class ApplicationWithdrawnMailer < ApplicationMailer
+  TEMPLATE_ID = "06c2b9f3-f7cb-4877-b2c1-595e68b7a86e".freeze
+
+  def application_withdrawn_mail(to:, full_name:, provider_name:, course_name:, ecf_id:)
+    template_mail(TEMPLATE_ID,
+                  to:,
+                  personalisation: {
+                    full_name:,
+                    provider_name:,
+                    course_name:,
+                    ecf_id:,
+                  })
+  end
+end

--- a/app/mailers/participant_outcome_failed_mailer.rb
+++ b/app/mailers/participant_outcome_failed_mailer.rb
@@ -1,0 +1,14 @@
+class ParticipantOutcomeFailedMailer < ApplicationMailer
+  TEMPLATE_ID = "a0c2bf2e-262e-4879-8485-5357e3bfb2f3".freeze
+
+  def failed_mail(to:, full_name:, provider_name:, course_name:, ecf_id:)
+    template_mail(TEMPLATE_ID,
+                  to:,
+                  personalisation: {
+                    full_name:,
+                    provider_name:,
+                    course_name:,
+                    ecf_id:,
+                  })
+  end
+end

--- a/app/mailers/participant_outcome_passed_mailer.rb
+++ b/app/mailers/participant_outcome_passed_mailer.rb
@@ -1,0 +1,14 @@
+class ParticipantOutcomePassedMailer < ApplicationMailer
+  TEMPLATE_ID = "cd7f52db-1c61-4774-85db-ebedb8a77abf".freeze
+
+  def passed_mail(to:, full_name:, provider_name:, course_name:, ecf_id:)
+    template_mail(TEMPLATE_ID,
+                  to:,
+                  personalisation: {
+                    full_name:,
+                    provider_name:,
+                    course_name:,
+                    ecf_id:,
+                  })
+  end
+end

--- a/app/services/applications/accept.rb
+++ b/app/services/applications/accept.rb
@@ -29,6 +29,14 @@ module Applications
 
       application.reload
 
+      ApplicationAcceptedMailer.application_accepted_mail(
+        to: user.email,
+        full_name: user.full_name,
+        provider_name: lead_provider.name,
+        course_name: course.name,
+        ecf_id: application.ecf_id,
+      ).deliver_later
+
       true
     end
 

--- a/app/services/applications/reject.rb
+++ b/app/services/applications/reject.rb
@@ -17,6 +17,14 @@ module Applications
       application.update!(lead_provider_approval_status: "rejected", reason_for_rejection:)
       application.reload
 
+      ApplicationRejectedMailer.application_rejected_mail(
+        to: application.user.email,
+        full_name: application.user.full_name,
+        provider_name: application.lead_provider.name,
+        course_name: application.course.name,
+        ecf_id: application.ecf_id,
+      ).deliver_later
+
       true
     end
 

--- a/app/services/participant_outcomes/create.rb
+++ b/app/services/participant_outcomes/create.rb
@@ -37,6 +37,7 @@ module ParticipantOutcomes
                              build_outcome.tap do |new_outcome|
                                new_outcome.save!
                                new_outcome.declaration.touch(time: new_outcome.updated_at)
+                               send_email_notification(new_outcome)
                              end
                            end
       end
@@ -90,6 +91,24 @@ module ParticipantOutcomes
 
     def participant_exists
       errors.add(:participant_id, :invalid_participant) if participant.blank?
+    end
+
+    def send_email_notification(outcome)
+      mail_params = {
+        to: participant.email,
+        full_name: participant.full_name,
+        provider_name: outcome.lead_provider.name,
+        course_name: outcome.course.name,
+        ecf_id: outcome.declaration.application.ecf_id,
+      }
+
+      if outcome.has_passed?
+        ParticipantOutcomePassedMailer.passed_mail(**mail_params).deliver_later
+      end
+
+      if outcome.has_failed?
+        ParticipantOutcomeFailedMailer.failed_mail(**mail_params).deliver_later
+      end
     end
   end
 end

--- a/app/services/participants/defer.rb
+++ b/app/services/participants/defer.rb
@@ -24,6 +24,7 @@ module Participants
         create_application_state!(state: :deferred, reason:)
         application.deferred_training_status!
         participant.reload
+        send_email
       end
 
       true
@@ -42,6 +43,16 @@ module Participants
 
     def has_declarations
       errors.add(:participant_id, :no_declarations) if application&.declarations&.none?
+    end
+
+    def send_email
+      ApplicationDeferredMailer.application_deferred_mail(
+        to: application.user.email,
+        full_name: application.user.full_name,
+        provider_name: application.lead_provider.name,
+        course_name: application.course.name,
+        ecf_id: application.ecf_id,
+      ).deliver_later
     end
   end
 end

--- a/app/services/participants/resume.rb
+++ b/app/services/participants/resume.rb
@@ -11,6 +11,7 @@ module Participants
         create_application_state!
         application.active_training_status!
         participant.reload
+        send_email
       end
 
       true
@@ -21,6 +22,16 @@ module Participants
 
     def not_already_active
       errors.add(:participant_id, :already_active) if application&.active_training_status?
+    end
+
+    def send_email
+      ApplicationResumedMailer.application_resumed_mail(
+        to: application.user.email,
+        full_name: application.user.full_name,
+        provider_name: application.lead_provider.name,
+        course_name: application.course.name,
+        ecf_id: application.ecf_id,
+      ).deliver_later
     end
   end
 end

--- a/app/services/participants/withdraw.rb
+++ b/app/services/participants/withdraw.rb
@@ -39,6 +39,7 @@ module Participants
         create_application_state!(state: :withdrawn, reason:)
         application.withdrawn_training_status!
         participant.reload
+        send_email
       end
 
       true
@@ -55,6 +56,16 @@ module Participants
       return if errors.any?
 
       errors.add(:participant_id, :no_started_declarations) unless application&.declarations&.any?(&:started_declaration_type?)
+    end
+
+    def send_email
+      ApplicationWithdrawnMailer.application_withdrawn_mail(
+        to: application.user.email,
+        full_name: application.user.full_name,
+        provider_name: application.lead_provider.name,
+        course_name: application.course.name,
+        ecf_id: application.ecf_id,
+      ).deliver_later
     end
   end
 end

--- a/spec/mailers/application_accepted_mailer_spec.rb
+++ b/spec/mailers/application_accepted_mailer_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe ApplicationAcceptedMailer, type: :mailer do
+  describe "#application_accepted_mail" do
+    let(:application) { build(:application, :accepted) }
+    let(:to) { application.user.email }
+    let(:full_name) { application.user.full_name }
+    let(:provider_name) { application.lead_provider.name }
+    let(:course_name) { application.course.name }
+    let(:ecf_id) { application.ecf_id }
+
+    subject(:mail) { described_class.application_accepted_mail(to:, full_name:, provider_name:, course_name:, ecf_id:) }
+
+    it "sends to the correct recipient" do
+      expect(mail.to).to eq([application.user.email])
+    end
+
+    it "sends the correct personalisation" do
+      expect(mail).to have_personalisation(
+        full_name: application.user.full_name,
+        provider_name: application.lead_provider.name,
+        course_name: application.course.name,
+        ecf_id: application.ecf_id,
+      )
+    end
+
+    it { is_expected.to use_template(described_class::TEMPLATE_ID) }
+
+    it_behaves_like "a mailer with redacted logs"
+  end
+end

--- a/spec/mailers/application_deferred_mailer_spec.rb
+++ b/spec/mailers/application_deferred_mailer_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe ApplicationDeferredMailer, type: :mailer do
+  describe "#application_deferred_mail" do
+    let(:application) { build(:application, :accepted) }
+    let(:to) { application.user.email }
+    let(:full_name) { application.user.full_name }
+    let(:provider_name) { application.lead_provider.name }
+    let(:course_name) { application.course.name }
+    let(:ecf_id) { application.ecf_id }
+
+    subject(:mail) { described_class.application_deferred_mail(to:, full_name:, provider_name:, course_name:, ecf_id:) }
+
+    it "sends to the correct recipient" do
+      expect(mail.to).to eq([application.user.email])
+    end
+
+    it "sends the correct personalisation" do
+      expect(mail).to have_personalisation(
+        full_name: application.user.full_name,
+        provider_name: application.lead_provider.name,
+        course_name: application.course.name,
+        ecf_id: application.ecf_id,
+      )
+    end
+
+    it { is_expected.to use_template(described_class::TEMPLATE_ID) }
+
+    it_behaves_like "a mailer with redacted logs", processing_log_entry_needs_redacting: false
+  end
+end

--- a/spec/mailers/application_rejected_mailer_spec.rb
+++ b/spec/mailers/application_rejected_mailer_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe ApplicationRejectedMailer, type: :mailer do
+  describe "#application_rejected_mail" do
+    let(:application) { build(:application, :rejected) }
+    let(:to) { application.user.email }
+    let(:full_name) { application.user.full_name }
+    let(:provider_name) { application.lead_provider.name }
+    let(:course_name) { application.course.name }
+    let(:ecf_id) { application.ecf_id }
+
+    subject(:mail) { described_class.application_rejected_mail(to:, full_name:, provider_name:, course_name:, ecf_id:) }
+
+    it "sends to the correct recipient" do
+      expect(mail.to).to eq([application.user.email])
+    end
+
+    it "sends the correct personalisation" do
+      expect(mail).to have_personalisation(
+        full_name: application.user.full_name,
+        provider_name: application.lead_provider.name,
+        course_name: application.course.name,
+        ecf_id: application.ecf_id,
+      )
+    end
+
+    it { is_expected.to use_template(described_class::TEMPLATE_ID) }
+
+    it_behaves_like "a mailer with redacted logs"
+  end
+end

--- a/spec/mailers/application_resumed_mailer_spec.rb
+++ b/spec/mailers/application_resumed_mailer_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe ApplicationResumedMailer, type: :mailer do
+  describe "#application_resumed_mail" do
+    let(:application) { build(:application, :accepted) }
+    let(:to) { application.user.email }
+    let(:full_name) { application.user.full_name }
+    let(:provider_name) { application.lead_provider.name }
+    let(:course_name) { application.course.name }
+    let(:ecf_id) { application.ecf_id }
+
+    subject(:mail) { described_class.application_resumed_mail(to:, full_name:, provider_name:, course_name:, ecf_id:) }
+
+    it "sends to the correct recipient" do
+      expect(mail.to).to eq([application.user.email])
+    end
+
+    it "sends the correct personalisation" do
+      expect(mail).to have_personalisation(
+        full_name: application.user.full_name,
+        provider_name: application.lead_provider.name,
+        course_name: application.course.name,
+        ecf_id: application.ecf_id,
+      )
+    end
+
+    it { is_expected.to use_template(described_class::TEMPLATE_ID) }
+
+    it_behaves_like "a mailer with redacted logs", processing_log_entry_needs_redacting: false
+  end
+end

--- a/spec/mailers/application_withdrawn_mailer_spec.rb
+++ b/spec/mailers/application_withdrawn_mailer_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe ApplicationWithdrawnMailer, type: :mailer do
+  describe "#application_withdrawn_mail" do
+    let(:application) { build(:application, :withdrawn) }
+    let(:to) { application.user.email }
+    let(:full_name) { application.user.full_name }
+    let(:provider_name) { application.lead_provider.name }
+    let(:course_name) { application.course.name }
+    let(:ecf_id) { application.ecf_id }
+
+    subject(:mail) { described_class.application_withdrawn_mail(to:, full_name:, provider_name:, course_name:, ecf_id:) }
+
+    it "sends to the correct recipient" do
+      expect(mail.to).to eq([application.user.email])
+    end
+
+    it "sends the correct personalisation" do
+      expect(mail).to have_personalisation(
+        full_name: application.user.full_name,
+        provider_name: application.lead_provider.name,
+        course_name: application.course.name,
+        ecf_id: application.ecf_id,
+      )
+    end
+
+    it { is_expected.to use_template(described_class::TEMPLATE_ID) }
+
+    it_behaves_like "a mailer with redacted logs", processing_log_entry_needs_redacting: false
+  end
+end

--- a/spec/mailers/participant_outcome_failed_mailer_spec.rb
+++ b/spec/mailers/participant_outcome_failed_mailer_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe ParticipantOutcomeFailedMailer, type: :mailer do
+  describe "#failed_mail" do
+    let(:application) { build(:application, :accepted) }
+    let(:to) { application.user.email }
+    let(:full_name) { application.user.full_name }
+    let(:provider_name) { application.lead_provider.name }
+    let(:course_name) { application.course.name }
+    let(:ecf_id) { application.ecf_id }
+
+    subject(:mail) { described_class.failed_mail(to:, full_name:, provider_name:, course_name:, ecf_id:) }
+
+    it "sends to the correct recipient" do
+      expect(mail.to).to eq([application.user.email])
+    end
+
+    it "sends the correct personalisation" do
+      expect(mail).to have_personalisation(
+        full_name: application.user.full_name,
+        provider_name: application.lead_provider.name,
+        course_name: application.course.name,
+        ecf_id: application.ecf_id,
+      )
+    end
+
+    it { is_expected.to use_template(described_class::TEMPLATE_ID) }
+
+    it_behaves_like "a mailer with redacted logs", processing_log_entry_needs_redacting: false
+  end
+end

--- a/spec/mailers/participant_outcome_passed_mailer_spec.rb
+++ b/spec/mailers/participant_outcome_passed_mailer_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe ParticipantOutcomePassedMailer, type: :mailer do
+  describe "#passed_mail" do
+    let(:application) { build(:application, :accepted) }
+    let(:to) { application.user.email }
+    let(:full_name) { application.user.full_name }
+    let(:provider_name) { application.lead_provider.name }
+    let(:course_name) { application.course.name }
+    let(:ecf_id) { application.ecf_id }
+
+    subject(:mail) { described_class.passed_mail(to:, full_name:, provider_name:, course_name:, ecf_id:) }
+
+    it "sends to the correct recipient" do
+      expect(mail.to).to eq([application.user.email])
+    end
+
+    it "sends the correct personalisation" do
+      expect(mail).to have_personalisation(
+        full_name: application.user.full_name,
+        provider_name: application.lead_provider.name,
+        course_name: application.course.name,
+        ecf_id: application.ecf_id,
+      )
+    end
+
+    it { is_expected.to use_template(described_class::TEMPLATE_ID) }
+
+    it_behaves_like "a mailer with redacted logs", processing_log_entry_needs_redacting: false
+  end
+end

--- a/spec/services/applications/accept_spec.rb
+++ b/spec/services/applications/accept_spec.rb
@@ -38,6 +38,16 @@ RSpec.describe Applications::Accept, :with_default_schedules, type: :model do
       expect(service.application).to have_received(:reload)
     end
 
+    it "sends an email to the user" do
+      expect(ApplicationAcceptedMailer).to send_mail(:application_accepted_mail)
+        .with_params(to: user.email,
+                     full_name: user.full_name,
+                     provider_name: lead_provider.name,
+                     course_name: course.name,
+                     ecf_id: application.ecf_id)
+      service.accept
+    end
+
     describe "validations" do
       it { is_expected.to validate_presence_of(:application).with_message("The entered '#/application' is missing from your request. Check details and try again.") }
 

--- a/spec/services/applications/reject_spec.rb
+++ b/spec/services/applications/reject_spec.rb
@@ -57,5 +57,15 @@ RSpec.describe Applications::Reject, type: :model do
     it "sets the reason for rejection" do
       expect { service.reject }.to change { application.reload.reason_for_rejection }.from(nil).to(reason_for_rejection)
     end
+
+    it "sends an email to the user" do
+      expect(ApplicationRejectedMailer).to send_mail(:application_rejected_mail)
+        .with_params(to: application.user.email,
+                     full_name: application.user.full_name,
+                     provider_name: application.lead_provider.name,
+                     course_name: application.course.name,
+                     ecf_id: application.ecf_id)
+      service.reject
+    end
   end
 end

--- a/spec/services/participant_outcomes/create_spec.rb
+++ b/spec/services/participant_outcomes/create_spec.rb
@@ -94,6 +94,12 @@ RSpec.describe ParticipantOutcomes::Create, type: :model do
           expect(created_outcome).to eq(existing_outcome)
         end
 
+        it "does not send an email to the user" do
+          expect(ParticipantOutcomePassedMailer).not_to send_mail(:passed_mail)
+          expect(ParticipantOutcomeFailedMailer).not_to send_mail(:failed_mail)
+          create_outcome
+        end
+
         it "does not update the completed declaration `updated_at`" do
           expect { create_outcome }.not_to(change { completed_declaration.reload.updated_at })
         end
@@ -110,6 +116,12 @@ RSpec.describe ParticipantOutcomes::Create, type: :model do
             expect(created_outcome).to eq(existing_outcome)
           end
 
+          it "does not send an email to the user" do
+            expect(ParticipantOutcomePassedMailer).not_to send_mail(:passed_mail)
+            expect(ParticipantOutcomeFailedMailer).not_to send_mail(:failed_mail)
+            create_outcome
+          end
+
           it "does not update the completed declaration `updated_at`" do
             expect { create_outcome }.not_to(change { completed_declaration.reload.updated_at })
           end
@@ -119,6 +131,16 @@ RSpec.describe ParticipantOutcomes::Create, type: :model do
 
             it "creates a new outcome" do
               expect { create_outcome }.to change(ParticipantOutcome, :count).by(1)
+            end
+
+            it "sends an email to the user" do
+              expect(ParticipantOutcomePassedMailer).to send_mail(:passed_mail)
+                .with_params(to: completed_declaration.user.email,
+                             full_name: completed_declaration.user.full_name,
+                             provider_name: completed_declaration.lead_provider.name,
+                             course_name: completed_declaration.course.name,
+                             ecf_id: completed_declaration.application.ecf_id)
+              create_outcome
             end
 
             it "sets the created_outcome to the newly created outcome" do
@@ -142,6 +164,16 @@ RSpec.describe ParticipantOutcomes::Create, type: :model do
             expect { create_outcome }.to change(ParticipantOutcome, :count).by(1)
           end
 
+          it "sends an email to the user" do
+            expect(ParticipantOutcomeFailedMailer).to send_mail(:failed_mail)
+              .with_params(to: completed_declaration.user.email,
+                           full_name: completed_declaration.user.full_name,
+                           provider_name: completed_declaration.lead_provider.name,
+                           course_name: completed_declaration.course.name,
+                           ecf_id: completed_declaration.application.ecf_id)
+            create_outcome
+          end
+
           it "sets the created_outcome to the newly created outcome" do
             create_outcome
             expect(created_outcome).not_to eq(existing_outcome)
@@ -162,6 +194,16 @@ RSpec.describe ParticipantOutcomes::Create, type: :model do
 
         it "creates a new outcome" do
           expect { create_outcome }.to change(ParticipantOutcome, :count).by(1)
+        end
+
+        it "sends an email to the user" do
+          expect(ParticipantOutcomePassedMailer).to send_mail(:passed_mail)
+            .with_params(to: completed_declaration.user.email,
+                         full_name: completed_declaration.user.full_name,
+                         provider_name: completed_declaration.lead_provider.name,
+                         course_name: completed_declaration.course.name,
+                         ecf_id: completed_declaration.application.ecf_id)
+          create_outcome
         end
 
         it "sets the created_outcome to the newly created outcome" do
@@ -206,6 +248,12 @@ RSpec.describe ParticipantOutcomes::Create, type: :model do
               expect { create_outcome }.not_to change(ParticipantOutcome, :count)
             end
 
+            it "does not send an email to the user" do
+              expect(ParticipantOutcomePassedMailer).not_to send_mail(:passed_mail)
+              expect(ParticipantOutcomeFailedMailer).not_to send_mail(:failed_mail)
+              create_outcome
+            end
+
             it "sets the created_outcome to the latest existing outcome" do
               create_outcome
               expect(created_outcome).to eq(not_matching_outcome)
@@ -225,6 +273,12 @@ RSpec.describe ParticipantOutcomes::Create, type: :model do
               expect { create_outcome }.not_to change(ParticipantOutcome, :count)
             end
 
+            it "does not send an email to the user" do
+              expect(ParticipantOutcomeFailedMailer).not_to send_mail(:failed_mail)
+              expect(ParticipantOutcomePassedMailer).not_to send_mail(:passed_mail)
+              create_outcome
+            end
+
             it "sets the created_outcome to the latest existing outcome" do
               create_outcome
               expect(created_outcome).to eq(matching_outcome)
@@ -238,6 +292,16 @@ RSpec.describe ParticipantOutcomes::Create, type: :model do
 
             it "creates a new outcome" do
               expect { create_outcome }.to change(ParticipantOutcome, :count).by(1)
+            end
+
+            it "sends an email to the user" do
+              expect(ParticipantOutcomeFailedMailer).to send_mail(:failed_mail)
+                .with_params(to: completed_declaration.user.email,
+                             full_name: completed_declaration.user.full_name,
+                             provider_name: completed_declaration.lead_provider.name,
+                             course_name: completed_declaration.course.name,
+                             ecf_id: completed_declaration.application.ecf_id)
+              create_outcome
             end
 
             it "sets the created_outcome to the newly created outcome" do
@@ -265,6 +329,16 @@ RSpec.describe ParticipantOutcomes::Create, type: :model do
 
       it "creates a new outcome" do
         expect { create_outcome }.to change(ParticipantOutcome, :count).by(1)
+      end
+
+      it "sends an email to the user" do
+        expect(ParticipantOutcomePassedMailer).to send_mail(:passed_mail)
+          .with_params(to: completed_declaration.user.email,
+                       full_name: completed_declaration.user.full_name,
+                       provider_name: completed_declaration.lead_provider.name,
+                       course_name: completed_declaration.course.name,
+                       ecf_id: completed_declaration.application.ecf_id)
+        create_outcome
       end
 
       it "sets the created_outcome to the newly created outcome" do

--- a/spec/support/matchers/mailer_matcher.rb
+++ b/spec/support/matchers/mailer_matcher.rb
@@ -1,0 +1,20 @@
+require "rspec/mocks"
+
+RSpec::Matchers.define :send_mail do |mailer_action, deliver_now: false|
+  match do |mailer_class|
+    message_delivery = instance_double(ActionMailer::MessageDelivery)
+    allow(mailer_class).to receive(mailer_action).and_return(message_delivery)
+    expect(mailer_class).to receive(mailer_action).with(@mailer_params)
+    delivery_method = deliver_now ? :deliver_now : :deliver_later
+    expect(message_delivery).to receive(delivery_method)
+  end
+
+  match_when_negated do |mailer_class|
+    expect(mailer_class).not_to receive(mailer_action)
+  end
+
+  def with_params(params)
+    @mailer_params = params
+    self
+  end
+end

--- a/spec/support/shared_examples/participant_action_support.rb
+++ b/spec/support/shared_examples/participant_action_support.rb
@@ -72,6 +72,14 @@ RSpec.shared_examples "a participant state transition" do |action, from_states, 
   let(:application) { create(:application, :accepted, :with_declaration, training_status: from_states.sample) }
   let(:course_identifier) { application.course.identifier }
 
+  let(:mailers) do
+    {
+      "active" => { mailer: ApplicationResumedMailer, mailer_action: :application_resumed_mail },
+      "deferred" => { mailer: ApplicationDeferredMailer, mailer_action: :application_deferred_mail },
+      "withdrawn" => { mailer: ApplicationWithdrawnMailer, mailer_action: :application_withdrawn_mail },
+    }
+  end
+
   it { expect(instance).to be_valid }
 
   describe "##{action}" do
@@ -99,6 +107,16 @@ RSpec.shared_examples "a participant state transition" do |action, from_states, 
 
         it "updates the application training status to #{to_state}" do
           expect { perform_action }.to change { application.reload.training_status }.to(to_state)
+        end
+
+        it "sends a notification email to the participant" do
+          expect(mailers[to_state][:mailer]).to send_mail(mailers[to_state][:mailer_action])
+            .with_params(to: application.user.email,
+                         full_name: application.user.full_name,
+                         provider_name: application.lead_provider.name,
+                         course_name: application.course.name,
+                         ecf_id: application.ecf_id)
+          perform_action
         end
       end
     end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/NPQ-3548

### Changes proposed in this pull request

send email notifications to the user when:
* application is accepted
* application is rejected
* application is deferred
* application is withdrawn
* application is resumed
* course is completed - passed
* course is completed - failed
