### PR TITLE
[NPQ-3744] Enable Teacher Auth in production

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -81,7 +81,7 @@ module NpqRegistration
     config.skylight.environments += %w[review sandbox staging]
 
     # TeacherAuth configuration
-    config.x.teacher_auth.enabled = Rails.env.local?
+    config.x.teacher_auth.enabled = true
     config.x.teacher_auth.domain = ENV["TEACHER_AUTH_DOMAIN"]
     config.x.teacher_auth.client_id = ENV["TEACHER_AUTH_CLIENT_ID"]
     config.x.teacher_auth.client_secret = ENV["TEACHER_AUTH_CLIENT_SECRET"]

--- a/config/environments/review.rb
+++ b/config/environments/review.rb
@@ -8,7 +8,6 @@ Rails.application.configure do
     Bullet.unused_eager_loading_enable  = false # Disabled due to the way our queries are structured
   end
 
-  config.x.teacher_auth.enabled = true
   config.x.api.previous_names = true
   config.x.api.cohort_suffix = true
 end

--- a/config/environments/sandbox.rb
+++ b/config/environments/sandbox.rb
@@ -3,6 +3,7 @@ require Rails.root.join("config/environments/production")
 Rails.application.configure do
   config.log_level = :info
 
+  config.x.teacher_auth.enabled = false
   config.x.api.previous_names = true
   config.x.api.cohort_suffix = true
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -3,7 +3,6 @@ require Rails.root.join("config/environments/production")
 Rails.application.configure do
   config.log_level = :debug
 
-  config.x.teacher_auth.enabled = true
   config.x.api.previous_names = true
   config.x.api.cohort_suffix = true
 end


### PR DESCRIPTION
### Context

Ticket: [NPQ-3744](https://dfedigital.atlassian.net/browse/NPQ-3744)

### Changes proposed in this pull request

1. Enable TeacherAuth in all environments except `sandbox`


[NPQ-3744]: https://dfedigital.atlassian.net/browse/NPQ-3744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ