### PR TITLE
[NPQ-3837] Add double click prevention to omniauth buttons

### DIFF
--- a/app/views/email_updates/unsubscribed.html.erb
+++ b/app/views/email_updates/unsubscribed.html.erb
@@ -22,7 +22,8 @@
         render GovukComponent::ContinueButtonComponent.new(
           text: "Re-subscribe",
           href: user_tra_openid_connect_omniauth_authorize_path(request_email_updates: "true"),
-          as_button: true
+          as_button: true,
+          html_attributes: { data: { "prevent-double-click": true } }
         )
       %>
     <% end %>

--- a/app/views/registration_closed/show.html.erb
+++ b/app/views/registration_closed/show.html.erb
@@ -28,7 +28,8 @@
         render GovukComponent::ContinueButtonComponent.new(
           text: "Sign up for email updates",
           href: user_tra_openid_connect_omniauth_authorize_path(request_email_updates: "true"),
-          as_button: true
+          as_button: true,
+          html_attributes: { data: { "prevent-double-click": true } }
         )
       %>
     <% end %>
@@ -51,6 +52,7 @@
           href: user_teacher_auth_omniauth_authorize_path,
           classes: "govuk-button--secondary",
           as_button: true,
+          html_attributes: { data: { "prevent-double-click": true } }
         )
       %>
     <% else %>
@@ -60,6 +62,7 @@
           href: user_tra_openid_connect_omniauth_authorize_path,
           classes: "govuk-button--secondary",
           as_button: true,
+          html_attributes: { data: { "prevent-double-click": true } }
         )
       %>
     <% end %>

--- a/app/views/registration_wizard/closed.html.erb
+++ b/app/views/registration_wizard/closed.html.erb
@@ -14,7 +14,8 @@
       render GovukComponent::ContinueButtonComponent.new(
         text: "Request email updates",
         href: user_tra_openid_connect_omniauth_authorize_path(request_email_updates: "true"),
-        as_button: true
+        as_button: true,
+        html_attributes: { data: { "prevent-double-click": true } }
       )
     %>
   </div>

--- a/app/views/registration_wizard/start.html.erb
+++ b/app/views/registration_wizard/start.html.erb
@@ -26,7 +26,7 @@
           You can also sign in
           through GOV.UK One Login to view a previous registration or change your personal details.
         </p>
-        <%= govuk_button_to("Sign in", user_teacher_auth_omniauth_authorize_path, secondary: true) %>
+        <%= govuk_button_to("Sign in", user_teacher_auth_omniauth_authorize_path, secondary: true, prevent_double_click: true) %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/shared/get_an_identity/_redirect_button.html.erb
+++ b/app/views/shared/get_an_identity/_redirect_button.html.erb
@@ -4,7 +4,10 @@
 <span <%= "class=govuk-visually-hidden" if hidden %>>
   <%=
     govuk_start_button(
-      text: button_text, href: user_tra_openid_connect_omniauth_authorize_path, as_button: true
+      text: button_text,
+      href: user_tra_openid_connect_omniauth_authorize_path,
+      as_button: true,
+      html_attributes: { data: { "prevent-double-click": true } }
     )
   %>
 </span>

--- a/app/views/shared/teacher_auth/_redirect_button.html.erb
+++ b/app/views/shared/teacher_auth/_redirect_button.html.erb
@@ -4,7 +4,10 @@
 <span <%= "class=govuk-visually-hidden" if hidden %>>
   <%=
     govuk_start_button(
-      text: button_text, href: user_teacher_auth_omniauth_authorize_path(start_now: true), as_button: true
+      text: button_text,
+      href: user_teacher_auth_omniauth_authorize_path(start_now: true),
+      as_button: true,
+      html_attributes: { data: { "prevent-double-click": true } }
     )
   %>
 </span>

--- a/spec/features/start_page_spec.rb
+++ b/spec/features/start_page_spec.rb
@@ -19,6 +19,13 @@ RSpec.feature "Start page", :no_js, type: :feature do
     expect(page).to have_text("To check your funding eligibility, you’ll need:")
   end
 
+  scenario "omniauth buttons prevent double clicks" do
+    visit "/"
+
+    expect(find_button("Start now")["data-prevent-double-click"]).to eq("true")
+    expect(find_button("Sign in")["data-prevent-double-click"]).to eq("true")
+  end
+
   context "when the user has no applications" do
     scenario "Start now button starts journey" do
       visit "/"


### PR DESCRIPTION
### Context

Ticket: [NPQ-3837](https://dfedigital.atlassian.net/browse/NPQ-3837)

We still see some omniauth CSRF errors now and then. The omniauth_openid_connect gem keeps a secret in the session, sends it through the OIDC provider, and checks it when the user comes back. One likely cause is a double click on a sign in button: the second click can overwrite the token in the session, so the check on return fails.

This PR adds the standard GOV.UK double click prevention to all the omniauth buttons.

### Changes proposed in this pull request

1. Added `data-prevent-double-click="true"` to every omniauth button on the site.
2. The buttons changed are: the Get an Identity and Teacher Auth redirect button partials, the start page "Sign in" button, the registration closed and temporarily closed pages, and the email updates unsubscribed page.
3. Added a test on the start page to check the buttons have the attribute.

[NPQ-3837]: https://dfedigital.atlassian.net/browse/NPQ-3837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ