### PR TITLE
[BAU] Reduce notifications about null user emails

### DIFF
--- a/app/services/users/archiver.rb
+++ b/app/services/users/archiver.rb
@@ -17,7 +17,10 @@ module Users
       user.provider = nil
       user.save!
 
-      send_sentry_capture_message if blank_email
+      # If we're archiving a user who still has applications then we want to
+      # know about it otherwise its a user account for expression of interest,
+      # or from a past incomplete registration
+      send_sentry_capture_message if blank_email && user.applications.any?
     end
 
     def set_uid_to_nil!

--- a/spec/services/users/archiver_spec.rb
+++ b/spec/services/users/archiver_spec.rb
@@ -35,6 +35,8 @@ RSpec.describe Users::Archiver do
     end
 
     context "when blank_email: true" do
+      before { allow(Sentry).to receive(:capture_message) }
+
       it "archives user with nil email" do
         travel_to archive_time do
           subject.archive!(blank_email: true)
@@ -48,23 +50,31 @@ RSpec.describe Users::Archiver do
         expect(user).to be_archived
       end
 
-      it "sends a Sentry message with the user's ecf_id" do
-        allow(Sentry).to receive(:capture_message)
-
+      it "does not send Sentry a message" do
         subject.archive!(blank_email: true)
 
-        expect(Sentry).to have_received(:capture_message).with(
-          "Blanked email on the user due to reuse when used by a later participant",
-          hash_including(level: :info, extra: { ecf_id: user.ecf_id }),
-        )
+        expect(Sentry).not_to have_received(:capture_message)
       end
 
-      it "does not touch the user's applications" do
-        application = create(:application, user:)
+      context "when user has applications" do
+        before { application }
 
-        subject.archive!(blank_email: true)
+        let(:application) { create(:application, user:) }
 
-        expect(application.reload.user).to eq(user)
+        it "sends a Sentry message with the user's ecf_id" do
+          subject.archive!(blank_email: true)
+
+          expect(Sentry).to have_received(:capture_message).with(
+            "Blanked email on the user due to reuse when used by a later participant",
+            hash_including(level: :info, extra: { ecf_id: user.ecf_id }),
+          )
+        end
+
+        it "does not touch the user's applications" do
+          subject.archive!(blank_email: true)
+
+          expect(application.reload.user).to eq(user)
+        end
       end
     end
 

--- a/spec/services/users/find_or_create_from_teacher_auth_spec.rb
+++ b/spec/services/users/find_or_create_from_teacher_auth_spec.rb
@@ -358,7 +358,10 @@ RSpec.describe Users::FindOrCreateFromTeacherAuth do
       end
 
       context "when the email clashes with a different existing user" do
-        let!(:clashing_user) { create(:user, :with_get_an_identity_id, email:) }
+        before { application }
+
+        let(:application) { create(:application, user: clashing_user) }
+        let(:clashing_user) { create(:user, :with_get_an_identity_id, email:) }
 
         it "blanks the clashing user's email and creates the new user" do
           expect { subject }.not_to raise_error
@@ -368,7 +371,6 @@ RSpec.describe Users::FindOrCreateFromTeacherAuth do
         end
 
         it "does not move applications from the clashing user" do
-          application = create(:application, user: clashing_user)
           subject
           expect(application.reload.user).to eq(clashing_user)
         end


### PR DESCRIPTION
### Context

Ticket: BAU

We only want to know about the nulling of email addresses for users who've applied. We also have users signing up via GAI to register for Expression of Interest who are unlikely to have a verified trn, will be applying via a different auth system (Teacher Auth) so will not be matched but its not a concern in this scenario and not visible on the API.

### Changes proposed in this pull request

1. Only notify sentry if the user has any applications
