### PR TITLE
[NPQ-3718] Tweaked dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,17 +4,31 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  open-pull-requests-limit: 10
+    time: "07:00"
+  allow:
+    - dependency-name: "rails"
+      update-types:
+      - version-update:semver-patch
+  open-pull-requests-limit: 20
 - package-ecosystem: npm
   directory: "/"
+  cooldown:
+    default-days: 5
   schedule:
-    interval: daily
-  open-pull-requests-limit: 10
+    interval: weekly
+    time: "07:00"
+    day: tuesday
+  open-pull-requests-limit: 20
 - package-ecosystem: docker
   directory: "/"
   schedule:
     interval: daily
+    time: "07:00"
   open-pull-requests-limit: 10
+  allow:
+    - dependency-name: "*"
+      update-types:
+      - "version-update:semver-patch"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
### Context

Ticket: [NPQ-3718](https://dfedigital.atlassian.net/browse/NPQ-3718)

### Changes proposed in this pull request

1. Check for ruby deps daily at 7am -> means they are always ready at the start of the day, I'm presuming crontab is off've UTC
2. Check JS deps weekly, there is constant churn with JS and it just creates noise for deps we primarily use for building assets - the actually assets we include client side have low rates of churn
3. Added cooldown period for javascript version updates
4. Only raise PRs for patch version changes with Docker images and `rails` gems - we're only getting notified of changes to the latest version rather than the patch updates we wish to know about



[NPQ-3718]: https://dfedigital.atlassian.net/browse/NPQ-3718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ