### PR TITLE
[BAU] do not use constantize on a param

### DIFF
--- a/app/controllers/npq_separation/admin/eligibility_lists_controller.rb
+++ b/app/controllers/npq_separation/admin/eligibility_lists_controller.rb
@@ -17,6 +17,15 @@ class NpqSeparation::Admin::EligibilityListsController < NpqSeparation::AdminCon
 
 private
 
+  BULK_OPERATION_MAPPING = {
+    "EligibilityList::Childminder" => BulkOperation::UploadEligibilityList::Childminder,
+    "EligibilityList::DisadvantagedEarlyYearsSchool" => BulkOperation::UploadEligibilityList::DisadvantagedEarlyYearsSchool,
+    "EligibilityList::LocalAuthorityNursery" => BulkOperation::UploadEligibilityList::LocalAuthorityNursery,
+    "EligibilityList::Pp50FurtherEducation" => BulkOperation::UploadEligibilityList::LocalAuthorityNursery::Pp50FurtherEducation,
+    "EligibilityList::Pp50School" => BulkOperation::UploadEligibilityList::LocalAuthorityNursery::Pp50School,
+    "EligibilityList::RiseSchool" => BulkOperation::UploadEligibilityList::RiseSchool,
+  }.freeze
+
   def set_bulk_operations
     bulk_operation_classes = BulkOperation::UploadEligibilityList.subclasses
     @bulk_operations = bulk_operation_classes.index_with do |bulk_operation_class|
@@ -30,7 +39,7 @@ private
   def set_bulk_operation
     @param_key = params.keys.select { |key| key.starts_with?("bulk_operation_upload_eligibility_list_") }.first
     eligibility_list_type = params.dig(@param_key, :eligibility_list_type)
-    bulk_operation_class = eligibility_list_type.constantize::BULK_OPERATION_CLASS
+    bulk_operation_class = BULK_OPERATION_MAPPING[eligibility_list_type]
     @bulk_operation = @bulk_operations[bulk_operation_class]
   end
 

--- a/app/models/eligibility_list/childminder.rb
+++ b/app/models/eligibility_list/childminder.rb
@@ -2,5 +2,4 @@ class EligibilityList::Childminder < EligibilityList::Entry
   IDENTIFIER_CSV_HEADERS = ["Childminder URN"].freeze
   IDENTIFIER_CSV_EXAMPLE = "CA000006\nEY248638\n225540".freeze
   IDENTIFIER_TYPE = :urn
-  BULK_OPERATION_CLASS = BulkOperation::UploadEligibilityList::Childminder
 end

--- a/app/models/eligibility_list/disadvantaged_early_years_school.rb
+++ b/app/models/eligibility_list/disadvantaged_early_years_school.rb
@@ -2,5 +2,4 @@ class EligibilityList::DisadvantagedEarlyYearsSchool < EligibilityList::Entry
   IDENTIFIER_CSV_HEADERS = ["Disadvantaged EY School URN", "Ofsted URN"].freeze
   IDENTIFIER_CSV_EXAMPLE = "150014,\n531156,EY555509".freeze
   IDENTIFIER_TYPE = :urn
-  BULK_OPERATION_CLASS = BulkOperation::UploadEligibilityList::DisadvantagedEarlyYearsSchool
 end

--- a/app/models/eligibility_list/local_authority_nursery.rb
+++ b/app/models/eligibility_list/local_authority_nursery.rb
@@ -2,5 +2,4 @@ class EligibilityList::LocalAuthorityNursery < EligibilityList::Entry
   IDENTIFIER_CSV_HEADERS = ["LA Nursery URN"].freeze
   IDENTIFIER_CSV_EXAMPLE = "123456\n112470".freeze
   IDENTIFIER_TYPE = :urn
-  BULK_OPERATION_CLASS = BulkOperation::UploadEligibilityList::LocalAuthorityNursery
 end

--- a/app/models/eligibility_list/pp50_further_education.rb
+++ b/app/models/eligibility_list/pp50_further_education.rb
@@ -2,5 +2,4 @@ class EligibilityList::Pp50FurtherEducation < EligibilityList::Entry
   IDENTIFIER_CSV_HEADERS = ["FE UKPRN"].freeze
   IDENTIFIER_CSV_EXAMPLE = "10000599\n10004502".freeze
   IDENTIFIER_TYPE = :ukprn
-  BULK_OPERATION_CLASS = BulkOperation::UploadEligibilityList::Pp50FurtherEducation
 end

--- a/app/models/eligibility_list/pp50_school.rb
+++ b/app/models/eligibility_list/pp50_school.rb
@@ -2,5 +2,4 @@ class EligibilityList::Pp50School < EligibilityList::Entry
   IDENTIFIER_CSV_HEADERS = ["PP50 School URN"].freeze
   IDENTIFIER_CSV_EXAMPLE = "100000\n100006".freeze
   IDENTIFIER_TYPE = :urn
-  BULK_OPERATION_CLASS = BulkOperation::UploadEligibilityList::Pp50School
 end

--- a/app/models/eligibility_list/rise_school.rb
+++ b/app/models/eligibility_list/rise_school.rb
@@ -2,5 +2,4 @@ class EligibilityList::RiseSchool < EligibilityList::Entry
   IDENTIFIER_CSV_HEADERS = ["RISE School URN"].freeze
   IDENTIFIER_CSV_EXAMPLE = "112543\n112578".freeze
   IDENTIFIER_TYPE = :urn
-  BULK_OPERATION_CLASS = BulkOperation::UploadEligibilityList::RiseSchool
 end


### PR DESCRIPTION
### Context

BAU

avoid using `constantize` on a parameter

### Changes proposed in this pull request

1. use a mapping hash instead of `constantize`
