### PR TITLE
[BAU] enable person.deactivated webhook

### DIFF
--- a/app/models/get_an_identity/webhook_message.rb
+++ b/app/models/get_an_identity/webhook_message.rb
@@ -21,6 +21,8 @@ class GetAnIdentity::WebhookMessage < ApplicationRecord
       TeachingRecordSystem::Webhooks::UserUpdatedProcessor
     when "trn_request.completed"
       TeachingRecordSystem::Webhooks::TrnRequestCompletedProcessor
+    when "person.deactivated"
+      TeachingRecordSystem::Webhooks::PersonDeactivatedProcessor
     end
   end
 

--- a/spec/models/get_an_identity/webhook_message_spec.rb
+++ b/spec/models/get_an_identity/webhook_message_spec.rb
@@ -61,5 +61,13 @@ RSpec.describe GetAnIdentity::WebhookMessage, type: :model do
         expect(subject.processor_klass).to eq(TeachingRecordSystem::Webhooks::TrnRequestCompletedProcessor)
       end
     end
+
+    context "when message_type is person.deactivated" do
+      subject { build(:trs_person_deactivated_webhook_message) }
+
+      it "returns a processor class" do
+        expect(subject.processor_klass).to eq(TeachingRecordSystem::Webhooks::PersonDeactivatedProcessor)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

BAU

The `TeachingRecordSystem::Webhooks::PersonDeactivatedProcessor` was merged, but it was not added to the list of supported processors.

### Changes proposed in this pull request

1. Add `TeachingRecordSystem::Webhooks::PersonDeactivatedProcessor` as the supported processor for `person.deactivated` webhook messages
