### PR TITLE
[NPQ-3788] Enable `cohort_suffix` and `previous_names` in production

### DIFF
--- a/app/views/api/guidance/release-notes.md
+++ b/app/views/api/guidance/release-notes.md
@@ -2,7 +2,17 @@
 
 If you have any questions or comments about these notes, please contact DfE via Microsoft Teams or email.
 
+## 2026 API changes released to production
+
+### 11 June 2026
+
+<strong class="govuk-tag govuk-tag--green">PRODUCTION</strong>
+
+The `cohort_suffix` and `previous_names` API changes previously released to `sandbox`
+are now included in our production APIs.
+
 ## API changes for 2026 reopening
+
 ### 13 May 2026
 
 <strong class="govuk-tag govuk-tag--yellow">SANDBOX</strong>

--- a/config/application.rb
+++ b/config/application.rb
@@ -88,7 +88,7 @@ module NpqRegistration
     config.x.teacher_auth.onelogin_home_uri = ENV["TEACHER_AUTH_ONELOGIN_HOME_URI"]
 
     # API configuration
-    config.x.api.previous_names = Rails.env.local?
-    config.x.api.cohort_suffix = Rails.env.local?
+    config.x.api.previous_names = true
+    config.x.api.cohort_suffix = true
   end
 end


### PR DESCRIPTION
### Context

Ticket: [NPQ-3788](https://dfedigital.atlassian.net/browse/NPQ-3788)

### Changes proposed in this pull request

1. Enable the `previous_names` and `cohort_suffix` attributes in production
2. Add a corresponding release note


[NPQ-3788]: https://dfedigital.atlassian.net/browse/NPQ-3788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ