### PR TITLE
[NPQ-3451] large scale seeding

### DIFF
--- a/app/jobs/seeding_job.rb
+++ b/app/jobs/seeding_job.rb
@@ -4,7 +4,7 @@ class SeedingJob < ApplicationJob
 
   queue_as :default
 
-  def perform(times: 1)
+  def perform(times: 1, multiplier: 20)
     return unless Rails.env.in?(%w[development review staging sandbox])
     return unless times.positive?
 
@@ -12,8 +12,8 @@ class SeedingJob < ApplicationJob
     Faker::Config.locale = "en-GB"
 
     ApplicationRecord.transaction do
-      SeedAddApplications.new.load(multiplier: 20)
-      SeedAddDeclarations.new.load(multiplier: 20)
+      SeedAddApplications.new.load(multiplier:)
+      SeedAddDeclarations.new.load(multiplier:)
     end
 
     SeedingJob.perform_later(times: times - 1) if times > 1

--- a/app/jobs/seeding_job.rb
+++ b/app/jobs/seeding_job.rb
@@ -12,8 +12,8 @@ class SeedingJob < ApplicationJob
     Faker::Config.locale = "en-GB"
 
     ApplicationRecord.transaction do
-      SeedAddApplications.new.load(multiplier: 30)
-      SeedAddDeclarations.new.load(multiplier: 30)
+      SeedAddApplications.new.load(multiplier: 20)
+      SeedAddDeclarations.new.load(multiplier: 20)
     end
 
     SeedingJob.perform_later(times: times - 1) if times > 1

--- a/app/jobs/seeding_job.rb
+++ b/app/jobs/seeding_job.rb
@@ -1,0 +1,22 @@
+class SeedingJob < ApplicationJob
+  load(Rails.root.join("db/seeds/base/add_applications.rb"))
+  load(Rails.root.join("db/seeds/base/add_declarations.rb"))
+
+  queue_as :default
+
+  def perform
+    return unless Rails.env.in?(%w[development review staging sandbox])
+
+    PaperTrail.enabled = false
+    Faker::Config.locale = "en-GB"
+
+    ApplicationRecord.transaction do
+      SeedAddApplications.new.load(multiplier: 30)
+      SeedAddDeclarations.new.load(multiplier: 30)
+    end
+  end
+
+  def max_attempts
+    1
+  end
+end

--- a/app/jobs/seeding_job.rb
+++ b/app/jobs/seeding_job.rb
@@ -4,8 +4,9 @@ class SeedingJob < ApplicationJob
 
   queue_as :default
 
-  def perform
+  def perform(times: 1)
     return unless Rails.env.in?(%w[development review staging sandbox])
+    return unless times.positive?
 
     PaperTrail.enabled = false
     Faker::Config.locale = "en-GB"
@@ -14,6 +15,8 @@ class SeedingJob < ApplicationJob
       SeedAddApplications.new.load(multiplier: 30)
       SeedAddDeclarations.new.load(multiplier: 30)
     end
+
+    SeedingJob.perform_later(times: times - 1) if times > 1
   end
 
   def max_attempts

--- a/config/application.rb
+++ b/config/application.rb
@@ -80,6 +80,8 @@ module NpqRegistration
 
     config.skylight.environments += %w[review sandbox staging]
 
+    config.active_storage.variant_processor = :disabled
+
     # TeacherAuth configuration
     config.x.teacher_auth.enabled = true
     config.x.teacher_auth.domain = ENV["TEACHER_AUTH_DOMAIN"]

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,22 +8,9 @@ PaperTrail.enabled = false
 Faker::Config.locale = "en-GB"
 
 def load_base_file(file)
-  base_file = Rails.root.join("db", "seeds", "base", file)
+  base_file = Rails.root.join("db/seeds/base", file)
 
   load(base_file)
-end
-
-def with_versioning
-  was_enabled = PaperTrail.enabled?
-  was_enabled_for_request = PaperTrail.request.enabled?
-  PaperTrail.enabled = true
-  PaperTrail.request.enabled = true
-  begin
-    yield
-  ensure
-    PaperTrail.enabled = was_enabled
-    PaperTrail.request.enabled = was_enabled_for_request
-  end
 end
 
 def load_csv(file, model_class)
@@ -56,29 +43,30 @@ ApplicationRecord.descendants.each(&:reset_column_information)
 # Ensure course/course group are first so the replant for
 # review apps doesn't cause the container to go into an
 # unhealthy state for too long (as courses are loaded in healthcheck).
-[
-  "add_course_groups.rb",
-  "add_courses.rb",
-  "add_feature_flags.rb",
-  "add_cohorts.rb",
-  "add_childcare_providers.rb",
-  "add_schools.rb",
-  "add_schedules.rb",
-  "add_lead_providers.rb",
-  "add_itt_providers.rb",
-  "add_users.rb",
-  "add_applications.rb",
-  "add_statements.rb",
-  "add_contracts.rb",
-  "add_declarations.rb",
-  "add_api_tokens.rb",
-  "process_statements.rb",
-  "add_delivery_partners.rb",
-  "add_eligibility_list_entries.rb",
-  "add_course_cohort_providers.rb",
-].each do |seed_file|
+{
+  "add_course_groups.rb" => nil,
+  "add_courses.rb" => nil,
+  "add_feature_flags.rb" => nil,
+  "add_cohorts.rb" => nil,
+  "add_childcare_providers.rb" => nil,
+  "add_schools.rb" => nil,
+  "add_schedules.rb" => nil,
+  "add_lead_providers.rb" => nil,
+  "add_itt_providers.rb" => nil,
+  "add_users.rb" => nil,
+  "add_applications.rb" => "SeedAddApplications",
+  "add_statements.rb" => nil,
+  "add_contracts.rb" => nil,
+  "add_declarations.rb" => "SeedAddDeclarations",
+  "add_api_tokens.rb" => nil,
+  "process_statements.rb" => nil,
+  "add_delivery_partners.rb" => nil,
+  "add_eligibility_list_entries.rb" => nil,
+  "add_course_cohort_providers.rb" => nil,
+}.each do |seed_file, seed_class|
   Rails.logger.info("seeding #{seed_file}")
   ApplicationRecord.transaction do
     load_base_file(seed_file)
+    seed_class.constantize.new.load if seed_class
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -43,30 +43,45 @@ ApplicationRecord.descendants.each(&:reset_column_information)
 # Ensure course/course group are first so the replant for
 # review apps doesn't cause the container to go into an
 # unhealthy state for too long (as courses are loaded in healthcheck).
-{
-  "add_course_groups.rb" => nil,
-  "add_courses.rb" => nil,
-  "add_feature_flags.rb" => nil,
-  "add_cohorts.rb" => nil,
-  "add_childcare_providers.rb" => nil,
-  "add_schools.rb" => nil,
-  "add_schedules.rb" => nil,
-  "add_lead_providers.rb" => nil,
-  "add_itt_providers.rb" => nil,
-  "add_users.rb" => nil,
-  "add_applications.rb" => "SeedAddApplications",
-  "add_statements.rb" => nil,
-  "add_contracts.rb" => nil,
-  "add_declarations.rb" => "SeedAddDeclarations",
-  "add_api_tokens.rb" => nil,
-  "process_statements.rb" => nil,
-  "add_delivery_partners.rb" => nil,
-  "add_eligibility_list_entries.rb" => nil,
-  "add_course_cohort_providers.rb" => nil,
-}.each do |seed_file, seed_class|
+[
+  "add_course_groups.rb",
+  "add_courses.rb",
+  "add_feature_flags.rb",
+  "add_cohorts.rb",
+  "add_childcare_providers.rb",
+  "add_schools.rb",
+  "add_schedules.rb",
+  "add_lead_providers.rb",
+  "add_itt_providers.rb",
+  "add_users.rb",
+  "add_statements.rb",
+  "add_contracts.rb",
+  "add_api_tokens.rb",
+  "process_statements.rb",
+  "add_delivery_partners.rb",
+  "add_eligibility_list_entries.rb",
+  "add_course_cohort_providers.rb",
+].each do |seed_file|
   Rails.logger.info("seeding #{seed_file}")
   ApplicationRecord.transaction do
     load_base_file(seed_file)
-    seed_class.constantize.new.load if seed_class
   end
+end
+
+# add_applications.rb and add_declarations.rb are dealt with separately
+if Rails.env.local?
+  ApplicationRecord.transaction do
+    Rails.logger.info("seeding applications")
+    load_base_file("add_applications.rb")
+    SeedAddApplications.new.load
+  end
+  ApplicationRecord.transaction do
+    Rails.logger.info("seeding declaration")
+    load_base_file("add_declarations.rb")
+    SeedAddDeclarations.new.load
+  end
+else
+  # use background job to speed up review app deployment
+  Rails.logger.info("seeding applications and declarations in background")
+  SeedingJob.perform_later(multiplier: 4)
 end

--- a/db/seeds/base/add_applications.rb
+++ b/db/seeds/base/add_applications.rb
@@ -16,6 +16,7 @@ class SeedAddApplications
           :with_random_user,
           :with_random_work_setting,
           :with_participant_id_change,
+          :with_random_cohort_bounded_created_at,
           lead_provider:,
           course: all_courses.sample,
           lead_provider_approval_status: "pending",
@@ -30,6 +31,7 @@ class SeedAddApplications
           :accepted,
           :with_random_participant_outcome_state,
           :with_random_work_setting,
+          :with_random_cohort_bounded_created_at,
           user:,
           lead_provider:,
           course: all_courses.sample,
@@ -42,6 +44,7 @@ class SeedAddApplications
           :rejected,
           :with_random_participant_outcome_state,
           :with_random_work_setting,
+          :with_random_cohort_bounded_created_at,
           user:,
           lead_provider:,
           course: all_courses.sample,
@@ -55,6 +58,7 @@ class SeedAddApplications
           :accepted,
           :with_random_user,
           :with_random_work_setting,
+          :with_random_cohort_bounded_created_at,
           lead_provider:,
           course: all_courses.sample,
           participant_outcome_state: "passed",
@@ -68,6 +72,7 @@ class SeedAddApplications
           :rejected,
           :with_random_user,
           :with_random_work_setting,
+          :with_random_cohort_bounded_created_at,
           lead_provider:,
           course: all_courses.sample,
           participant_outcome_state: "failed",
@@ -83,6 +88,7 @@ class SeedAddApplications
           :with_random_user,
           :with_random_work_setting,
           :with_random_participant_outcome_state,
+          :with_random_cohort_bounded_created_at,
           lead_provider:,
           course: all_courses.sample,
           cohort: funded_cohorts.sample,
@@ -97,6 +103,7 @@ class SeedAddApplications
           :with_random_user,
           :with_random_work_setting,
           :with_random_participant_outcome_state,
+          :with_random_cohort_bounded_created_at,
           lead_provider:,
           course: all_courses.sample,
           cohort: funded_cohorts.sample,
@@ -111,6 +118,7 @@ class SeedAddApplications
           :with_random_user,
           :with_random_work_setting,
           :with_participant_id_change,
+          :with_random_cohort_bounded_created_at,
           lead_provider:,
           course: all_courses.sample,
           funded_place: Faker::Boolean.boolean(true_ratio: 0.6),
@@ -125,6 +133,7 @@ class SeedAddApplications
           :with_random_user,
           :with_random_work_setting,
           :with_participant_id_change,
+          :with_random_cohort_bounded_created_at,
           lead_provider:,
           course: all_courses.sample,
           funded_place: false,
@@ -139,6 +148,7 @@ class SeedAddApplications
           :with_random_user,
           :with_random_work_setting,
           :with_participant_id_change,
+          :with_random_cohort_bounded_created_at,
           eligible_for_funding: Faker::Boolean.boolean,
           lead_provider:,
           course: all_courses.sample,
@@ -159,12 +169,7 @@ class SeedAddApplications
       { employment_type: :other },
       { referred_by_return_to_teaching_adviser: "yes" },
     ].each do |application_attrs|
-      FactoryBot.create(:application, :manual_review, **application_attrs.merge(course:))
+      FactoryBot.create(:application, :manual_review, :with_random_cohort_bounded_created_at, **application_attrs.merge(course:))
     end
-
-    # temporarily comment the below out, to see if the large-scale seeding job will complete
-    # Application.order(id: :desc).each.with_index do |a, i|
-    #   a.update!(created_at: i.days.ago)
-    # end
   end
 end

--- a/db/seeds/base/add_applications.rb
+++ b/db/seeds/base/add_applications.rb
@@ -1,165 +1,170 @@
 # frozen_string_literal: true
 
-all_courses = Course.all.to_a
-funded_cohorts = Cohort.capped_funding.or(Cohort.full_funding).to_a
+class SeedAddApplications
+  def load(multiplier: nil)
+    all_courses = Course.all.to_a
+    funded_cohorts = Cohort.capped_funding.or(Cohort.full_funding).to_a
 
-LeadProvider.find_each do |lead_provider|
-  quantity = { "review" => 4, "development" => 1 }.fetch(Rails.env, 0)
+    LeadProvider.find_each do |lead_provider|
+      quantity = multiplier || { "review" => 4, "development" => 1 }.fetch(Rails.env, 0)
 
-  quantity.times do
-    # users with one application each
-    FactoryBot.create_list(
-      :application,
-      5,
-      :with_random_user,
-      :with_random_work_setting,
-      :with_participant_id_change,
-      lead_provider:,
-      course: all_courses.sample,
-      lead_provider_approval_status: "pending",
-      cohort: funded_cohorts.sample,
-    )
+      quantity.times do
+        # users with one application each
+        FactoryBot.create_list(
+          :application,
+          5,
+          :with_random_user,
+          :with_random_work_setting,
+          :with_participant_id_change,
+          lead_provider:,
+          course: all_courses.sample,
+          lead_provider_approval_status: "pending",
+          cohort: funded_cohorts.sample,
+        )
 
-    # users with 3 applications each
-    user = FactoryBot.create(:user, :with_random_name)
+        # users with 3 applications each
+        user = FactoryBot.create(:user, :with_random_name)
 
-    FactoryBot.create(
-      :application,
-      :accepted,
-      :with_random_participant_outcome_state,
-      :with_random_work_setting,
-      user:,
-      lead_provider:,
-      course: all_courses.sample,
-      cohort: funded_cohorts.sample,
-    )
+        FactoryBot.create(
+          :application,
+          :accepted,
+          :with_random_participant_outcome_state,
+          :with_random_work_setting,
+          user:,
+          lead_provider:,
+          course: all_courses.sample,
+          cohort: funded_cohorts.sample,
+        )
 
-    FactoryBot.create_list(
-      :application,
-      2,
-      :rejected,
-      :with_random_participant_outcome_state,
-      :with_random_work_setting,
-      user:,
-      lead_provider:,
-      course: all_courses.sample,
-      cohort: funded_cohorts.sample,
-    )
+        FactoryBot.create_list(
+          :application,
+          2,
+          :rejected,
+          :with_random_participant_outcome_state,
+          :with_random_work_setting,
+          user:,
+          lead_provider:,
+          course: all_courses.sample,
+          cohort: funded_cohorts.sample,
+        )
 
-    # users with one accepted application each
-    FactoryBot.create_list(
-      :application,
-      2,
-      :accepted,
-      :with_random_user,
-      :with_random_work_setting,
-      lead_provider:,
-      course: all_courses.sample,
-      participant_outcome_state: "passed",
-      cohort: funded_cohorts.sample,
-    )
+        # users with one accepted application each
+        FactoryBot.create_list(
+          :application,
+          2,
+          :accepted,
+          :with_random_user,
+          :with_random_work_setting,
+          lead_provider:,
+          course: all_courses.sample,
+          participant_outcome_state: "passed",
+          cohort: funded_cohorts.sample,
+        )
 
-    # users with one rejected application each
-    FactoryBot.create_list(
-      :application,
-      2,
-      :rejected,
-      :with_random_user,
-      :with_random_work_setting,
-      lead_provider:,
-      course: all_courses.sample,
-      participant_outcome_state: "failed",
-      cohort: funded_cohorts.sample,
-    )
+        # users with one rejected application each
+        FactoryBot.create_list(
+          :application,
+          2,
+          :rejected,
+          :with_random_user,
+          :with_random_work_setting,
+          lead_provider:,
+          course: all_courses.sample,
+          participant_outcome_state: "failed",
+          cohort: funded_cohorts.sample,
+        )
 
-    # users with one deferred application each
-    FactoryBot.create_list(
-      :application,
-      2,
-      :deferred,
-      %i[accepted rejected].sample,
-      :with_random_user,
-      :with_random_work_setting,
-      :with_random_participant_outcome_state,
-      lead_provider:,
-      course: all_courses.sample,
-      cohort: funded_cohorts.sample,
-    )
+        # users with one deferred application each
+        FactoryBot.create_list(
+          :application,
+          2,
+          :deferred,
+          %i[accepted rejected].sample,
+          :with_random_user,
+          :with_random_work_setting,
+          :with_random_participant_outcome_state,
+          lead_provider:,
+          course: all_courses.sample,
+          cohort: funded_cohorts.sample,
+        )
 
-    # users with one withdrawn application each
-    FactoryBot.create_list(
-      :application,
-      2,
-      :withdrawn,
-      %i[accepted rejected].sample,
-      :with_random_user,
-      :with_random_work_setting,
-      :with_random_participant_outcome_state,
-      lead_provider:,
-      course: all_courses.sample,
-      cohort: funded_cohorts.sample,
-    )
+        # users with one withdrawn application each
+        FactoryBot.create_list(
+          :application,
+          2,
+          :withdrawn,
+          %i[accepted rejected].sample,
+          :with_random_user,
+          :with_random_work_setting,
+          :with_random_participant_outcome_state,
+          lead_provider:,
+          course: all_courses.sample,
+          cohort: funded_cohorts.sample,
+        )
 
-    # users with one eligible for funded place application each (cohort funding_cap true)
-    FactoryBot.create_list(
-      :application,
-      2,
-      :accepted,
-      :eligible_for_funding,
-      :with_random_user,
-      :with_random_work_setting,
-      :with_participant_id_change,
-      lead_provider:,
-      course: all_courses.sample,
-      funded_place: Faker::Boolean.boolean(true_ratio: 0.6),
-      cohort: Cohort.where(funding: "capped").sample,
-    )
+        # users with one eligible for funded place application each (cohort funding_cap true)
+        FactoryBot.create_list(
+          :application,
+          2,
+          :accepted,
+          :eligible_for_funding,
+          :with_random_user,
+          :with_random_work_setting,
+          :with_participant_id_change,
+          lead_provider:,
+          course: all_courses.sample,
+          funded_place: Faker::Boolean.boolean(true_ratio: 0.6),
+          cohort: Cohort.where(funding: "capped").sample,
+        )
 
-    # users with one not eligible for funded place application each (cohort funding_cap true)
-    FactoryBot.create_list(
-      :application,
-      2,
-      :accepted,
-      :with_random_user,
-      :with_random_work_setting,
-      :with_participant_id_change,
-      lead_provider:,
-      course: all_courses.sample,
-      funded_place: false,
-      cohort: Cohort.where(funding: "capped").sample,
-    )
+        # users with one not eligible for funded place application each (cohort funding_cap true)
+        FactoryBot.create_list(
+          :application,
+          2,
+          :accepted,
+          :with_random_user,
+          :with_random_work_setting,
+          :with_participant_id_change,
+          lead_provider:,
+          course: all_courses.sample,
+          funded_place: false,
+          cohort: Cohort.where(funding: "capped").sample,
+        )
 
-    # users with one funded place nil application each (cohort funding_cap false)
-    FactoryBot.create_list(
-      :application,
-      2,
-      :accepted,
-      :with_random_user,
-      :with_random_work_setting,
-      :with_participant_id_change,
-      eligible_for_funding: Faker::Boolean.boolean,
-      lead_provider:,
-      course: all_courses.sample,
-      cohort: Cohort.where(funding: "full").sample,
-    )
+        # users with one funded place nil application each (cohort funding_cap false)
+        FactoryBot.create_list(
+          :application,
+          2,
+          :accepted,
+          :with_random_user,
+          :with_random_work_setting,
+          :with_participant_id_change,
+          eligible_for_funding: Faker::Boolean.boolean,
+          lead_provider:,
+          course: all_courses.sample,
+          cohort: Cohort.where(funding: "full").sample,
+        )
+      end
+    end
+
+    course = Course.find_by!(identifier: Course::IDENTIFIERS.first.to_sym)
+
+    # Make sure some applications will appear in the In Review list
+    [
+      { employment_type: :hospital_school },
+      { employment_type: :lead_mentor_for_accredited_itt_provider },
+      { employment_type: :local_authority_supply_teacher },
+      { employment_type: :local_authority_virtual_school },
+      { employment_type: :young_offender_institution },
+      { employment_type: :other },
+      { referred_by_return_to_teaching_adviser: "yes" },
+    ].each do |application_attrs|
+      FactoryBot.create(:application, :manual_review, **application_attrs.merge(course:))
+    end
+
+    # temporarily comment the below out, to see if the large-scale seeding job will complete
+    # Application.order(id: :desc).each.with_index do |a, i|
+    #   a.update!(created_at: i.days.ago)
+    # end
   end
-end
-
-course = Course.find_by!(identifier: Course::IDENTIFIERS.first.to_sym)
-
-# Make sure some applications will appear in the In Review list
-[
-  { employment_type: :hospital_school },
-  { employment_type: :lead_mentor_for_accredited_itt_provider },
-  { employment_type: :local_authority_supply_teacher },
-  { employment_type: :local_authority_virtual_school },
-  { employment_type: :young_offender_institution },
-  { employment_type: :other },
-  { referred_by_return_to_teaching_adviser: "yes" },
-].each do |application_attrs|
-  FactoryBot.create(:application, :manual_review, **application_attrs.merge(course:))
-end
-
-Application.order(id: :desc).each.with_index do |a, i|
-  a.update!(created_at: i.days.ago)
 end

--- a/db/seeds/base/add_applications.rb
+++ b/db/seeds/base/add_applications.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
 class SeedAddApplications
-  def load(multiplier: nil)
+  def load(multiplier: 1)
     all_courses = Course.all.to_a
     funded_cohorts = Cohort.capped_funding.or(Cohort.full_funding).to_a
 
     LeadProvider.find_each do |lead_provider|
-      quantity = multiplier || { "review" => 4, "development" => 1 }.fetch(Rails.env, 0)
-
-      quantity.times do
+      multiplier.times do
         # users with one application each
         FactoryBot.create_list(
           :application,

--- a/db/seeds/base/add_declarations.rb
+++ b/db/seeds/base/add_declarations.rb
@@ -1,73 +1,92 @@
 # frozen_string_literal: true
 
-helpers            = Class.new { include ActiveSupport::Testing::TimeHelpers }.new
-lead_providers     = LeadProvider.alphabetical.limit(2) # it's very slow to do this for all lead providers
-application_count  = 1
+class SeedAddDeclarations
+  def load(multiplier: 1)
+    helpers            = Class.new { include ActiveSupport::Testing::TimeHelpers }.new
+    lead_providers     = LeadProvider.alphabetical.limit(2) # it's very slow to do this for all lead providers
+    application_count  = multiplier
 
-lead_providers.each do |lead_provider|
-  Schedule.find_each do |schedule|
-    schedule.courses.each do |course|
-      application_count.times do
-        eligible_for_funding = schedule.cohort.funding != "unfunded"
-        application = FactoryBot.create(
-          :application,
-          :accepted,
-          :with_random_user,
-          :with_random_work_setting,
-          eligible_for_funding:,
-          cohort: schedule.cohort,
-          lead_provider:,
-          course:,
-          schedule:,
-        )
+    lead_providers.each do |lead_provider|
+      Schedule.find_each do |schedule|
+        schedule.courses.each do |course|
+          application_count.times do
+            eligible_for_funding = schedule.cohort.funding != "unfunded"
+            application = FactoryBot.create(
+              :application,
+              :accepted,
+              :with_random_user,
+              :with_random_work_setting,
+              eligible_for_funding:,
+              cohort: schedule.cohort,
+              lead_provider:,
+              course:,
+              schedule:,
+            )
 
-        schedule.allowed_declaration_types.each.with_index do |declaration_type, i|
-          declaration = nil
-          date        = schedule.applies_from + (application_count * i * 2).months
+            schedule.allowed_declaration_types.each.with_index do |declaration_type, i|
+              declaration = nil
+              date        = schedule.applies_from + (application_count * i * 2).months
 
-          next if date.future?
+              next if date.future?
 
-          helpers.travel_to date do
-            with_versioning do
-              declaration = FactoryBot.create(
-                :declaration,
-                :submitted_or_eligible,
-                :with_sometimes_nil_delivery_partner,
-                application:,
-                declaration_type:,
-              )
-            end
+              helpers.travel_to date do
+                with_versioning do
+                  declaration = FactoryBot.create(
+                    :declaration,
+                    :submitted_or_eligible,
+                    :with_sometimes_nil_delivery_partner,
+                    application:,
+                    declaration_type:,
+                  )
+                end
 
-            Declarations::StatementAttacher.new(declaration:).attach
+                Declarations::StatementAttacher.new(declaration:).attach
 
-            if declaration_type == "completed" && (application.id % 5).zero?
-              ParticipantOutcomes::Create::STATES.reverse.each do |state|
-                FactoryBot.create(:participant_outcome,
-                                  declaration:,
-                                  state:,
-                                  completion_date: declaration.declaration_date.to_s)
-                next unless state == "passed"
+                if declaration_type == "completed" && (application.id % 5).zero?
+                  ParticipantOutcomes::Create::STATES.reverse.each do |state|
+                    FactoryBot.create(:participant_outcome,
+                                      declaration:,
+                                      state:,
+                                      completion_date: declaration.declaration_date.to_s)
+                    next unless state == "passed"
 
-                user = application.user
-                old_full_name = user.full_name
-                user.full_name = "Outcome #{old_full_name}"
-                user.save!
+                    user = application.user
+                    old_full_name = user.full_name
+                    user.full_name = "Outcome #{old_full_name}"
+                    user.save!
+                  end
+                end
+              end
+
+              # create some voided declarations
+              if schedule.allowed_declaration_types.count < 4 && declaration_type == "retained-1" && declaration.statements.any?
+                voidable_statement = declaration.statements.first
+                helpers.travel_to voidable_statement.deadline_date + 1.month do
+                  Declarations::Void.new(declaration:).void
+                end
               end
             end
           end
 
-          # create some voided declarations
-          if schedule.allowed_declaration_types.count < 4 && declaration_type == "retained-1" && declaration.statements.any?
-            voidable_statement = declaration.statements.first
-            helpers.travel_to voidable_statement.deadline_date + 1.month do
-              Declarations::Void.new(declaration:).void
-            end
-          end
+          application_count += 1
+          application_count = 1 if application_count > 3
         end
       end
+    end
+  end
 
-      application_count += 1
-      application_count = 1 if application_count > 3
+private
+
+  def with_versioning
+    was_enabled = PaperTrail.enabled?
+    was_enabled_for_request = PaperTrail.request.enabled?
+    PaperTrail.enabled = true
+    PaperTrail.request.enabled = true
+    begin
+      yield
+    ensure
+      PaperTrail.enabled = was_enabled
+      PaperTrail.request.enabled = was_enabled_for_request
     end
   end
 end

--- a/db/seeds/base/add_declarations.rb
+++ b/db/seeds/base/add_declarations.rb
@@ -16,6 +16,7 @@ class SeedAddDeclarations
               :accepted,
               :with_random_user,
               :with_random_work_setting,
+              :with_random_cohort_bounded_created_at,
               eligible_for_funding:,
               cohort: schedule.cohort,
               lead_provider:,

--- a/docs/database_seeding.md
+++ b/docs/database_seeding.md
@@ -3,11 +3,14 @@
 # Database seeding
 
 All environments except production can be seeded using `db:seed` or `db:seed:replant`.
-By default, this will create ~1300 applications, ~1500 declarations, and ~1200 users.
+By default, this will create:
+
+* locally: ~800 applications, ~1500 declarations, and ~800 users.
+* on review apps: ~1300 applications, ~1500 declarations, and ~1200 users.
 
 ## Large-scale seeding
 
-To seed a database with a large number of applications - approx ~19,000 applications, ~6,000 declarations, and ~17,000 users,
+To seed a database with a large number of applications - approx ~18,000 applications, ~7,000 declarations, and ~17,000 users,
 run the following rake task:
 
 ```bash

--- a/docs/database_seeding.md
+++ b/docs/database_seeding.md
@@ -1,0 +1,21 @@
+[< Back to Navigation](../README.md)
+
+# Database seeding
+
+All environments except production can be seeded using `db:seed` or `db:seed:replant`.
+By default, this will create ~1300 applications, ~1500 declarations, and ~1200 users.
+
+## Large-scale seeding
+
+To seed a database iwth a large number of applications - approx ~? applications, ~? declarations, and ~? users.
+
+Run the following rake task using the web pod (`make review aks-web-ssh`)(the worker pod does not have enough memory):
+
+```bash
+  rake 'large_seed:background'
+```
+
+This will set off a background job, to repeatedly run our application and declaration seeds,
+which should result in ~20,000 applications and ~20,000 declarations, and ~? users being created in the database.
+
+To check on the progress of the background job, run the task `rake large_seed:check`.

--- a/docs/database_seeding.md
+++ b/docs/database_seeding.md
@@ -7,15 +7,14 @@ By default, this will create ~1300 applications, ~1500 declarations, and ~1200 u
 
 ## Large-scale seeding
 
-To seed a database iwth a large number of applications - approx ~? applications, ~? declarations, and ~? users.
-
-Run the following rake task using the web pod (`make review aks-web-ssh`)(the worker pod does not have enough memory):
+To seed a database with a large number of applications - approx ~19,000 applications, ~6,000 declarations, and ~17,000 users,
+run the following rake task:
 
 ```bash
   rake 'large_seed:background'
 ```
 
 This will set off a background job, to repeatedly run our application and declaration seeds,
-which should result in ~20,000 applications and ~20,000 declarations, and ~? users being created in the database.
+which should result in ~20,000 applications and ~20,000 declarations, and ~17,000 users being created in the database.
 
 To check on the progress of the background job, run the task `rake large_seed:check`.

--- a/docs/database_seeding.md
+++ b/docs/database_seeding.md
@@ -14,7 +14,6 @@ run the following rake task:
   rake 'large_seed:background'
 ```
 
-This will set off a background job, to repeatedly run our application and declaration seeds,
-which should result in ~20,000 applications and ~20,000 declarations, and ~17,000 users being created in the database.
+This will set off a background job, to repeatedly run our application and declaration seeds.
 
 To check on the progress of the background job, run the task `rake large_seed:check`.

--- a/lib/tasks/large_seed.rake
+++ b/lib/tasks/large_seed.rake
@@ -32,7 +32,7 @@ namespace :large_seed do
       puts "Locked at: #{job.locked_at}" if job.locked_at
       scheduled_or_running = job.run_at.future? ? " (scheduled)" : " (running)"
       puts "Run at: #{job.run_at}#{scheduled_or_running}"
-      iterations_left = job.payload_object.job_data["arguments"].first["times"]
+      iterations_left = job.payload_object.job_data["arguments"].first["times"] || 1
       puts "Iterations left: #{iterations_left}"
 
       next unless job.failed_at

--- a/lib/tasks/large_seed.rake
+++ b/lib/tasks/large_seed.rake
@@ -1,7 +1,7 @@
 namespace :large_seed do
   desc "Load large-scale application seeds in background"
   task background: :versioned_environment do
-    SeedingJob.perform_later(times: 2)
+    SeedingJob.perform_later(times: 3)
   end
 
   desc "Load large-scale application seeds in foreground"

--- a/lib/tasks/large_seed.rake
+++ b/lib/tasks/large_seed.rake
@@ -1,0 +1,43 @@
+namespace :large_seed do
+  desc "Load large-scale application seeds in background"
+  task background: :versioned_environment do
+    SeedingJob.perform_later
+  end
+
+  desc "Load large-scale application seeds in foreground"
+  task now: :versioned_environment do
+    puts "Application count: #{Application.count}"
+    puts "Loading seeds"
+    SeedingJob.perform_now
+    puts "Application count: #{Application.count}"
+  end
+
+  desc "Check the status of large-scale application seeds background jobs"
+  task check: :versioned_environment do
+    jobs = Delayed::Job.all.select { |job| job.payload_object.job_data["job_class"] == SeedingJob.to_s }
+    puts "-------------------------"
+    puts "Application count: #{Application.count}"
+    puts "Declaration count: #{Declaration.count}"
+    puts "User count: #{User.count}"
+
+    if jobs.empty?
+      puts "No SeedingJob jobs found."
+      exit 0
+    end
+
+    jobs.each do |job|
+      puts "-------------------------"
+      puts "Job ID: #{job.id}"
+      puts "Created at: #{job.created_at}"
+      puts "Locked at: #{job.locked_at}" if job.locked_at
+      scheduled_or_running = job.run_at.future? ? " (scheduled)" : " (running)"
+      puts "Run at: #{job.run_at}#{scheduled_or_running}"
+
+      next unless job.failed_at
+
+      puts "Failed at: #{job.failed_at}"
+      puts "Last error: #{job.last_error}"
+      puts "Attempts: #{job.attempts}"
+    end
+  end
+end

--- a/lib/tasks/large_seed.rake
+++ b/lib/tasks/large_seed.rake
@@ -1,7 +1,7 @@
 namespace :large_seed do
   desc "Load large-scale application seeds in background"
   task background: :versioned_environment do
-    SeedingJob.perform_later
+    SeedingJob.perform_later(times: 2)
   end
 
   desc "Load large-scale application seeds in foreground"
@@ -32,6 +32,8 @@ namespace :large_seed do
       puts "Locked at: #{job.locked_at}" if job.locked_at
       scheduled_or_running = job.run_at.future? ? " (scheduled)" : " (running)"
       puts "Run at: #{job.run_at}#{scheduled_or_running}"
+      iterations_left = job.payload_object.job_data["arguments"].first["times"]
+      puts "Iterations left: #{iterations_left}"
 
       next unless job.failed_at
 

--- a/spec/factories/applications.rb
+++ b/spec/factories/applications.rb
@@ -164,5 +164,11 @@ FactoryBot.define do
       senco_in_role { "yes" }
       senco_start_date { Time.zone.today }
     end
+
+    trait :with_random_cohort_bounded_created_at do
+      created_at do
+        Faker::Time.between(from: cohort.registration_start_date, to: (cohort.registration_start_date + 6.months))
+      end
+    end
   end
 end

--- a/spec/jobs/seeding_job_spec.rb
+++ b/spec/jobs/seeding_job_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe SeedingJob do
+  load(Rails.root.join("db/seeds/base/add_applications.rb"))
+  load(Rails.root.join("db/seeds/base/add_declarations.rb"))
+
+  describe "#perform" do
+    let(:add_applications_stub) { instance_double(SeedAddApplications, load: nil) }
+    let(:add_declarations_stub) { instance_double(SeedAddDeclarations, load: nil) }
+    let(:environment) { "review" }
+
+    before do
+      allow(SeedingJob).to receive(:set).and_return(SeedingJob)
+      allow(SeedAddApplications).to receive(:new).and_return(add_applications_stub)
+      allow(SeedAddDeclarations).to receive(:new).and_return(add_declarations_stub)
+      allow(Rails).to receive(:env) { environment.inquiry }
+    end
+
+    context "when the repetitions argument is not used" do
+      subject(:run_job) { described_class.new.perform }
+
+      it "seeds applications" do
+        expect(add_applications_stub).to receive(:load).with(multiplier: 30)
+        subject
+      end
+
+      it "seeds declarations" do
+        expect(add_declarations_stub).to receive(:load).with(multiplier: 30)
+        subject
+      end
+    end
+
+    context "when the environment is production" do
+      let(:environment) { "production" }
+
+      subject(:run_job) { described_class.new.perform }
+
+      it "does not perform any seeding" do
+        expect(add_applications_stub).not_to receive(:load)
+        expect(add_declarations_stub).not_to receive(:load)
+        subject
+      end
+    end
+  end
+end

--- a/spec/jobs/seeding_job_spec.rb
+++ b/spec/jobs/seeding_job_spec.rb
@@ -16,16 +16,35 @@ RSpec.describe SeedingJob do
       allow(Rails).to receive(:env) { environment.inquiry }
     end
 
-    context "when the repetitions argument is not used" do
-      subject(:run_job) { described_class.new.perform }
-
+    shared_examples_for "seeding" do
       it "seeds applications" do
         expect(add_applications_stub).to receive(:load).with(multiplier: 30)
         subject
       end
 
       it "seeds declarations" do
-        expect(add_declarations_stub).to receive(:load).with(multiplier: 30)
+        expect(add_declarations_stub).to receive(:load)
+        subject
+      end
+    end
+
+    context "when the times argument is not used" do
+      subject(:run_job) { described_class.new.perform }
+
+      it_behaves_like "seeding"
+
+      it "does not enqueue the job again" do
+        expect(SeedingJob).not_to receive(:perform_later)
+        subject
+      end
+    end
+
+    context "when times is less than 1" do
+      subject(:run_job) { described_class.new.perform(times: 0) }
+
+      it "does not perform any seeding" do
+        expect(add_applications_stub).not_to receive(:load)
+        expect(add_declarations_stub).not_to receive(:load)
         subject
       end
     end
@@ -41,5 +60,11 @@ RSpec.describe SeedingJob do
         subject
       end
     end
+  end
+
+  describe "#max_attempts" do
+    subject(:max_attempts) { described_class.new.max_attempts }
+
+    it { is_expected.to eq 1 }
   end
 end

--- a/spec/jobs/seeding_job_spec.rb
+++ b/spec/jobs/seeding_job_spec.rb
@@ -18,12 +18,12 @@ RSpec.describe SeedingJob do
 
     shared_examples_for "seeding" do
       it "seeds applications" do
-        expect(add_applications_stub).to receive(:load).with(multiplier: 30)
+        expect(add_applications_stub).to receive(:load).with(multiplier: 20)
         subject
       end
 
       it "seeds declarations" do
-        expect(add_declarations_stub).to receive(:load)
+        expect(add_declarations_stub).to receive(:load).with(multiplier: 20)
         subject
       end
     end

--- a/spec/lib/tasks/large_seed_spec.rb
+++ b/spec/lib/tasks/large_seed_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe "Loading application seeds" do
+  describe "large_seed:background" do
+    subject(:run_task) { Rake::Task["large_seed:background"].invoke }
+
+    after { Rake::Task["large_seed:background"].reenable }
+
+    it "enqueues a SeedingJob" do
+      expect { run_task }.to have_enqueued_job(SeedingJob)
+    end
+  end
+
+  describe "large_seed:now" do
+    subject(:run_task) { Rake::Task["large_seed:now"].invoke }
+
+    after { Rake::Task["large_seed:now"].reenable }
+
+    it "runs the SeedingJob immediately" do
+      expect(SeedingJob).to receive(:perform_now)
+      run_task
+    end
+  end
+end

--- a/spec/lib/tasks/large_seed_spec.rb
+++ b/spec/lib/tasks/large_seed_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Loading application seeds" do
     after { Rake::Task["large_seed:background"].reenable }
 
     it "enqueues a SeedingJob" do
-      expect { run_task }.to have_enqueued_job(SeedingJob).with(times: 2)
+      expect { run_task }.to have_enqueued_job(SeedingJob).with(times: 3)
     end
   end
 

--- a/spec/lib/tasks/large_seed_spec.rb
+++ b/spec/lib/tasks/large_seed_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Loading application seeds" do
     after { Rake::Task["large_seed:background"].reenable }
 
     it "enqueues a SeedingJob" do
-      expect { run_task }.to have_enqueued_job(SeedingJob)
+      expect { run_task }.to have_enqueued_job(SeedingJob).with(times: 2)
     end
   end
 


### PR DESCRIPTION
### Context

Ticket: [NPQ-3451](https://dfedigital.atlassian.net/browse/NPQ-3451)

rake task to allow ~20,000 applications to be seeded into a review app

### Changes proposed in this pull request

1. change `add_applications.rb` and `add_declarations.rb` to use classes, so their functionality can be resued
2. create a job `SeedingJob` to allow seeding to happen in the background, as doing it in one go causes an out-of-memory error on the worker pod - the `multiplier` value has been carefully chosen, `30` causes the worker to run out of memory, `20` is fine.
3. switched standard DB seeds to use the background job - should speed up review app deployment
4. rake task to invoke the seeding
5. rake task to check the status of the seeding
6. created a document describing how to use the rake tasks: `docs/database_seeding.md`

[NPQ-3451]: https://dfedigital.atlassian.net/browse/NPQ-3451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ