### PR TITLE
[NPQ-3818] Use a Spring 2026 Notify template for Spring 2026 registrations

### DIFF
--- a/app/mailers/application_submission_mailer.rb
+++ b/app/mailers/application_submission_mailer.rb
@@ -1,8 +1,9 @@
 class ApplicationSubmissionMailer < ApplicationMailer
   TEMPLATE_ID = "b8b53310-fa6f-4587-972a-f3f3c6e0892e".freeze
+  SPRING_2026_TEMPLATE_ID = "7ca4bae1-d5ac-4761-87ae-36bd790254bb".freeze
 
-  def application_submitted_mail(_template_id, to:, full_name:, provider_name:, course_name:, amount:, ecf_id:)
-    template_mail(TEMPLATE_ID,
+  def application_submitted_mail(template_id, to:, full_name:, provider_name:, course_name:, amount:, ecf_id:)
+    template_mail(template_id || TEMPLATE_ID,
                   to:,
                   personalisation: {
                     full_name:,

--- a/app/services/handle_submission_for_store.rb
+++ b/app/services/handle_submission_for_store.rb
@@ -1,4 +1,7 @@
 class HandleSubmissionForStore
+  # Spring 2026 cohort uses a dedicated Notify template (see NPQ-3818)
+  SPRING_2026_COHORT_IDENTIFIER = "2026a".freeze
+
   attr_reader :store, :application
 
   def initialize(store:)
@@ -185,7 +188,11 @@ private
   end
 
   def email_template
-    EmailTemplateLookup.call(store["email_template"])
+    if cohort.identifier == SPRING_2026_COHORT_IDENTIFIER
+      ApplicationSubmissionMailer::SPRING_2026_TEMPLATE_ID
+    else
+      ApplicationSubmissionMailer::TEMPLATE_ID
+    end
   end
 
   delegate :ineligible_institution_type?,

--- a/spec/mailers/application_submission_mailer_spec.rb
+++ b/spec/mailers/application_submission_mailer_spec.rb
@@ -37,6 +37,22 @@ RSpec.describe ApplicationSubmissionMailer, type: :mailer do
 
     it { is_expected.to use_template(ApplicationSubmissionMailer::TEMPLATE_ID) }
 
+    context "when a template id is given" do
+      subject(:mail) do
+        described_class.application_submitted_mail(
+          ApplicationSubmissionMailer::SPRING_2026_TEMPLATE_ID,
+          to:,
+          full_name:,
+          provider_name:,
+          course_name:,
+          amount:,
+          ecf_id:,
+        )
+      end
+
+      it { is_expected.to use_template(ApplicationSubmissionMailer::SPRING_2026_TEMPLATE_ID) }
+    end
+
     it_behaves_like "a mailer with redacted logs"
   end
 end

--- a/spec/services/handle_submission_for_store_spec.rb
+++ b/spec/services/handle_submission_for_store_spec.rb
@@ -336,6 +336,24 @@ RSpec.describe HandleSubmissionForStore do
       it "enqueues SendApplicationSubmissionEmailJob" do
         expect { subject.call }.to have_enqueued_job(SendApplicationSubmissionEmailJob).exactly(:once).on_queue("default")
       end
+
+      context "when the application is for the Spring 2026 cohort" do
+        let(:cohort) { create(:cohort, start_year: 2026, suffix: "a") }
+
+        it "enqueues the email with the Spring 2026 template" do
+          expect { subject.call }.to have_enqueued_job(SendApplicationSubmissionEmailJob)
+            .with(hash_including(email_template: ApplicationSubmissionMailer::SPRING_2026_TEMPLATE_ID))
+        end
+      end
+
+      context "when the application is for a non-Spring-2026 cohort" do
+        let(:cohort) { create(:cohort, start_year: 2026, suffix: "b") }
+
+        it "enqueues the email with the default template" do
+          expect { subject.call }.to have_enqueued_job(SendApplicationSubmissionEmailJob)
+            .with(hash_including(email_template: ApplicationSubmissionMailer::TEMPLATE_ID))
+        end
+      end
     end
 
     context "when teacher catchment is not in the UK catchment area" do


### PR DESCRIPTION
### Context

Ticket: https://dfedigital.atlassian.net/browse/NPQ-3818

Applicants registering for the Spring 2026 cohort were getting a confirmation email that said the course started in the wrong season (Autumn). The registration itself was correct, only the Notify email template was wrong.

### Changes proposed in this pull request

1. Pick the new Spring 2026 Notify template for Spring 2026 applications (cohort `2026a`) and keep the current template for the rest.
2. Make `ApplicationSubmissionMailer` use the template id it is given (it was ignored before), with the existing template as a safe default.
3. Decide the template in `HandleSubmissionForStore` based on the application cohort.
4. Add specs for the mailer and the handler covering both cohorts.

The Spring 2026 Notify template (`7ca4bae1-d5ac-4761-87ae-36bd790254bb`) has already been created in Notify.