### PR TITLE
[NPQ-3526] - Prevent GAI sign in taking over TeacherAuth accounts

### DIFF
--- a/app/services/users/find_or_create_from_provider_data.rb
+++ b/app/services/users/find_or_create_from_provider_data.rb
@@ -2,6 +2,8 @@
 
 module Users
   class FindOrCreateFromProviderData
+    class TeacherAuthAccountExistsError < StandardError; end
+
     def initialize(provider_data:, feature_flag_id:)
       @provider_data = provider_data
       @feature_flag_id = feature_flag_id
@@ -20,6 +22,12 @@ module Users
         Rails.logger.info("[GAI] User not found using UID, UID=#{provider_data.uid}, using email to find user")
         check_if_supplied_uid_matches_archived_account # CPDNPQ-2647
         user = User.find_or_initialize_by(email: provider_email, archived_at: nil)
+
+        if user.teacher_auth_provider?
+          raise TeacherAuthAccountExistsError,
+                "GAI sign-in matched a Teacher Auth user by email (user_id=#{user.id}); refusing to take over the account"
+        end
+
         user.assign_attributes(provider: provider_data.provider, uid: provider_data.uid)
       end
 

--- a/spec/services/users/find_or_create_from_provider_data_spec.rb
+++ b/spec/services/users/find_or_create_from_provider_data_spec.rb
@@ -297,6 +297,23 @@ RSpec.describe Users::FindOrCreateFromProviderData do
       end
     end
 
+    context "when the user with email is a Teacher Auth user" do
+      let!(:teacher_auth_user) { create(:user, :with_teacher_auth, email: provider_data_email) }
+
+      it "raises an error refusing to take over the account" do
+        expect { subject }.to raise_error(described_class::TeacherAuthAccountExistsError)
+      end
+
+      it "does not change the Teacher Auth user's provider or uid" do
+        original_uid = teacher_auth_user.uid
+
+        expect { subject }.to raise_error(described_class::TeacherAuthAccountExistsError)
+
+        expect(teacher_auth_user.reload.provider).to eq("teacher_auth")
+        expect(teacher_auth_user.uid).to eq(original_uid)
+      end
+    end
+
     context "when user with email does not exist" do
       it "creates a new user with the UID and email" do
         expect(subject.uid).to eq provider_data_uid


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/NPQ-3526

### Changes proposed in this pull request
- Raise an error when a user that has signed in via TeacherAuth when trying to sign into the same account via GetAnIdentity
- Prevents the provider and uuid being updated on the teacher_auth user on sign in.

### Test notes
- Change config.x.teacher_auth.enabled = false in config/application.rb
- Change config/environments/development to have 
```
config.consider_all_requests_local = false
  ```
  
Take a user that you have signed in with TA locally, should have provider set at "teacher_auth"

Go to localhost:3000 and try to sign in. Should fail and take you to the home page with an error

