### PR TITLE
[NPQ-3864] Update rate limiting

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -31,18 +31,27 @@ class Rack::Attack
     request.path.starts_with?("/api/v1/get_an_identity/webhook_messages")
   end
 
+  def self.teacher_auth_webhook_path?(request)
+    request.path.starts_with?("/api/teaching-record-system/v1/webhook_messages")
+  end
+
   def self.auth_token(request)
     request.get_header("HTTP_AUTHORIZATION")
   end
 
-  # Throttle protected routes by IP (5rpm)
-  throttle("protected routes (hitting external services)", limit: 10, period: 2.minutes) do |request|
+  # Throttle protected routes by IP (10 requests per 5 minutes)
+  throttle("protected routes (hitting external services)", limit: 10, period: 5.minutes) do |request|
     request.ip if protected_path?(request)
   end
 
-  # Throttle /api/v1/get_an_identity/webhook_messages requests by IP (1000 requests per 5 minutes)
-  throttle("API get an identity webhook message requests by ip", limit: 1000, period: 5.minutes) do |request|
+  # Throttle /api/v1/get_an_identity/webhook_messages requests by IP (100 requests per 5 minutes)
+  throttle("API get an identity webhook message requests by ip", limit: 100, period: 5.minutes) do |request|
     request.ip if get_an_identity_webhook_path?(request)
+  end
+
+  # Throttle /api/teaching-record-system/v1/webhook_messages requests by IP (100 requests per 5 minutes)
+  throttle("API TeacherAuth webhook message requests by ip", limit: 100, period: 5.minutes) do |request|
+    request.ip if teacher_auth_webhook_path?(request)
   end
 
   # Throttle private /api requests by auth token (1000 requests per 5 minutes)

--- a/spec/requests/rate_limiting_spec.rb
+++ b/spec/requests/rate_limiting_spec.rb
@@ -114,6 +114,36 @@ RSpec.describe "Rate limiting" do
     end
   end
 
+  describe "throttle configuration" do
+    it "limits protected routes to 10 requests per 5 minutes" do
+      expect(Rack::Attack.throttles["protected routes (hitting external services)"]).to have_attributes(limit: 10, period: 5.minutes)
+    end
+
+    it "limits API get an identity webhook messages to 100 requests per 5 minutes" do
+      expect(Rack::Attack.throttles["API get an identity webhook message requests by ip"]).to have_attributes(limit: 100, period: 5.minutes)
+    end
+
+    it "limits API TeacherAuth webhook messages to 100 requests per 5 minutes" do
+      expect(Rack::Attack.throttles["API TeacherAuth webhook message requests by ip"]).to have_attributes(limit: 100, period: 5.minutes)
+    end
+
+    it "limits API requests by auth token to 1000 requests per 5 minutes" do
+      expect(Rack::Attack.throttles["API requests by auth token"]).to have_attributes(limit: 1000, period: 5.minutes)
+    end
+
+    it "limits public API requests by ip to 300 requests per 5 minutes" do
+      expect(Rack::Attack.throttles["public API requests by ip"]).to have_attributes(limit: 300, period: 5.minutes)
+    end
+
+    it "limits non-API requests by ip to 300 requests per 5 minutes" do
+      expect(Rack::Attack.throttles["non-API requests by ip"]).to have_attributes(limit: 300, period: 5.minutes)
+    end
+
+    it "limits catch all requests by ip to 1500 requests per 5 minutes" do
+      expect(Rack::Attack.throttles["catch all requests by ip"]).to have_attributes(limit: 1500, period: 5.minutes)
+    end
+  end
+
   def set_request_ip(request_ip)
     default_headers[:REMOTE_ADDR] = request_ip
   end

--- a/spec/requests/rate_limiting_spec.rb
+++ b/spec/requests/rate_limiting_spec.rb
@@ -63,6 +63,20 @@ RSpec.describe "Rate limiting" do
     end
   end
 
+  it_behaves_like "a rate limited endpoint", "API TeacherAuth webhook message requests by ip" do
+    before { allow(Linzer).to receive(:verify!).and_return(true) }
+
+    def perform_request
+      post api_teaching_record_system_v1_webhook_messages_path,
+           params: { message: "test" }.to_json,
+           headers: { "ce-time" => Time.current.to_s }
+    end
+
+    def change_condition
+      set_request_ip(other_ip)
+    end
+  end
+
   it_behaves_like "a rate limited endpoint", "API requests by auth token" do
     let(:lead_provider) { create(:lead_provider) }
     let(:other_lead_provider) { create(:lead_provider) }


### PR DESCRIPTION
### Context

Ticket: [NPQ-3864](https://dfedigital.atlassian.net/browse/NPQ-3864)

We need to set a rate limit to the new TeacherAuth webhooks endpoint, same as we already do for the GetAnIdentity one. We also need to adjust that of the admin sign.

### Changes proposed in this pull request

1. Add a new throttle for the TeacherAuth webhooks endpoint, limited to 100 requests per 5 minutes.
2. Lower the GetAnIdentity webhooks throttle from 1000 to 100 requests per 5 minutes.
3. Change the admin sign in throttle from 2 minutes to 5 minutes (limit stays at 10).
4. Add specs to check the limit and period of every throttle.

### Notes

[NPQ-3864]: https://dfedigital.atlassian.net/browse/NPQ-3864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ