### PR TITLE
[NPQ-3847] Fix user email clash on sign in

### DIFF
--- a/app/services/users/find_or_create_from_teacher_auth.rb
+++ b/app/services/users/find_or_create_from_teacher_auth.rb
@@ -18,6 +18,9 @@ module Users
       user_matched_using_trn = verified_trn_matching_users.first
 
       if user_matched_using_trn
+        merge_and_archive_other_users(user_matched_using_trn, verified_trn_matching_users[1..])
+        blank_clashing_email_user(except: user_matched_using_trn)
+
         ApplicationRecord.transaction do
           user_matched_using_trn.update!(
             always_updated_attributes.merge(
@@ -28,7 +31,6 @@ module Users
           )
           persist_token(user_matched_using_trn, provider_data)
         end
-        merge_and_archive_other_users(user_matched_using_trn, verified_trn_matching_users[1..])
 
         return user_matched_using_trn
       end

--- a/spec/services/users/find_or_create_from_teacher_auth_spec.rb
+++ b/spec/services/users/find_or_create_from_teacher_auth_spec.rb
@@ -278,7 +278,7 @@ RSpec.describe Users::FindOrCreateFromTeacherAuth do
     end
 
     context "when one of the matching users by TRN already holds the incoming email" do
-      let(:older_user) { create(:user, trn:, trn_verified: true, updated_at: 2.days.ago, email:) }
+      let!(:older_user) { create(:user, trn:, trn_verified: true, updated_at: 2.days.ago, email:) }
 
       it "frees the email by merging and sets it on the kept user" do
         expect { subject }.not_to raise_error

--- a/spec/services/users/find_or_create_from_teacher_auth_spec.rb
+++ b/spec/services/users/find_or_create_from_teacher_auth_spec.rb
@@ -152,6 +152,17 @@ RSpec.describe Users::FindOrCreateFromTeacherAuth do
       end
     end
 
+    context "when the incoming email clashes with a different existing user" do
+      let!(:clashing_user) { create(:user, :with_get_an_identity_id, trn: "7654321", trn_verified: true, email:) }
+
+      it "blanks the clashing user's email and takes over the matched account" do
+        expect { subject }.not_to raise_error
+        expect(clashing_user.reload).to have_attributes(email: nil, archived_email: email)
+        expect(clashing_user).to be_archived
+        expect(user.reload).to have_attributes(email:, uid:, provider: "teacher_auth", archived_at: nil)
+      end
+    end
+
     it_behaves_like "destroying the refresh token"
   end
 
@@ -263,6 +274,16 @@ RSpec.describe Users::FindOrCreateFromTeacherAuth do
       it "stores previous_names on the kept user" do
         subject
         expect(most_recently_updated_user.reload.previous_names).to eq(["Sarah Johnson"])
+      end
+    end
+
+    context "when one of the matching users by TRN already holds the incoming email" do
+      let(:older_user) { create(:user, trn:, trn_verified: true, updated_at: 2.days.ago, email:) }
+
+      it "frees the email by merging and sets it on the kept user" do
+        expect { subject }.not_to raise_error
+        expect(older_user.reload).to be_archived
+        expect(most_recently_updated_user.reload).to have_attributes(email:, uid:, provider: "teacher_auth")
       end
     end
 


### PR DESCRIPTION
### Context

Ticket: [NPQ-3847](https://dfedigital.atlassian.net/browse/NPQ-3847)

When a user signs in with Teacher Auth and we match them by their verified TRN, we update that user with the email from Teacher Auth.
If a different account already had that email, the save failed because email
must be unique. 
The other two paths (match by UID, and create a new user) already free the email first, so the verified TRN path was the only one that could crash.

### Changes proposed in this pull request

1. In the verified TRN path, merge the other users with the same TRN first. This archives them and frees the email if one of them had it.
2. Then blank the email on any other account that still has it, before updating the matched user and taking over the account.
3. Add specs for the verified TRN match when a different account holds the incoming email, and when one of the same TRN duplicates holds it.

[NPQ-3847]: https://dfedigital.atlassian.net/browse/NPQ-3847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ