### PR TITLE
[NPQ-3806] Don't provide closed_registration_exception page unless TA enabled

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,7 +1,13 @@
 class PagesController < PublicPagesController
   def show
-    if params[:page] == "closed_registration_exception" && !Feature.registration_closed?(current_user)
-      return redirect_to root_path
+    if params[:page] == "closed_registration_exception"
+      unless Feature.registration_closed?(current_user)
+        return redirect_to root_path
+      end
+
+      unless Rails.configuration.x.teacher_auth.enabled
+        return redirect_to registration_closed_path
+      end
     end
 
     render template: "pages/#{params[:page]}"

--- a/spec/features/service_closed_spec.rb
+++ b/spec/features/service_closed_spec.rb
@@ -185,6 +185,17 @@ RSpec.feature "Service is closed", :no_js, type: :feature do
         expect(page).to have_current_path("/")
       end
     end
+
+    context "when teacher auth is deactivated" do
+      before do
+        allow(Rails.configuration.x.teacher_auth).to receive(:enabled).and_return(false)
+      end
+
+      scenario "the late registration page redirects to the home page" do
+        visit "/closed_registration_exception"
+        expect(page).to have_current_path("/registration_closed")
+      end
+    end
   end
 
   context "when using email updates" do


### PR DESCRIPTION
### Context

Ticket: [NPQ-3806](https://dfedigital.atlassian.net/browse/NPQ-3806)

### Changes proposed in this pull request

1. Redirect the `/closed_registration_exception` page back to the `/registration_closed` page if TeacherAuth is deactivated because the page cannot work in that scenario


[NPQ-3806]: https://dfedigital.atlassian.net/browse/NPQ-3806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ