### PR TITLE
[NPQ-3872] Don't notify Sentry of a blank cohort selection in the application journey

### DIFF
--- a/app/forms/questionnaires/course_start_date.rb
+++ b/app/forms/questionnaires/course_start_date.rb
@@ -15,7 +15,7 @@ module Questionnaires
     attribute QUESTION_NAME
 
     validates QUESTION_NAME, presence: true, inclusion: { in: OPTIONS.keys }
-    validate :cohort_exists
+    validate :cohort_exists, if: -> { course_start_cohort.present? }
 
     def self.permitted_params
       [QUESTION_NAME]
@@ -55,12 +55,10 @@ module Questionnaires
   private
 
     def cohort_exists
-      cohort_identifier = course_start_cohort
-      cohort = Cohort.find_by(identifier: cohort_identifier)
-      unless cohort
-        errors.add(QUESTION_NAME, :invalid)
-        Sentry.capture_message("Cohort selected by user does not exist: #{cohort_identifier}")
-      end
+      return if Cohort.find_by(identifier: course_start_cohort)
+
+      errors.add(QUESTION_NAME, :invalid)
+      Sentry.capture_message("Cohort selected by user does not exist: #{course_start_cohort}")
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -449,9 +449,10 @@ en:
               blank: Select an option that tells us about your experience of mastery approaches to teaching maths.
         questionnaires/course_start_date:
           attributes:
-            course_start_date:
+            course_start_cohort:
               blank: Choose your course start date.
               inclusion: Choose your course start date.
+              invalid: Cohort selected does not exist.
         questionnaires/choose_your_provider:
           attributes:
             lead_provider_id:

--- a/spec/forms/questionnaires/course_start_date_spec.rb
+++ b/spec/forms/questionnaires/course_start_date_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Questionnaires::CourseStartDate, type: :model do
     context "when the chosen cohort that does not correspond to an existing cohort" do
       before { instance.course_start_cohort = described_class::OPTIONS.keys.last }
 
-      it { is_expected.to have_error(:course_start_cohort, :invalid) }
+      it { is_expected.to have_error(:course_start_cohort, :invalid, "Cohort selected does not exist.") }
 
       it "notifies Sentry" do
         expect(Sentry).to receive(:capture_message).with(/Cohort selected by user does not exist/)
@@ -24,7 +24,7 @@ RSpec.describe Questionnaires::CourseStartDate, type: :model do
     end
 
     context "when no cohort is selected" do
-      it { is_expected.to have_error(:course_start_cohort, :blank) }
+      it { is_expected.to have_error(:course_start_cohort, :blank, "Choose your course start date.") }
 
       it "does not notify Sentry" do
         expect(Sentry).not_to receive(:capture_message)

--- a/spec/forms/questionnaires/course_start_date_spec.rb
+++ b/spec/forms/questionnaires/course_start_date_spec.rb
@@ -12,8 +12,24 @@ RSpec.describe Questionnaires::CourseStartDate, type: :model do
     it { is_expected.to validate_presence_of(:course_start_cohort) }
     it { is_expected.to validate_inclusion_of(:course_start_cohort).in_array(described_class::OPTIONS.keys) }
 
-    context "when the course_start_cohort does not correspond to an existing cohort" do
+    context "when the chosen cohort that does not correspond to an existing cohort" do
+      before { instance.course_start_cohort = described_class::OPTIONS.keys.last }
+
       it { is_expected.to have_error(:course_start_cohort, :invalid) }
+
+      it "notifies Sentry" do
+        expect(Sentry).to receive(:capture_message).with(/Cohort selected by user does not exist/)
+        instance.valid?
+      end
+    end
+
+    context "when no cohort is selected" do
+      it { is_expected.to have_error(:course_start_cohort, :blank) }
+
+      it "does not notify Sentry" do
+        expect(Sentry).not_to receive(:capture_message)
+        instance.valid?
+      end
     end
 
     context "when the course_start_cohort corresponds to an existing cohort" do


### PR DESCRIPTION
### Context

Ticket: [NPQ-3872](https://dfedigital.atlassian.net/browse/NPQ-3872)

We were getting a Sentry alert every time a user did not pick a cohort on the course start date screen. We only want it when the user picks a cohort we cannot find in the database.

### Changes proposed in this pull request

1. Skip the `cohort_exists` check when the cohort is blank, so we no longer notify Sentry for an empty selection. The presence validation already handles the empty case.
2. Update the specs to cover both cases: an unknown cohort still notifies Sentry, and no cohort selected does not.

### Notes


[NPQ-3872]: https://dfedigital.atlassian.net/browse/NPQ-3872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ