### PR TITLE
[NPQ-3213] Add a session id to log lines and Sentry events

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,12 @@
 class ApplicationController < ActionController::Base
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
+  around_action :add_session_id_to_logs
   around_action :set_time_zone
   before_action :clear_null_user_sessions
   before_action :set_cache_headers
   before_action :authenticate_user!
-  before_action :set_sentry_user
+  before_action :set_sentry_context
   before_action :initialize_store
 
   include DfE::Analytics::Requests
@@ -26,13 +27,25 @@ private
   end
   helper_method :feature_flag_id
 
+  # A identifier per session attached to every log line and Sentry event so a
+  # user's whole navigation in the service can be reconstructed from a single Sentry error.
+  # To not expose in the logs the real user session value, a new UUID is generated.
+  def log_session_id
+    session[:log_session_id] ||= SecureRandom.uuid
+  end
+
   def current_user
     logged_in_user
   end
   helper_method :current_user
 
-  def set_sentry_user
+  def set_sentry_context
     Sentry.set_user(id: current_user.id) if current_user
+    Sentry.set_tags(session_id: log_session_id)
+  end
+
+  def add_session_id_to_logs(&block)
+    SemanticLogger.tagged(session_id: log_session_id, &block)
   end
 
   # Use current_user instead!

--- a/spec/requests/session_id_logging_spec.rb
+++ b/spec/requests/session_id_logging_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Session ID logging", type: :request do
+  let(:current_lead_provider) { create(:lead_provider) }
+
+  it "stores a session id once a request has been made" do
+    get root_path
+
+    expect(session[:log_session_id]).to be_present
+  end
+
+  it "keeps the same session id across requests in the same session" do
+    get root_path
+    first_id = session[:log_session_id]
+
+    get root_path
+
+    expect(session[:log_session_id]).to eq(first_id)
+  end
+
+  it "sends the session id to Sentry" do
+    allow(Sentry).to receive(:set_tags)
+
+    get root_path
+
+    expect(Sentry).to have_received(:set_tags).with(session_id: session[:log_session_id])
+  end
+
+  it "add session id to log lines" do
+    allow(SemanticLogger).to receive(:tagged).and_call_original
+
+    get root_path
+
+    expect(SemanticLogger).to have_received(:tagged).with(session_id: session[:log_session_id])
+  end
+end


### PR DESCRIPTION
### Context

Ticket: [NPQ-3213](https://dfedigital.atlassian.net/browse/NPQ-3213)

When there is an exception it is very hard to follow the steps a user took in the
registration journey. Our logs and Sentry reports are heavily redacted and there is no
single id shared by all the requests of one user. This adds a session id so we can go
from a Sentry error to all the Rails logs of that session: read the session id in Sentry
and search Logit for it.

### Changes proposed in this pull request

1. Add `log_session_id` in `ApplicationController`, a generated UUID kept in the session.
2. Tag every log line of the request with this `session_id` (Semantic Logger named tag),
   so it is a searchable field in the JSON logs (Logit).
3. Send the same `session_id` to Sentry as a tag, so any exception in the request has it.
4. Add a request spec for this behaviour.

### Notes

- Only applicants and admin requests, not the API ones.
- The id is a generated UUID, not the real session value, so it is safe to expose in logs.

[NPQ-3213]: https://dfedigital.atlassian.net/browse/NPQ-3213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ