### PR TITLE
NPQ-3715 - Add missing specs for accounts page

### DIFF
--- a/spec/views/accounts/show.html.erb_spec.rb
+++ b/spec/views/accounts/show.html.erb_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe "accounts/show.html.erb", type: :view do
+  subject { render }
+
+  before do
+    applications
+    allow(view).to receive(:current_user).and_return(user)
+  end
+
+  let(:user) { create(:user) }
+  let(:applications) { create_list :application, 2, user: }
+
+  it { is_expected.to have_content "Register for another NPQ" }
+  it { is_expected.to have_css ".govuk-summary-card", count: 2 }
+  it { is_expected.to have_link "View details", href: accounts_user_registration_path(applications[0]) }
+  it { is_expected.to have_link "View details", href: accounts_user_registration_path(applications[1]) }
+
+  context "with expired applications" do
+    before do
+      applications[0].update!(lead_provider_approval_status: :rejected,
+                              created_at: Application.cut_off_date_for_expired_applications - 1.day)
+    end
+
+    it { is_expected.to have_content "Register for another NPQ" }
+    it { is_expected.to have_css ".govuk-summary-card", count: 2 }
+    it { is_expected.not_to have_link "View details", href: accounts_user_registration_path(applications[0]) }
+    it { is_expected.to have_link "View details", href: accounts_user_registration_path(applications[1]) }
+  end
+end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/NPQ-3715

### Changes proposed in this pull request

1. Added missing specs for the Accounts page

_Note: #3311 Moved several partials but moved one which shouldn't have been moved. This wasn't picked up because of missing specs_

_I've done a separate quick fix in #3313 - this branch is initially derived from `main` prior to the fix. The specs should fail. When I merge it'll be combined with the fix and should pass - if the combined branch does not pass then the merge will fail_