### PR TITLE
[NPQ-3783] cope with TRNs being nil

### DIFF
--- a/app/services/teaching_record_system/webhooks/base.rb
+++ b/app/services/teaching_record_system/webhooks/base.rb
@@ -30,15 +30,15 @@ private
   end
 
   def no_user_found_failure
-    record_error("No user found with uid: #{user_uid}")
+    record_error("No user found with uid: #{user_uid}", send_to_sentry: false)
   end
 
-  def record_error(message)
+  def record_error(message, send_to_sentry: true)
     webhook_message.update!(
       status: :failed,
       status_comment: message,
       processed_at: Time.zone.now,
     )
-    Sentry.capture_message("[#{self.class::WEBHOOK_NAME}] #{message}")
+    Sentry.capture_message("[#{self.class::WEBHOOK_NAME}] #{message}") if send_to_sentry
   end
 end

--- a/app/services/users/find_or_create_from_teacher_auth.rb
+++ b/app/services/users/find_or_create_from_teacher_auth.rb
@@ -94,12 +94,18 @@ module Users
 
     def verified_trn_matching_users
       @verified_trn_matching_users ||=
-        User.where(trn:, trn_verified: true, archived_at: nil).order(updated_at: :desc).all.to_a
+        User
+          .where(trn:, trn_verified: true, archived_at: nil)
+          .where.not(trn: nil)
+          .order(updated_at: :desc)
+          .all.to_a
     end
 
     def unverified_trn_matching_user
       @unverified_trn_matching_user ||=
-        User.find_by(provider: Omniauth::Strategies::TraOpenidConnect::NAME, trn:, trn_verified: false, email:, archived_at: nil)
+        User
+          .where.not(trn: nil)
+          .find_by(provider: Omniauth::Strategies::TraOpenidConnect::NAME, trn:, trn_verified: false, email:, archived_at: nil)
     end
 
     def always_updated_attributes
@@ -141,8 +147,8 @@ module Users
         full_name:,
         previous_names:,
         trn:,
-        trn_auto_verified: true,
-        trn_verified: true,
+        trn_auto_verified: trn.present?,
+        trn_verified: trn.present?,
       )
     end
   end

--- a/app/services/users/find_or_create_from_teacher_auth.rb
+++ b/app/services/users/find_or_create_from_teacher_auth.rb
@@ -98,7 +98,7 @@ module Users
           .where(trn:, trn_verified: true, archived_at: nil)
           .where.not(trn: nil)
           .order(updated_at: :desc)
-          .all.to_a
+          .to_a
     end
 
     def unverified_trn_matching_user

--- a/spec/features/journeys/happy_paths/when_teacher_auth_returns_no_trn_spec.rb
+++ b/spec/features/journeys/happy_paths/when_teacher_auth_returns_no_trn_spec.rb
@@ -72,7 +72,12 @@ RSpec.feature "Sad journeys", :no_js, :with_cohorts, :with_default_schedules, :w
 
       expect_applicant_reached_end_of_journey
 
-      expect(retrieve_latest_application_user_data).to include(user_attributes_from_stubbed_callback_response)
+      expect(retrieve_latest_application_user_data).to include(
+        user_attributes_from_stubbed_callback_response.merge(
+          "trn_verified" => false,
+          "trn_auto_verified" => false,
+        ),
+      )
     end
   end
 end

--- a/spec/services/users/find_or_create_from_teacher_auth_spec.rb
+++ b/spec/services/users/find_or_create_from_teacher_auth_spec.rb
@@ -10,13 +10,12 @@ RSpec.describe Users::FindOrCreateFromTeacherAuth do
   let(:verified_name) { %w[Test User] }
   let(:api_previous_names) { [] }
   let(:refresh_token) { nil }
-  let(:user) { create(:user, trn:, trn_verified: true, archived_at: 1.day.ago) }
 
   let(:provider_data) do
     OpenStruct.new({
       uid:,
       credentials: OpenStruct.new({
-        token: "123456",
+        token: "some-token",
         refresh_token:,
       }),
       info: OpenStruct.new({
@@ -36,7 +35,7 @@ RSpec.describe Users::FindOrCreateFromTeacherAuth do
     stub_request(:get, "#{ENV['TRS_API_URL']}/v3/person")
       .with(
         headers: {
-          "Authorization" => "Bearer 123456",
+          "Authorization" => "Bearer some-token",
           "X-Api-Version" => "Next",
         },
         query: { "include" => "PreviousNames" },
@@ -67,7 +66,7 @@ RSpec.describe Users::FindOrCreateFromTeacherAuth do
   end
 
   before do
-    user
+    create(:user, trn:, trn_verified: true, archived_at: 1.day.ago)
 
     if trn.present?
       stub_person_api
@@ -351,8 +350,8 @@ RSpec.describe Users::FindOrCreateFromTeacherAuth do
         expect(User.find_by(provider: "teacher_auth", uid:)).to have_attributes(
           email:,
           trn:,
-          trn_verified: true,
-          trn_auto_verified: true,
+          trn_verified: trn.present?,
+          trn_auto_verified: trn.present?,
           full_name: verified_name.join(" "),
           feature_flag_id:,
         )
@@ -425,7 +424,32 @@ RSpec.describe Users::FindOrCreateFromTeacherAuth do
   context "when no TRN is specified" do
     let(:trn) { nil }
 
+    before { create(:user, :with_teacher_auth, trn: nil) }
+
     it_behaves_like "logging in using provider and UID"
     it_behaves_like "storing the refresh token"
+
+    it "does not mark the nil TRN as verified" do
+      subject
+      expect(User.last).to have_attributes(trn: nil, trn_verified: false, trn_auto_verified: false)
+    end
+
+    context "when there is a user with a nil TRN, marked as verified" do
+      # users were created like this before NPQ-3783
+      # keeping this test, as there isn't a database constraint to stop this scenario
+      before { create(:user, :with_teacher_auth, trn: nil, trn_verified: true) }
+
+      it "does not match users with nil TRNs, but instead creates a new user" do
+        expect { subject }.to change(User, :count).by(1)
+      end
+    end
+
+    context "when there is a GAI user with a nil TRN but matching email" do
+      before { create(:user, :with_get_an_identity_id, email:, trn: nil, trn_verified: false) }
+
+      it "does not match the user with nil TRNs, but instead creates a new user" do
+        expect { subject }.to change(User, :count).by(1)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/NPQ-3783

### Changes proposed in this pull request

* don't set `trn_verified` or `trn_auto_verified` to true when the TRN from teacher auth is `nil`
* don't match on `nil` verified TRNs 
* don't match on `nil` unverified TRNs