### PR TITLE
[NPQ-3841] "Do you work in England?" step routing

### DIFF
--- a/app/controllers/registration_wizard_controller.rb
+++ b/app/controllers/registration_wizard_controller.rb
@@ -12,6 +12,12 @@ class RegistrationWizardController < PublicPagesController
   include Questionnaires::FlowHelper
   helper_method :first_questionnaire_step
 
+  FORMS_FOR_STEPS_BEFORE_COURSE_IS_CHOSEN = [
+    Questionnaires::ChooseYourNpq,
+    Questionnaires::FundingYourNpq,
+    Questionnaires::IneligibleForFunding,
+  ].freeze
+
   def show
     @form.flag_as_changing_answer if params[:changing_answer] == "1"
 
@@ -107,7 +113,7 @@ private
   end
 
   def check_course_defined
-    redirect_to_course_start_date if !@form.instance_of?(Questionnaires::ChooseYourNpq) && defined?(@form.course) && !@form.course
+    redirect_to_course_start_date if !FORMS_FOR_STEPS_BEFORE_COURSE_IS_CHOSEN.include?(@form.class) && defined?(@form.course) && !@form.course
     redirect_to_course_start_date if @form.instance_of?(Questionnaires::CheckAnswers) && !@wizard.course
   end
 

--- a/app/forms/questionnaires/ineligible_for_funding.rb
+++ b/app/forms/questionnaires/ineligible_for_funding.rb
@@ -15,10 +15,16 @@ module Questionnaires
     attribute :version
 
     def next_step
-      :funding_your_npq
+      if course
+        :funding_your_npq
+      else
+        :choose_your_npq
+      end
     end
 
     def previous_step
+      return :teacher_catchment unless course
+
       if works_in_another_setting? && employment_type_other?
         :choose_your_npq
       elsif course.npqlpm?

--- a/app/forms/questionnaires/teacher_catchment.rb
+++ b/app/forms/questionnaires/teacher_catchment.rb
@@ -25,7 +25,11 @@ module Questionnaires
     def next_step
       return :check_answers if changing_answer? && !answers_will_change?
 
-      :work_setting
+      if teacher_catchment == "england"
+        :choose_your_npq
+      else
+        :ineligible_for_funding
+      end
     end
 
     def previous_step

--- a/app/views/registration_wizard/ineligible_for_funding.erb
+++ b/app/views/registration_wizard/ineligible_for_funding.erb
@@ -12,7 +12,7 @@
     chosen_cohort: Questionnaires::CourseStartDate::OPTIONS[@wizard.query_store.course_start_cohort][:cohort_description]
   %>
 
-  <%= govuk_button_link_to "Continue", registration_wizard_show_path(@wizard.next_step_path) %>
+  <%= govuk_button_link_to "Continue to register", registration_wizard_show_path(@wizard.next_step_path) %>
 
 <% end %>
 

--- a/app/views/registration_wizard/ineligible_for_funding/_not_in_england.html.erb
+++ b/app/views/registration_wizard/ineligible_for_funding/_not_in_england.html.erb
@@ -1,12 +1,3 @@
 <%= funding_title(:not_eligible) %>
 
-<p class="govuk-body">You’re not eligible for scholarship funding for <%= localise_sentence_embedded_course_name(course) %> course as you do not work in England.</p>
-
-<p class="govuk-body">This means that you would need to pay for the course another way. For example, you could pay for the course fees yourself or ask your workplace or trust to:</p>
-
-<p class="govuk-body">
-  <ul class="govuk-list govuk-list--bullet">
-    <li>cover the full cost of the course</li>
-    <li>share the cost of the course with you</li>
-  </ul>
-</p>
+<p class="govuk-body">You’re not eligible for DfE scholarship funding because you do not work in England.</p>

--- a/spec/features/journeys/post_mvp/check_if_youre_eligible_spec.rb
+++ b/spec/features/journeys/post_mvp/check_if_youre_eligible_spec.rb
@@ -24,10 +24,16 @@ RSpec.feature "Happy journeys", :no_js, :with_cohorts, type: :feature do
 
     expect_page_to_have(path: "/registration/teacher-catchment", submit_form: true) do
       expect(page).to have_text("Do you work in England?")
-      # choose("Yes", visible: :all) # TOOD: will be part of NPQ-3841
+      choose("Yes", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/choose-your-npq", submit_form: false) do
+      expect(page).to have_text("Choose an NPQ")
     end
 
     # check back links
+    click_link("Back")
+    expect(page).to have_current_path("/registration/teacher-catchment")
     click_link("Back")
     expect(page).to have_current_path("/registration/check-funding")
     click_link("Back")
@@ -42,10 +48,23 @@ RSpec.feature "Happy journeys", :no_js, :with_cohorts, type: :feature do
     end
 
     expect_page_to_have(path: "/registration/teacher-catchment", submit_form: true) do
-      # choose("No", visible: :all) # TOOD: will be part of NPQ-3841
+      choose("No", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
+      expect(page).to have_text("You’re not eligible for DfE scholarship funding because you do not work in England")
+      click_link("Continue to register")
+    end
+
+    expect_page_to_have(path: "/registration/choose-your-npq", submit_form: false) do
+      expect(page).to have_text("Choose an NPQ")
     end
 
     # check back links
+    click_link("Back")
+    expect(page).to have_current_path("/registration/ineligible-for-funding")
+    click_link("Back")
+    expect(page).to have_current_path("/registration/teacher-catchment")
     click_link("Back")
     expect(page).to have_current_path("/registration/check-funding")
     click_link("Back")

--- a/spec/forms/questionnaires/ineligible_for_funding_spec.rb
+++ b/spec/forms/questionnaires/ineligible_for_funding_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe Questionnaires::IneligibleForFunding, type: :model do
+  subject(:instance) { described_class.new(wizard:) }
+
+  let(:current_step) { :ineligible_for_funding }
+  let(:wizard) { RegistrationWizard.new(current_step:, store: {}, request: nil, current_user: nil) }
+
+  describe "#next_step" do
+    subject { instance.next_step }
+
+    context "when the user has not chosen a course" do
+      it { is_expected.to eq(:choose_your_npq) }
+    end
+
+    context "when the user has chosen a course" do
+      before { wizard.store["course_identifier"] = "npq-senior-leadership" }
+
+      it { is_expected.to eq(:funding_your_npq) }
+    end
+  end
+
+  describe "#previous_step" do
+    subject { instance.previous_step }
+
+    context "when the user has not chosen a course" do
+      it { is_expected.to eq(:teacher_catchment) }
+    end
+  end
+end

--- a/spec/forms/questionnaires/teacher_catchment_spec.rb
+++ b/spec/forms/questionnaires/teacher_catchment_spec.rb
@@ -1,7 +1,35 @@
 require "rails_helper"
 
 RSpec.describe Questionnaires::TeacherCatchment, type: :model do
+  let(:wizard) { RegistrationWizard.new(current_step:, store: {}, request: nil, current_user: nil) }
+  let(:current_step) { :teacher_catchment }
+  let(:instance) { described_class.new(wizard:, teacher_catchment:) }
+
   describe "validations" do
     it { is_expected.to validate_presence_of(:teacher_catchment) }
+  end
+
+  describe "#next_step" do
+    subject { instance.next_step }
+
+    context "when the user is in England" do
+      let(:teacher_catchment) { "england" }
+
+      it { is_expected.to eq(:choose_your_npq) }
+    end
+
+    context "when the user is not in England" do
+      let(:teacher_catchment) { "another" }
+
+      it { is_expected.to eq(:ineligible_for_funding) }
+    end
+  end
+
+  describe "#previous_step" do
+    subject { instance.previous_step }
+
+    let(:teacher_catchment) { "another" }
+
+    it { is_expected.to eq(:check_funding) }
   end
 end

--- a/spec/services/registration_query_store_spec.rb
+++ b/spec/services/registration_query_store_spec.rb
@@ -47,8 +47,8 @@ RSpec.describe RegistrationQueryStore do
       it { is_expected.to be true }
     end
 
-    context "when check_funding is nil" do
-      let(:check_funding) { nil }
+    context "when check_funding is 'no'" do
+      let(:check_funding) { "no" }
 
       it { is_expected.to be false }
     end


### PR DESCRIPTION
### Context

Ticket: [NPQ-3841](https://dfedigital.atlassian.net/browse/NPQ-3841)

"Do you work in England?" step - if 'No' is chosen, shows an ineligible page, before continuing on to "Choose an NPQ".

### Changes proposed in this pull request

1. `#next_step` updated for `Questionnaires::TeacherCatchment`
2. `#next_step` and `#previous_step` updated for `Questionnaires::IneligibleForFunding`
3. updated course validation in the controller, as there are a number of steps that now come before the user has chosen a course


[NPQ-3841]: https://dfedigital.atlassian.net/browse/NPQ-3841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ