### PR TITLE
[NPQ-3793] only send status and outcome mailers when user has an email

### DIFF
--- a/app/services/applications/accept.rb
+++ b/app/services/applications/accept.rb
@@ -30,14 +30,7 @@ module Applications
       end
 
       application.reload
-
-      ApplicationAcceptedMailer.application_accepted_mail(
-        to: user.email,
-        full_name: user.full_name,
-        provider_name: lead_provider.name,
-        course_name: course.name,
-        ecf_id: application.ecf_id,
-      ).deliver_later
+      send_email
 
       true
     end
@@ -189,6 +182,18 @@ module Applications
 
       TeachingRecordSystem::AllocateTrnJob
         .perform_later(user_id: application.user_id)
+    end
+
+    def send_email
+      return if user.email.blank?
+
+      ApplicationAcceptedMailer.application_accepted_mail(
+        to: user.email,
+        full_name: user.full_name,
+        provider_name: lead_provider.name,
+        course_name: course.name,
+        ecf_id: application.ecf_id,
+      ).deliver_later
     end
   end
 end

--- a/app/services/applications/reject.rb
+++ b/app/services/applications/reject.rb
@@ -20,14 +20,7 @@ module Applications
       end
 
       application.reload
-
-      ApplicationRejectedMailer.application_rejected_mail(
-        to: application.user.email,
-        full_name: application.user.full_name,
-        provider_name: application.lead_provider.name,
-        course_name: application.course.name,
-        ecf_id: application.ecf_id,
-      ).deliver_later
+      send_email
 
       true
     end
@@ -55,6 +48,18 @@ module Applications
       return unless application.declarations.billable_or_changeable.any?
 
       errors.add(:application, :cannot_reject_with_declarations)
+    end
+
+    def send_email
+      return if application.user.email.blank?
+
+      ApplicationRejectedMailer.application_rejected_mail(
+        to: application.user.email,
+        full_name: application.user.full_name,
+        provider_name: application.lead_provider.name,
+        course_name: application.course.name,
+        ecf_id: application.ecf_id,
+      ).deliver_later
     end
   end
 end

--- a/app/services/participant_outcomes/create.rb
+++ b/app/services/participant_outcomes/create.rb
@@ -94,6 +94,8 @@ module ParticipantOutcomes
     end
 
     def send_email_notification(outcome)
+      return if participant.email.blank?
+
       mail_params = {
         to: participant.email,
         full_name: participant.full_name,

--- a/app/services/participants/defer.rb
+++ b/app/services/participants/defer.rb
@@ -46,6 +46,8 @@ module Participants
     end
 
     def send_email
+      return if application.user.email.blank?
+
       ApplicationDeferredMailer.application_deferred_mail(
         to: application.user.email,
         full_name: application.user.full_name,

--- a/app/services/participants/resume.rb
+++ b/app/services/participants/resume.rb
@@ -25,6 +25,8 @@ module Participants
     end
 
     def send_email
+      return if application.user.email.blank?
+
       ApplicationResumedMailer.application_resumed_mail(
         to: application.user.email,
         full_name: application.user.full_name,

--- a/app/services/participants/withdraw.rb
+++ b/app/services/participants/withdraw.rb
@@ -59,6 +59,8 @@ module Participants
     end
 
     def send_email
+      return if application.user.email.blank?
+
       ApplicationWithdrawnMailer.application_withdrawn_mail(
         to: application.user.email,
         full_name: application.user.full_name,

--- a/spec/services/applications/accept_spec.rb
+++ b/spec/services/applications/accept_spec.rb
@@ -49,6 +49,15 @@ RSpec.describe Applications::Accept, :with_default_schedules, type: :model do
       service.accept
     end
 
+    context "when the user has no email address" do
+      let(:user) { create(:user, :with_verified_trn, :archived, email: nil) }
+
+      it "does not send an email" do
+        expect(ApplicationAcceptedMailer).not_to send_mail(:application_accepted_mail)
+        service.accept
+      end
+    end
+
     describe "validations" do
       it { is_expected.to validate_presence_of(:application).with_message("The entered '#/application' is missing from your request. Check details and try again.") }
 

--- a/spec/services/applications/reject_spec.rb
+++ b/spec/services/applications/reject_spec.rb
@@ -68,6 +68,16 @@ RSpec.describe Applications::Reject, type: :model do
       service.reject
     end
 
+    context "when the user has no email address" do
+      let(:user) { create(:user, :archived, email: nil) }
+      let(:application) { create(:application, :pending, user:) }
+
+      it "does not send an email" do
+        expect(ApplicationRejectedMailer).not_to send_mail(:application_rejected_mail)
+        service.reject
+      end
+    end
+
     describe "refresh token clearing" do
       let(:user) { create(:user, :with_fresh_refresh_token, trn: nil, token: "live-token") }
       let(:application) { create(:application, :pending, user:) }

--- a/spec/services/participant_outcomes/create_spec.rb
+++ b/spec/services/participant_outcomes/create_spec.rb
@@ -341,6 +341,22 @@ RSpec.describe ParticipantOutcomes::Create, type: :model do
         create_outcome
       end
 
+      context "when the participant has no email address" do
+        before do
+          completed_declaration.user.update_columns(
+            email: nil,
+            archived_email: "archived@example.com",
+            archived_at: Time.zone.now,
+          )
+        end
+
+        it "does not send an email to the user" do
+          expect(ParticipantOutcomePassedMailer).not_to send_mail(:passed_mail)
+          expect(ParticipantOutcomeFailedMailer).not_to send_mail(:failed_mail)
+          create_outcome
+        end
+      end
+
       it "sets the created_outcome to the newly created outcome" do
         create_outcome
         expect(created_outcome).to have_attributes({

--- a/spec/support/shared_examples/participant_action_support.rb
+++ b/spec/support/shared_examples/participant_action_support.rb
@@ -118,6 +118,21 @@ RSpec.shared_examples "a participant state transition" do |action, from_states, 
                          ecf_id: application.ecf_id)
           perform_action
         end
+
+        context "when the participant has no email address" do
+          before do
+            application.user.update_columns(
+              email: nil,
+              archived_email: "archived@example.com",
+              archived_at: Time.zone.now,
+            )
+          end
+
+          it "does not send a notification email" do
+            expect(mailers[to_state][:mailer]).not_to send_mail(mailers[to_state][:mailer_action])
+            perform_action
+          end
+        end
       end
     end
 


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/NPQ-3793

The recently added application-status and participant-outcome mailers send to `application.user.email` / `participant.email` with no guard, so an archived recipient (email `nil`) would pass `to: nil` to GOV.UK Notify and fail in the background job.

### Changes proposed in this pull request

- Guard each newly added mailer so it is only enqueued when the recipient has an email address (`return if ...email.blank?`):
  - `ApplicationAcceptedMailer` (`Applications::Accept`)
  - `ApplicationRejectedMailer` (`Applications::Reject`)
  - `ApplicationDeferredMailer` (`Participants::Defer`)
  - `ApplicationWithdrawnMailer` (`Participants::Withdraw`)
  - `ApplicationResumedMailer` (`Participants::Resume`)
  - `ParticipantOutcomePassedMailer` / `ParticipantOutcomeFailedMailer` (`ParticipantOutcomes::Create`)
- Added specs asserting no mail is sent when the user has no email address.
