### PR TITLE
[NPQ-3835] Fix GAI warning being triggered

### DIFF
--- a/app/controllers/registration_wizard_controller.rb
+++ b/app/controllers/registration_wizard_controller.rb
@@ -136,7 +136,7 @@ private
   def check_teacher_auth_user
     return unless Rails.configuration.x.teacher_auth.enabled
     return if params[:step].to_s == "start"
-    return if current_user&.teacher_auth_provider?
+    return unless current_user&.get_an_identity_provider?
 
     Sentry.capture_message("User attempted registration from GAI")
 

--- a/spec/features/journeys/sad_paths/attempting_registration_with_gai_spec.rb
+++ b/spec/features/journeys/sad_paths/attempting_registration_with_gai_spec.rb
@@ -34,4 +34,22 @@ RSpec.feature "Registration whilst already signed in with DfE Identity", :no_js,
       expect(Sentry).to have_received(:capture_message)
     end
   end
+
+  scenario "visiting course page whilst not being signed in" do
+    allow(Feature).to receive(:registration_closed?).and_return(false)
+
+    visit("/registration/course-start-date")
+
+    expect_page_to_have(path: "/")
+    expect(Sentry).not_to have_received(:capture_message)
+  end
+
+  scenario "visiting course page directly whilst not being signed in and registration is closed" do
+    allow(Feature).to receive(:registration_closed?).and_return(true)
+
+    visit("/registration/course_start_date")
+
+    expect_page_to_have(path: "/registration/closed")
+    expect(Sentry).not_to have_received(:capture_message)
+  end
 end


### PR DESCRIPTION
### Context

Ticket: [NPQ-3835](https://dfedigital.atlassian.net/browse/NPQ-3835)

We are getting errors about GAI users attempting registration - every one of these was from the 'closed' step and I think this is bots directly accessing the closed step

### Changes proposed in this pull request

1. Change the check to ignore the closed step

[NPQ-3835]: https://dfedigital.atlassian.net/browse/NPQ-3835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ