### PR TITLE
[NPQ-3450] schedule cron jobs on deployment

### DIFF
--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -12,6 +12,7 @@
 # https://github.com/codez/delayed_cron_job#custom-cronjob-superclass
 class CronJob < ApplicationJob
   class_attribute :cron_expression
+  class_attribute :production_only, default: false
 
   class << self
     # Schedules the cron job, ensuring that it is not rescheduled while already in progress.

--- a/app/jobs/crons/check_analytics_entity.rb
+++ b/app/jobs/crons/check_analytics_entity.rb
@@ -1,6 +1,9 @@
 class Crons::CheckAnalyticsEntity < CronJob
   include Sentry::Cron::MonitorCheckIns
 
+  self.production_only = true
+
+  # run every day at 2 AM
   self.cron_expression = "0 2 * * *"
 
   sentry_monitor_check_ins slug: "check-analytics-entity"

--- a/app/jobs/crons/enqueue_token_refreshes_job.rb
+++ b/app/jobs/crons/enqueue_token_refreshes_job.rb
@@ -1,6 +1,7 @@
 class Crons::EnqueueTokenRefreshesJob < CronJob
   include Sentry::Cron::MonitorCheckIns
 
+  # run every hour at 0 minutes past
   self.cron_expression = "0 * * * *"
 
   sentry_monitor_check_ins slug: "enqueue-token-refreshes"

--- a/app/jobs/crons/mark_statements_as_payable_job.rb
+++ b/app/jobs/crons/mark_statements_as_payable_job.rb
@@ -1,7 +1,7 @@
 class Crons::MarkStatementsAsPayableJob < CronJob
   include Sentry::Cron::MonitorCheckIns
 
-  # run at 12AM every day
+  # run every day at midnight
   self.cron_expression = "0 0 * * *"
 
   sentry_monitor_check_ins slug: "mark-statements-as-payable"

--- a/app/jobs/crons/output_statement_notifications_job.rb
+++ b/app/jobs/crons/output_statement_notifications_job.rb
@@ -1,6 +1,8 @@
 class Crons::OutputStatementNotificationsJob < CronJob
   include Sentry::Cron::MonitorCheckIns
 
+  self.production_only = true
+
   # run on the 1st of every month at 8:30 AM
   self.cron_expression = "30 8 1 * *"
 

--- a/app/jobs/crons/sentry_healthcheck_job.rb
+++ b/app/jobs/crons/sentry_healthcheck_job.rb
@@ -2,7 +2,9 @@
 class Crons::SentryHealthcheckJob < CronJob
   include Sentry::Cron::MonitorCheckIns
 
-  # run every hour
+  self.production_only = true
+
+  # run every hour at midnight
   self.cron_expression = "0 * * * *"
 
   sentry_monitor_check_ins slug: "sentry-healthcheck"

--- a/app/jobs/crons/sentry_healthcheck_job.rb
+++ b/app/jobs/crons/sentry_healthcheck_job.rb
@@ -4,7 +4,7 @@ class Crons::SentryHealthcheckJob < CronJob
 
   self.production_only = true
 
-  # run every hour at midnight
+  # run every hour at 0 minutes past
   self.cron_expression = "0 * * * *"
 
   sentry_monitor_check_ins slug: "sentry-healthcheck"

--- a/app/jobs/crons/sweep_stale_sessions_job.rb
+++ b/app/jobs/crons/sweep_stale_sessions_job.rb
@@ -1,7 +1,7 @@
 class Crons::SweepStaleSessionsJob < CronJob
   include Sentry::Cron::MonitorCheckIns
 
-  # run at 3:30 AM every day
+  # run every day at 3:30 AM
   self.cron_expression = "30 3 * * *"
 
   sentry_monitor_check_ins slug: "sweep-stale-sessions"

--- a/app/jobs/crons/update_schools_job.rb
+++ b/app/jobs/crons/update_schools_job.rb
@@ -1,7 +1,7 @@
 class Crons::UpdateSchoolsJob < CronJob
   include Sentry::Cron::MonitorCheckIns
 
-  # run at 4:30 AM every day
+  # run every day at 4:30 AM
   self.cron_expression = "30 4 * * *"
 
   sentry_monitor_check_ins slug: "update-schools"

--- a/lib/tasks/delayed_cron_job.rake
+++ b/lib/tasks/delayed_cron_job.rake
@@ -41,7 +41,7 @@ private
       cron_job = cron_job_class_constant(cron_job_class)
 
       if cron_job
-        next unless cron_job.cron_expression != delayed_job.cron
+        next if cron_job.cron_expression == delayed_job.cron
 
         logger.info "delayed job found with out-of-date cron expression - rescheduling cron job: #{cron_job_class}"
         delayed_job.destroy!

--- a/lib/tasks/delayed_cron_job.rake
+++ b/lib/tasks/delayed_cron_job.rake
@@ -1,0 +1,79 @@
+class DelayedCronJobRakeTask
+  include Rake::DSL
+
+  def initialize
+    namespace :delayed_cron_job do
+      desc "Schedule or delete delayed cron jobs"
+      task schedule: :versioned_environment do
+        # Need to load all jobs definitions in order to find subclasses
+        # based on: https://github.com/codez/delayed_cron_job#automatic-scheduling-after-dbmigrate
+        glob = Rails.root.join("app/jobs/**/*_job.rb")
+        Dir.glob(glob).each { |file| require file }
+
+        Delayed::Job.transaction do
+          Delayed::Job.with_advisory_lock!("lock-delayed-cron-job", blocking: true, transaction: true) do
+            handle_new_cron_jobs
+            handle_existing_cron_delayed_jobs
+          end
+        end
+      end
+    end
+  end
+
+private
+
+  def handle_new_cron_jobs
+    CronJob.subclasses.each do |cron_job_class|
+      if cron_job_class.scheduled?
+        logger.info "cron job already scheduled: #{cron_job_class}"
+      else
+        next if cron_job_class.production_only && !Rails.env.production?
+
+        logger.info "scheduling new cron job: #{cron_job_class}"
+        cron_job_class.schedule
+      end
+    end
+  end
+
+  def handle_existing_cron_delayed_jobs
+    cron_delayed_jobs.each do |delayed_job|
+      cron_job_class = cron_job_class(delayed_job)
+      cron_job = cron_job_class_constant(cron_job_class)
+
+      if cron_job
+        next unless cron_job.cron_expression != delayed_job.cron
+
+        logger.info "delayed job found with out-of-date cron expression - rescheduling cron job: #{cron_job_class}"
+        delayed_job.destroy!
+        cron_job.schedule
+      else
+        logger.info "delayed job found for deleted cron job - deleting delayed job"
+        delayed_job.destroy!
+      end
+    end
+  end
+
+  def cron_job_class(delayed_job)
+    delayed_job.payload_object.job_data["job_class"]
+  end
+
+  def cron_delayed_jobs
+    Delayed::Job.where.not(cron: nil)
+  end
+
+  def cron_job_class_constant(cron_job_class)
+    cron_job_class.constantize
+  rescue NameError
+    nil
+  end
+
+  def logger
+    @logger ||= Rails.env.test? ? Rails.logger : Logger.new($stdout)
+  end
+end
+
+DelayedCronJobRakeTask.new
+
+Rake::Task["db:migrate"].enhance do
+  Rake::Task["delayed_cron_job:schedule"].invoke
+end

--- a/lib/tasks/delayed_cron_job.rake
+++ b/lib/tasks/delayed_cron_job.rake
@@ -41,13 +41,19 @@ private
       cron_job = cron_job_class_constant(cron_job_class)
 
       if cron_job
+        if cron_job.production_only && !Rails.env.production?
+          logger.info "delayed job has changed to production only - deleting delayed job: #{cron_job_class}"
+          delayed_job.destroy!
+          next
+        end
+
         next if cron_job.cron_expression == delayed_job.cron
 
         logger.info "delayed job found with out-of-date cron expression - rescheduling cron job: #{cron_job_class}"
         delayed_job.destroy!
         cron_job.schedule
       else
-        logger.info "delayed job found for deleted cron job - deleting delayed job"
+        logger.info "delayed job found for deleted cron job - deleting delayed job: #{cron_job_class}"
         delayed_job.destroy!
       end
     end

--- a/lib/tasks/jobs.rake
+++ b/lib/tasks/jobs.rake
@@ -1,8 +1,0 @@
-namespace :db do
-  desc "Schedule all cron jobs"
-  task schedule_jobs: :versioned_environment do
-    glob = Rails.root.join("app/jobs/**/*_job.rb")
-    Dir.glob(glob).each { |file| require file }
-    CronJob.subclasses.each(&:schedule)
-  end
-end

--- a/spec/lib/tasks/delayed_cron_job_spec.rb
+++ b/spec/lib/tasks/delayed_cron_job_spec.rb
@@ -115,6 +115,26 @@ RSpec.describe "Delayed::Cron::Job tasks" do
       end
     end
 
+    context "when a cron job is changed from 'all environments allowed' to production-only" do
+      let(:current_cron_jobs) { [ScheduledCronJob] }
+
+      before do
+        scheduled_job = Delayed::Job.enqueue ActiveJob::QueueAdapters::DelayedJobAdapter::JobWrapper.new("job_class" => ScheduledCronJob.to_s)
+        scheduled_job.update!(cron: "31 1 * * *")
+        stub_const("ScheduledCronJob", production_only_cron_job_class)
+      end
+
+      it_behaves_like "using an advisory lock"
+
+      it "deletes the delayed job for the deleted cron job" do
+        expect { run_task }.to change(cron_delayed_jobs, :count).from(1).to(0)
+      end
+
+      it "does not re-schedule to cron job" do
+        expect { run_task }.not_to have_enqueued_job
+      end
+    end
+
     context "when the cron schedule changes on an existing cron job" do
       let(:current_cron_jobs) { [ScheduledCronJob] }
 

--- a/spec/lib/tasks/delayed_cron_job_spec.rb
+++ b/spec/lib/tasks/delayed_cron_job_spec.rb
@@ -1,0 +1,147 @@
+require "rails_helper"
+
+RSpec.describe "Delayed::Cron::Job tasks" do
+  describe "delayed_cron_job:schedule" do
+    include ActiveJob::TestHelper
+
+    subject(:run_task) { Rake::Task["delayed_cron_job:schedule"].invoke }
+
+    after { Rake::Task["delayed_cron_job:schedule"].reenable }
+
+    let(:current_cron_jobs) { [] }
+    let(:all_delayed_jobs) { Delayed::Job }
+    let(:cron_delayed_jobs) { Delayed::Job.where.not(cron: nil) }
+
+    let(:scheduled_cron_job_class) do
+      Class.new(CronJob) do
+        self.cron_expression = "31 1 * * *"
+
+        def self.scheduled?
+          true
+        end
+
+        def self.delayed_job
+          Delayed::Job.new
+        end
+      end
+    end
+
+    let(:not_scheduled_cron_job_class) do
+      Class.new(CronJob) do
+        def self.scheduled?
+          false
+        end
+      end
+    end
+
+    let(:production_only_cron_job_class) do
+      Class.new(CronJob) do
+        self.production_only = true
+
+        def self.scheduled?
+          false
+        end
+      end
+    end
+
+    before do
+      stub_const("ScheduledCronJob", scheduled_cron_job_class)
+      stub_const("NotScheduledCronJob", not_scheduled_cron_job_class)
+      stub_const("NonCronJob", Class.new(ApplicationJob))
+      stub_const("ProductionOnlyNotScheduledCronJob", production_only_cron_job_class)
+      allow(CronJob).to receive(:subclasses).and_return(current_cron_jobs)
+    end
+
+    shared_examples_for "using an advisory lock" do
+      it "uses an advisory lock" do
+        expect(Delayed::Job).to receive(:with_advisory_lock!)
+          .with("lock-delayed-cron-job", blocking: true, transaction: true)
+          .and_yield
+        subject
+      end
+    end
+
+    context "when there is a new delayed cron job" do
+      let(:current_cron_jobs) { [ScheduledCronJob, NotScheduledCronJob] }
+
+      before { ScheduledCronJob.schedule }
+
+      it_behaves_like "using an advisory lock"
+
+      it "schedules the new cron job" do
+        expect { run_task }.to have_enqueued_job(NotScheduledCronJob)
+      end
+
+      it "does not schedule the existing cron job" do
+        expect { run_task }.not_to have_enqueued_job(ScheduledCronJob)
+      end
+
+      context "when the cron job is production only" do
+        let(:current_cron_jobs) { [ScheduledCronJob, ProductionOnlyNotScheduledCronJob] }
+
+        context "and the environment is production" do
+          before { allow(Rails).to receive(:env) { "production".inquiry } }
+
+          it "schedules the new cron job" do
+            expect { run_task }.to have_enqueued_job(ProductionOnlyNotScheduledCronJob)
+          end
+        end
+
+        context "and the environment is not production" do
+          it "does not schedule the new cron job" do
+            expect { run_task }.not_to have_enqueued_job(ProductionOnlyNotScheduledCronJob)
+          end
+        end
+      end
+    end
+
+    context "when there is a deleted delayed cron job" do
+      let(:current_cron_jobs) { [ScheduledCronJob] }
+
+      before do
+        scheduled_job = Delayed::Job.enqueue ActiveJob::QueueAdapters::DelayedJobAdapter::JobWrapper.new("job_class" => ScheduledCronJob.to_s)
+        scheduled_job.update!(cron: "31 1 * * *")
+        deleted_job = Delayed::Job.enqueue ActiveJob::QueueAdapters::DelayedJobAdapter::JobWrapper.new("job_class" => "DeletedCronJob")
+        deleted_job.update!(cron: "31 1 * * *")
+        Delayed::Job.enqueue NonCronJob.new
+      end
+
+      it_behaves_like "using an advisory lock"
+
+      it "deletes the delayed job for the deleted cron job" do
+        expect { run_task }.to change(all_delayed_jobs, :count).from(3).to(2)
+          .and(change(cron_delayed_jobs, :count).from(2).to(1))
+        expect(cron_delayed_jobs.first.payload_object.job_data["job_class"]).to eq ScheduledCronJob.to_s
+      end
+    end
+
+    context "when the cron schedule changes on an existing cron job" do
+      let(:current_cron_jobs) { [ScheduledCronJob] }
+
+      before do
+        scheduled_job = Delayed::Job.enqueue ActiveJob::QueueAdapters::DelayedJobAdapter::JobWrapper.new("job_class" => ScheduledCronJob.to_s)
+        scheduled_job.update!(cron: "31 2 * * *")
+      end
+
+      it_behaves_like "using an advisory lock"
+
+      it "reschedules the job" do
+        expect { run_task }.to change(cron_delayed_jobs, :count).from(1).to(0).and have_enqueued_job(ScheduledCronJob)
+      end
+    end
+
+    context "when db:migrate is run" do
+      let(:rake_task_stub) { instance_double(Rake::Task, reenable: true) }
+
+      before do
+        allow(Rake::Task).to receive(:[]).and_call_original
+        allow(Rake::Task).to receive(:[]).with("delayed_cron_job:schedule").and_return(rake_task_stub)
+      end
+
+      it "invokes the delayed_cron_job:schedule task" do
+        expect(rake_task_stub).to receive(:invoke)
+        Rake::Task["db:migrate"].invoke
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: [NPQ-3450](https://dfedigital.atlassian.net/browse/NPQ-3450)

[Brief description of objective driving this change]

### Changes proposed in this pull request

1. if there is a new `CronJob` class that has not been scheduled - schedule it
2. if there is a delayed cron job that refers to a `CronJob` class that has been deleted - delete the delayed cron jobs
3. if there is a delayed cron job whose cron expression does not match that defined on the `CronJob` class, delete and reschedule the job
4. use an advisory lock to prevent concurrent instances of updating the jobs at the same time
5. add a `production_only` attribute to delayed cron jobs, so only certain jobs are scheduled on staging/sandbox environments
6. review app environments have no cron jobs scheduled, because `db:seed:replant` removes them all
7. run all of this when `db:migrate` is run


[NPQ-3450]: https://dfedigital.atlassian.net/browse/NPQ-3450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ