### PR TITLE
[NPQ-3823] user clash bug

### DIFF
--- a/app/services/users/find_or_create_from_provider_data.rb
+++ b/app/services/users/find_or_create_from_provider_data.rb
@@ -28,6 +28,16 @@ module Users
                 "GAI sign-in matched a Teacher Auth user by email (user_id=#{user.id}); refusing to take over the account"
         end
 
+        teacher_auth_user_with_same_trn = User.find_by(
+          trn: provider_data.extra.raw_info.trn,
+          trn_verified: true,
+          provider: Omniauth::Strategies::TeacherAuth::NAME,
+        )
+        if teacher_auth_user_with_same_trn
+          raise TeacherAuthAccountExistsError,
+            "Teacher Auth account exists with the same TRN (user_id=#{teacher_auth_user_with_same_trn.id}); refusing to create a new account"
+        end
+
         user.assign_attributes(provider: provider_data.provider, uid: provider_data.uid)
       end
 

--- a/app/services/users/find_or_create_from_provider_data.rb
+++ b/app/services/users/find_or_create_from_provider_data.rb
@@ -35,7 +35,7 @@ module Users
         )
         if teacher_auth_user_with_same_trn
           raise TeacherAuthAccountExistsError,
-            "Teacher Auth account exists with the same TRN (user_id=#{teacher_auth_user_with_same_trn.id}); refusing to create a new account"
+                "Teacher Auth account exists with the same TRN (user_id=#{teacher_auth_user_with_same_trn.id}); refusing to create a new account"
         end
 
         user.assign_attributes(provider: provider_data.provider, uid: provider_data.uid)

--- a/app/services/users/find_or_create_from_teacher_auth.rb
+++ b/app/services/users/find_or_create_from_teacher_auth.rb
@@ -15,7 +15,7 @@ module Users
     attr_reader :provider_data, :access_token, :uid, :trn, :email, :full_name, :feature_flag_id
 
     def call
-      user_matched_using_trn = verified_trn_matching_users.first
+      user_matched_using_trn = verified_teacher_auth_matching_users.first || verified_trn_matching_users.first
 
       if user_matched_using_trn
         merge_and_archive_other_users(user_matched_using_trn, verified_trn_matching_users[1..])
@@ -92,6 +92,13 @@ module Users
       else
         false
       end
+    end
+
+    def verified_teacher_auth_matching_users
+      User
+        .where(trn:, trn_verified: true, archived_at: nil, provider: Omniauth::Strategies::TeacherAuth::NAME)
+        .where.not(trn: nil)
+        .order(updated_at: :desc)
     end
 
     def verified_trn_matching_users

--- a/app/services/users/find_or_create_from_teacher_auth.rb
+++ b/app/services/users/find_or_create_from_teacher_auth.rb
@@ -18,7 +18,7 @@ module Users
       user_matched_using_trn = verified_teacher_auth_matching_users.first || verified_trn_matching_users.first
 
       if user_matched_using_trn
-        merge_and_archive_other_users(user_matched_using_trn, verified_trn_matching_users[1..])
+        merge_and_archive_other_users(user_matched_using_trn, verified_trn_matching_users.excluding(user_matched_using_trn))
         blank_clashing_email_user(except: user_matched_using_trn)
 
         ApplicationRecord.transaction do

--- a/app/views/registration_closed/show.html.erb
+++ b/app/views/registration_closed/show.html.erb
@@ -12,26 +12,28 @@
       You can register for an NPQ or the early headship coaching offer when registration reopens.
     </p>
 
-    <p class="govuk-body">
-      Sign up for email updates to find out when registration reopens.
-    </p>
+    <% unless @one_login %>
+      <p class="govuk-body">
+        Sign up for email updates to find out when registration reopens.
+      </p>
 
-    <% if current_user&.persisted? %>
-      <%=
-        render GovukComponent::ContinueButtonComponent.new(
-          text: "Sign up for email updates",
-          href: new_email_update_path,
-        )
-      %>
-    <% else %>
-      <%=
-        render GovukComponent::ContinueButtonComponent.new(
-          text: "Sign up for email updates",
-          href: user_tra_openid_connect_omniauth_authorize_path(request_email_updates: "true"),
-          as_button: true,
-          html_attributes: { data: { "prevent-double-click": true } }
-        )
-      %>
+      <% if current_user&.persisted? %>
+        <%=
+          render GovukComponent::ContinueButtonComponent.new(
+            text: "Sign up for email updates",
+            href: new_email_update_path,
+          )
+        %>
+      <% else %>
+        <%=
+          render GovukComponent::ContinueButtonComponent.new(
+            text: "Sign up for email updates",
+            href: user_tra_openid_connect_omniauth_authorize_path(request_email_updates: "true"),
+            as_button: true,
+            html_attributes: { data: { "prevent-double-click": true } }
+          )
+        %>
+      <% end %>
     <% end %>
 
     <h3 class="govuk-heading-m">Check your existing registrations</h3>

--- a/spec/features/service_closed_spec.rb
+++ b/spec/features/service_closed_spec.rb
@@ -35,6 +35,9 @@ RSpec.feature "Service is closed", :no_js, type: :feature do
         click_button("Sign in to your DfE Identity account")
         expect(page).to have_content "Your account is now registered with One Login. Please sign in using your One Login account."
         expect(page).to have_current_path "/registration_closed?one_login=true"
+        expect(page).not_to have_content "Sign up for email updates to find out when registration reopens."
+        expect(page).not_to have_button "Sign up for email updates"
+
         click_button("Sign in to your One Login account")
         expect(page).to have_current_path account_path
       end

--- a/spec/services/users/find_or_create_from_provider_data_spec.rb
+++ b/spec/services/users/find_or_create_from_provider_data_spec.rb
@@ -314,6 +314,17 @@ RSpec.describe Users::FindOrCreateFromProviderData do
       end
     end
 
+    context "when there is a teacher auth user with the same TRN" do
+      let!(:teacher_auth_user) { create(:user, :with_teacher_auth, :with_verified_trn, trn: provider_data_trn) }
+
+      it "raises an error refusing to create a new account" do
+        expect { subject }.to raise_error(
+          described_class::TeacherAuthAccountExistsError,
+          "Teacher Auth account exists with the same TRN (user_id=#{teacher_auth_user.id}); refusing to create a new account",
+        )
+      end
+    end
+
     context "when user with email does not exist" do
       it "creates a new user with the UID and email" do
         expect(subject.uid).to eq provider_data_uid

--- a/spec/services/users/find_or_create_from_teacher_auth_spec.rb
+++ b/spec/services/users/find_or_create_from_teacher_auth_spec.rb
@@ -475,4 +475,29 @@ RSpec.describe Users::FindOrCreateFromTeacherAuth do
       end
     end
   end
+
+  context "when there is an existing GAI account with the same TRN (NPQ-3823)" do
+    let(:trn) { "1234567" }
+    let(:email) { personal_email }
+    let(:personal_email) { "personal@example.com" }
+    let(:work_email) { "work@example.com" }
+
+    let(:existing_teacher_auth_account) { create(:user, :with_teacher_auth, :with_verified_trn, trn:, uid:, email: personal_email) }
+    let(:application) { create(:application, user: existing_teacher_auth_account) }
+    let(:old_gai_account) { create(:user, :with_get_an_identity_id, :with_verified_trn, trn:, email: work_email) }
+
+    before do
+      # teacher auth account is deliberately older than the GAI account to simulate the bug,
+      # as it is a GAI account that was created first, then updated to be a teacher auth account
+      existing_teacher_auth_account
+      old_gai_account
+    end
+
+    it "archives the clashing GAI account" do
+      subject
+      expect(old_gai_account.reload).to be_archived
+      expect(existing_teacher_auth_account.reload).not_to be_archived
+      expect(application.reload.user).to eq(existing_teacher_auth_account)
+    end
+  end
 end


### PR DESCRIPTION
### Context

Ticket: [NPQ-3823](https://dfedigital.atlassian.net/browse/NPQ-3823)

This bug occurs when a use has a GAI user account (_account1_),
which is then converted to a Teacher Auth account by the login process.
After that, a newer GAI account is created with the same TRN (_account2_).

When the user tries to log in via One Login in this scenario, the code cannot update the details on _account2_ because they clash with _account1_.

### Changes proposed in this pull request

1. check for teacher auth accounts with the TRN first, before checking GAI accounts.
2. do not show the 'sign up for email updates' content or button for one login accounts, as this only works for DfE Identity users.

[NPQ-3823]: https://dfedigital.atlassian.net/browse/NPQ-3823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ