### PR TITLE
[BAU] make release note content html_safe

### DIFF
--- a/app/views/api/guidance/index.html.erb
+++ b/app/views/api/guidance/index.html.erb
@@ -29,7 +29,7 @@
         <p class="govuk-body">
           <%= govuk_link_to(@latest_release_note.date, api_guidance_page_path(page: "release-notes", anchor: @latest_release_note.date.parameterize)) %>
         </p>
-        <%= @latest_release_note.content.html_safe %>
+        <%= sanitize(@latest_release_note.content.html_safe) %>
         <p class="govuk-body">
           <%= govuk_link_to("Browse our latest release notes", api_guidance_page_path(page: "release-notes")) %>
         </p>


### PR DESCRIPTION
### Context

BAU

do not use `.html_safe` in views

### Changes proposed in this pull request

1. the `ReleaseNote` content is now marked as `html_safe` in the model

### Notes
you can see the rendered release notes here: https://npq-registration-review-3443-web.test.teacherservices.cloud/api/guidance/release-notes