### PR TITLE
[NPQ-3797] remove get_and_identity_id from query store and FundingEligibility class

### DIFF
--- a/app/forms/questionnaires/choose_your_npq.rb
+++ b/app/forms/questionnaires/choose_your_npq.rb
@@ -145,8 +145,7 @@ module Questionnaires
         institution: query_store.institution,
         approved_itt_provider: approved_itt_provider?,
         inside_catchment: inside_catchment?,
-        trn: wizard.query_store.trn,
-        get_an_identity_id: wizard.query_store.get_an_identity_id,
+        user_ecf_id: wizard.query_store.user_ecf_id,
         query_store: wizard.query_store,
       ).funded?
     end
@@ -157,8 +156,7 @@ module Questionnaires
         institution: query_store.institution,
         approved_itt_provider: approved_itt_provider?,
         inside_catchment: inside_catchment?,
-        trn: wizard.query_store.trn,
-        get_an_identity_id: wizard.query_store.get_an_identity_id,
+        user_ecf_id: wizard.query_store.user_ecf_id,
         query_store: wizard.query_store,
       )
     end

--- a/app/forms/questionnaires/choose_your_provider.rb
+++ b/app/forms/questionnaires/choose_your_provider.rb
@@ -89,7 +89,6 @@ module Questionnaires
              :course,
              :inside_catchment?,
              :new_headteacher?,
-             :trn,
              to: :query_store
 
     def validate_lead_provider_valid

--- a/app/forms/questionnaires/choose_your_provider.rb
+++ b/app/forms/questionnaires/choose_your_provider.rb
@@ -72,8 +72,7 @@ module Questionnaires
         institution: query_store.institution,
         approved_itt_provider: approved_itt_provider?,
         inside_catchment: inside_catchment?,
-        trn:,
-        get_an_identity_id:,
+        user_ecf_id: query_store.user_ecf_id,
         query_store: wizard.query_store,
       )
     end
@@ -91,7 +90,6 @@ module Questionnaires
              :inside_catchment?,
              :new_headteacher?,
              :trn,
-             :get_an_identity_id,
              to: :query_store
 
     def validate_lead_provider_valid

--- a/app/forms/questionnaires/ehco_new_headteacher.rb
+++ b/app/forms/questionnaires/ehco_new_headteacher.rb
@@ -51,8 +51,7 @@ module Questionnaires
         institution: query_store.institution,
         approved_itt_provider: approved_itt_provider?,
         inside_catchment: inside_catchment?,
-        trn:,
-        get_an_identity_id:,
+        user_ecf_id: query_store.user_ecf_id,
         query_store:,
       )
     end
@@ -61,7 +60,6 @@ module Questionnaires
              :course,
              :inside_catchment?,
              :trn,
-             :get_an_identity_id,
              to: :query_store
 
     def new_headteacher?

--- a/app/forms/questionnaires/ehco_new_headteacher.rb
+++ b/app/forms/questionnaires/ehco_new_headteacher.rb
@@ -59,7 +59,6 @@ module Questionnaires
     delegate :approved_itt_provider?,
              :course,
              :inside_catchment?,
-             :trn,
              to: :query_store
 
     def new_headteacher?

--- a/app/forms/questionnaires/ineligible_for_funding.rb
+++ b/app/forms/questionnaires/ineligible_for_funding.rb
@@ -73,8 +73,7 @@ module Questionnaires
         institution: query_store.institution,
         approved_itt_provider: approved_itt_provider?,
         inside_catchment: inside_catchment?,
-        trn: wizard.query_store.trn,
-        get_an_identity_id: wizard.query_store.get_an_identity_id,
+        user_ecf_id: query_store.current_user.ecf_id,
         query_store: wizard.query_store,
       )
     end

--- a/app/forms/questionnaires/ineligible_for_funding.rb
+++ b/app/forms/questionnaires/ineligible_for_funding.rb
@@ -73,7 +73,7 @@ module Questionnaires
         institution: query_store.institution,
         approved_itt_provider: approved_itt_provider?,
         inside_catchment: inside_catchment?,
-        user_ecf_id: query_store.current_user.ecf_id,
+        user_ecf_id: query_store.user_ecf_id,
         query_store: wizard.query_store,
       )
     end

--- a/app/forms/questionnaires/maths_eligibility_teaching_for_mastery.rb
+++ b/app/forms/questionnaires/maths_eligibility_teaching_for_mastery.rb
@@ -56,13 +56,12 @@ module Questionnaires
         institution: query_store.institution,
         approved_itt_provider: approved_itt_provider?,
         inside_catchment: inside_catchment?,
-        trn:,
-        get_an_identity_id:,
+        user_ecf_id: query_store.user_ecf_id,
         query_store:,
       )
     end
 
     delegate :inside_catchment?, :approved_itt_provider?, :lead_mentor_for_accredited_itt_provider?, :trn,
-             :get_an_identity_id, :course, to: :query_store
+             :course, to: :query_store
   end
 end

--- a/app/forms/questionnaires/maths_eligibility_teaching_for_mastery.rb
+++ b/app/forms/questionnaires/maths_eligibility_teaching_for_mastery.rb
@@ -61,7 +61,7 @@ module Questionnaires
       )
     end
 
-    delegate :inside_catchment?, :approved_itt_provider?, :lead_mentor_for_accredited_itt_provider?, :trn,
+    delegate :inside_catchment?, :approved_itt_provider?, :lead_mentor_for_accredited_itt_provider?,
              :course, to: :query_store
   end
 end

--- a/app/forms/questionnaires/maths_understanding_of_approach.rb
+++ b/app/forms/questionnaires/maths_understanding_of_approach.rb
@@ -47,7 +47,7 @@ module Questionnaires
   private
 
     delegate :inside_catchment?, :approved_itt_provider?, :lead_mentor_for_accredited_itt_provider?, :trn,
-             :get_an_identity_id, :course, to: :query_store
+             :course, to: :query_store
 
     def funding_eligibility_calculator
       @funding_eligibility_calculator ||= FundingEligibility.new_from_query_store(
@@ -55,8 +55,7 @@ module Questionnaires
         institution: query_store.institution,
         approved_itt_provider: approved_itt_provider?,
         inside_catchment: inside_catchment?,
-        trn:,
-        get_an_identity_id:,
+        user_ecf_id: query_store.user_ecf_id,
         query_store:,
       )
     end

--- a/app/forms/questionnaires/maths_understanding_of_approach.rb
+++ b/app/forms/questionnaires/maths_understanding_of_approach.rb
@@ -46,7 +46,7 @@ module Questionnaires
 
   private
 
-    delegate :inside_catchment?, :approved_itt_provider?, :lead_mentor_for_accredited_itt_provider?, :trn,
+    delegate :inside_catchment?, :approved_itt_provider?, :lead_mentor_for_accredited_itt_provider?,
              :course, to: :query_store
 
     def funding_eligibility_calculator

--- a/app/forms/questionnaires/senco_in_role.rb
+++ b/app/forms/questionnaires/senco_in_role.rb
@@ -61,6 +61,6 @@ module Questionnaires
     end
 
     delegate :course, :lead_mentor_for_accredited_itt_provider?, :new_headteacher?, :inside_catchment?,
-             :approved_itt_provider?, :works_in_another_setting?, :referred_by_return_to_teaching_adviser?, :trn, to: :query_store
+             :approved_itt_provider?, :works_in_another_setting?, :referred_by_return_to_teaching_adviser?, to: :query_store
   end
 end

--- a/app/forms/questionnaires/senco_in_role.rb
+++ b/app/forms/questionnaires/senco_in_role.rb
@@ -55,13 +55,12 @@ module Questionnaires
         institution: query_store.institution,
         approved_itt_provider: approved_itt_provider?,
         inside_catchment: inside_catchment?,
-        trn:,
-        get_an_identity_id:,
+        user_ecf_id: query_store.user_ecf_id,
         query_store:,
       )
     end
 
     delegate :course, :lead_mentor_for_accredited_itt_provider?, :new_headteacher?, :inside_catchment?,
-             :approved_itt_provider?, :get_an_identity_id, :works_in_another_setting?, :referred_by_return_to_teaching_adviser?, :trn, to: :query_store
+             :approved_itt_provider?, :works_in_another_setting?, :referred_by_return_to_teaching_adviser?, :trn, to: :query_store
   end
 end

--- a/app/forms/questionnaires/senco_start_date.rb
+++ b/app/forms/questionnaires/senco_start_date.rb
@@ -53,8 +53,7 @@ module Questionnaires
         institution: query_store.institution,
         approved_itt_provider: approved_itt_provider?,
         inside_catchment: inside_catchment?,
-        trn:,
-        get_an_identity_id:,
+        user_ecf_id: query_store.user_ecf_id,
         query_store:,
       )
     end
@@ -74,6 +73,6 @@ module Questionnaires
     end
 
     delegate :course, :lead_mentor_for_accredited_itt_provider?, :new_headteacher?, :inside_catchment?, :referred_by_return_to_teaching_adviser?,
-             :approved_itt_provider?, :get_an_identity_id, :trn, :works_in_another_setting?, :employment_type_other?, to: :query_store
+             :approved_itt_provider?, :trn, :works_in_another_setting?, :employment_type_other?, to: :query_store
   end
 end

--- a/app/forms/questionnaires/senco_start_date.rb
+++ b/app/forms/questionnaires/senco_start_date.rb
@@ -73,6 +73,6 @@ module Questionnaires
     end
 
     delegate :course, :lead_mentor_for_accredited_itt_provider?, :new_headteacher?, :inside_catchment?, :referred_by_return_to_teaching_adviser?,
-             :approved_itt_provider?, :trn, :works_in_another_setting?, :employment_type_other?, to: :query_store
+             :approved_itt_provider?, :works_in_another_setting?, :employment_type_other?, to: :query_store
   end
 end

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -222,7 +222,6 @@ private
            :employment_type_hospital_school?,
            :employment_type_other?,
            :formatted_date_of_birth,
-           :get_an_identity_id,
            :has_ofsted_urn?,
            :inside_catchment?,
            :itt_provider,
@@ -260,8 +259,7 @@ private
       institution: institution_from_store,
       approved_itt_provider: approved_itt_provider?,
       inside_catchment: inside_catchment?,
-      trn:,
-      get_an_identity_id:,
+      user_ecf_id: query_store.user_ecf_id,
       query_store:,
     )
   end

--- a/app/services/funding_eligibility.rb
+++ b/app/services/funding_eligibility.rb
@@ -44,9 +44,8 @@ class FundingEligibility
   attr_reader :cohort,
               :institution,
               :course,
-              :trn,
               :approved_itt_provider,
-              :get_an_identity_id,
+              :user_ecf_id,
               :inside_catchment,
               :new_headteacher,
               :employment_type,
@@ -58,8 +57,7 @@ class FundingEligibility
     def new_from_query_store(institution:,
                              course:,
                              inside_catchment:,
-                             trn:,
-                             get_an_identity_id:,
+                             user_ecf_id:,
                              approved_itt_provider: false,
                              query_store: nil)
       cohort = Cohort.find_by(identifier: query_store.course_start_cohort)
@@ -68,8 +66,7 @@ class FundingEligibility
           institution:,
           course:,
           inside_catchment:,
-          trn:,
-          get_an_identity_id:,
+          user_ecf_id:,
           approved_itt_provider:,
           new_headteacher: query_store.new_headteacher?,
           employment_type: query_store.employment_type,
@@ -84,8 +81,7 @@ class FundingEligibility
                  institution:,
                  course:,
                  inside_catchment:,
-                 trn:,
-                 get_an_identity_id:,
+                 user_ecf_id:,
                  approved_itt_provider:,
                  new_headteacher:,
                  employment_type:,
@@ -98,8 +94,7 @@ class FundingEligibility
     @inside_catchment = inside_catchment
     @new_headteacher = new_headteacher
     @approved_itt_provider = approved_itt_provider
-    @get_an_identity_id = get_an_identity_id
-    @trn = trn
+    @user_ecf_id = user_ecf_id
     @employment_type = employment_type
     @childminder = childminder
     @referred_by_return_to_teaching_adviser = referred_by_return_to_teaching_adviser
@@ -231,35 +226,19 @@ private
     end
   end
 
-  def users
-    get_an_identity_id_users.or(trn_users).distinct
-  end
-
-  def get_an_identity_id_users
-    return User.none if get_an_identity_id.blank?
-
-    User.with_get_an_identity_id.where(uid: get_an_identity_id)
-  end
-
-  def trn_users
-    return User.none if trn.blank?
-
-    User.where(trn:)
+  def user
+    User.find_by(ecf_id: user_ecf_id)
   end
 
   def accepted_applications
-    @accepted_applications ||= begin
-      application_ids = users.flat_map do |user|
-        user.applications
-            .where(course: course.rebranded_alternative_courses)
-            .accepted
-            .eligible_for_funding
-            .where(funded_place: [nil, true])
-            .pluck(:id)
-      end
+    return [] unless user
 
-      Application.where(id: application_ids)
-    end
+    @accepted_applications ||=
+      user.applications
+      .where(course: course.rebranded_alternative_courses)
+      .accepted
+      .eligible_for_funding
+      .where(funded_place: [nil, true])
   end
 
   def mandatory_institution

--- a/app/services/funding_eligibility.rb
+++ b/app/services/funding_eligibility.rb
@@ -227,7 +227,7 @@ private
   end
 
   def user
-    User.find_by(ecf_id: user_ecf_id)
+    @user ||= User.find_by(ecf_id: user_ecf_id)
   end
 
   def accepted_applications

--- a/app/services/handle_submission_for_store.rb
+++ b/app/services/handle_submission_for_store.rb
@@ -170,8 +170,7 @@ private
       institution: query_store.institution,
       approved_itt_provider:,
       inside_catchment: inside_catchment?,
-      trn: query_store.trn,
-      get_an_identity_id: query_store.get_an_identity_id,
+      user_ecf_id: query_store.user_ecf_id,
       query_store:,
     )
   end

--- a/app/services/registration_query_store.rb
+++ b/app/services/registration_query_store.rb
@@ -17,8 +17,8 @@ class RegistrationQueryStore
     ::IttProvider.currently_approved.find_by(legal_name: itt_provider).present?
   end
 
-  def get_an_identity_id
-    current_user.get_an_identity_id
+  def user_ecf_id
+    current_user.ecf_id
   end
 
   def trn_set_via_fallback_verification_question?

--- a/spec/services/funding_eligibility_spec.rb
+++ b/spec/services/funding_eligibility_spec.rb
@@ -6,8 +6,7 @@ RSpec.describe FundingEligibility do
                         institution:,
                         course:,
                         inside_catchment:,
-                        trn: "1234567",
-                        get_an_identity_id: SecureRandom.uuid,
+                        user_ecf_id: user.ecf_id,
                         approved_itt_provider:,
                         new_headteacher: (new_headteacher == "yes"),
                         employment_type:,
@@ -40,6 +39,7 @@ RSpec.describe FundingEligibility do
   let(:referred_by_return_to_teaching_adviser) { nil }
   let(:new_headteacher) { "no" }
   let(:query_store) { RegistrationQueryStore.new(store:) }
+  let(:user) { build(:user, :with_teacher_auth) }
 
   before do
     unfunded_cohort
@@ -65,20 +65,17 @@ RSpec.describe FundingEligibility do
       described_class.new_from_query_store(institution:,
                                            course:,
                                            inside_catchment:,
-                                           trn: "1234567",
-                                           get_an_identity_id:,
+                                           user_ecf_id: user.ecf_id,
                                            approved_itt_provider:,
                                            query_store:)
     end
 
     let(:course) { build(:course, :headship) }
-    let(:get_an_identity_id) { SecureRandom.uuid }
 
     it { is_expected.to have_attributes institution: }
     it { is_expected.to have_attributes course: }
     it { is_expected.to have_attributes inside_catchment: }
-    it { is_expected.to have_attributes trn: "1234567" }
-    it { is_expected.to have_attributes get_an_identity_id: }
+    it { is_expected.to have_attributes user_ecf_id: user.ecf_id }
     it { is_expected.to have_attributes approved_itt_provider: }
     it { is_expected.to have_attributes new_headteacher: false }
     it { is_expected.to have_attributes employment_type: }
@@ -141,7 +138,6 @@ RSpec.describe FundingEligibility do
 
     context "and the applicant has previously received funding" do
       before do
-        user = build(:user, :with_get_an_identity_id, uid: funding_eligibility.get_an_identity_id)
         create(:application, :with_funded_place, :accepted, user:, course:)
       end
 


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/NPQ-3797

### Changes proposed in this pull request

* change `FundingEligibilty`
  * no need for `trn` attribute, this is not used
  * change `get_an_identity_id` to `user_ecf_id`
* update all calls to `FundingEligibilty`