### PR TITLE
[NPQ-3804] Show recent users by default in users admin area

### DIFF
--- a/app/controllers/npq_separation/admin/users_controller.rb
+++ b/app/controllers/npq_separation/admin/users_controller.rb
@@ -1,5 +1,6 @@
 class NpqSeparation::Admin::UsersController < NpqSeparation::AdminController
   MIN_SEARCH_LENGTH = 2
+  RECENT_USERS_PAGES = 10
 
   def index
     @performing_search = params.key?(:q)
@@ -7,9 +8,9 @@ class NpqSeparation::Admin::UsersController < NpqSeparation::AdminController
     @valid_search = search_term.present? && search_term.length >= MIN_SEARCH_LENGTH
 
     if @performing_search
-      @pagy, @users = pagy(scope) if @valid_search
+      @pagy, @users = pagy(search_scope) if @valid_search
     else
-      @users = User.order(created_at: :desc, id: :desc).limit(Pagy::DEFAULT[:limit])
+      @pagy, @users = pagy(recent_users_scope)
     end
   end
 
@@ -20,7 +21,13 @@ class NpqSeparation::Admin::UsersController < NpqSeparation::AdminController
 
 private
 
-  def scope
+  def search_scope
     AdminService::UsersSearch.new(q: params[:q]).call
+  end
+
+  def recent_users_scope
+    User
+      .order(created_at: :desc, id: :desc)
+      .limit(Pagy::DEFAULT[:limit] * RECENT_USERS_PAGES)
   end
 end

--- a/app/controllers/npq_separation/admin/users_controller.rb
+++ b/app/controllers/npq_separation/admin/users_controller.rb
@@ -2,10 +2,15 @@ class NpqSeparation::Admin::UsersController < NpqSeparation::AdminController
   MIN_SEARCH_LENGTH = 2
 
   def index
+    @performing_search = params.key?(:q)
     search_term = params[:q]
     @valid_search = search_term.present? && search_term.length >= MIN_SEARCH_LENGTH
 
-    @pagy, @users = pagy(scope) if @valid_search
+    if @performing_search
+      @pagy, @users = pagy(scope) if @valid_search
+    else
+      @users = User.order(created_at: :desc, id: :desc).limit(Pagy::DEFAULT[:limit])
+    end
   end
 
   def show

--- a/app/services/admin_service/users_search.rb
+++ b/app/services/admin_service/users_search.rb
@@ -31,7 +31,7 @@ private
   end
 
   def default_scope
-    User.left_joins(:applications).order(created_at: :desc)
+    User.left_joins(:applications).order(created_at: :desc, id: :desc)
   end
 
   def find_private_childcare_providers

--- a/app/views/npq_separation/admin/users/_users.html.erb
+++ b/app/views/npq_separation/admin/users/_users.html.erb
@@ -1,0 +1,21 @@
+<%=
+  govuk_table do |table|
+    table.with_head do |header|
+      header.with_row do |row|
+        row.with_cell(text: "Name")
+        row.with_cell(text: "TRN")
+        row.with_cell(text: "Date added")
+      end
+    end
+
+    table.with_body do |body|
+      users.each do |user|
+        body.with_row do |row|
+          row.with_cell(text: govuk_link_to(user.full_name, npq_separation_admin_user_path(user)))
+          row.with_cell(text: user.trn)
+          row.with_cell(text: user.created_at.to_date.to_formatted_s(:govuk))
+        end
+      end
+    end
+  end
+%>

--- a/app/views/npq_separation/admin/users/index.html.erb
+++ b/app/views/npq_separation/admin/users/index.html.erb
@@ -25,5 +25,6 @@
   <h2 class="govuk-heading-m">Recently added</h2>
 
   <%= render "users", users: @users %>
+  <%= govuk_pagination(pagy: @pagy) %>
 <% end %>
 

--- a/app/views/npq_separation/admin/users/index.html.erb
+++ b/app/views/npq_separation/admin/users/index.html.erb
@@ -15,29 +15,15 @@
 </div>
 
 <% if @valid_search %>
-  <%=
-    govuk_table do |table|
-      table.with_head do |header|
-        header.with_row do |row|
-          row.with_cell(text: "Name")
-          row.with_cell(text: "TRN")
-          row.with_cell(text: "Date added")
-        end
-      end
+  <h2 class="govuk-heading-m">Search results</h2>
 
-      table.with_body do |body|
-        @users.each do |user|
-          body.with_row do |row|
-            row.with_cell(text: govuk_link_to(user.full_name, npq_separation_admin_user_path(user)))
-            row.with_cell(text: user.trn)
-            row.with_cell(text: user.created_at.to_date.to_formatted_s(:govuk))
-          end
-        end
-      end
-    end
-  %>
-<% else %>
+  <%= render "users", users: @users %>
+  <%= govuk_pagination(pagy: @pagy) %>
+<% elsif @performing_search %>
   <p class="govuk-inset-text">Please enter at least 2 characters to search and see results.</p>
+<% else %>
+  <h2 class="govuk-heading-m">Recently added</h2>
+
+  <%= render "users", users: @users %>
 <% end %>
 
-<%= govuk_pagination(pagy: @pagy) %>

--- a/spec/features/npq_separation/admin/users_spec.rb
+++ b/spec/features/npq_separation/admin/users_spec.rb
@@ -14,18 +14,30 @@ RSpec.feature "User administration", :no_js, type: :feature do
   end
 
   feature "listing users" do
-    before { another_user }
-
     let(:another_user) { create(:user, :with_teacher_auth, full_name: "Dave J") }
 
     scenario "viewing the list of users" do
+      another_user
+
       visit(npq_separation_admin_users_path)
 
       expect(page).to have_css("h1", text: "Users")
       expect(page).to have_css("h2", text: "Recently added")
       expect(page).to have_css("tbody tr:first-of-type td", text: another_user.trn)
       expect(page).to have_css("tbody tr", count: users_per_page)
-      expect(page).not_to have_css("nav.govuk-pagination")
+      expect(page).to have_css("nav.govuk-pagination")
+
+      within("nav.govuk-pagination") do
+        click_on("2")
+      end
+
+      expect(page).to have_css("h1", text: "Users")
+      expect(page).to have_css("h2", text: "Recently added")
+      expect(page).to have_css("tbody tr", count: 1)
+    end
+
+    scenario "searching for users" do
+      visit(npq_separation_admin_users_path)
 
       fill_in("Find a user", with: "J")
       click_on("Search")
@@ -36,14 +48,14 @@ RSpec.feature "User administration", :no_js, type: :feature do
       expect(page).to have_css("h2", text: "Search results")
       expect(page).to have_css("tbody tr", count: users_per_page)
 
-      User.where.not(id: another_user.id).find_each do |user|
+      User.find_each do |user|
         expect(page).to have_link(user.full_name, href: npq_separation_admin_user_path(user))
         expect(page).to have_css("td", text: user.trn)
         expect(page).to have_css("td", text: user.created_at.to_date.to_formatted_s(:govuk))
       end
     end
 
-    scenario "navigating to the second page of users" do
+    scenario "navigating to the second page of search results" do
       create :user, :with_get_an_identity_id # exceed pagination threshold
 
       visit(npq_separation_admin_users_path)

--- a/spec/features/npq_separation/admin/users_spec.rb
+++ b/spec/features/npq_separation/admin/users_spec.rb
@@ -5,23 +5,38 @@ RSpec.feature "User administration", :no_js, type: :feature do
 
   let(:users_per_page) { Pagy::DEFAULT[:limit] }
   let(:user) { User.first }
+  let(:users) { create_list(:user, users_per_page, :with_get_an_identity_id) }
 
   before do
-    create_list(:user, users_per_page, :with_get_an_identity_id)
+    users
     user.update!(national_insurance_number: "QQ123456C", preferred_name: "Jonny D")
     sign_in_as(create(:admin))
   end
 
   feature "listing users" do
+    before { another_user }
+
+    let(:another_user) { create(:user, :with_teacher_auth, full_name: "Dave J") }
+
     scenario "viewing the list of users" do
       visit(npq_separation_admin_users_path)
 
       expect(page).to have_css("h1", text: "Users")
+      expect(page).to have_css("h2", text: "Recently added")
+      expect(page).to have_css("tbody tr:first-of-type td", text: another_user.trn)
+      expect(page).to have_css("tbody tr", count: users_per_page)
+      expect(page).not_to have_css("nav.govuk-pagination")
+
+      fill_in("Find a user", with: "J")
+      click_on("Search")
+      expect(page).to have_css(".govuk-inset-text", text: "at least 2")
 
       fill_in("Find a user", with: "Jo")
       click_on("Search")
+      expect(page).to have_css("h2", text: "Search results")
+      expect(page).to have_css("tbody tr", count: users_per_page)
 
-      User.all.find_each do |user|
+      User.where.not(id: another_user.id).find_each do |user|
         expect(page).to have_link(user.full_name, href: npq_separation_admin_user_path(user))
         expect(page).to have_css("td", text: user.trn)
         expect(page).to have_css("td", text: user.created_at.to_date.to_formatted_s(:govuk))


### PR DESCRIPTION
### Context

Ticket: [NPQ-3804](https://dfedigital.atlassian.net/browse/NPQ-3804)

### Changes proposed in this pull request

1. Show recently created users by default in the users screen - this users `limit` rather than pagination to avoid a slow full scan of the entire users index
2. Only show the help text if they user types an invalid search
3. Added subheadings to differentiate between search results and the recent users listing


[NPQ-3804]: https://dfedigital.atlassian.net/browse/NPQ-3804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ