### PR TITLE
[NPQ-3729] account page fix for pre-2026 applications

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,7 +39,8 @@ module ApplicationHelper
   end
 
   def application_cohort_description(application)
-    Questionnaires::CourseStartDate::OPTIONS[application.cohort.identifier][:cohort_description]
+    cohort_option = Questionnaires::CourseStartDate::OPTIONS[application.cohort.identifier]
+    cohort_option ? cohort_option[:cohort_description] : application.cohort.start_year
   end
 
   def show_otp_code_in_ui(current_env, admin)

--- a/spec/features/account_spec.rb
+++ b/spec/features/account_spec.rb
@@ -1,7 +1,16 @@
 require "rails_helper"
 
 RSpec.feature "Account", type: :feature do
+  include Helpers::JourneyAssertionHelper
+
   include_context "Stub Get An Identity Omniauth Responses"
+
+  let(:user_uid) { SecureRandom.uuid }
+  let(:user) { create(:user, uid: user_uid, email: "user@example.com") }
+  let(:cohort) { create(:cohort, start_year: 2025) }
+  let(:application) { create(:application, user:, cohort:) }
+
+  before { application }
 
   describe "accounts page" do
     scenario "when not logged in, it redirects to sign in" do
@@ -9,11 +18,34 @@ RSpec.feature "Account", type: :feature do
       expect(page).to be_accessible
       expect(page).to have_current_path("/sign-in")
     end
+
+    context "when logged in" do
+      before do
+        navigate_to_page(path: "/", submit_form: false, axe_check: false) do
+          page.click_button("Start now")
+        end
+      end
+
+      scenario "when logged in, it shows the application details" do
+        visit "/account"
+
+        expect(page).to have_current_path("/accounts/user_registrations/#{application.id}")
+        expect(page).to have_summary_item("Course start", "2025")
+      end
+
+      context "when the user's previous application is in a 2026 cohort" do
+        let(:cohort) { create(:cohort, start_year: 2026) }
+
+        scenario "it shows the correct cohort description" do
+          visit "/account"
+
+          expect(page).to have_summary_item("Course start", "Spring 2026")
+        end
+      end
+    end
   end
 
   describe "accounts user registration page" do
-    let!(:application) { FactoryBot.create(:application) }
-
     scenario "when not logged in, it redirects to sign in" do
       visit(accounts_user_registration_path(application.id))
 


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/NPQ-3729

### Changes proposed in this pull request

cope with pre-2026 cohorts that do not have an entry in `Questionnaires::CourseStartDate::OPTIONS`
