### PR TITLE
[NPQ-3758] Prevent registrations from GAI users

### DIFF
--- a/app/controllers/registration_wizard_controller.rb
+++ b/app/controllers/registration_wizard_controller.rb
@@ -1,10 +1,10 @@
 class RegistrationWizardController < PublicPagesController
   before_action :registration_closed
-  before_action :check_teacher_auth_user
   before_action :set_wizard
   before_action :set_form
   before_action :check_end_of_journey, only: %i[update]
   before_action :check_course_defined, only: %i[show]
+  before_action :check_teacher_auth_user
 
   rescue_from FundingEligibility::MissingMandatoryInstitution, with: :redirect_to_institution_picker
   rescue_from RegistrationWizard::RemovedStep, with: :redirect_to_course_start_date

--- a/app/controllers/registration_wizard_controller.rb
+++ b/app/controllers/registration_wizard_controller.rb
@@ -4,6 +4,7 @@ class RegistrationWizardController < PublicPagesController
   before_action :set_form
   before_action :check_end_of_journey, only: %i[update]
   before_action :check_course_defined, only: %i[show]
+  before_action :check_teacher_auth_user
 
   rescue_from FundingEligibility::MissingMandatoryInstitution, with: :redirect_to_institution_picker
   rescue_from RegistrationWizard::RemovedStep, with: :redirect_to_course_start_date
@@ -130,5 +131,16 @@ private
     return {} if Feature.registration_closed?(current_user)
 
     params.fetch(:registration_wizard, {}).permit(RegistrationWizard.permitted_params_for_step(params[:step].underscore))
+  end
+
+  def check_teacher_auth_user
+    return unless Rails.configuration.x.teacher_auth.enabled
+    return if params[:step].to_s == "start"
+    return if current_user&.teacher_auth_provider?
+
+    sign_out_all_scopes
+    flash[:error] = "Please restart your registration"
+
+    redirect_to(root_path)
   end
 end

--- a/app/controllers/registration_wizard_controller.rb
+++ b/app/controllers/registration_wizard_controller.rb
@@ -1,10 +1,10 @@
 class RegistrationWizardController < PublicPagesController
   before_action :registration_closed
+  before_action :check_teacher_auth_user
   before_action :set_wizard
   before_action :set_form
   before_action :check_end_of_journey, only: %i[update]
   before_action :check_course_defined, only: %i[show]
-  before_action :check_teacher_auth_user
 
   rescue_from FundingEligibility::MissingMandatoryInstitution, with: :redirect_to_institution_picker
   rescue_from RegistrationWizard::RemovedStep, with: :redirect_to_course_start_date
@@ -137,6 +137,8 @@ private
     return unless Rails.configuration.x.teacher_auth.enabled
     return if params[:step].to_s == "start"
     return if current_user&.teacher_auth_provider?
+
+    Sentry.capture_message("User attempted registration from GAI")
 
     sign_out_all_scopes
     flash[:error] = "Please restart your registration"

--- a/spec/controllers/registration_wizard_controller_spec.rb
+++ b/spec/controllers/registration_wizard_controller_spec.rb
@@ -11,7 +11,10 @@ RSpec.describe RegistrationWizardController do
 
   let(:current_user) { create(:user) }
 
-  before { session["user_id"] = current_user.id }
+  before do
+    allow(Rails.configuration.x.teacher_auth).to receive(:enabled).and_return(false)
+    session["user_id"] = current_user.id
+  end
 
   subject(:page_response) { make_request && response }
 

--- a/spec/features/journeys/sad_paths/attempting_registration_with_gai_spec.rb
+++ b/spec/features/journeys/sad_paths/attempting_registration_with_gai_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.feature "Registration whilst already signed in with DfE Identity", :no_js, type: :feature do
   include Helpers::JourneyAssertionHelper
 
+  before { allow(Sentry).to receive(:capture_message) }
+
   let(:user) { User.find_by(email: "user@example.com") }
 
   include_context "Stub Get An Identity Omniauth Responses"
@@ -28,6 +30,8 @@ RSpec.feature "Registration whilst already signed in with DfE Identity", :no_js,
       expect(page).not_to have_link("Sign out")
 
       expect(page).to have_css(".govuk-notification-banner", text: /restart.*registration/i)
+
+      expect(Sentry).to have_received(:capture_message)
     end
   end
 end

--- a/spec/features/journeys/sad_paths/attempting_registration_with_gai_spec.rb
+++ b/spec/features/journeys/sad_paths/attempting_registration_with_gai_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.feature "Registration whilst already signed in with DfE Identity", :no_js, type: :feature do
+  include Helpers::JourneyAssertionHelper
+
+  let(:user) { User.find_by(email: "user@example.com") }
+
+  include_context "Stub Get An Identity Omniauth Responses"
+
+  scenario "attempting to register whilst signed in with DfE Sign In" do
+    allow(Feature).to receive(:registration_closed?).and_return(true)
+
+    navigate_to_page(path: "/registration_closed", submit_form: false, axe_check: false) do
+      page.click_button("Sign in to your DfE Identity account")
+    end
+
+    expect(page).to have_current_path("/account")
+
+    allow(Feature).to receive(:registration_closed?).and_return(false)
+
+    expect(page).to have_link("DfE Identity account")
+    expect(page).to have_link("Sign out")
+
+    visit("/registration/course-start-date")
+
+    expect_page_to_have(path: "/") do
+      expect(page).not_to have_link("DfE Identity account")
+      expect(page).not_to have_link("Sign out")
+
+      expect(page).to have_css(".govuk-notification-banner", text: /restart.*registration/i)
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: [NPQ-3758](https://dfedigital.atlassian.net/browse/NPQ-3758)

If a user is already signed in via GAI, and have a cached copy of the account page, its conceivable they are able to register without being signed in as TeacherAuth

### Changes proposed in this pull request

1. Actively sign them about and force restarting registration in this scenario

[NPQ-3578]: https://dfedigital.atlassian.net/browse/NPQ-3578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[NPQ-3758]: https://dfedigital.atlassian.net/browse/NPQ-3758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ