### PR TITLE
[NPQ-3746] Use Teacher Auth for registration exception

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,11 +51,18 @@ class User < ApplicationRecord
   }
 
   def refresh_token
-    oauth_tokens.refresh_token.find_or_initialize_by({})
+    oauth_tokens.refresh_token.first
+  end
+
+  def store_refresh_token!(token)
+    return if token.blank?
+
+    (refresh_token || oauth_tokens.refresh_token.build)
+      .tap { |t| t.store!(token) }
   end
 
   def needs_token_refresh?
-    trn.blank? && refresh_token.persisted?
+    trn.blank? && refresh_token.present?
   end
 
   EMAIL_UPDATES_STATES = %i[senco other_npq].freeze

--- a/app/services/applications/reject.rb
+++ b/app/services/applications/reject.rb
@@ -37,7 +37,7 @@ module Applications
     def clear_token_if_no_remaining_applications
       user = application.user
       return if user.trn.present?
-      return if user.refresh_token.new_record?
+      return if user.refresh_token.blank?
       return if user.applications.pending_lead_provider_approval_status.where.not(id: application.id).exists?
 
       user.refresh_token.destroy!

--- a/app/services/users/find_or_create_from_teacher_auth.rb
+++ b/app/services/users/find_or_create_from_teacher_auth.rb
@@ -82,9 +82,9 @@ module Users
     def persist_token(user, provider_data)
       refresh_token = provider_data.credentials&.refresh_token
       if user.trn.blank? && refresh_token.present?
-        user.refresh_token.store!(refresh_token)
+        user.store_refresh_token!(refresh_token)
         true
-      elsif user.trn.present? && user.refresh_token.persisted?
+      elsif user.trn.present? && user.refresh_token.present?
         user.refresh_token.destroy!
         false
       else

--- a/app/views/pages/closed_registration_exception.html.erb
+++ b/app/views/pages/closed_registration_exception.html.erb
@@ -1,45 +1,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Register late for a national professional qualification (NPQ)</h1>
-
-    <p class="govuk-body">You’ve been given access to make a late registration for an NPQ whilst the service is closed.</p>
-
-    <p class="govuk-body">You will also need to apply separately with your training provider.</p>
-
-    <h2 class="govuk-heading-m">Before you start</h2>
-
-    <p class="govuk-body">
-      You should have already chosen which NPQ you want to do and who your provider is.
-      If you have not chosen yet,
-      <%= external_link_to("find out about NPQ courses", :find_out_about_npq_courses) %>.
-    </p>
-
-    <p class="govuk-body">
-      You’ll also need a teacher reference number (TRN) to register, even if
-      you’re not a teacher.
-      <%= external_link_to "Learn about TRNs", :learn_about_trns %>
-      including how to request on if you do not have one.
-    </p>
-
-    <p class="govuk-body">
-      If you work in early years or childcare,
-      <%= external_link_to("check if your workplace is registered with Ofsted", :check_if_your_workplace_is_registered_with_ofsted) %>
-      and get their Ofsted unique reference number (URN), if they have one.
-    </p>
-
-    <p class="govuk-body">
-      Before registering for an NPQ you’ll be asked to create a DfE Identity
-      account or sign in to your existing account.
-    </p>
-
-    <p class="govuk-body">
-      By continuing, you agree to our <%= govuk_link_to("privacy notice", PRIVACY_NOTICE) %>.
-    </p>
+    <%= render "registration_wizard/shared/start_page_content" %>
 
     <% if Feature.registration_enabled? %>
       <%=
         render(
-          'shared/get_an_identity/redirect_button',
+          'shared/teacher_auth/redirect_button',
           button_text: "Start now"
         )
       %>

--- a/app/views/registration_wizard/shared/_start_page_content.html.erb
+++ b/app/views/registration_wizard/shared/_start_page_content.html.erb
@@ -1,0 +1,66 @@
+<h1 class="govuk-heading-xl">Register for a national professional qualification (NPQ)</h1>
+
+<p class="govuk-body">Use this service to:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>register for an NPQ or <%= localise_sentence_embedded_course_name(Course.ehco) %></li>
+  <li>check your registration details, if you already registered</li>
+  <li>check your course outcome, if you have completed your course</li>
+</ul>
+
+<h2 class="govuk-heading-m">What happens when you register</h2>
+
+<p class="govuk-body">
+  When you register with the Department for Education (DfE) we:
+</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>check if you’re eligible for scholarship funding</li>
+  <li>send your registration details to your chosen training provider</li>
+</ul>
+
+<p class="govuk-body">
+  Your provider will then email you an application form to complete.
+</p>
+
+<%= govuk_inset_text do %>
+  <h3 class="govuk-heading-s">Being eligible for funding does not guarantee a funded place</h3>
+  Your training provider must confirm two things after you apply with them:
+  <ul class="govuk-list govuk-list--bullet">
+    <li>a funded place is available</li>
+    <li>you meet their suitability requirements for the course</li>
+  </ul>
+<% end %>
+
+<h2 class="govuk-heading-m">Before you start</h2>
+
+<p class="govuk-body">
+  You’ll need:
+</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>
+    to know which
+    <%= external_link_to("NPQ course", :find_out_about_npq_courses) %>
+    you want to take and who your provider will be
+  </li>
+  <li>the address and postcode of your workplace setting</li>
+  <li>a teacher reference number (TRN) – even if you’re not a teacher</li>
+  <li>your provider’s Ofsted URN if you work in early years or childcare</li>
+  <li>a DfE Identity account (you’ll be prompted to sign in or create one)</li>
+</ul>
+
+<p class="govuk-body">
+  Your TRN can be found on your payslip, teaching contract or pension documents. If you do not know your TRN, you can:
+</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li><%= external_link_to("find a lost TRN", :find_a_lost_trn, new_tab: true) %></li>
+  <li><%= external_link_to("get a TRN", :get_a_trn, new_tab: true) %></li>
+</ul>
+
+<p class="govuk-body">
+  By continuing, you agree to our <%= govuk_link_to("privacy notice", PRIVACY_NOTICE) %>.
+</p>
+
+

--- a/app/views/registration_wizard/shared/_start_page_content.html.erb
+++ b/app/views/registration_wizard/shared/_start_page_content.html.erb
@@ -62,5 +62,3 @@
 <p class="govuk-body">
   By continuing, you agree to our <%= govuk_link_to("privacy notice", PRIVACY_NOTICE) %>.
 </p>
-
-

--- a/app/views/registration_wizard/start.html.erb
+++ b/app/views/registration_wizard/start.html.erb
@@ -1,69 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Register for a national professional qualification (NPQ)</h1>
-
-    <p class="govuk-body">Use this service to:</p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>register for an NPQ or <%= localise_sentence_embedded_course_name(Course.ehco) %></li>
-      <li>check your registration details, if you already registered</li>
-      <li>check your course outcome, if you have completed your course</li>
-    </ul>
-
-    <h2 class="govuk-heading-m">What happens when you register</h2>
-
-    <p class="govuk-body">
-      When you register with the Department for Education (DfE) we:
-    </p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>check if you’re eligible for scholarship funding</li>
-      <li>send your registration details to your chosen training provider</li>
-    </ul>
-
-    <p class="govuk-body">
-      Your provider will then email you an application form to complete.
-    </p>
-
-    <%= govuk_inset_text do %>
-      <h3 class="govuk-heading-s">Being eligible for funding does not guarantee a funded place</h3>
-      Your training provider must confirm two things after you apply with them:
-      <ul class="govuk-list govuk-list--bullet">
-        <li>a funded place is available</li>
-        <li>you meet their suitability requirements for the course</li>
-      </ul>
-    <% end %>
-
-    <h2 class="govuk-heading-m">Before you start</h2>
-
-    <p class="govuk-body">
-      You’ll need:
-    </p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>
-        to know which
-        <%= external_link_to("NPQ course", :find_out_about_npq_courses) %>
-        you want to take and who your provider will be
-      </li>
-      <li>the address and postcode of your workplace setting</li>
-      <li>a teacher reference number (TRN) – even if you’re not a teacher</li>
-      <li>your provider’s Ofsted URN if you work in early years or childcare</li>
-      <li>a DfE Identity account (you’ll be prompted to sign in or create one)</li>
-    </ul>
-
-    <p class="govuk-body">
-      Your TRN can be found on your payslip, teaching contract or pension documents. If you do not know your TRN, you can:
-    </p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li><%= external_link_to("find a lost TRN", :find_a_lost_trn, new_tab: true) %></li>
-      <li><%= external_link_to("get a TRN", :get_a_trn, new_tab: true) %></li>
-    </ul>
-
-    <p class="govuk-body">
-      By continuing, you agree to our <%= govuk_link_to("privacy notice", PRIVACY_NOTICE) %>.
-    </p>
+    <%= render "registration_wizard/shared/start_page_content" %>
 
     <% if Feature.registration_enabled? %>
       <% unless Rails.configuration.x.teacher_auth.enabled %>
@@ -83,15 +20,14 @@
           )
         %>
 
-      <h2 class="govuk-heading-m">Sign in</h2>
+        <h2 class="govuk-heading-m">Sign in</h2>
 
-      <p class="govuk-body">
-        You can also sign in
-        through GOV.UK One Login to view a previous registration or change your personal details.
-      </p>
-      <%= govuk_button_to("Sign in", user_teacher_auth_omniauth_authorize_path, secondary: true) %>
+        <p class="govuk-body">
+          You can also sign in
+          through GOV.UK One Login to view a previous registration or change your personal details.
+        </p>
+        <%= govuk_button_to("Sign in", user_teacher_auth_omniauth_authorize_path, secondary: true) %>
       <% end %>
     <% end %>
-
   </div>
 </div>

--- a/app/views/shared/get_an_identity/_redirect_button.html.erb
+++ b/app/views/shared/get_an_identity/_redirect_button.html.erb
@@ -4,7 +4,7 @@
 <span <%= "class=govuk-visually-hidden" if hidden %>>
   <%=
     govuk_start_button(
-      text: button_text, href: user_tra_openid_connect_omniauth_authorize_path(start_now: true), as_button: true
+      text: button_text, href: user_tra_openid_connect_omniauth_authorize_path, as_button: true
     )
   %>
 </span>

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -70,8 +70,11 @@ FactoryBot.define do
       end
 
       after(:create) do |user, evaluator|
-        user.refresh_token.update!(token: evaluator.token,
-                                   token_updated_at: evaluator.token_updated_at)
+        user
+          .oauth_tokens
+          .refresh_token
+          .create!(token: evaluator.token,
+                   token_updated_at: evaluator.token_updated_at)
       end
     end
 

--- a/spec/features/journeys/happy_paths/dfe_sign_in_spec.rb
+++ b/spec/features/journeys/happy_paths/dfe_sign_in_spec.rb
@@ -20,7 +20,10 @@ RSpec.feature "DfE Sign In", :with_default_schedules, type: :feature do
     WebMock.disable_net_connect!(allow_localhost: previous_webmock_allow_localhost, allow: previous_webmock_allow)
   end
 
-  before { allow(Rails.application.config.x.teacher_auth).to receive(:enabled).and_return(false) }
+  before do
+    # Needed for DfE Identity access during change over period
+    allow(Feature).to receive(:registration_closed?).and_return(true)
+  end
 
   regenerate_fixtures = false # set to true to regenerate fixtures
 
@@ -47,8 +50,8 @@ RSpec.feature "DfE Sign In", :with_default_schedules, type: :feature do
   end
 
   def login_with_email(email)
-    navigate_to_page(path: "/", submit_form: false, axe_check: false) do
-      click_button("Start now")
+    navigate_to_page(path: "/registration_closed", submit_form: false, axe_check: false) do
+      page.click_button("Sign in to your DfE Identity account")
     end
 
     click_link "Sign in"
@@ -69,7 +72,7 @@ RSpec.feature "DfE Sign In", :with_default_schedules, type: :feature do
   scenario "capture omniauth authentication hash for user with TRN", skip: !regenerate_fixtures do
     login_with_email(email_for_account_with_trn)
 
-    expect(page).to have_current_path "/registration/course-start-date"
+    expect(page).to have_current_path "/account"
     File.open(fixtures_path.join("tra_openid_connect_auth_with_trn.json"), "w") do |file|
       file.write JSON.pretty_generate(strip_pii(User.last.raw_tra_provider_data))
     end
@@ -78,7 +81,7 @@ RSpec.feature "DfE Sign In", :with_default_schedules, type: :feature do
   scenario "capture omniauth authentication hash for user without TRN", skip: !regenerate_fixtures do
     login_with_email(email_for_account_without_trn)
 
-    expect(page).to have_current_path "/registration/teacher-reference-number"
+    expect(page).to have_current_path "/account"
     File.open(fixtures_path.join("tra_openid_connect_auth_no_trn.json"), "w") do |file|
       file.write JSON.pretty_generate(strip_pii(User.last.raw_tra_provider_data))
     end
@@ -89,11 +92,11 @@ RSpec.feature "DfE Sign In", :with_default_schedules, type: :feature do
     OmniAuth.config.test_mode = true
     OmniAuth.config.add_mock(:tra_openid_connect, stubbed_callback_response)
 
-    navigate_to_page(path: "/", submit_form: false, axe_check: false) do
-      click_button("Start now")
+    navigate_to_page(path: "/registration_closed", submit_form: false, axe_check: false) do
+      page.click_button("Sign in to your DfE Identity account")
     end
 
-    expect(page).to have_current_path "/registration/course-start-date"
+    expect(page).to have_current_path "/account"
     expect(User.last.trn).not_to be_blank
   end
 
@@ -102,11 +105,11 @@ RSpec.feature "DfE Sign In", :with_default_schedules, type: :feature do
     OmniAuth.config.test_mode = true
     OmniAuth.config.add_mock(:tra_openid_connect, stubbed_callback_response)
 
-    navigate_to_page(path: "/", submit_form: false, axe_check: false) do
-      click_button("Start now")
+    navigate_to_page(path: "/registration_closed", submit_form: false, axe_check: false) do
+      page.click_button("Sign in to your DfE Identity account")
     end
 
-    expect(page).to have_current_path "/registration/course-start-date"
+    expect(page).to have_current_path "/account"
     expect(User.last.trn).to be_blank
   end
 end

--- a/spec/features/journeys/sad_paths/dfe_sign_in_spec.rb
+++ b/spec/features/journeys/sad_paths/dfe_sign_in_spec.rb
@@ -5,7 +5,10 @@ RSpec.feature "DfE sign in", :no_js, type: :feature do
 
   let(:user) { User.find_by(email: "user@example.com") }
 
-  before { allow(Rails.application.config.x.teacher_auth).to receive(:enabled).and_return(false) }
+  before do
+    # Needed for DfE Identity access during change over period
+    allow(Feature).to receive(:registration_closed?).and_return(true)
+  end
 
   context "when there is an existing user with the provided DfE Identity UID" do
     let(:existing_user_with_dfe_id) { create(:user, :with_get_an_identity_id, email: "old@example.com", full_name: "old name") }
@@ -18,8 +21,8 @@ RSpec.feature "DfE sign in", :no_js, type: :feature do
       end
 
       scenario "the user should be updated with new email from DfE Identity" do
-        navigate_to_page(path: "/", submit_form: false, axe_check: false) do
-          page.click_button("Start now")
+        navigate_to_page(path: "/registration_closed", submit_form: false, axe_check: false) do
+          page.click_button("Sign in to your DfE Identity account")
         end
 
         expect(existing_user_with_dfe_id.reload.email).to eq "user@example.com"
@@ -33,8 +36,8 @@ RSpec.feature "DfE sign in", :no_js, type: :feature do
       end
 
       scenario "the user should log in successfully" do
-        navigate_to_page(path: "/", submit_form: false, axe_check: false) do
-          page.click_button("Start now")
+        navigate_to_page(path: "/registration_closed", submit_form: false, axe_check: false) do
+          page.click_button("Sign in to your DfE Identity account")
         end
 
         expect(existing_user_with_dfe_id.reload.email).to eq "old@example.com"
@@ -51,8 +54,8 @@ RSpec.feature "DfE sign in", :no_js, type: :feature do
       let!(:application_for_user_without_dfe_id) { create(:application, :accepted, user: user_without_dfe_id, course: create(:course, :leading_teaching)) }
 
       scenario "the clashing user account should be archived" do
-        navigate_to_page(path: "/", submit_form: false, axe_check: false) do
-          page.click_button("Start now")
+        navigate_to_page(path: "/registration_closed", submit_form: false, axe_check: false) do
+          page.click_button("Sign in to your DfE Identity account")
         end
 
         expect(user_without_dfe_id.reload.email).to eq "archived-user@example.com"
@@ -81,8 +84,8 @@ RSpec.feature "DfE sign in", :no_js, type: :feature do
       let!(:existing_user_with_dfe_id) { create(:user, :with_get_an_identity_id, full_name: "old name", email: "old@example.com", provider: "tra_openid_connect") }
 
       scenario "the clashing user account should be archived" do
-        navigate_to_page(path: "/", submit_form: false, axe_check: false) do
-          page.click_button("Start now")
+        navigate_to_page(path: "/registration_closed", submit_form: false, axe_check: false) do
+          page.click_button("Sign in to your DfE Identity account")
         end
 
         expect(user_with_same_email_different_dfe_uid.reload.email).to eq "archived-user@example.com"
@@ -109,8 +112,8 @@ RSpec.feature "DfE sign in", :no_js, type: :feature do
       before { create(:application, :accepted, user: user, course: create(:course, :leading_teaching)) }
 
       scenario "the archived account should have its UID blanked, and the non-archived account should be updated with the UID" do
-        navigate_to_page(path: "/", submit_form: false, axe_check: false) do
-          page.click_button("Start now")
+        navigate_to_page(path: "/registration_closed", submit_form: false, axe_check: false) do
+          page.click_button("Sign in to your DfE Identity account")
         end
 
         expect(user.reload.uid).to eq existing_user_with_dfe_id.uid
@@ -131,8 +134,8 @@ RSpec.feature "DfE sign in", :no_js, type: :feature do
         end
 
         scenario "the user account should be updated with the UID" do
-          navigate_to_page(path: "/", submit_form: false, axe_check: false) do
-            page.click_button("Start now")
+          navigate_to_page(path: "/registration_closed", submit_form: false, axe_check: false) do
+            page.click_button("Sign in to your DfE Identity account")
           end
 
           expect(existing_user.reload.uid).to eq uid
@@ -153,8 +156,8 @@ RSpec.feature "DfE sign in", :no_js, type: :feature do
         end
 
         scenario "the clashing user account be updated with the new UID" do # or should it be archived, and a new user created? (way more complex to implement)
-          navigate_to_page(path: "/", submit_form: false, axe_check: false) do
-            page.click_button("Start now")
+          navigate_to_page(path: "/registration_closed", submit_form: false, axe_check: false) do
+            page.click_button("Sign in to your DfE Identity account")
           end
 
           expect(clashing_user.reload.email).to eq "user@example.com"
@@ -176,11 +179,11 @@ RSpec.feature "DfE sign in", :no_js, type: :feature do
       end
 
       scenario "a new user account should be created with the UID and email" do
-        navigate_to_page(path: "/", submit_form: false, axe_check: false) do
-          page.click_button("Start now")
+        navigate_to_page(path: "/registration_closed", submit_form: false, axe_check: false) do
+          page.click_button("Sign in to your DfE Identity account")
         end
 
-        expect(page).to have_current_path("/registration/course-start-date")
+        expect(page).to have_current_path("/account")
         expect(new_user_created_with_uid.email).to eq "user@example.com"
         expect(new_user_created_with_uid.provider).to eq "tra_openid_connect"
         expect(new_user_created_with_uid.full_name).to eq "John Doe"

--- a/spec/features/service_closed_spec.rb
+++ b/spec/features/service_closed_spec.rb
@@ -45,7 +45,8 @@ RSpec.feature "Service is closed", :no_js, type: :feature do
   end
 
   context "when using late registration" do
-    include_context "Stub Get An Identity Omniauth Responses"
+    include_context "with stubbed Teacher Auth OmniAuth responses"
+    include_context "with stubbed Teaching Record System person API"
 
     let(:super_admin) { create(:super_admin) }
     let(:email) { "example@example.com" }
@@ -54,7 +55,7 @@ RSpec.feature "Service is closed", :no_js, type: :feature do
 
     before { close_registration! }
 
-    scenario "Allow user to register using DfE Identity" do
+    scenario "Allow user to register using Teacher Auth" do
       visit "/"
       expect(page).to have_content("Registration is temporarily closed")
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -335,9 +335,29 @@ RSpec.describe User do
     context "with a user who does not have a refresh token" do
       let(:user) { create :user }
 
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe "#store_refresh_token!" do
+    subject { user.store_refresh_token!("some-token") }
+
+    before { freeze_time }
+
+    context "with user who has a refresh token" do
+      let(:user) { create :user, :with_refresh_token }
+
       it { is_expected.to be_instance_of OauthToken }
-      it { is_expected.to have_attributes token_type: "refresh_token" }
-      it { is_expected.to be_new_record }
+      it { is_expected.to have_attributes token_type: "refresh_token", token: "some-token", token_updated_at: Time.current }
+      it { is_expected.to be_persisted }
+    end
+
+    context "with a user who does not have a refresh token" do
+      let(:user) { create :user }
+
+      it { is_expected.to be_instance_of OauthToken }
+      it { is_expected.to have_attributes token_type: "refresh_token", token: "some-token", token_updated_at: Time.current }
+      it { is_expected.to be_persisted }
     end
   end
 

--- a/spec/services/applications/reject_spec.rb
+++ b/spec/services/applications/reject_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Applications::Reject, type: :model do
 
       context "when the user has no TRN and this is their only pending application" do
         it "destroys the refresh token record" do
-          expect { service.reject }.to change { user.reload.refresh_token.persisted? }.from(true).to(false)
+          expect { service.reject }.to change { user.reload.refresh_token.present? }.from(true).to(false)
         end
       end
 

--- a/spec/services/users/find_or_create_from_teacher_auth_spec.rb
+++ b/spec/services/users/find_or_create_from_teacher_auth_spec.rb
@@ -56,12 +56,12 @@ RSpec.describe Users::FindOrCreateFromTeacherAuth do
 
   shared_examples "destroying the refresh token" do
     context "when the user has a persisted refresh token" do
-      before { user.refresh_token.store!("some-refresh-token") }
+      before { user.store_refresh_token!("some-refresh-token") }
 
       it "destroys the persisted refresh token" do
         expect(user.reload.refresh_token).to be_persisted
         subject
-        expect(user.reload.refresh_token).not_to be_persisted
+        expect(user.reload.refresh_token).to be_nil
       end
     end
   end


### PR DESCRIPTION
### Context

Ticket: [NPQ-3746](https://dfedigital.atlassian.net/browse/NPQ-3746)

### Changes proposed in this pull request

1. Use Teacher Auth for sign ins from registration exception page
2. Shared content of registration exception page with start page for now


[NPQ-3746]: https://dfedigital.atlassian.net/browse/NPQ-3746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ