### PR TITLE
[NPQ-3817] prompt teacher auth users to login in via One Login when they try and log in via DfE Identity

### DIFF
--- a/app/controllers/omniauth_controller.rb
+++ b/app/controllers/omniauth_controller.rb
@@ -45,6 +45,9 @@ class OmniauthController < Devise::OmniauthCallbacksController
       flash[:error] = failure_message
       redirect_to failed_sign_in_path
     end
+  rescue Users::FindOrCreateFromProviderData::TeacherAuthAccountExistsError
+    flash[:error] = "Your account is now registered with One Login. Please sign in using your One Login account."
+    redirect_to root_path(one_login: true)
   rescue StandardError => e
     id = @user.try(:id)
     Rails.logger.info("[GAI] #{e} raised, user_id=#{id} uid=#{try_to_extract_user_uid}")

--- a/app/controllers/registration_closed_controller.rb
+++ b/app/controllers/registration_closed_controller.rb
@@ -1,5 +1,6 @@
 class RegistrationClosedController < PublicPagesController
   def show
+    @one_login = params[:one_login] == "true"
     redirect_to root_path unless Feature.registration_closed?(current_user)
   end
 

--- a/app/controllers/registration_wizard_controller.rb
+++ b/app/controllers/registration_wizard_controller.rb
@@ -116,7 +116,7 @@ private
 
     if Feature.registration_closed?(current_user)
       if params[:step] == "start"
-        redirect_to registration_closed_path
+        redirect_to registration_closed_path(one_login: params[:one_login])
       else
         redirect_to registration_wizard_show_path(:closed)
       end

--- a/app/views/registration_closed/show.html.erb
+++ b/app/views/registration_closed/show.html.erb
@@ -44,13 +44,24 @@
       <li>course outcome, if you have completed your course</li>
     </ul>
 
-    <%=
-      render GovukComponent::ContinueButtonComponent.new(
-        text: "Sign in to your DfE Identity account",
-        href: user_tra_openid_connect_omniauth_authorize_path,
-        classes: "govuk-button--secondary",
-        as_button: true,
-      )
-    %>
+    <% if @one_login %>
+      <%=
+        render GovukComponent::ContinueButtonComponent.new(
+          text: "Sign in to your One Login account",
+          href: user_teacher_auth_omniauth_authorize_path,
+          classes: "govuk-button--secondary",
+          as_button: true,
+        )
+      %>
+    <% else %>
+      <%=
+        render GovukComponent::ContinueButtonComponent.new(
+          text: "Sign in to your DfE Identity account",
+          href: user_tra_openid_connect_omniauth_authorize_path,
+          classes: "govuk-button--secondary",
+          as_button: true,
+        )
+      %>
+    <% end %>
   </div>
 </div>

--- a/spec/features/service_closed_spec.rb
+++ b/spec/features/service_closed_spec.rb
@@ -22,6 +22,24 @@ RSpec.feature "Service is closed", :no_js, type: :feature do
       expect(page).to be_accessible
     end
 
+    context "when a user has a teacher auth account" do
+      include_context "with stubbed Teacher Auth OmniAuth responses"
+      include_context "with stubbed Teaching Record System person API"
+
+      before do
+        create(:user, :with_teacher_auth, :with_verified_trn, email: "user@example.com", trn: "1234567")
+      end
+
+      scenario "Service prompts to log in with One Login" do
+        visit "/"
+        click_button("Sign in to your DfE Identity account")
+        expect(page).to have_content "Your account is now registered with One Login. Please sign in using your One Login account."
+        expect(page).to have_current_path "/registration_closed?one_login=true"
+        click_button("Sign in to your One Login account")
+        expect(page).to have_current_path account_path
+      end
+    end
+
     context "when registration reopens" do
       before { open_registration! }
 


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/NPQ-3817

### Changes proposed in this pull request

* if a user already has a teacher auth account, and they try and sign in via DfE Identity on the /registration_closed page, then show an error message, and show a "Sign in to your One Login account" button instead of the DfE Identity one.