### PR TITLE
[NPQ-3787] - Change webhooks to use blocklist

### DIFF
--- a/app/jobs/get_an_identity/process_webhook_message_job.rb
+++ b/app/jobs/get_an_identity/process_webhook_message_job.rb
@@ -1,5 +1,7 @@
 module GetAnIdentity
   class ProcessWebhookMessageJob < ApplicationJob
+    class UnknownMessageTypeError < StandardError; end
+
     queue_as :default
 
     def perform(webhook_message:)
@@ -7,16 +9,17 @@ module GetAnIdentity
 
       webhook_processor_klass = webhook_message.processor_klass
 
-      if webhook_processor_klass.blank?
+      if webhook_processor_klass.present?
+        webhook_processor_klass.call(webhook_message:)
+      elsif webhook_message.ignored_message_type?
         webhook_message.update!(
           status: :unhandled_message_type,
           status_comment: "No processor found for webhook message",
           processed_at: Time.zone.now,
         )
-        return
+      else
+        raise UnknownMessageTypeError, "No processor found for webhook message type: #{webhook_message.message_type}"
       end
-
-      webhook_processor_klass.call(webhook_message:)
     end
   end
 end

--- a/app/models/get_an_identity/webhook_message.rb
+++ b/app/models/get_an_identity/webhook_message.rb
@@ -7,6 +7,12 @@ class GetAnIdentity::WebhookMessage < ApplicationRecord
     unhandled_message_type: "unhandled_message_type",
   }, suffix: true
 
+  IGNORED_MESSAGE_TYPES = %w[].freeze
+
+  def ignored_message_type?
+    IGNORED_MESSAGE_TYPES.include?(message_type)
+  end
+
   def processor_klass
     case message_type
     when "UserUpdated"

--- a/spec/jobs/get_an_identity/process_webhook_message_job_spec.rb
+++ b/spec/jobs/get_an_identity/process_webhook_message_job_spec.rb
@@ -14,11 +14,26 @@ RSpec.describe GetAnIdentity::ProcessWebhookMessageJob do
 
     let(:sent_at) { Time.zone.now }
 
-    context "when webhook message is unhandled" do
+    context "when the message type is unknown" do
       let(:message_type) { "UserMerged" }
       let(:message) { {} }
 
-      it "updates the webhook message status to unhandled_message_type" do
+      it "raises an exception so the job retries and we are notified" do
+        expect {
+          described_class.perform_now(webhook_message:)
+        }.to raise_error(described_class::UnknownMessageTypeError, /No processor found for webhook message type: UserMerged/)
+      end
+    end
+
+    context "when the message type is on the ignore list" do
+      let(:message_type) { "UserMerged" }
+      let(:message) { {} }
+
+      before do
+        stub_const("GetAnIdentity::WebhookMessage::IGNORED_MESSAGE_TYPES", %w[UserMerged])
+      end
+
+      it "silently ignores it by setting the status to unhandled_message_type" do
         expect {
           described_class.perform_now(webhook_message:)
         }.to change(webhook_message, :status).from("pending").to("unhandled_message_type")

--- a/spec/models/get_an_identity/webhook_message_spec.rb
+++ b/spec/models/get_an_identity/webhook_message_spec.rb
@@ -25,6 +25,26 @@ RSpec.describe GetAnIdentity::WebhookMessage, type: :model do
     end
   end
 
+  describe "#ignored_message_type?" do
+    subject { build(:trs_user_updated_webhook_message, message_type:) }
+
+    before do
+      stub_const("GetAnIdentity::WebhookMessage::IGNORED_MESSAGE_TYPES", %w[ignore_me])
+    end
+
+    context "when the message_type is on the ignore list" do
+      let(:message_type) { "ignore_me" }
+
+      it { is_expected.to be_ignored_message_type }
+    end
+
+    context "when the message_type is not on the ignore list" do
+      let(:message_type) { "one_login_user.updated" }
+
+      it { is_expected.not_to be_ignored_message_type }
+    end
+  end
+
   describe "#processor_klass" do
     context "when message_type is one_login_user.updated" do
       subject { build(:trs_user_updated_webhook_message) }


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/NPQ-3787

### Changes proposed in this pull request
- Switch from using an allowlist to a blocklist.
- Unexpected messages types raise an exception so we get notified.
- Message types on our ignore list silently fail in the same way we currently do (Setting unhandled_message_type)


