### PR TITLE
[NPQ-3677] clear school/childcare-provider/private-childcare-provider when revisiting the choose step

### DIFF
--- a/app/forms/questionnaires/choose_childcare_provider.rb
+++ b/app/forms/questionnaires/choose_childcare_provider.rb
@@ -18,6 +18,11 @@ module Questionnaires
       ]
     end
 
+    def before_render
+      super
+      clear_previous_childcare_provider_choice
+    end
+
     def questions
       [
         QuestionTypes::AutoCompleteInstitution.new(
@@ -91,6 +96,11 @@ module Questionnaires
       if search_term_entered_in_no_js_fallback_form? && possible_institutions.blank? && childcare_name.present?
         errors.add(:childcare_name, :no_results, name: childcare_name)
       end
+    end
+
+    def clear_previous_childcare_provider_choice
+      self.childcare_identifier = nil
+      self.childcare_name = nil
     end
   end
 end

--- a/app/forms/questionnaires/choose_private_childcare_provider.rb
+++ b/app/forms/questionnaires/choose_private_childcare_provider.rb
@@ -16,6 +16,11 @@ module Questionnaires
       ]
     end
 
+    def before_render
+      super
+      clear_previous_private_childcare_provider_choice
+    end
+
     # In the no js scenario we want the step to loop, showing a different screen
     # the second time but without showing an error - hence a negative response to
     # #valid? preventing saving but without appending errors
@@ -81,6 +86,11 @@ module Questionnaires
       return if institution.present?
 
       errors.add(:private_childcare_identifier, :no_results, urn: private_childcare_identifier.split("-").last)
+    end
+
+    def clear_previous_private_childcare_provider_choice
+      self.private_childcare_identifier = nil
+      self.private_childcare_name = nil
     end
   end
 end

--- a/app/forms/questionnaires/choose_school.rb
+++ b/app/forms/questionnaires/choose_school.rb
@@ -23,6 +23,11 @@ module Questionnaires
       super(...) && institution_identifier.present? && institution_identifier != "other"
     end
 
+    def before_render
+      super
+      clear_previous_institution_choice
+    end
+
     def next_step
       if institution.in_england?
         :choose_your_npq
@@ -85,6 +90,11 @@ module Questionnaires
       if search_term_entered_in_no_js_fallback_form? && possible_institutions.blank? && institution_name.present?
         errors.add(:institution_name, :no_results, name: institution_name)
       end
+    end
+
+    def clear_previous_institution_choice
+      self.institution_identifier = nil
+      self.institution_name = nil
     end
   end
 end

--- a/spec/features/journeys/happy_paths/changing_cohort_to_one_lead_provider_no_longer_supports_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_cohort_to_one_lead_provider_no_longer_supports_spec.rb
@@ -102,7 +102,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, :with_de
       page.choose("A school", visible: :all)
     end
 
-    choose_a_school(js:, name: "open", already_searched_for_workplace: true)
+    choose_a_school(js:, name: "open")
 
     expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do
       page.choose("Headship", visible: :all)

--- a/spec/features/journeys/sad_paths/going_back_to_choose_childcare_provider_step_spec.rb
+++ b/spec/features/journeys/sad_paths/going_back_to_choose_childcare_provider_step_spec.rb
@@ -1,0 +1,90 @@
+require "rails_helper"
+
+RSpec.feature "Sad journeys", :with_cohorts, :with_default_schedules, :with_default_school, type: :feature do
+  include Helpers::JourneyAssertionHelper
+  include Helpers::JourneyStepHelper
+  include ApplicationHelper
+
+  include_context "with stubbed Teacher Auth OmniAuth responses"
+  include_context "with stubbed Teaching Record System person API"
+
+  let(:school_name) { "open" }
+  # let(:school) { create(:school, urn: 100_000, name: "some school", establishment_status_code: "1") }
+
+  # before { school }
+
+  context "when JavaScript is enabled", :js do
+    scenario("going back to the choose childcare provider step") { run_scenario(js: true) }
+  end
+
+  context "when JavaScript is disabled", :no_js do
+    scenario("going back to the choose childcare provider step") { run_scenario(js: false) }
+  end
+
+  def run_scenario(js:)
+    # first, get past the choose childcare provider step
+
+    stub_participant_validation_request
+
+    navigate_to_page(path: "/", submit_form: false, axe_check: false) do
+      page.click_button("Start now")
+    end
+
+    choose_course_start_date
+
+    navigate_to_page(path: "/registration/provider-check", submit_form: true) do
+      page.choose("Yes", visible: :all)
+    end
+
+    navigate_to_page(path: "/registration/teacher-catchment", axe_check: false, submit_form: true) do
+      page.choose("Yes", visible: :all)
+    end
+
+    navigate_to_page(path: "/registration/work-setting", submit_form: true) do
+      page.choose("Early years or childcare", visible: :all)
+    end
+
+    navigate_to_page(path: "/registration/kind-of-nursery", submit_form: true) do
+      page.choose("Local authority-maintained nursery", visible: :all)
+    end
+
+    choose_a_childcare_provider(js:, name: school_name)
+
+    expect_page_to_have(path: "/registration/choose-your-npq", submit_form: false)
+
+    # try to go back to the choose childcare provider step and continue without changing anything
+
+    click_link "Back"
+    click_button "Continue"
+
+    expect(page).to have_text("Enter a childcare provider")
+
+    # try going to the check your answers page and then back to the choose childcare provider step
+
+    choose_a_childcare_provider(js:, name: school_name)
+
+    expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do
+      page.choose("Early years leadership", visible: :all)
+    end
+
+    navigate_to_page(path: "/registration/possible-funding", submit_form: false) do
+      page.click_button("Continue")
+    end
+
+    navigate_to_page(path: "/registration/choose-your-provider", submit_form: true) do
+      page.choose("Teach First", visible: :all)
+    end
+
+    navigate_to_page(path: "/registration/share-provider", submit_form: true) do
+      page.check("Yes, I agree to share my information", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/check-answers", submit_form: false) do
+      page.click_link("Change", href: "/registration/choose-childcare-provider/change")
+    end
+
+    click_button "Continue"
+
+    expect(page).to have_text("Enter a childcare provider")
+  end
+end

--- a/spec/features/journeys/sad_paths/going_back_to_choose_private_childcare_provider_step_spec.rb
+++ b/spec/features/journeys/sad_paths/going_back_to_choose_private_childcare_provider_step_spec.rb
@@ -1,0 +1,96 @@
+require "rails_helper"
+
+RSpec.feature "Sad journeys", :with_cohorts, :with_default_schedules, :with_default_school, type: :feature do
+  include Helpers::JourneyAssertionHelper
+  include Helpers::JourneyStepHelper
+  include ApplicationHelper
+
+  include_context "with stubbed Teacher Auth OmniAuth responses"
+  include_context "with stubbed Teaching Record System person API"
+
+  let(:school_name) { "open" }
+  # let(:school) { create(:school, urn: 100_000, name: "some school", establishment_status_code: "1") }
+
+  # before { school }
+
+  context "when JavaScript is enabled", :js do
+    scenario("going back to the choose private childcare provider step") { run_scenario(js: true) }
+  end
+
+  context "when JavaScript is disabled", :no_js do
+    scenario("going back to the choose private childcare provider step") { run_scenario(js: false) }
+  end
+
+  def run_scenario(js:)
+    # first, get past the choose private childcare provider step
+
+    stub_participant_validation_request
+
+    navigate_to_page(path: "/", submit_form: false, axe_check: false) do
+      page.click_button("Start now")
+    end
+
+    choose_course_start_date
+
+    navigate_to_page(path: "/registration/provider-check", submit_form: true) do
+      page.choose("Yes", visible: :all)
+    end
+
+    navigate_to_page(path: "/registration/teacher-catchment", axe_check: false, submit_form: true) do
+      page.choose("Yes", visible: :all)
+    end
+
+    navigate_to_page(path: "/registration/work-setting", submit_form: true) do
+      page.choose("Early years or childcare", visible: :all)
+    end
+
+    navigate_to_page(path: "/registration/kind-of-nursery", submit_form: true) do
+      page.choose("Private nursery", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/have-ofsted-urn", submit_form: true) do
+      expect(page).to have_text("Do you or your employer have an Ofsted unique reference number (URN)?")
+      page.choose("Yes", visible: :all)
+    end
+
+    choose_a_private_childcare_provider(js:, urn: "EY487263", name: "searchable childcare provider")
+
+    expect_page_to_have(path: "/registration/choose-your-npq", submit_form: false)
+
+    # try to go back to the choose private childcare provider step and continue without changing anything
+
+    click_link "Back"
+    click_button "Continue"
+
+    expect(page).to have_text("Enter a private childcare provider")
+
+    # try going to the check your answers page and then back to the choose private childcare provider step
+
+    choose_a_childcare_provider(js:, name: school_name)
+
+    expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do
+      page.choose("Early years leadership", visible: :all)
+    end
+
+    navigate_to_page(path: "/registration/possible-funding", submit_form: false) do
+      page.click_button("Continue")
+    end
+
+    navigate_to_page(path: "/registration/choose-your-provider", submit_form: true) do
+      page.choose("Teach First", visible: :all)
+    end
+
+    navigate_to_page(path: "/registration/share-provider", submit_form: true) do
+      page.check("Yes, I agree to share my information", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/check-answers", submit_form: true) do
+      page.click_link("Change", href: "/registration/have-ofsted-urn/change")
+      page.choose("Yes", visible: :all)
+    end
+
+    click_button "Continue"
+
+    expect(page).to have_text("Enter a private childcare provider")
+  end
+end

--- a/spec/features/journeys/sad_paths/going_back_to_choose_school_step_spec.rb
+++ b/spec/features/journeys/sad_paths/going_back_to_choose_school_step_spec.rb
@@ -1,0 +1,89 @@
+require "rails_helper"
+
+RSpec.feature "Sad journeys", :with_cohorts, :with_default_schedules, :with_default_school, type: :feature do
+  include Helpers::JourneyAssertionHelper
+  include Helpers::JourneyStepHelper
+  include ApplicationHelper
+
+  include_context "with stubbed Teacher Auth OmniAuth responses"
+  include_context "with stubbed Teaching Record System person API"
+
+  let(:school_name) { "open" }
+
+  context "when JavaScript is enabled", :js do
+    scenario("going back to the choose school step") { run_scenario(js: true) }
+  end
+
+  context "when JavaScript is disabled", :no_js do
+    scenario("going back to the choose school step") { run_scenario(js: false) }
+  end
+
+  def run_scenario(js:)
+    # first, get past the choose school step
+
+    stub_participant_validation_request
+
+    navigate_to_page(path: "/", submit_form: false, axe_check: false) do
+      page.click_button("Start now")
+    end
+
+    choose_course_start_date
+
+    navigate_to_page(path: "/registration/provider-check", submit_form: true) do
+      page.choose("Yes", visible: :all)
+    end
+
+    navigate_to_page(path: "/registration/teacher-catchment", axe_check: false, submit_form: true) do
+      page.choose("Yes", visible: :all)
+    end
+
+    navigate_to_page(path: "/registration/work-setting", submit_form: true) do
+      page.choose("A school", visible: :all)
+    end
+
+    choose_a_school(js:, name: school_name)
+
+    expect_page_to_have(path: "/registration/choose-your-npq", submit_form: false)
+
+    # try to go back to the choose school step and continue without changing anything
+
+    click_link "Back"
+    click_button "Continue"
+
+    expect(page).to have_text("There is a problem")
+    expect(page).to have_text("Enter your workplace")
+
+    # try going to the check your answers page and then back to the choose school step
+
+    choose_a_school(js:, name: school_name)
+
+    expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do
+      page.choose("Headship", visible: :all)
+    end
+
+    navigate_to_page(path: "/registration/ineligible-for-funding", submit_form: false) do
+      page.click_link("Continue")
+    end
+
+    navigate_to_page(path: "/registration/funding-your-npq", submit_form: true) do
+      page.choose "My trust is paying", visible: :all
+    end
+
+    navigate_to_page(path: "/registration/choose-your-provider", submit_form: true) do
+      page.choose("Teach First", visible: :all)
+    end
+
+    navigate_to_page(path: "/registration/share-provider", submit_form: true) do
+      page.check("Yes, I agree to share my information", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/check-answers", submit_form: false) do
+      page.click_link("Change", href: "/registration/choose-school/change")
+    end
+
+    click_button "Continue"
+
+    expect(page).to have_text("There is a problem")
+    expect(page).to have_text("Enter your workplace")
+  end
+end

--- a/spec/features/journeys/sad_paths/school_not_in_england_spec.rb
+++ b/spec/features/journeys/sad_paths/school_not_in_england_spec.rb
@@ -53,8 +53,7 @@ RSpec.feature "Sad journeys", :with_cohorts, :with_default_schedules, type: :fea
     end
 
     expect_page_to_have(path: "/registration/choose-school", submit_form: false) do
-      expected_text = js ? "What is the name of your workplace?" : "Select your workplace"
-      expect(page).to have_text(expected_text)
+      expect(page).to have_text("What is the name of your workplace?")
     end
 
     expect(retrieve_latest_application_user_data).to match(nil)

--- a/spec/forms/questionnaires/choose_childcare_provider_spec.rb
+++ b/spec/forms/questionnaires/choose_childcare_provider_spec.rb
@@ -150,4 +150,26 @@ RSpec.describe Questionnaires::ChooseChildcareProvider, type: :model do
       expect(subject.next_step).to be(:choose_your_npq)
     end
   end
+
+  describe "#before_render" do
+    subject { instance.before_render }
+
+    let(:identifier) { "some-identifier" }
+    let(:name) { "some-name" }
+
+    it "clears previous institution choice" do
+      subject
+      expect(instance.childcare_identifier).to be_nil
+      expect(instance.childcare_name).to be_nil
+    end
+
+    context "when the wizard is submitted" do
+      before { store["submitted"] = true }
+
+      it "clears the store" do
+        subject
+        expect(store).to be_empty
+      end
+    end
+  end
 end

--- a/spec/forms/questionnaires/choose_private_childcare_provider_spec.rb
+++ b/spec/forms/questionnaires/choose_private_childcare_provider_spec.rb
@@ -147,4 +147,26 @@ RSpec.describe Questionnaires::ChoosePrivateChildcareProvider, type: :model do
   describe "#previous_step" do
     it { expect(subject.previous_step).to be(:have_ofsted_urn) }
   end
+
+  describe "#before_render" do
+    subject { instance.before_render }
+
+    let(:identifier) { "some-identifier" }
+    let(:name) { "some-name" }
+
+    it "clears previous institution choice" do
+      subject
+      expect(instance.private_childcare_name).to be_nil
+      expect(instance.private_childcare_name).to be_nil
+    end
+
+    context "when the wizard is submitted" do
+      before { store["submitted"] = true }
+
+      it "clears the store" do
+        subject
+        expect(store).to be_empty
+      end
+    end
+  end
 end

--- a/spec/forms/questionnaires/choose_school_spec.rb
+++ b/spec/forms/questionnaires/choose_school_spec.rb
@@ -150,4 +150,26 @@ RSpec.describe Questionnaires::ChooseSchool, type: :model do
       expect(subject.next_step).to be(:choose_your_npq)
     end
   end
+
+  describe "#before_render" do
+    subject { instance.before_render }
+
+    let(:identifier) { "some-identifier" }
+    let(:name) { "some-name" }
+
+    it "clears previous institution choice" do
+      subject
+      expect(instance.institution_identifier).to be_nil
+      expect(instance.institution_name).to be_nil
+    end
+
+    context "when the wizard is submitted" do
+      before { store["submitted"] = true }
+
+      it "clears the store" do
+        subject
+        expect(store).to be_empty
+      end
+    end
+  end
 end

--- a/spec/support/helpers/journey_step_helper.rb
+++ b/spec/support/helpers/journey_step_helper.rb
@@ -1,6 +1,6 @@
 module Helpers
   module JourneyStepHelper
-    def choose_a_school(js:, name:, already_searched_for_workplace: false)
+    def choose_a_school(js:, name:)
       if js
         navigate_to_page(path: "/registration/choose-school", submit_form: true) do
           within ".npq-js-reveal" do
@@ -11,12 +11,11 @@ module Helpers
         end
       else
         navigate_to_page(path: "/registration/choose-school", submit_form: true) do
-          unless already_searched_for_workplace
-            within ".npq-js-hidden" do
-              page.fill_in "What is the name of your workplace?", with: name
-            end
-            page.click_button("Continue")
+          within ".npq-js-hidden" do
+            page.fill_in "What is the name of your workplace?", with: name
           end
+          page.click_button("Continue")
+
           expect(page).to have_text("Select your workplace")
           page.choose name
         end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/NPQ-3677

### Changes proposed in this pull request

This affects 3 very similar steps:
* choose-school
* choose-childcare-provider
* choose-private-childcare-provider

The entered name and corresponding identifier are cleared on those steps in the `before_render`