### PR TITLE
bugfix - only send sentry message if the cohort does not exist

### DIFF
--- a/app/forms/questionnaires/course_start_date.rb
+++ b/app/forms/questionnaires/course_start_date.rb
@@ -53,8 +53,10 @@ module Questionnaires
     def cohort_exists
       cohort_identifier = course_start_cohort
       cohort = Cohort.find_by(identifier: cohort_identifier)
-      errors.add(QUESTION_NAME, :invalid) unless cohort
-      Sentry.capture_message("Cohort selected by user does not exist: #{cohort_identifier}")
+      unless cohort
+        errors.add(QUESTION_NAME, :invalid)
+        Sentry.capture_message("Cohort selected by user does not exist: #{cohort_identifier}")
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

bugfix

### Changes proposed in this pull request

Currently a sentry message is always send when the cohort is selected.
We only want the message sent if the cohort does not exist.