### PR TITLE
[NPQ-3667] allow unverified GAI account to be converted to a teacher auth account

### DIFF
--- a/app/services/users/find_or_create_from_teacher_auth.rb
+++ b/app/services/users/find_or_create_from_teacher_auth.rb
@@ -15,19 +15,47 @@ module Users
     attr_reader :access_token, :uid, :trn, :email, :full_name, :date_of_birth, :feature_flag_id
 
     def call
-      user_matched_using_trn = matching_users.first
+      user_matched_using_trn = verified_trn_matching_users.first
 
       if user_matched_using_trn
-        user_matched_using_trn.update!(uid:, provider: Omniauth::Strategies::TeacherAuth::NAME, email:, full_name:, feature_flag_id:, previous_names:)
-        merge_and_archive_other_users(user_matched_using_trn, matching_users[1..])
+        user_matched_using_trn.update!(
+          uid:,
+          provider: Omniauth::Strategies::TeacherAuth::NAME,
+          email:,
+          full_name:,
+          feature_flag_id:,
+          previous_names:,
+        )
+        merge_and_archive_other_users(user_matched_using_trn, verified_trn_matching_users[1..])
         return user_matched_using_trn
       end
 
       user_matched_using_uid = User.find_by(provider: Omniauth::Strategies::TeacherAuth::NAME, uid:)
 
       if user_matched_using_uid
-        user_matched_using_uid.update!(email: email, trn:, trn_verified: true, trn_auto_verified: true, full_name:, feature_flag_id:, previous_names:)
+        user_matched_using_uid.update!(
+          email: email,
+          trn:,
+          trn_verified: true,
+          trn_auto_verified: true,
+          full_name:,
+          feature_flag_id:,
+          previous_names:,
+        )
         return user_matched_using_uid
+      end
+
+      if unverified_trn_matching_user
+        unverified_trn_matching_user.update!(
+          uid:,
+          provider: Omniauth::Strategies::TeacherAuth::NAME,
+          trn_verified: true,
+          trn_auto_verified: true,
+          full_name:,
+          feature_flag_id:,
+          previous_names:,
+        )
+        return unverified_trn_matching_user
       end
 
       create_user_with_provider_data
@@ -35,8 +63,14 @@ module Users
 
   private
 
-    def matching_users
-      @matching_users ||= User.where(trn:, trn_verified: true, archived_at: nil).order(updated_at: :desc).all.to_a
+    def verified_trn_matching_users
+      @verified_trn_matching_users ||=
+        User.where(trn:, trn_verified: true, archived_at: nil).order(updated_at: :desc).all.to_a
+    end
+
+    def unverified_trn_matching_user
+      @unverified_trn_matching_user ||=
+        User.find_by(provider: Omniauth::Strategies::TraOpenidConnect::NAME, trn:, trn_verified: false, email:, archived_at: nil)
     end
 
     def merge_and_archive_other_users(user_to_keep, users_to_merge)

--- a/app/views/npq_separation/admin/users/show.html.erb
+++ b/app/views/npq_separation/admin/users/show.html.erb
@@ -20,7 +20,7 @@
       </div>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-          Preferred Name
+          Preferred name
         </dt>
         <dd class="govuk-summary-list__value">
           <%= @user.preferred_name.presence || @user.full_name %>
@@ -50,7 +50,15 @@
       </div>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-          Get an Identity ID
+          Login provider
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= @user.provider %>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          UID
         </dt>
         <dd class="govuk-summary-list__value">
           <%= @user.uid %>

--- a/config/environments/review.rb
+++ b/config/environments/review.rb
@@ -8,7 +8,7 @@ Rails.application.configure do
     Bullet.unused_eager_loading_enable  = false # Disabled due to the way our queries are structured
   end
 
-  config.x.teacher_auth.enabled = false
+  config.x.teacher_auth.enabled = true
   config.x.api.previous_names = true
   config.x.api.cohort_suffix = true
 end

--- a/spec/features/npq_separation/admin/users_spec.rb
+++ b/spec/features/npq_separation/admin/users_spec.rb
@@ -80,11 +80,12 @@ RSpec.feature "User administration", :no_js, type: :feature do
 
       within(".govuk-summary-card", text: "Overview") do |summary_card|
         expect(summary_card).to have_summary_item("User ID", user.ecf_id)
-        expect(summary_card).to have_summary_item("Preferred Name", user.preferred_name)
+        expect(summary_card).to have_summary_item("Preferred name", user.preferred_name)
         expect(summary_card).to have_summary_item("Email", user.email)
         expect(summary_card).to have_summary_item("TRN", user.trn, "Not verified")
         expect(page).to have_link("View teaching record", href: "#{ENV['TRS_URL']}/persons?Search=#{user.trn}")
-        expect(summary_card).to have_summary_item("Get an Identity ID", user.uid)
+        expect(summary_card).to have_summary_item("Login provider", user.provider)
+        expect(summary_card).to have_summary_item("UID", user.uid)
       end
     end
 

--- a/spec/services/users/find_or_create_from_teacher_auth_spec.rb
+++ b/spec/services/users/find_or_create_from_teacher_auth_spec.rb
@@ -116,6 +116,44 @@ RSpec.describe Users::FindOrCreateFromTeacherAuth do
     end
   end
 
+  context "when the TRN matches an unverified TRN on one GAI user" do
+    context "when the email matches a user" do
+      let(:user) { create(:user, :with_get_an_identity_id, trn:, trn_verified: false, email:) }
+
+      before { user }
+
+      it "sets the uid, provider and trn_verified on the matched user" do
+        subject
+        expect(user.reload).to have_attributes(uid:, provider: "teacher_auth", trn_verified: true, trn_auto_verified: true)
+      end
+    end
+
+    context "when the email does not match a user" do
+      it "creates a new user" do
+        subject
+        expect(User.find_by(provider: "teacher_auth", uid:)).to have_attributes(
+          email:,
+          trn:,
+          trn_verified: true,
+          trn_auto_verified: true,
+          full_name: verified_name.join(" "),
+          date_of_birth: Date.parse("1990-01-01"),
+          feature_flag_id:,
+        )
+      end
+
+      context "when the email clashes with an existing user with a different TRN" do
+        let(:user) { create(:user, :with_get_an_identity_id, trn: "111111", trn_verified: true, email:) }
+
+        before { user }
+
+        it "raises an error" do
+          expect { subject }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Email Email address must be unique")
+        end
+      end
+    end
+  end
+
   context "when the TRN matches a verified TRN on more than one user" do
     let(:most_recently_updated_user) { create(:user, trn:, trn_verified: true) }
     let(:older_user) { create(:user, trn:, trn_verified: true, updated_at: 2.days.ago) }


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/NPQ-3667

### Changes proposed in this pull request
* if a user logs in with teacher auth, and we find a matching account that is DfE Identity, with the same email and TRN, but the TRN is unverified - we will update the provider and UID on the matched account, and allow the user to log in.
* The TRN will be marked as verified
* enable teacher auth for review apps

