### PR TITLE
[NPQ-3877] swap sign out link for a confirmation form

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,10 @@
 class SessionsController < PublicPagesController
+  def confirm_sign_out
+    return redirect_to(root_path) unless current_user || current_admin
+
+    @cancel_url = cancel_url
+  end
+
   def destroy
     admin = current_admin
     user = current_user
@@ -18,6 +24,19 @@ class SessionsController < PublicPagesController
   end
 
 private
+
+  # Only send the user back to the referer if it's in this domain and different to the current page.
+  def cancel_url
+    referer = URI.parse(request.referer.to_s)
+
+    if referer.host == request.host && referer.path != request.path
+      request.referer
+    else
+      root_path
+    end
+  rescue URI::InvalidURIError
+    root_path
+  end
 
   def get_an_identity_sign_out_uri
     tra_domain_uri = URI.parse(ENV["TRA_OIDC_DOMAIN"])

--- a/app/views/sessions/confirm_sign_out.html.erb
+++ b/app/views/sessions/confirm_sign_out.html.erb
@@ -1,0 +1,17 @@
+<% content_for :title, "Sign out" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Sign out</h1>
+
+    <p class="govuk-body">Are you sure you want to sign out?</p>
+
+    <p class="govuk-body">If you sign out, you will need to sign in again to continue using this service.</p>
+
+    <%= form_with url: sign_out_user_path, method: :delete do |f| %>
+      <%= f.govuk_submit "Sign out" do %>
+        <%= govuk_button_link_to "Stay signed in", @cancel_url, secondary: true %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,7 +37,8 @@ Rails.application.routes.draw do
   get "/registration-interest/sign-up/confirm", to: "interest_notification_sign_up#confirm"
 
   get "/sign-in", to: "session_wizard#show", step: "sign_in"
-  get "/sign-out", to: "sessions#destroy", as: "sign_out_user"
+  get "/sign-out", to: "sessions#confirm_sign_out", as: "sign_out_user"
+  delete "/sign-out", to: "sessions#destroy"
 
   get "/session/:step", to: "session_wizard#show", as: "session_wizard_show"
   patch "/session/:step", to: "session_wizard#update", as: "session_wizard_update"

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,70 +1,151 @@
 require "rails_helper"
 
 RSpec.describe SessionsController do
-  include Helpers::JourneyHelper
-
   let(:post_logout_uri) { "http://test.host/sign-out" }
 
-  context "with a Get an Identity user is signed in" do
-    before do
-      allow(controller).to receive(:current_user).and_return(user)
+  describe "#confirm_sign_out" do
+    render_views
+
+    context "when a user is signed in" do
+      before do
+        allow(controller).to receive(:current_user).and_return(create(:user))
+      end
+
+      it "renders the sign out confirmation page" do
+        get :confirm_sign_out
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Are you sure you want to sign out?")
+      end
+
+      it "uses the referer as the cancel URL" do
+        request.headers["HTTP_REFERER"] = "http://test.host/account"
+
+        get :confirm_sign_out
+
+        cancel_link = Capybara.string(response.body).find_link("Stay signed in")
+        expect(cancel_link[:href]).to eq("http://test.host/account")
+      end
+
+      it "uses the root path as the cancel URL when there is no referer" do
+        get :confirm_sign_out
+
+        cancel_link = Capybara.string(response.body).find_link("Stay signed in")
+        expect(cancel_link[:href]).to eq(root_path)
+      end
+
+      it "uses the root path as the cancel URL when the referer is from another site" do
+        request.headers["HTTP_REFERER"] = "https://another.com/page"
+
+        get :confirm_sign_out
+
+        cancel_link = Capybara.string(response.body).find_link("Stay signed in")
+        expect(cancel_link[:href]).to eq(root_path)
+      end
+
+      it "uses the root path as the cancel URL when the referer is the sign out page itself" do
+        request.headers["HTTP_REFERER"] = "http://test.host/sign-out"
+
+        get :confirm_sign_out
+
+        cancel_link = Capybara.string(response.body).find_link("Stay signed in")
+        expect(cancel_link[:href]).to eq(root_path)
+      end
+
+      it "uses the root path as the cancel URL when the referer is not a valid URI" do
+        request.headers["HTTP_REFERER"] = "http://test.host/  th"
+
+        get :confirm_sign_out
+
+        cancel_link = Capybara.string(response.body).find_link("Stay signed in")
+        expect(cancel_link[:href]).to eq(root_path)
+      end
     end
 
-    let(:user) { create(:user, :with_get_an_identity_id) }
+    context "when an admin is signed in" do
+      before do
+        allow(controller).to receive(:current_admin).and_return(create(:admin))
+      end
 
-    it "redirects to the external OIDC provider's signout endpoint" do
-      expect(controller).to receive(:sign_out_all_scopes)
+      it "renders the sign out confirmation page" do
+        get :confirm_sign_out
 
-      expected_redirect_url = "https://tra-domain.com:443/connect/signout?client_id=register-for-npq&post_logout_redirect_uri=#{CGI.escape(post_logout_uri)}"
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Are you sure you want to sign out?")
+      end
+    end
 
-      get :destroy
+    context "when no one is signed in (direct request or callback from a provider after signing out)" do
+      it "redirects to root" do
+        get :confirm_sign_out
 
-      expect(response).to redirect_to(expected_redirect_url)
+        expect(response).to redirect_to(root_path)
+      end
     end
   end
 
-  context "when a TeacherAuth user is signed in" do
-    before do
-      allow(controller).to receive(:current_user).and_return(user)
+  describe "#destroy" do
+    context "when a Get an Identity user is signed in" do
+      before do
+        allow(controller).to receive(:current_user).and_return(user)
+      end
+
+      let(:user) { create(:user, :with_get_an_identity_id) }
+
+      it "redirects to the external OIDC provider's signout endpoint" do
+        expect(controller).to receive(:sign_out_all_scopes)
+
+        expected_redirect_url = "https://tra-domain.com:443/connect/signout?client_id=register-for-npq&post_logout_redirect_uri=#{CGI.escape(post_logout_uri)}"
+
+        delete :destroy
+
+        expect(response).to redirect_to(expected_redirect_url)
+      end
     end
 
-    let(:user) { create(:user, :with_teacher_auth) }
-    let(:id_token) { "test-id-token" }
+    context "when a TeacherAuth user is signed in" do
+      before do
+        allow(controller).to receive(:current_user).and_return(user)
+      end
 
-    it "redirects to the external OIDC provider's signout endpoint" do
-      expect(controller).to receive(:sign_out_all_scopes)
+      let(:user) { create(:user, :with_teacher_auth) }
+      let(:id_token) { "test-id-token" }
 
-      session[:id_token] = id_token
+      it "redirects to the external OIDC provider's signout endpoint" do
+        expect(controller).to receive(:sign_out_all_scopes)
 
-      expected_redirect_url = "/users/auth/teacher_auth/logout?id_token_hint=#{id_token}"
+        session[:id_token] = id_token
 
-      get :destroy
+        expected_redirect_url = "/users/auth/teacher_auth/logout?id_token_hint=#{id_token}"
 
-      expect(response).to redirect_to(expected_redirect_url)
+        delete :destroy
+
+        expect(response).to redirect_to(expected_redirect_url)
+      end
     end
-  end
 
-  context "when an admin is signed in" do
-    before do
-      allow(controller).to receive(:current_admin).and_return(create(:admin))
+    context "when an admin is signed in" do
+      before do
+        allow(controller).to receive(:current_admin).and_return(create(:admin))
+      end
+
+      it "redirects to admin path" do
+        expect(controller).to receive(:sign_out_all_scopes)
+
+        delete :destroy
+
+        expect(response).to redirect_to(root_path)
+      end
     end
 
-    it "redirects to admin path" do
-      expect(controller).to receive(:sign_out_all_scopes)
+    context "when no user is signed in" do
+      it "redirects to root" do
+        expect(controller).to receive(:sign_out_all_scopes)
 
-      get :destroy
+        delete :destroy
 
-      expect(response).to redirect_to(root_path)
-    end
-  end
-
-  context "when no user is signed in (callback from provider)" do
-    it "redirects to root" do
-      expect(controller).to receive(:sign_out_all_scopes)
-
-      get :destroy
-
-      expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(root_path)
+      end
     end
   end
 end

--- a/spec/features/service_closed_spec.rb
+++ b/spec/features/service_closed_spec.rb
@@ -104,6 +104,7 @@ RSpec.feature "Service is closed", :no_js, type: :feature do
       expect(page).to have_content("Added #{email}")
 
       click_link("Sign out")
+      click_button("Sign out")
       visit "/closed_registration_exception"
       click_on("Start now")
 
@@ -198,6 +199,7 @@ RSpec.feature "Service is closed", :no_js, type: :feature do
         fill_in("Email address", with: email)
         click_on("Add user")
         click_link("Sign out")
+        click_button("Sign out")
         open_registration!
       end
 

--- a/spec/features/sign_out_spec.rb
+++ b/spec/features/sign_out_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.feature "Signing out", :no_js, type: :feature do
+  include Helpers::AdminLogin
+
+  let(:admin) { create(:admin) }
+
+  scenario "signing out via the confirmation page" do
+    sign_in_as(admin)
+
+    click_link "Sign out"
+
+    expect(page).to have_current_path("/sign-out")
+    expect(page).to have_content("Are you sure you want to sign out?")
+    expect(page).to be_accessible
+
+    click_button "Sign out"
+
+    expect(page).to have_current_path("/")
+    visit "/npq-separation/admin"
+    expect(page).to have_current_path(sign_in_path)
+  end
+
+  scenario "cancelling returns to the previous page" do
+    sign_in_as(admin)
+
+    click_link "Sign out"
+    click_link "Stay signed in"
+
+    expect(page).to have_current_path("/npq-separation/admin")
+  end
+
+  scenario "visiting the confirmation page when signed out redirects to the homepage" do
+    visit "/sign-out"
+
+    expect(page).to have_current_path("/")
+  end
+
+  context "with a Get an Identity user" do
+    include_context "Stub Get An Identity Omniauth Responses"
+
+    before do
+      allow(User).to receive(:find_by).and_return(create(:user, :with_get_an_identity_id))
+    end
+
+    scenario "the header link shows the confirmation page" do
+      visit "/"
+      click_link "Sign out"
+
+      expect(page).to have_current_path("/sign-out")
+      expect(page).to have_content("Are you sure you want to sign out?")
+      expect(page).to have_button("Sign out")
+      expect(page).to have_link("Stay signed in")
+    end
+  end
+end


### PR DESCRIPTION
### Context

Ticket: [NPQ-3877](https://dfedigital.atlassian.net/browse/NPQ-3877)

We want signing out to go through a confirmation page with a button, instead of a plain link.

### Changes proposed in this pull request

1. GET /sign-out now shows a confirmation page with a "Sign out" button and a "Stay signed in" button, instead of signing the user out straight away.
2. The sign out button submits a form that runs the existing sign out code.
3. "Stay signed in" takes the user back to the page they came from, falling back to the home page.
4. If nobody is signed in, the page redirects to the home page.
5. Added and updated specs for the new behaviour.


[NPQ-3877]: https://dfedigital.atlassian.net/browse/NPQ-3877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ