### PR TITLE
2683 - Validate infra workflow with required vars

### DIFF
--- a/.github/workflows/validate-infrastructure.yml
+++ b/.github/workflows/validate-infrastructure.yml
@@ -41,3 +41,5 @@ jobs:
           teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL_INFRA }}
           gcp-wip: projects/808138694727/locations/global/workloadIdentityPools/npq-registration/providers/npq-registration
           gcp-project-id: ecf-bq
+          docker-repo: true
+          service-name: npq-registration


### PR DESCRIPTION
### Context

Adding a validate infra workflow to detect any changes in SD Infra Terraform 

### Changes proposed in this pull request

Additional docker image string variables supplied

### Guidance to review

You can run the "Validate Infra" workflow if it already exists for the service. You can point it at the branch but that will always produce a false positive as the docker image will be different for main/master and the branch. This will produce a workflow Teams message in SD Infra Alerts.

<img width="500" height="150" alt="image" src="https://github.com/user-attachments/assets/b2f7861d-33c5-4382-ab95-1b73e580fc86" />

There are 3 jobs in the workflow, AKS infrastructure, Domains infrastructure and Domains environment. The workflow card will show which job to look at in the bottom left corner (Infrastructure in the image above). You can click the Workflow Run button to go to the correct run.
The jobs must show a green tick not a red cross.
You can alter any value in the terraform production.tfvars.json in your branch to check that the terraform plan picks up those changes, remembering that the docker image is a false positive.

If the workflow does not exist you will have to test locally using the service specific `make production terraform-plan` command for the service. 

### Link to Trello card

https://trello.com/c/p76gfyrn/2683-schedule-validate-infra-workflow

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
