### PR TITLE
Pin 3rd party github actions

### DIFF
--- a/.github/workflows/build-nocache.yml
+++ b/.github/workflows/build-nocache.yml
@@ -32,7 +32,7 @@ jobs:
         snyk-token: ${{ secrets.SNYK_TOKEN }}
 
     - name: Notify slack on failure
-      uses: rtCamp/action-slack-notify@master
+      uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # Pinned at 2.3.3
       if: ${{ failure() }}
       with:
         SLACK_USERNAME: CI Deployment

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Post sticky pull request comment
         if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # Pinned at v2.9.4
         with:
           message: |
             Review app deployed to ${{ steps.deploy.outputs.url }}
@@ -109,7 +109,7 @@ jobs:
 
       - name: Notify on failure
         if: failure()
-        uses: rtCamp/action-slack-notify@master
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # Pinned at 2.3.3
         env:
           SLACK_COLOR: failure
           SLACK_TITLE: Failure deploying to staging
@@ -140,7 +140,7 @@ jobs:
 
       - name: Notify on failure
         if: failure()
-        uses: rtCamp/action-slack-notify@master
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # Pinned at 2.3.3
         env:
           SLACK_COLOR: failure
           SLACK_TITLE: Failure deploying to sandbox
@@ -171,7 +171,7 @@ jobs:
 
       - name: Notify on failure
         if: failure()
-        uses: rtCamp/action-slack-notify@master
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # Pinned at 2.3.3
         env:
           SLACK_COLOR: failure
           SLACK_TITLE: Failure deploying to production

--- a/.github/workflows/refresh_knapsack_manifest.yml
+++ b/.github/workflows/refresh_knapsack_manifest.yml
@@ -3,7 +3,7 @@ name: "Refresh Knapsack manifest"
 on:
   schedule:
     - cron: '0 8 * * 1' # Monday at 8am
-  workflow_dispatch: 
+  workflow_dispatch:
 
 jobs:
   refresh_manifest:
@@ -64,8 +64,8 @@ jobs:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - name: Create pull request 
-        uses: peter-evans/create-pull-request@v7
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # Pinned at v7.0.11
         with:
           token: ${{ steps.generate-token.outputs.token }}
           branch: refresh-knapsack-manifest

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -156,7 +156,7 @@ jobs:
           bundler-cache: true
 
       - name: Setup sonarqube
-        uses: warchant/setup-sonar-scanner@v9
+        uses: warchant/setup-sonar-scanner@7a89a4622e5c3b5d9c9673cf04f15f005f69d2eb # Pinned at v9
 
       - name: Download Artifacts
         uses: actions/download-artifact@v8


### PR DESCRIPTION
### Trello card

https://trello.com/c/8RwMeaL4/2682-pin-third-party-github-actions-mobilise

### Changes proposed in this pull request

- pin all 3rd party github actions at specific versions (for security)

### Guidance to review

see successful workflows run by this PR