### PR TITLE
[NPQ-3851] Redirect /registration to root

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,8 @@ Rails.application.routes.draw do
 
   root "registration_wizard#show", step: "start"
 
+  get "/registration", to: redirect("/")
+
   get "/registration/:step", to: "registration_wizard#show", as: "registration_wizard_show"
   get "/registration/:step/change", to: "registration_wizard#show", as: "registration_wizard_show_change", changing_answer: "1"
   patch "/registration/:step", to: "registration_wizard#update", as: "registration_wizard_update"

--- a/spec/requests/registration_redirect_spec.rb
+++ b/spec/requests/registration_redirect_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Registration redirect" do
+  describe "GET /registration" do
+    before { get "/registration" }
+
+    it { expect(response).to redirect_to("/") }
+    it { expect(response).to have_http_status(:moved_permanently) }
+  end
+
+  describe "GET /registration/:step still works" do
+    before { get "/registration/start" }
+
+    it { expect(response).to have_http_status(:success) }
+  end
+end


### PR DESCRIPTION
### Context

Ticket: [NPQ-3851](https://dfedigital.atlassian.net/browse/NPQ-3851)

Some traffic (around 90 hits per day) is going to `/registration` without a step. That path is a 404 because the only valid registration routes are `/registration/:step`. No code in the app links or redirects users there, so I think this is bot traffic. The path is listed in `robots.txt` (`Disallow: /registration`). Surely scanners check it.

### Changes proposed in this pull request

1. Add a route so `GET /registration` redirects to root (`/`).
2. Add a request spec to check the redirect works and that `/registration/:step` keeps working as before.

[NPQ-3851]: https://dfedigital.atlassian.net/browse/NPQ-3851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ