### PR TITLE
[NPQ-3785] redirect to home page when on a registration closed page and registration reopens

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,9 @@
 class PagesController < PublicPagesController
   def show
+    if params[:page] == "closed_registration_exception" && !Feature.registration_closed?(current_user)
+      return redirect_to root_path
+    end
+
     render template: "pages/#{params[:page]}"
   end
 end

--- a/app/controllers/registration_closed_controller.rb
+++ b/app/controllers/registration_closed_controller.rb
@@ -1,4 +1,7 @@
 class RegistrationClosedController < PublicPagesController
-  def show; end
+  def show
+    redirect_to root_path unless Feature.registration_closed?(current_user)
+  end
+
   def change; end
 end

--- a/app/forms/questionnaires/closed.rb
+++ b/app/forms/questionnaires/closed.rb
@@ -1,7 +1,7 @@
 module Questionnaires
   class Closed < Base
     def requirements_met?
-      true
+      Feature.registration_closed?(query_store.current_user) # redirects to root path if registration is open
     end
   end
 end

--- a/spec/features/journeys/sad_paths/navigating_directly_to_pages_spec.rb
+++ b/spec/features/journeys/sad_paths/navigating_directly_to_pages_spec.rb
@@ -31,11 +31,20 @@ RSpec.feature "Sad journeys", :no_js, :with_default_schedules, type: :feature do
     senco-start-date
   ]
 
+  steps_that_require_closed_registration = %w[
+    closed
+  ]
+
   RegistrationWizard::VALID_REGISTRATION_STEPS
     .excluding(:choose_your_npq)
     .map { |step| step.to_s.dasherize }.each do |step|
     scenario "Navigating directly to the #{step} page does not raise an error" do
+      if steps_that_require_closed_registration.include?(step)
+        Flipper.disable(Feature::REGISTRATION_OPEN)
+      end
+
       visit "/registration/#{step}"
+
       if steps_that_require_course.include?(step)
         expect(page).to have_current_path("/registration/course-start-date")
       else

--- a/spec/features/service_closed_spec.rb
+++ b/spec/features/service_closed_spec.rb
@@ -12,35 +12,50 @@ RSpec.feature "Service is closed", :no_js, type: :feature do
 
     scenario "Service prompts to register for email updates using DfE Identity login" do
       visit "/"
+      expect(page).to have_current_path(registration_closed_path)
       expect(page).to have_content("Registration is temporarily closed")
       expect(page).to be_accessible
 
       page.click_button("Sign up for email updates")
-
       expect(page).to have_current_path(new_email_update_path)
       expect(page).to have_content("Get email updates about registration opening")
       expect(page).to be_accessible
     end
+
+    context "when registration reopens" do
+      before { open_registration! }
+
+      scenario "registration closed page redirects to home page" do
+        visit registration_closed_path
+        expect(page).to have_current_path("/")
+      end
+    end
   end
 
-  context "when registration is open" do
+  context "when registration closes whilst in the middle of a registration journey" do
     include_context "with stubbed Teacher Auth OmniAuth responses"
     include_context "with stubbed Teaching Record System person API"
 
-    before { open_registration! }
-
-    scenario "Services closes while registration in progress" do
+    before do
       visit "/"
-      expect(page).to have_text("Before you start")
       page.click_button("Start now")
-
       choose_course_start_date
-
-      # Registration is now closed
       close_registration!
       page.click_button("Continue")
+    end
 
+    scenario "the registration closed step is shown" do
+      expect(page).to have_current_path(registration_wizard_show_path(:closed))
       expect(page).to have_content("Registration has closed temporarily")
+    end
+
+    context "when registration reopens" do
+      before { open_registration! }
+
+      scenario "registration closed step redirects to home page" do
+        visit registration_wizard_show_path(:closed)
+        expect(page).to have_current_path("/")
+      end
     end
   end
 
@@ -68,19 +83,15 @@ RSpec.feature "Service is closed", :no_js, type: :feature do
       expect(page).to have_content("Added #{email}")
 
       click_link("Sign out")
-
       visit "/closed_registration_exception"
-
       click_on("Start now")
 
       expect(page).to have_content("Registration has closed temporarily")
 
       Flipper.enable(Feature::CLOSED_REGISTRATION_ENABLED)
-
       visit "/closed_registration_exception"
       click_on("Start now")
-
-      choose_course_start_date
+      expect(page).to have_current_path("/registration/course-start-date")
     end
 
     scenario "When user is deleted" do
@@ -156,6 +167,23 @@ RSpec.feature "Service is closed", :no_js, type: :feature do
       click_on("Start now")
 
       expect_page_to_have(path: "/registration/closed")
+    end
+
+    context "when registration reopens" do
+      before do
+        visit "/"
+        sign_in_as(super_admin)
+        visit "/npq-separation/admin/registration-closed/closed-registration-users"
+        fill_in("Email address", with: email)
+        click_on("Add user")
+        click_link("Sign out")
+        open_registration!
+      end
+
+      scenario "the late registration page redirects to the home page" do
+        visit "/closed_registration_exception"
+        expect(page).to have_current_path("/")
+      end
     end
   end
 


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/NPQ-3785

### Changes proposed in this pull request

when registration re-opens, redirect the following pages to the home page:
* /registration_closed
* /registration/closed
* /closed_registration_exception

