### PR TITLE
[BAU] Fix flaky test for course ordering

### DIFF
--- a/spec/services/courses/query_spec.rb
+++ b/spec/services/courses/query_spec.rb
@@ -11,8 +11,7 @@ RSpec.describe Courses::Query do
 
     it "orders courses by name in ascending order" do
       query = Courses::Query.new
-      course_names = query.courses.map(&:name)
-      expect(course_names).to eq(course_names.sort)
+      expect(query.courses).to eq(Course.order(name: :asc))
     end
   end
 


### PR DESCRIPTION
### Context

Ticket: BAU

### Changes proposed in this pull request

The test "orders courses by name in ascending order" was comparing the
database order with Ruby Array#sort. They not use the same order
(collation), so the test fail sometimes. Now it compare with
Course.order(name: :asc), so it use the same order as the database.