### PR TITLE
[BAU] use dataset instead of getAttribute

### DIFF
--- a/app/javascript/institution-picker.js
+++ b/app/javascript/institution-picker.js
@@ -45,7 +45,7 @@ institutionPicker.enhanceSelectElement = (configurationOptions) => {
     suggestion: formatObject
   }
 
-  const location = configurationOptions.selectElement.getAttribute("data-institution-location")
+  const location = configurationOptions.selectElement.dataset.institutionLocation;
 
   configurationOptions.source = debounce( async ( query, populateResults ) => {
     const res = await fetchSource(configurationOptions.lookupPath, query, location);


### PR DESCRIPTION
### Context

BAU

### Changes proposed in this pull request

As highlighted by SonarQube, we should be using `dataset` rather than `getAttribute` in our javascript.

This change was originally in this PR: https://github.com/DFE-Digital/npq-registration/pull/3384,
but got accidentally lost in this PR: https://github.com/DFE-Digital/npq-registration/pull/3369