### PR TITLE
[NPQ-3786] Prevent blank TRNs from being verified

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,6 +34,7 @@ class User < ApplicationRecord
 
   validates :uid, uniqueness: { allow_blank: true }
   validates :ecf_id, uniqueness: { case_sensitive: false }
+  validates :trn_verified, absence: true, if: -> { trn.blank? }
 
   after_commit :touch_significantly_updated_at
 

--- a/app/services/users/find_or_create_from_teacher_auth.rb
+++ b/app/services/users/find_or_create_from_teacher_auth.rb
@@ -45,7 +45,7 @@ module Users
             always_updated_attributes.merge(
               email:,
               trn:,
-              trn_verified: true,
+              trn_verified: trn.present?,
             ),
           )
           persist_token(user_matched_using_uid, provider_data)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -326,6 +326,8 @@ en:
               taken: "Email address must be unique"
             ecf_id:
               *ecf_id
+            trn_verified:
+              present: "TRN cannot be marked as verified when it is blank"
   activemodel:
     attributes:
       questionnaires/funding_your_npq:

--- a/db/migrate/20260624114119_add_trn_present_when_verified_constraint_to_users.rb
+++ b/db/migrate/20260624114119_add_trn_present_when_verified_constraint_to_users.rb
@@ -1,0 +1,10 @@
+class AddTrnPresentWhenVerifiedConstraintToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint(
+      :users,
+      "NOT trn_verified OR (trn IS NOT NULL AND trn <> '')",
+      name: "users_trn_present_when_verified",
+      validate: false,
+    )
+  end
+end

--- a/db/migrate/20260624114119_add_trn_present_when_verified_constraint_to_users.rb
+++ b/db/migrate/20260624114119_add_trn_present_when_verified_constraint_to_users.rb
@@ -1,10 +1,24 @@
 class AddTrnPresentWhenVerifiedConstraintToUsers < ActiveRecord::Migration[8.0]
-  def change
+  def up
+    # Clean rows that would fail the constraint before adding it.
+    safety_assured do
+      execute(<<~SQL)
+        UPDATE users
+        SET trn_verified = false
+        WHERE trn_verified = true
+          AND (trn IS NULL OR trn = '')
+      SQL
+    end
+
     add_check_constraint(
       :users,
       "NOT trn_verified OR (trn IS NOT NULL AND trn <> '')",
       name: "users_trn_present_when_verified",
       validate: false,
     )
+  end
+
+  def down
+    remove_check_constraint :users, name: "users_trn_present_when_verified"
   end
 end

--- a/db/migrate/20260624114120_validate_trn_present_when_verified_constraint_on_users.rb
+++ b/db/migrate/20260624114120_validate_trn_present_when_verified_constraint_on_users.rb
@@ -1,17 +1,7 @@
 class ValidateTrnPresentWhenVerifiedConstraintOnUsers < ActiveRecord::Migration[8.0]
-  def up
-    # Clean rows that would fail the constraint before validating it.
-    safety_assured do
-      execute(<<~SQL)
-        UPDATE users
-        SET trn_verified = false
-        WHERE trn_verified = true
-          AND (trn IS NULL OR trn = '')
-      SQL
-    end
+  disable_ddl_transaction!
 
+  def change
     validate_check_constraint :users, name: "users_trn_present_when_verified"
   end
-
-  def down; end
 end

--- a/db/migrate/20260624114120_validate_trn_present_when_verified_constraint_on_users.rb
+++ b/db/migrate/20260624114120_validate_trn_present_when_verified_constraint_on_users.rb
@@ -1,0 +1,17 @@
+class ValidateTrnPresentWhenVerifiedConstraintOnUsers < ActiveRecord::Migration[8.0]
+  def up
+    # Clean rows that would fail the constraint before validating it.
+    safety_assured do
+      execute(<<~SQL)
+        UPDATE users
+        SET trn_verified = false
+        WHERE trn_verified = true
+          AND (trn IS NULL OR trn = '')
+      SQL
+    end
+
+    validate_check_constraint :users, name: "users_trn_present_when_verified"
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_12_142546) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_24_114120) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -689,6 +689,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_12_142546) do
     t.index ["significantly_updated_at"], name: "index_users_on_significantly_updated_at"
     t.index ["trn"], name: "index_users_on_trn"
     t.index ["uid"], name: "index_users_on_uid", unique: true
+    t.check_constraint "NOT trn_verified OR trn IS NOT NULL AND trn <> ''::text", name: "users_trn_present_when_verified"
     t.check_constraint "email IS NOT NULL OR archived_email IS NOT NULL AND archived_at IS NOT NULL", name: "users_email_null_only_when_archived"
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe User do
       expect(user).not_to be_valid
     end
 
-    it "allows a verified trn when the trn is present" do
+    it "allows trn_verified when the TRN is present" do
       user = build(:user, :with_verified_trn, trn: "1234567")
       expect(user).to be_valid
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe User do
   end
 
   describe "database constraints" do
-    it "rejects a blank trn marked as verified" do
+    it "rejects a blank TRN marked as verified" do
       expect {
         create(:user, trn: nil).update_column(:trn_verified, true)
       }.to raise_error(ActiveRecord::StatementInvalid, /users_trn_present_when_verified/)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -79,6 +79,35 @@ RSpec.describe User do
       user = build(:user, email: nil)
       expect(user).not_to be_valid
     end
+
+    it "allows a verified trn when the trn is present" do
+      user = build(:user, :with_verified_trn, trn: "1234567")
+      expect(user).to be_valid
+    end
+
+    it "does not allow trn_verified when the trn is nil" do
+      user = build(:user, :with_verified_trn, trn: nil)
+      expect(user).not_to be_valid
+      expect(user.errors[:trn_verified]).to include("TRN cannot be marked as verified when it is blank")
+    end
+
+    it "does not allow trn_verified when the trn is blank" do
+      user = build(:user, :with_verified_trn, trn: "")
+      expect(user).not_to be_valid
+    end
+
+    it "allows a blank trn when it is not verified" do
+      user = build(:user, trn: nil, trn_verified: false)
+      expect(user).to be_valid
+    end
+  end
+
+  describe "database constraints" do
+    it "rejects a blank trn marked as verified" do
+      expect {
+        create(:user, trn: nil).update_column(:trn_verified, true)
+      }.to raise_error(ActiveRecord::StatementInvalid, /users_trn_present_when_verified/)
+    end
   end
 
   describe "scopes" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe User do
       expect(user).not_to be_valid
     end
 
-    it "allows a blank trn when it is not verified" do
+    it "allows a blank TRN when it is not verified" do
       user = build(:user, trn: nil, trn_verified: false)
       expect(user).to be_valid
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -194,17 +194,6 @@ RSpec.describe User do
       it "returns only users with a verified TRN" do
         expect(User.with_trn("1234567")).to contain_exactly(user_with_verified_trn)
       end
-
-      # can be removed when constraint added (NPQ-3786)
-      context "when the TRN is blank" do
-        let(:user_with_blank_trn) { create(:user, trn: nil, trn_verified: true) }
-
-        before { user_with_blank_trn }
-
-        it "does not retrun users with a blank TRN" do
-          expect(User.with_trn(nil)).to be_empty
-        end
-      end
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe User do
       expect(user.errors[:trn_verified]).to include("TRN cannot be marked as verified when it is blank")
     end
 
-    it "does not allow trn_verified when the trn is blank" do
+    it "does not allow trn_verified when the TRN is blank" do
       user = build(:user, :with_verified_trn, trn: "")
       expect(user).not_to be_valid
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe User do
       expect(user).to be_valid
     end
 
-    it "does not allow trn_verified when the trn is nil" do
+    it "does not allow trn_verified when the TRN is nil" do
       user = build(:user, :with_verified_trn, trn: nil)
       expect(user).not_to be_valid
       expect(user.errors[:trn_verified]).to include("TRN cannot be marked as verified when it is blank")

--- a/spec/services/users/find_or_create_from_teacher_auth_spec.rb
+++ b/spec/services/users/find_or_create_from_teacher_auth_spec.rb
@@ -66,6 +66,8 @@ RSpec.describe Users::FindOrCreateFromTeacherAuth do
   end
 
   before do
+    create(:user, trn:, trn_verified: trn.present?, archived_at: 1.day.ago)
+
     if trn.present?
       stub_person_api
         .to_return(status: 200, body: { previousNames: api_previous_names }.to_json)
@@ -343,7 +345,7 @@ RSpec.describe Users::FindOrCreateFromTeacherAuth do
 
         it "updates the verified TRN on the user" do
           subject
-          expect(existing_user.reload).to have_attributes(trn:, trn_verified: true, trn_auto_verified: true)
+          expect(existing_user.reload).to have_attributes(trn:, trn_verified: trn.present?, trn_auto_verified: true)
         end
       end
 
@@ -520,16 +522,6 @@ RSpec.describe Users::FindOrCreateFromTeacherAuth do
     it "does not mark the nil TRN as verified" do
       subject
       expect(User.last).to have_attributes(trn: nil, trn_verified: false, trn_auto_verified: false)
-    end
-
-    context "when there is a user with a nil TRN, marked as verified" do
-      # users were created like this before NPQ-3783
-      # this test can be removed when database constraint added (NPQ-3786)
-      before { create(:user, :with_teacher_auth, trn: nil, trn_verified: true) }
-
-      it "does not match users with nil TRNs, but instead creates a new user" do
-        expect { subject }.to change(User, :count).by(1)
-      end
     end
 
     context "when there is a GAI user with a nil TRN but matching email" do

--- a/spec/services/users/find_or_create_from_teacher_auth_spec.rb
+++ b/spec/services/users/find_or_create_from_teacher_auth_spec.rb
@@ -66,8 +66,6 @@ RSpec.describe Users::FindOrCreateFromTeacherAuth do
   end
 
   before do
-    create(:user, trn:, trn_verified: trn.present?, archived_at: 1.day.ago)
-
     if trn.present?
       stub_person_api
         .to_return(status: 200, body: { previousNames: api_previous_names }.to_json)


### PR DESCRIPTION
### Context

Ticket: [NPQ-3786](https://dfedigital.atlassian.net/browse/NPQ-3786)

It should not be possible to have a user with a TRN that is blank but marked as verified. We add a model validation and a database constraint to stop this.

### Changes proposed in this pull request

1. Add a model validation to `User` so `trn_verified` cannot be `true` when the TRN is blank.
2. Add a database check constraint for the same rule, in two migrations: the first adds it with `validate: false`, the second validates it.
3. Before validating the constraint, the second migration cleans any rows that would break it: it sets `trn_verified` to `false` where the TRN is null or empty.
4. Fix `Users::FindOrCreateFromTeacherAuth` which set `trn_verified` to `true` even when the incoming TRN was blank. Now it only marks the TRN as verified when the TRN is present.
5. Update specs, and remove an old test that is no longer possible now the constraint exists.

### Notes

The data cleanup runs as part of the migration, so all environments are fixed automatically on deploy.


[NPQ-3786]: https://dfedigital.atlassian.net/browse/NPQ-3786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ