### PR TITLE
[NPQ-3764] Only show register again link if TeacherAuth user

### DIFF
--- a/app/views/registration_wizard/shared/_register_for_an_npq.html.erb
+++ b/app/views/registration_wizard/shared/_register_for_an_npq.html.erb
@@ -20,7 +20,7 @@
 
     </div>
   </div>
-<% else %>
+<% elsif current_user.teacher_auth_provider? %>
   <div class="govuk-!-padding-top-7">
     <h2 class="govuk-heading-l">Register for another NPQ</h2>
 

--- a/spec/views/accounts/show.html.erb_spec.rb
+++ b/spec/views/accounts/show.html.erb_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "accounts/show.html.erb", type: :view do
     allow(view).to receive(:current_user).and_return(user)
   end
 
-  let(:user) { create(:user) }
+  let(:user) { create(:user, :with_teacher_auth) }
   let(:applications) { create_list :application, 2, user: }
 
   it { is_expected.to have_content "Register for another NPQ" }
@@ -31,5 +31,11 @@ RSpec.describe "accounts/show.html.erb", type: :view do
     it { is_expected.to have_css ".govuk-summary-card", count: 2 }
     it { is_expected.to have_link "View details", href: accounts_user_registration_path(active) }
     it { is_expected.not_to have_link "View details", href: accounts_user_registration_path(expired) }
+  end
+
+  context "when signed in via Get an Identity" do
+    let(:user) { create(:user, :with_get_an_identity_id) }
+
+    it { is_expected.not_to have_content "Register for another NPQ" }
   end
 end


### PR DESCRIPTION
### Context

Ticket: [NPQ-3764](https://dfedigital.atlassian.net/browse/NPQ-3764)

### Changes proposed in this pull request

1. We should not be showing the register again link if a user is signed in via GetAnIdentity even if they have been added to the early registration list. The Wizard will prevent them registering and this will only serve to confuse them


[NPQ-3764]: https://dfedigital.atlassian.net/browse/NPQ-3764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ