### PR TITLE
[NPQ-3803] TRS webhooks - take no action if user not found

### DIFF
--- a/app/services/teaching_record_system/webhooks/base.rb
+++ b/app/services/teaching_record_system/webhooks/base.rb
@@ -9,9 +9,8 @@ class TeachingRecordSystem::Webhooks::Base
 
   def call
     return incorrect_format_failure unless correct_format?
-    return no_user_found_failure unless user
 
-    process!
+    process! if user
     webhook_message.make_processed!
   end
 
@@ -27,10 +26,6 @@ private
 
   def incorrect_format_failure
     record_error("Invalid message format")
-  end
-
-  def no_user_found_failure
-    record_error("No user found with uid: #{user_uid}", send_to_sentry: false)
   end
 
   def record_error(message, send_to_sentry: true)

--- a/app/services/teaching_record_system/webhooks/trn_request_completed_processor.rb
+++ b/app/services/teaching_record_system/webhooks/trn_request_completed_processor.rb
@@ -19,8 +19,7 @@ module TeachingRecordSystem
 
       def correct_format?
         message["trnRequest"].present? &&
-          message["trnRequest"]["trn"].present? &&
-          message["trnRequest"]["oneLoginUserSubject"].present?
+          message["trnRequest"]["trn"].present?
       end
     end
   end

--- a/app/services/teaching_record_system/webhooks/user_updated_processor.rb
+++ b/app/services/teaching_record_system/webhooks/user_updated_processor.rb
@@ -32,8 +32,7 @@ module TeachingRecordSystem
       end
 
       def correct_format?
-        message["oneLoginUser"].present? &&
-          message["oneLoginUser"]["subject"].present?
+        message["oneLoginUser"].present?
       end
     end
   end

--- a/spec/services/teaching_record_system/webhooks/trn_request_completed_processor_spec.rb
+++ b/spec/services/teaching_record_system/webhooks/trn_request_completed_processor_spec.rb
@@ -48,12 +48,16 @@ RSpec.describe TeachingRecordSystem::Webhooks::TrnRequestCompletedProcessor do
       let(:webhook_message) { create(:trs_trn_request_completed_webhook_message, user_uid:, user_trn: new_trn) }
       let(:user_uid) { "nonexistent-uid" }
 
-      it "marks the webhook message as failed" do
-        subject
-        expect(webhook_message.reload).to have_attributes(
-          status: "failed",
-          status_comment: "No user found with uid: #{user_uid}",
-        )
+      it "marks the webhook message as processed" do
+        expect { subject }.to change(webhook_message, :status).from("pending").to("processed")
+      end
+    end
+
+    context "when the user UID is blank" do
+      let(:webhook_message) { create(:trs_trn_request_completed_webhook_message, user_uid: nil, user_trn: new_trn) }
+
+      it "marks the webhook message as processed" do
+        expect { subject }.to change(webhook_message, :status).from("pending").to("processed")
       end
     end
   end

--- a/spec/services/teaching_record_system/webhooks/user_updated_processor_spec.rb
+++ b/spec/services/teaching_record_system/webhooks/user_updated_processor_spec.rb
@@ -77,12 +77,19 @@ RSpec.describe TeachingRecordSystem::Webhooks::UserUpdatedProcessor do
       let(:webhook_message) { create(:trs_user_updated_webhook_message, user_uid: user_uid, user_trn: user.trn) }
       let(:user_uid) { "nonexistent-uid" }
 
-      it "marks the webhook message as failed" do
+      it "marks the webhook message as processed" do
         subject
         expect(webhook_message.reload).to have_attributes(
-          status: "failed",
-          status_comment: "No user found with uid: #{user_uid}",
+          status: "processed",
         )
+      end
+    end
+
+    context "when the user UID is blank" do
+      let(:webhook_message) { create(:trs_user_updated_webhook_message, user_uid: nil, user_trn: user.trn) }
+
+      it "marks the webhook message as processed" do
+        expect { subject }.to change(webhook_message, :status).from("pending").to("processed")
       end
     end
   end


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/NPQ-3803

### Changes proposed in this pull request
If TRS webhook messages are received, that either have a blank user UID, or have a UID that does not exist in NPQ,
we should just do nothing, and mark the webhook message as processed.

