### PR TITLE
[NPQ-3773] Change staging URL to use CDN

### DIFF
--- a/terraform/application/config/staging.yml
+++ b/terraform/application/config/staging.yml
@@ -1,1 +1,2 @@
 ---
+ACCESS_EXTERNAL_DOMAIN: staging.register-npq.education.gov.uk


### PR DESCRIPTION
### Context

Ticket: [NPQ-3773](https://dfedigital.atlassian.net/browse/NPQ-3773)

When the user authenticates with TeacherAuth they are redirected to whatever application's view of its own URL, potentially changing the URL the user is on. We want our primary address for the staging environment to be the `staging.register-npq.education.gov.uk` address so when a user authenticates they should stay on this address.

The applications internal view of its domain is defined by `HOSTING_DOMAIN` - this will default to the `.cloud` address k8s knows about. We can override this using the `ACCESS_EXTERNAL_DOMAIN` env var. 

### Changes proposed in this pull request

1. Tell the application its own domain is the the CDN one not the `.cloud` one




[NPQ-3773]: https://dfedigital.atlassian.net/browse/NPQ-3773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ