### PR TITLE
[NPQ-3752] Don't call Person API if no teaching record

### DIFF
--- a/app/services/users/find_or_create_from_teacher_auth.rb
+++ b/app/services/users/find_or_create_from_teacher_auth.rb
@@ -91,6 +91,8 @@ module Users
     end
 
     def previous_names
+      return [] if @trn.blank?
+
       @previous_names ||= TeachingRecordSystem::FetchPerson.fetch(access_token:).previous_names
     end
 

--- a/spec/features/journeys/happy_paths/when_teacher_auth_returns_no_trn_spec.rb
+++ b/spec/features/journeys/happy_paths/when_teacher_auth_returns_no_trn_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Sad journeys", :no_js, :with_default_schedules, :with_default_sch
   include ApplicationHelper
 
   include_context "with stubbed Teacher Auth OmniAuth responses"
-  include_context "with stubbed Teaching Record System person API"
+  include_context "with stubbed missing Teaching Record System person record"
 
   context "when Teacher Auth returns no TRN" do
     let(:user_trn) { nil }

--- a/spec/services/teaching_record_system/v3/person_spec.rb
+++ b/spec/services/teaching_record_system/v3/person_spec.rb
@@ -17,17 +17,23 @@ RSpec.describe TeachingRecordSystem::V3::Person do
     }
   end
 
+  let :stub_person_api do
+    stub_request(:get, "#{base_url}/v3/person")
+      .with(
+        headers: {
+          "Authorization" => "Bearer #{access_token}",
+          "X-Api-Version" => "Next",
+        },
+        query: { "include" => "PreviousNames" },
+      )
+  end
+
   describe ".find_with_token" do
+    subject(:call_api) { described_class.find_with_token(access_token:) }
+
     context "when successful" do
       before do
-        stub_request(:get, "#{base_url}/v3/person")
-          .with(
-            headers: {
-              "Authorization" => "Bearer #{access_token}",
-              "X-Api-Version" => "Next",
-            },
-            query: { "include" => "PreviousNames" },
-          )
+        stub_person_api
           .to_return(status: 200, body: teaching_record_response.to_json)
       end
 
@@ -41,61 +47,41 @@ RSpec.describe TeachingRecordSystem::V3::Person do
     end
 
     context "when unauthorized (401)" do
-      before do
-        stub_request(:get, "#{base_url}/v3/person")
-          .with(
-            headers: {
-              "Authorization" => "Bearer #{access_token}",
-              "X-Api-Version" => "Next",
-            },
-            query: { "include" => "PreviousNames" },
-          )
-          .to_return(status: 401)
-      end
+      before { stub_person_api.to_return(status: 401) }
 
       it "raises ApiError with 401" do
         expect {
-          described_class.find_with_token(access_token:)
+          call_api
         }.to raise_error(TeachingRecordSystem::ApiError, "API request failed (HTTP 401)")
       end
     end
 
     context "when timeout occurs" do
-      before do
-        stub_request(:get, "#{base_url}/v3/person")
-          .with(
-            headers: {
-              "Authorization" => "Bearer #{access_token}",
-              "X-Api-Version" => "Next",
-            },
-            query: { "include" => "PreviousNames" },
-          )
-          .to_timeout
-      end
+      before { stub_person_api.to_timeout }
 
       it "raises Timeout::Error" do
         expect {
-          described_class.find_with_token(access_token:)
+          call_api
         }.to raise_error(TeachingRecordSystem::TimeoutError)
       end
     end
 
-    context "when server error (500)" do
-      before do
-        stub_request(:get, "#{base_url}/v3/person")
-          .with(
-            headers: {
-              "Authorization" => "Bearer #{access_token}",
-              "X-Api-Version" => "Next",
-            },
-            query: { "include" => "PreviousNames" },
-          )
-          .to_return(status: 500, body: "Internal Server Error")
+    context "when teaching record does not yet exist (403)" do
+      before { stub_person_api.to_return(status: 403, body: "Forbidden") }
+
+      it "raises a forbidden error" do
+        expect {
+          call_api
+        }.to raise_error TeachingRecordSystem::ApiError, "API request failed (HTTP 403)"
       end
+    end
+
+    context "when server error (500)" do
+      before { stub_person_api.to_return(status: 500, body: "Internal Server Error") }
 
       it "raises ApiError with 500" do
         expect {
-          described_class.find_with_token(access_token:)
+          call_api
         }.to raise_error(TeachingRecordSystem::ApiError, "API request failed (HTTP 500)")
       end
     end

--- a/spec/services/users/find_or_create_from_teacher_auth_spec.rb
+++ b/spec/services/users/find_or_create_from_teacher_auth_spec.rb
@@ -29,9 +29,7 @@ RSpec.describe Users::FindOrCreateFromTeacherAuth do
     })
   end
 
-  before do
-    create(:user, trn:, trn_verified: true, archived_at: 1.day.ago)
-
+  let :stub_person_api do
     stub_request(:get, "#{ENV['TRS_API_URL']}/v3/person")
       .with(
         headers: {
@@ -40,7 +38,17 @@ RSpec.describe Users::FindOrCreateFromTeacherAuth do
         },
         query: { "include" => "PreviousNames" },
       )
-      .to_return(status: 200, body: { previousNames: api_previous_names }.to_json)
+  end
+
+  before do
+    create(:user, trn:, trn_verified: true, archived_at: 1.day.ago)
+
+    if trn.present?
+      stub_person_api
+        .to_return(status: 200, body: { previousNames: api_previous_names }.to_json)
+    else
+      stub_person_api.to_return(status: 403, body: nil)
+    end
   end
 
   context "when the TRN matches a verified TRN on one user" do
@@ -257,7 +265,7 @@ RSpec.describe Users::FindOrCreateFromTeacherAuth do
 
         it "updates previous_names on the user" do
           subject
-          expect(existing_user.reload.previous_names).to eq(["Sarah Johnson"])
+          expect(existing_user.reload.previous_names).to eq(trn ? ["Sarah Johnson"] : [])
         end
       end
 
@@ -266,13 +274,14 @@ RSpec.describe Users::FindOrCreateFromTeacherAuth do
           create(:user, :with_teacher_auth, email: "oldemail@example.com", uid:,
                                             previous_names: ["Old Previous Name"])
         end
+
         let(:api_previous_names) do
           [{ "firstName" => "Sarah", "lastName" => "Johnson" }]
         end
 
         it "replaces old previous_names with new API data" do
           subject
-          expect(existing_user.reload.previous_names).to eq(["Sarah Johnson"])
+          expect(existing_user.reload.previous_names).to eq(trn ? ["Sarah Johnson"] : [])
         end
       end
     end
@@ -337,10 +346,15 @@ RSpec.describe Users::FindOrCreateFromTeacherAuth do
         it "creates the user with previous_names from API" do
           subject
           created_user = User.find_by(provider: "teacher_auth", uid:)
-          expect(created_user.previous_names).to eq([
-            "Sarah Johnson",
-            "Sarah Ann Williams",
-          ])
+
+          if created_user.trn
+            expect(created_user.previous_names).to eq([
+              "Sarah Johnson",
+              "Sarah Ann Williams",
+            ])
+          else
+            expect(created_user.previous_names).to be_empty
+          end
         end
       end
     end

--- a/spec/support/shared_contexts/stub_teaching_record_system_person_api.rb
+++ b/spec/support/shared_contexts/stub_teaching_record_system_person_api.rb
@@ -14,8 +14,16 @@ RSpec.shared_context("with stubbed Teaching Record System person API") do
           { "firstName" => "Jane", "middleName" => "", "lastName" => "Doe" },
         ],
       }
-    stub_request(:get, "#{ENV['TRS_API_URL']}/v3/person")
+    stub_request(:get, "#{ENV["TRS_API_URL"]}/v3/person")
       .with(query: { "include" => "PreviousNames" })
       .to_return(status: 200, body: trs_response.to_json)
+  end
+end
+
+RSpec.shared_context("with stubbed missing Teaching Record System person record") do
+  before do
+    stub_request(:get, "#{ENV["TRS_API_URL"]}/v3/person")
+      .with(query: { "include" => "PreviousNames" })
+      .to_return(status: 403, body: nil)
   end
 end


### PR DESCRIPTION
### Context

Ticket: [NPQ-3752](https://dfedigital.atlassian.net/browse/NPQ-3752)

Currently if a user without a teaching record signs into the service via TeacherAuth it 500s. This caused by unconditionally attempting to fetch the Teaching Record even if the user does not have a TRN (so does not have a Teaching Record)

### Changes proposed in this pull request

1. Only call TRS' Person API on TeacherAuth sign in if the user has a TRN set




[NPQ-3752]: https://dfedigital.atlassian.net/browse/NPQ-3752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ