### PR TITLE
[NPQ-3799] fix CSP violations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -640,7 +640,7 @@ GEM
       sass (~> 3.5, >= 3.5.5)
     scss_lint-govuk (0.2.0)
       scss_lint
-    secure_headers (7.2.0)
+    secure_headers (7.3.0)
       cgi (>= 0.1)
     securerandom (0.4.1)
     semantic_logger (4.17.0)

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -13,7 +13,15 @@ SecureHeaders::Configuration.default do |config|
   google_analytics = %w[*.google-analytics.com *.analytics.google.com *.googletagmanager.com tagmanager.google.com *.googleusercontent.com *.gstatic.com]
   tracking_pixels = %w[www.facebook.com px.ads.linkedin.com]
   identity_domain = [ENV["TRA_OIDC_DOMAIN"]]
-  teacher_auth_domain = [ENV["TEACHER_AUTH_DOMAIN"]].compact
+
+  teacher_auth_domains = [
+    ENV["TEACHER_AUTH_DOMAIN"],
+    "oidc.integration.account.gov.uk",
+    "oidc.account.gov.uk",
+    "signin.integration.account.gov.uk",
+    "signin.account.gov.uk",
+  ].compact
+
   sentry = %w[*.sentry-cdn.com *.ingest.us.sentry.io]
 
   if ENV["SENTRY_CSP_REPORT_URI"]
@@ -38,7 +46,10 @@ SecureHeaders::Configuration.default do |config|
     child_src: %w['self'],
     connect_src: %w['self'] + google_analytics + sentry,
     font_src: %w['self' *.gov.uk fonts.gstatic.com],
-    form_action: %w['self'] + identity_domain + teacher_auth_domain, # needed because the POST to /users/auth/tra_openid_connect' redirects to the identity domain
+    # form action directives needed because:
+    #  POST to /users/auth/tra_openid_connect' redirects to the identity domain
+    #  POST to /users/auth/teacher_auth redirects to the teacher auth domain, which redirects to oidc.account.gov.uk, which redirects to signin.account.gov.uk
+    form_action: %w['self'] + identity_domain + teacher_auth_domains,
     frame_ancestors: %w['self'],
     frame_src: %w['self'] + google_analytics,
     img_src: %w['self' *.gov.uk] + google_analytics + tracking_pixels + %w[data:],


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/NPQ-3799

### Changes proposed in this pull request

* the teacher auth authorize path redirects twice before showing the final sign-in-or-create page - I've added these additional paths to the CSP rule (both pre-prod and production domains)
* updated the secure headers gem - not required for this fix, but may as well