### PR TITLE
[BAU] use `system` correctly so it sanitizes shell inputs

### DIFF
--- a/app/services/registration_wizard_visualiser.rb
+++ b/app/services/registration_wizard_visualiser.rb
@@ -2,8 +2,8 @@ require "method_source"
 
 class RegistrationWizardVisualiser
   class << self
-    def call(generate_image: true)
-      new.call(generate_image:)
+    def call
+      new.call
     end
   end
 
@@ -83,12 +83,12 @@ class RegistrationWizardVisualiser
     margin: "25,15",
   }.freeze
 
-  def call(generate_image: true)
+  def call
     Rails.logger.debug("Generating .dot file")
 
     make_output_dir
     save_graphviz_output
-    generate_png_output if generate_image
+    generate_png_output
   end
 
 private
@@ -110,21 +110,21 @@ private
   end
 
   def output_dot_filename
-    output_dir.join("registration_wizard_visualisation.dot")
+    output_dir.join("registration_wizard_visualisation.dot").to_s
   end
 
   def output_png_filename
-    output_dir.join("registration_wizard_visualisation.png")
+    output_dir.join("registration_wizard_visualisation.png").to_s
   end
 
   def generate_png_output
     Rails.logger.debug("Generating #{output_png_filename}")
-    generate_png_command = "dot -Tpng #{output_dot_filename} -o #{output_png_filename}"
+    generate_png_command_array = "dot", "-Tpng", output_dot_filename, "-o", output_png_filename
 
-    Rails.logger.debug(generate_png_command)
-    system(generate_png_command)
+    Rails.logger.debug(generate_png_command_array.join(" "))
+    result = system(*generate_png_command_array)
 
-    raise "Graph generation failed" unless $CHILD_STATUS.exitstatus.zero?
+    raise "Graph generation failed" unless result
   end
 
   def save_file(name, content)

--- a/spec/services/registration_wizard_visualiser_spec.rb
+++ b/spec/services/registration_wizard_visualiser_spec.rb
@@ -1,14 +1,30 @@
 require "rails_helper"
 
 RSpec.describe RegistrationWizardVisualiser do
-  before { FileUtils.rm_rf Rails.root.join("tmp/visualisations_test") }
+  let(:dot_file) { Rails.root.join("tmp/visualisations_test/registration_wizard_visualisation.dot") }
+  let(:png_file) { Rails.root.join("tmp/visualisations_test/registration_wizard_visualisation.png") }
 
-  let :dot_file do
-    Rails.root.join("tmp/visualisations_test/registration_wizard_visualisation.dot")
+  before do
+    FileUtils.rm_rf dot_file
+    allow_any_instance_of(Object).to receive(:system).and_return(true)
   end
 
-  it "generates an dot graph of the wizard" do
-    expect { described_class.call(generate_image: false) }
-      .to change(dot_file, :exist?).from(false).to(true)
+  describe ".call" do
+    subject { described_class.call }
+
+    it "generates an dot graph of the wizard" do
+      expect { subject }.to change(dot_file, :exist?).from(false).to(true)
+    end
+
+    it "generates a PNG of the wizard" do
+      expect_any_instance_of(Object).to receive(:system).with(
+        "dot",
+        "-Tpng",
+        dot_file.to_s,
+        "-o",
+        png_file.to_s,
+      )
+      subject
+    end
   end
 end


### PR DESCRIPTION
### Context

use `system` correctly so it sanitises its inputs

### Changes proposed in this pull request

1. use `system` correctly, with multiple parameters
2. fix test to test system call is made correctly - stubbing the call the `system` for speed and test reliability
