### PR TITLE
[NPQ-3858] TRN allocated email

### DIFF
--- a/app/jobs/teaching_record_system/allocate_trn_job.rb
+++ b/app/jobs/teaching_record_system/allocate_trn_job.rb
@@ -16,7 +16,9 @@ module TeachingRecordSystem
       if new_trn.present?
         # Received TRN from API response so don't need to wait for webhook to receive TRN
         user.update!(trn: new_trn, trn_verified: true, trn_auto_verified: true)
-        TrnAllocatedMailer.trn_allocated_mail(to: user.email, full_name: user.full_name, trn: new_trn).deliver_now
+        if user.email.present?
+          TrnAllocatedMailer.trn_allocated_mail(to: user.email, full_name: user.full_name, trn: new_trn).deliver_now
+        end
       end
 
       user.refresh_token.destroy!

--- a/app/jobs/teaching_record_system/allocate_trn_job.rb
+++ b/app/jobs/teaching_record_system/allocate_trn_job.rb
@@ -16,6 +16,7 @@ module TeachingRecordSystem
       if new_trn.present?
         # Received TRN from API response so don't need to wait for webhook to receive TRN
         user.update!(trn: new_trn, trn_verified: true, trn_auto_verified: true)
+        TrnAllocatedMailer.trn_allocated_mail(to: user.email, full_name: user.full_name, trn: new_trn).deliver_now
       end
 
       user.refresh_token.destroy!

--- a/app/mailers/trn_allocated_mailer.rb
+++ b/app/mailers/trn_allocated_mailer.rb
@@ -1,0 +1,12 @@
+class TrnAllocatedMailer < ApplicationMailer
+  TEMPLATE_ID = "208495e9-7cfc-4fc6-abb4-30df2c5329c4".freeze
+
+  def trn_allocated_mail(to:, full_name:, trn:)
+    template_mail(TEMPLATE_ID,
+                  to:,
+                  personalisation: {
+                    full_name:,
+                    trn:,
+                  })
+  end
+end

--- a/app/services/teaching_record_system/webhooks/trn_request_completed_processor.rb
+++ b/app/services/teaching_record_system/webhooks/trn_request_completed_processor.rb
@@ -6,7 +6,7 @@ module TeachingRecordSystem
       def process!
         user.update!(trn: new_trn, trn_verified: true, trn_auto_verified: true)
 
-        if user.trn_previously_changed?(from: nil)
+        if user.trn_previously_changed?(from: nil) && user.email.present?
           TrnAllocatedMailer.trn_allocated_mail(to: user.email, full_name: user.full_name, trn: new_trn).deliver_later
         end
       end

--- a/app/services/teaching_record_system/webhooks/trn_request_completed_processor.rb
+++ b/app/services/teaching_record_system/webhooks/trn_request_completed_processor.rb
@@ -5,7 +5,10 @@ module TeachingRecordSystem
 
       def process!
         user.update!(trn: new_trn, trn_verified: true, trn_auto_verified: true)
-        TrnAllocatedMailer.trn_allocated_mail(to: user.email, full_name: user.full_name, trn: new_trn).deliver_later
+
+        if user.trn_previously_changed?(from: nil)
+          TrnAllocatedMailer.trn_allocated_mail(to: user.email, full_name: user.full_name, trn: new_trn).deliver_later
+        end
       end
 
     private

--- a/app/services/teaching_record_system/webhooks/trn_request_completed_processor.rb
+++ b/app/services/teaching_record_system/webhooks/trn_request_completed_processor.rb
@@ -5,6 +5,7 @@ module TeachingRecordSystem
 
       def process!
         user.update!(trn: new_trn, trn_verified: true, trn_auto_verified: true)
+        TrnAllocatedMailer.trn_allocated_mail(to: user.email, full_name: user.full_name, trn: new_trn).deliver_later
       end
 
     private

--- a/spec/jobs/teaching_record_system/allocate_trn_job_spec.rb
+++ b/spec/jobs/teaching_record_system/allocate_trn_job_spec.rb
@@ -48,6 +48,11 @@ RSpec.describe TeachingRecordSystem::AllocateTrnJob, type: :job do
         expect(TeachingRecordSystem::RefreshTokens).not_to have_received(:refresh!)
         expect(TeachingRecordSystem::ActivateTrnRequest).not_to have_received(:activate!)
       end
+
+      it "does not send a TRN allocated email" do
+        expect(TrnAllocatedMailer).not_to send_mail(:trn_allocated_mail, deliver_now: true)
+        perform_job
+      end
     end
 
     context "with user without TRN" do
@@ -59,6 +64,14 @@ RSpec.describe TeachingRecordSystem::AllocateTrnJob, type: :job do
             .to change { user.reload.trn }.from(nil).to(allocated_trn)
             .and change(user.oauth_tokens, :count).from(1).to(0)
         end
+
+        it "sends a TRN allocated email" do
+          expect(TrnAllocatedMailer).to send_mail(:trn_allocated_mail, deliver_now: true)
+            .with_params(to: user.email,
+                         full_name: user.full_name,
+                         trn: allocated_trn)
+          perform_job
+        end
       end
 
       context "when activate API does not return a TRN" do
@@ -66,6 +79,11 @@ RSpec.describe TeachingRecordSystem::AllocateTrnJob, type: :job do
           expect { perform_job }
             .to not_change { user.reload.trn }
             .and change(user.oauth_tokens, :count).from(1).to(0)
+        end
+
+        it "does not send a TRN allocated email" do
+          expect(TrnAllocatedMailer).not_to send_mail(:trn_allocated_mail, deliver_now: true)
+          perform_job
         end
       end
     end

--- a/spec/jobs/teaching_record_system/allocate_trn_job_spec.rb
+++ b/spec/jobs/teaching_record_system/allocate_trn_job_spec.rb
@@ -72,6 +72,15 @@ RSpec.describe TeachingRecordSystem::AllocateTrnJob, type: :job do
                          trn: allocated_trn)
           perform_job
         end
+
+        context "when the user's email is nil" do
+          let(:user) { create(:user, :with_teacher_auth, :with_fresh_refresh_token, :archived, trn:, email: nil) }
+
+          it "does not send a TRN allocated email" do
+            expect(TrnAllocatedMailer).not_to send_mail(:trn_allocated_mail, deliver_now: true)
+            perform_job
+          end
+        end
       end
 
       context "when activate API does not return a TRN" do

--- a/spec/mailers/trn_allocated_mailer_spec.rb
+++ b/spec/mailers/trn_allocated_mailer_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe TrnAllocatedMailer, type: :mailer do
+  describe "#trn_allocated_mail" do
+    let(:user) { build(:user, :with_verified_trn, trn:) }
+    let(:to) { user.email }
+    let(:full_name) { user.full_name }
+    let(:trn) { "2345678" }
+
+    subject(:mail) { described_class.trn_allocated_mail(to:, full_name:, trn:) }
+
+    it "sends to the correct recipient" do
+      expect(mail.to).to eq([user.email])
+    end
+
+    it "sends the correct personalisation" do
+      expect(mail).to have_personalisation(
+        full_name: user.full_name,
+        trn: user.trn,
+      )
+    end
+
+    it { is_expected.to use_template(described_class::TEMPLATE_ID) }
+
+    it_behaves_like "a mailer with redacted logs"
+  end
+end

--- a/spec/services/teaching_record_system/webhooks/trn_request_completed_processor_spec.rb
+++ b/spec/services/teaching_record_system/webhooks/trn_request_completed_processor_spec.rb
@@ -38,6 +38,15 @@ RSpec.describe TeachingRecordSystem::Webhooks::TrnRequestCompletedProcessor do
                        trn: new_trn)
         subject
       end
+
+      context "when the user's email is nil" do
+        let(:user) { create(:user, :with_teacher_auth, :archived, trn: nil, email: nil) }
+
+        it "does not send a TRN allocated email" do
+          expect(TrnAllocatedMailer).not_to send_mail(:trn_allocated_mail)
+          subject
+        end
+      end
     end
 
     context "when the message format is incorrect" do

--- a/spec/services/teaching_record_system/webhooks/trn_request_completed_processor_spec.rb
+++ b/spec/services/teaching_record_system/webhooks/trn_request_completed_processor_spec.rb
@@ -8,25 +8,36 @@ RSpec.describe TeachingRecordSystem::Webhooks::TrnRequestCompletedProcessor do
     let(:user) { create(:user, :with_teacher_auth) }
     let(:new_trn) { "2345678" }
 
-    it "updates the user's TRN" do
-      subject
-      expect(user.reload).to have_attributes(
-        trn: new_trn,
-        trn_verified: true,
-        trn_auto_verified: true,
-      )
-    end
+    context "when the user's TRN was initially set" do
+      it "updates the user's TRN" do
+        subject
+        expect(user.reload).to have_attributes(
+          trn: new_trn,
+          trn_verified: true,
+          trn_auto_verified: true,
+        )
+      end
 
-    it "sends a TRN allocated email" do
-      expect(TrnAllocatedMailer).to send_mail(:trn_allocated_mail)
-        .with_params(to: user.email,
-                     full_name: user.full_name,
-                     trn: new_trn)
-      subject
+      it "does not send a TRN allocated email" do
+        expect(TrnAllocatedMailer).not_to send_mail(:trn_allocated_mail)
+        subject
+      end
     end
 
     it "marks the webhook message as processed" do
       expect { subject }.to change(webhook_message, :status).from("pending").to("processed")
+    end
+
+    context "when the user's TRN was initially nil" do
+      let(:user) { create(:user, :with_teacher_auth, trn: nil) }
+
+      it "sends a TRN allocated email" do
+        expect(TrnAllocatedMailer).to send_mail(:trn_allocated_mail)
+          .with_params(to: user.email,
+                       full_name: user.full_name,
+                       trn: new_trn)
+        subject
+      end
     end
 
     context "when the message format is incorrect" do

--- a/spec/services/teaching_record_system/webhooks/trn_request_completed_processor_spec.rb
+++ b/spec/services/teaching_record_system/webhooks/trn_request_completed_processor_spec.rb
@@ -17,6 +17,14 @@ RSpec.describe TeachingRecordSystem::Webhooks::TrnRequestCompletedProcessor do
       )
     end
 
+    it "sends a TRN allocated email" do
+      expect(TrnAllocatedMailer).to send_mail(:trn_allocated_mail)
+        .with_params(to: user.email,
+                     full_name: user.full_name,
+                     trn: new_trn)
+      subject
+    end
+
     it "marks the webhook message as processed" do
       expect { subject }.to change(webhook_message, :status).from("pending").to("processed")
     end


### PR DESCRIPTION
### Context

Ticket: [NPQ-3858](https://dfedigital.atlassian.net/browse/NPQ-3858)

send an email when a TRN is allocated

### Changes proposed in this pull request

1. an email is sent when a TRN is allocated immediately (allocate TRN job)
2. an email is send if a TRN is allocated later (TRN request completion webhook)



[NPQ-3858]: https://dfedigital.atlassian.net/browse/NPQ-3858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ