### PR TITLE
[NPQ-3774] Fix closed registration users admin link

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -842,7 +842,7 @@ en:
           closed_registration_enabled_html: |
             <p class="govuk-body">When this feature is turned on, specified users can register for an NPQ even when the service is closed to the general public.</p>
             <p class="govuk-body">Use the <a href="/npq-separation/admin/features/Registration%20open" class="govuk-link">Registration open</a> feature flag if you need to close the service to the general public.
-            <p class="govuk-body">To view or manage who can register while the service is closed, visit <a href="/admin/closed_registration_users" class="govuk-link">Closed registration users</a>.</p>
+            <p class="govuk-body">To view or manage who can register while the service is closed, visit <a href="/npq-separation/admin/registration-closed/closed-registration-users" class="govuk-link">Closed registration users</a>.</p>
             <p class="govuk-body">When both the Registration open and Closed registration enabled feature flags are turned off, no one will be able to register.</p>
           declarations_require_delivery_partner_html: |
             <p class="govuk-body">When this feature is turned on, submitting a declaration for the 2024 cohort onwards will require the delivery partner to be included.</p>

--- a/spec/features/npq_separation/admin/feature_flags_spec.rb
+++ b/spec/features/npq_separation/admin/feature_flags_spec.rb
@@ -31,6 +31,20 @@ RSpec.feature "Administering feature flags", :rack_test_driver, type: :feature d
     expect(Flipper.enabled?(Feature::REGISTRATION_OPEN)).to be(false)
   end
 
+  scenario "the 'Closed registration enabled' feature flag page links to the closed registration users page" do
+    sign_in_as_super_admin
+
+    visit npq_separation_admin_features_path
+    within("tr", text: "Closed registration enabled") do
+      page.click_link("View")
+    end
+
+    expect(page).to have_link(
+      "Closed registration users",
+      href: "/npq-separation/admin/registration-closed/closed-registration-users",
+    )
+  end
+
   scenario "check all feature flag pages are not missing translations" do
     sign_in_as_super_admin
 


### PR DESCRIPTION
### Context

Ticket: [NPQ-3774](https://dfedigital.atlassian.net/browse/NPQ-3774)

One link in the admin console pointed to a dead page.

### Changes proposed in this pull request

1. Fix the "Closed registration users" link in config/locales/en.yml so it points to `/npq-separation/admin/registration-closed/closed-registration-users`

### Notes

The link is a path harcoded in the locale file so it affected all environments and now should be correct in all of them.

[NPQ-3774]: https://dfedigital.atlassian.net/browse/NPQ-3774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ