### PR TITLE
[NPQ-3862] track OTP attempts on admin sign in

### DIFF
--- a/app/forms/session_wizard_steps/sign_in.rb
+++ b/app/forms/session_wizard_steps/sign_in.rb
@@ -24,8 +24,7 @@ module SessionWizardSteps
       admin = Admin.find_by(email:)
 
       if admin
-        otp = OTP.generate
-        admin.update!(otp_hash: otp.code, otp_expires_at: otp.expires_at)
+        otp = admin.start_otp!
         ConfirmEmailMailer.confirmation_code_mail(to: email, code: otp.code).deliver_now
       end
     end

--- a/app/forms/session_wizard_steps/sign_in_code.rb
+++ b/app/forms/session_wizard_steps/sign_in_code.rb
@@ -4,6 +4,8 @@ module SessionWizardSteps
 
     validates :code, presence: true, length: { is: 8 }, user_otp_code: true
 
+    after_validation :register_otp_attempt
+
     def self.permitted_params
       [
         :code,
@@ -18,5 +20,11 @@ module SessionWizardSteps
       @admin ||= Admin.find_by(email: wizard.store["email"])
     end
     alias_method :user, :admin
+
+  private
+
+    def register_otp_attempt
+      admin&.register_otp_attempt!(success: errors.none?) if code.present?
+    end
   end
 end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,4 +1,6 @@
 class Admin < ApplicationRecord
+  include OTPAuthenticatable
+
   has_many :bulk_operations
 
   validates :full_name, presence: true, length: { maximum: 64 }

--- a/app/models/concerns/otp_authenticatable.rb
+++ b/app/models/concerns/otp_authenticatable.rb
@@ -1,0 +1,43 @@
+module OTPAuthenticatable
+  extend ActiveSupport::Concern
+
+  # Requires the including model to have otp_hash, otp_expires_at and otp_failed_attempts columns.
+  MAX_OTP_FAILED_ATTEMPTS = 5
+
+  def otp_locked?
+    otp_failed_attempts >= MAX_OTP_FAILED_ATTEMPTS
+  end
+
+  def otp
+    OTP.new(code: otp_hash, expires_at: otp_expires_at)
+  rescue OTP::Invalid
+    nil
+  end
+
+  def register_failed_otp_attempt!
+    transaction do
+      increment!(:otp_failed_attempts)
+      clear_otp! if otp_locked?
+    end
+  end
+
+  def register_otp_attempt!(success:)
+    if success
+      clear_otp!
+    else
+      register_failed_otp_attempt!
+    end
+  end
+
+  def start_otp!
+    OTP.generate.tap do |otp|
+      update!(otp_hash: otp.code, otp_expires_at: otp.expires_at, otp_failed_attempts: 0)
+    end
+  end
+
+private
+
+  def clear_otp!
+    update!(otp_hash: nil, otp_expires_at: nil)
+  end
+end

--- a/app/services/otp.rb
+++ b/app/services/otp.rb
@@ -13,12 +13,8 @@ class OTP
   attr_reader :code, :expires_at
 
   class << self
-    def from(code:, expires_at:)
-      new(code:, expires_at:)
-    end
-
     def generate
-      from(code: random_code, expires_at: VALIDITY_PERIOD.from_now)
+      new(code: random_code, expires_at: VALIDITY_PERIOD.from_now)
     end
 
     def normalize(code)

--- a/app/validators/user_otp_code_validator.rb
+++ b/app/validators/user_otp_code_validator.rb
@@ -2,19 +2,14 @@
 
 class UserOTPCodeValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    otp = user_otp(record.user)
+    otp = record.user&.otp
 
-    incorrect_error(record, otp, attribute, value) ||
+    locked_error(record, attribute) ||
+      incorrect_error(record, otp, attribute, value) ||
       expired_error(record, otp, attribute)
   end
 
 private
-
-  def user_otp(user)
-    if user && OTP.valid_code_format?(user.otp_hash) && user.otp_expires_at.present?
-      OTP.from(code: user.otp_hash, expires_at: user.otp_expires_at)
-    end
-  end
 
   def expired_error(record, otp, attribute)
     record.errors.add(attribute, :expired) if otp.expired?
@@ -22,5 +17,9 @@ private
 
   def incorrect_error(record, otp, attribute, value)
     record.errors.add(attribute, :incorrect) if otp.nil? || !otp.matches?(value)
+  end
+
+  def locked_error(record, attribute)
+    record.errors.add(attribute, :locked) if record.user&.otp_locked?
   end
 end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -64,6 +64,7 @@ shared:
     - super_admin
     - otp_hash
     - otp_expires_at
+    - otp_failed_attempts
     - created_at
     - updated_at
     - archived_at

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -560,6 +560,8 @@ en:
             code:
               blank: Code can’t be blank
               incorrect: Code is not correct. Please try again
+              expired: This code has expired. Please request a new code to sign in
+              locked: Too many failed attempts. Please request a new code to sign in
         participants/resume:
           attributes:
             course_identifier:

--- a/db/migrate/20260630000000_add_otp_failed_attempts_to_admins.rb
+++ b/db/migrate/20260630000000_add_otp_failed_attempts_to_admins.rb
@@ -1,0 +1,5 @@
+class AddOTPFailedAttemptsToAdmins < ActiveRecord::Migration[8.1]
+  def change
+    add_column :admins, :otp_failed_attempts, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_24_114120) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_30_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "citext"
@@ -81,6 +81,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_24_114120) do
     t.string "email", limit: 64, null: false
     t.string "full_name", limit: 64, null: false
     t.datetime "otp_expires_at", precision: nil
+    t.integer "otp_failed_attempts", default: 0, null: false
     t.text "otp_hash"
     t.boolean "super_admin", default: false, null: false
     t.datetime "updated_at", null: false

--- a/spec/factories/admins.rb
+++ b/spec/factories/admins.rb
@@ -6,6 +6,12 @@ FactoryBot.define do
     trait :archived do
       archived_at { Time.current }
     end
+
+    trait :otp_locked do
+      otp_hash { nil }
+      otp_expires_at { nil }
+      otp_failed_attempts { Admin::MAX_OTP_FAILED_ATTEMPTS }
+    end
   end
 
   factory :super_admin, class: "Admin" do

--- a/spec/forms/session_wizard_steps/sign_in_code_spec.rb
+++ b/spec/forms/session_wizard_steps/sign_in_code_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe SessionWizardSteps::SignInCode, type: :model do
 
       it "fails" do
         subject.valid?
-        expect(subject.errors).to be_of_kind(:code, :expired)
+        expect(subject).to have_error(:code, :expired, "This code has expired. Please request a new code to sign in")
       end
     end
 
@@ -63,7 +63,7 @@ RSpec.describe SessionWizardSteps::SignInCode, type: :model do
       it "fails" do
         subject.valid?
 
-        expect(subject.errors).to be_of_kind(:code, :incorrect)
+        expect(subject).to have_error(:code, :incorrect, "Code is not correct. Please try again")
       end
     end
 
@@ -73,7 +73,7 @@ RSpec.describe SessionWizardSteps::SignInCode, type: :model do
 
       it "is incorrect and does not raise" do
         expect { subject.valid? }.not_to raise_error
-        expect(subject.errors).to be_of_kind(:code, :incorrect)
+        expect(subject).to have_error(:code, :incorrect, "Code is not correct. Please try again")
       end
     end
 
@@ -83,7 +83,7 @@ RSpec.describe SessionWizardSteps::SignInCode, type: :model do
 
       it "is incorrect and does not raise" do
         expect { subject.valid? }.not_to raise_error
-        expect(subject.errors).to be_of_kind(:code, :incorrect)
+        expect(subject).to have_error(:code, :incorrect, "Code is not correct. Please try again")
       end
     end
 
@@ -93,7 +93,79 @@ RSpec.describe SessionWizardSteps::SignInCode, type: :model do
 
       it "is incorrect and does not raise" do
         expect { subject.valid? }.not_to raise_error
-        expect(subject.errors).to be_of_kind(:code, :incorrect)
+        expect(subject).to have_error(:code, :incorrect, "Code is not correct. Please try again")
+      end
+    end
+  end
+
+  describe "failed attempts" do
+    let(:admin) { FactoryBot.create(:admin, otp_hash: "ABCD2345", otp_expires_at: 10.minutes.from_now, otp_failed_attempts:) }
+    let(:otp_failed_attempts) { 0 }
+    let(:code) { "WXYZ6789" }
+
+    context "when a wrong code is entered against a live code" do
+      it "records a failed attempt" do
+        expect { subject.valid? }.to change { admin.reload.otp_failed_attempts }.from(0).to(1)
+        expect(subject).to have_error(:code, :incorrect, "Code is not correct. Please try again")
+      end
+    end
+
+    context "when a blank code is submitted" do
+      let(:code) { "" }
+
+      it "does not record a failed attempt" do
+        expect { subject.valid? }.not_to(change { admin.reload.otp_failed_attempts })
+      end
+    end
+
+    context "when the wrong code is the one that reaches the limit" do
+      let(:otp_failed_attempts) { Admin::MAX_OTP_FAILED_ATTEMPTS - 1 }
+
+      it "OTP locks the admin and deletes the stored code" do
+        subject.valid?
+
+        expect(admin.reload).to be_otp_locked
+        expect(admin.otp_hash).to be_nil
+      end
+    end
+
+    context "when the admin is already OTP locked" do
+      let(:admin) { FactoryBot.create(:admin, :otp_locked) }
+
+      it "shows the locked error and keeps the admin OTP locked" do
+        subject.valid?
+
+        expect(subject).to have_error(:code, :locked, "Too many failed attempts. Please request a new code to sign in")
+        expect(admin.reload).to be_otp_locked
+      end
+    end
+
+    context "when the correct code is entered" do
+      let(:code) { "ABCD2345" }
+
+      it "is valid, deletes the code and sets no failed attempts" do
+        expect(subject).to be_valid
+        expect(admin.reload.otp_failed_attempts).to eq(0)
+        expect(admin.otp_hash).to be_nil
+      end
+    end
+
+    context "when the stored code has expired" do
+      let(:admin) { FactoryBot.create(:admin, otp_hash: "ABCD2345", otp_expires_at: 1.minute.ago, otp_failed_attempts:) }
+      let(:code) { "ABCD2345" }
+
+      it "records the expired error and a failed otp attempt" do
+        expect { subject.valid? }.to change { admin.reload.otp_failed_attempts }.from(0).to(1)
+        expect(subject).to have_error(:code, :expired, "This code has expired. Please request a new code to sign in")
+      end
+    end
+
+    context "when the email does not match any admin" do
+      let(:store) { { "email" => "noexist@example.com" } }
+
+      it "is incorrect and does not raise" do
+        expect { subject.valid? }.not_to raise_error
+        expect(subject).to have_error(:code, :incorrect, "Code is not correct. Please try again")
       end
     end
   end

--- a/spec/forms/session_wizard_steps/sign_in_spec.rb
+++ b/spec/forms/session_wizard_steps/sign_in_spec.rb
@@ -35,5 +35,13 @@ RSpec.describe SessionWizardSteps::SignIn, type: :model do
       expect(mailer_double).to receive(:deliver_now)
       subject
     end
+
+    context "when the admin had failed attempts from a previous code" do
+      let(:admin) { create(:admin, otp_failed_attempts: 3) }
+
+      it "resets the failed attempts counter" do
+        expect { subject }.to change { admin.reload.otp_failed_attempts }.from(3).to(0)
+      end
+    end
   end
 end

--- a/spec/models/admin_spec.rb
+++ b/spec/models/admin_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Admin, type: :model do
+  it_behaves_like "an OTP authenticatable model"
+
   describe "validation" do
     describe "full_name" do
       it { is_expected.to validate_presence_of(:full_name).with_message("Enter a full name") }

--- a/spec/services/otp_spec.rb
+++ b/spec/services/otp_spec.rb
@@ -27,33 +27,33 @@ RSpec.describe OTP do
     end
   end
 
-  describe ".from" do
+  describe "initialisation" do
     it "uses the code it was given" do
-      expect(described_class.from(code:, expires_at:).code).to eq(code)
+      expect(described_class.new(code:, expires_at:).code).to eq(code)
     end
 
     it "uses the expiry it was given" do
-      expect(described_class.from(code:, expires_at:).expires_at).to eq(expires_at)
+      expect(described_class.new(code:, expires_at:).expires_at).to eq(expires_at)
     end
 
     it "rejects a nil code" do
-      expect { described_class.from(code: nil, expires_at:) }.to raise_error(OTP::Invalid)
+      expect { described_class.new(code: nil, expires_at:) }.to raise_error(OTP::Invalid)
     end
 
     it "rejects a code that is not 8 characters" do
-      expect { described_class.from(code: "ABCD234", expires_at:) }.to raise_error(OTP::Invalid)
+      expect { described_class.new(code: "ABCD234", expires_at:) }.to raise_error(OTP::Invalid)
     end
 
     it "rejects a code with characters outside the alphabet" do
-      expect { described_class.from(code: "ABCDILO1", expires_at:) }.to raise_error(OTP::Invalid)
+      expect { described_class.new(code: "ABCDILO1", expires_at:) }.to raise_error(OTP::Invalid)
     end
 
     it "rejects a nil expiry" do
-      expect { described_class.from(code:, expires_at: nil) }.to raise_error(OTP::Invalid)
+      expect { described_class.new(code:, expires_at: nil) }.to raise_error(OTP::Invalid)
     end
 
     it "rejects an expiry that is not a time" do
-      expect { described_class.from(code:, expires_at: "soon") }.to raise_error(OTP::Invalid)
+      expect { described_class.new(code:, expires_at: "soon") }.to raise_error(OTP::Invalid)
     end
   end
 
@@ -76,7 +76,7 @@ RSpec.describe OTP do
   end
 
   describe "#matches?" do
-    subject(:otp) { described_class.from(code:, expires_at:) }
+    subject(:otp) { described_class.new(code:, expires_at:) }
 
     it "matches when the entered code is identical" do
       expect(otp.matches?(code)).to be(true)
@@ -97,7 +97,7 @@ RSpec.describe OTP do
       it "treats '#{typed}' as '#{digit}'" do
         stored = "#{digit}BCD2345"
         entered = "#{typed}BCD2345"
-        expect(described_class.from(code: stored, expires_at:).matches?(entered)).to be(true)
+        expect(described_class.new(code: stored, expires_at:).matches?(entered)).to be(true)
       end
     end
 
@@ -112,11 +112,11 @@ RSpec.describe OTP do
 
   describe "#expired?" do
     it "is false when the expiry is in the future" do
-      expect(described_class.from(code:, expires_at: 5.minutes.from_now).expired?).to be(false)
+      expect(described_class.new(code:, expires_at: 5.minutes.from_now).expired?).to be(false)
     end
 
     it "is true when the expiry is in the past" do
-      expect(described_class.from(code:, expires_at: 1.minute.ago).expired?).to be(true)
+      expect(described_class.new(code:, expires_at: 1.minute.ago).expired?).to be(true)
     end
   end
 end

--- a/spec/support/shared_examples/otp_authenticatable_support.rb
+++ b/spec/support/shared_examples/otp_authenticatable_support.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.shared_examples "an OTP authenticatable model" do
+  let(:factory) { described_class.name.underscore }
+  let(:max_attempts) { described_class::MAX_OTP_FAILED_ATTEMPTS }
+
+  describe "#otp_locked?" do
+    context "when below the limit" do
+      subject { create(factory, otp_failed_attempts: max_attempts - 1) }
+
+      it { is_expected.not_to be_otp_locked }
+    end
+
+    context "when at the limit" do
+      subject { create(factory, :otp_locked) }
+
+      it { is_expected.to be_otp_locked }
+    end
+  end
+
+  describe "#otp" do
+    subject(:record) { create(factory, otp_hash:, otp_expires_at:) }
+
+    let(:otp_hash) { "ABCD2345" }
+    let(:otp_expires_at) { 5.minutes.from_now }
+
+    it "returns the stored code as an OTP" do
+      expect(record.otp).to be_a(OTP)
+      expect(record.otp).to have_attributes(code: otp_hash, expires_at: otp_expires_at)
+    end
+
+    context "when the stored code has expired" do
+      let(:otp_expires_at) { 1.minute.ago }
+
+      it "returns an expired OTP" do
+        expect(record.otp).to be_a(OTP)
+        expect(record.otp).to be_expired
+      end
+    end
+
+    context "when there is no stored code" do
+      let(:otp_hash) { nil }
+
+      it { expect(record.otp).to be_nil }
+    end
+
+    context "when the stored code is not a valid format" do
+      let(:otp_hash) { "123456" }
+
+      it { expect(record.otp).to be_nil }
+    end
+
+    context "when the stored expiry is missing" do
+      let(:otp_expires_at) { nil }
+
+      it { expect(record.otp).to be_nil }
+    end
+  end
+
+  describe "#register_otp_attempt!" do
+    subject(:record) { create(factory, otp_hash: "ABCD2345", otp_expires_at: 5.minutes.from_now, otp_failed_attempts: 2) }
+
+    context "when the attempt succeeded" do
+      it "clears the stored code and leaves the counter untouched" do
+        expect { record.register_otp_attempt!(success: true) }
+          .not_to change(record, :otp_failed_attempts)
+        expect(record.otp_hash).to be_nil
+      end
+    end
+
+    context "when the attempt failed" do
+      it "records a failed attempt" do
+        expect { record.register_otp_attempt!(success: false) }
+          .to change(record, :otp_failed_attempts).from(2).to(3)
+      end
+    end
+  end
+
+  describe "#register_failed_otp_attempt!" do
+    subject(:record) { create(factory, otp_hash: "ABCD2345", otp_expires_at: 5.minutes.from_now, otp_failed_attempts:) }
+
+    context "when below the limit" do
+      let(:otp_failed_attempts) { 0 }
+
+      it "increments the counter and keeps the stored code" do
+        expect { record.register_failed_otp_attempt! }
+          .to change(record, :otp_failed_attempts).from(0).to(1)
+        expect(record.otp_hash).to eq("ABCD2345")
+        expect(record).not_to be_otp_locked
+      end
+    end
+
+    context "when the attempt reaches the limit" do
+      let(:otp_failed_attempts) { max_attempts - 1 }
+
+      it "locks the record and deletes the stored code" do
+        record.register_failed_otp_attempt!
+
+        expect(record).to be_otp_locked
+        expect(record.otp_hash).to be_nil
+        expect(record.otp_expires_at).to be_nil
+      end
+    end
+  end
+end

--- a/spec/validators/user_otp_code_validator_spec.rb
+++ b/spec/validators/user_otp_code_validator_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe UserOTPCodeValidator do
   let(:stored_code) { "ABCD2345" }
   let(:expires_at) { 5.minutes.from_now }
   let(:entered_code) { stored_code }
-  let(:user) { instance_double(Admin, otp_hash: stored_code, otp_expires_at: expires_at) }
+  let(:otp) { OTP.new(code: stored_code, expires_at:) }
+  let(:user) { instance_double(Admin, otp:, otp_locked?: false) }
 
   before do
     stub_const("TestModel", Class.new).class_eval do
@@ -58,17 +59,18 @@ RSpec.describe UserOTPCodeValidator do
     end
   end
 
-  context "when the stored code is not a valid OTP" do
-    let(:user) { instance_double(Admin, otp_hash: "123456", otp_expires_at: expires_at) }
+  context "when the user is locked" do
+    let(:user) { instance_double(Admin, otp:, otp_locked?: true) }
 
-    it "adds an incorrect error and does not raise" do
-      expect { model.valid? }.not_to raise_error
-      expect(model.errors).to be_of_kind(:code, :incorrect)
+    it "adds a locked error and does not check the code" do
+      model.valid?
+      expect(model.errors).to be_of_kind(:code, :locked)
+      expect(model.errors).not_to be_of_kind(:code, :incorrect)
     end
   end
 
-  context "when the stored expiry is missing" do
-    let(:user) { instance_double(Admin, otp_hash: stored_code, otp_expires_at: nil) }
+  context "when the user has no usable OTP" do
+    let(:user) { instance_double(Admin, otp: nil, otp_locked?: false) }
 
     it "adds an incorrect error and does not raise" do
       expect { model.valid? }.not_to raise_error


### PR DESCRIPTION
### Context

Ticket: [NPQ-3862](https://dfedigital.atlassian.net/browse/NPQ-3862)

Admin sign in uses an email OTP code. This groups the admin OTP logic in one place and keeps a count of the attempts made for each code.

### Changes proposed in this pull request

1. Add an `otp_failed_attempts` column to admins.
2. Move the admin OTP logic (generate, read, match, count, reset) into a new `OTPAuthenticatable` concern that `Admin` includes.
3. Count each attempt when a code is entered, and reset the count when a new code is sent.
4. Once the count reaches a set number the stored code is cleared and the admin has to request a new one.


[NPQ-3862]: https://dfedigital.atlassian.net/browse/NPQ-3862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ