### PR TITLE
[NPQ-3904] fix deleting of overdue refresh tokens

### DIFF
--- a/app/jobs/teaching_record_system/allocate_trn_job.rb
+++ b/app/jobs/teaching_record_system/allocate_trn_job.rb
@@ -5,7 +5,7 @@ module TeachingRecordSystem
 
       if user.trn.present?
         # TRN has been allocated already and token no longer needed
-        user.refresh_token.destroy!
+        user.refresh_token&.destroy!
         return
       end
 

--- a/app/services/teaching_record_system/webhooks/trn_request_completed_processor.rb
+++ b/app/services/teaching_record_system/webhooks/trn_request_completed_processor.rb
@@ -4,7 +4,10 @@ module TeachingRecordSystem
       WEBHOOK_NAME = "TRN request completed webhook".freeze
 
       def process!
-        user.update!(trn: new_trn, trn_verified: true, trn_auto_verified: true)
+        User.transaction do
+          user.update!(trn: new_trn, trn_verified: true, trn_auto_verified: true)
+          user.refresh_token&.destroy!
+        end
 
         if user.trn_previously_changed?(from: nil) && user.email.present?
           TrnAllocatedMailer.trn_allocated_mail(to: user.email, full_name: user.full_name, trn: new_trn).deliver_later

--- a/app/services/teaching_record_system/webhooks/user_updated_processor.rb
+++ b/app/services/teaching_record_system/webhooks/user_updated_processor.rb
@@ -4,7 +4,10 @@ module TeachingRecordSystem
       WEBHOOK_NAME = "One Login user updated webhook".freeze
 
       def process!
-        user.update!(params_to_update)
+        User.transaction do
+          user.update!(params_to_update)
+          user.refresh_token&.destroy! if new_trn.present?
+        end
       end
 
     private

--- a/lib/tasks/one_off/remove_refresh_tokens.rake
+++ b/lib/tasks/one_off/remove_refresh_tokens.rake
@@ -1,0 +1,17 @@
+namespace :one_off do
+  desc "Remove OAuth refresh tokens for users with TRNs"
+  task remove_refresh_tokens_for_users_with_trns: :versioned_environment do
+    logger = Rails.env.test? ? Rails.logger : Logger.new($stdout)
+
+    tokens = OauthToken.overdue_refresh.joins(:user).where.not(user: { trn: nil })
+    logger.info("Overdue OAuth refresh tokens for users with TRNs: #{tokens.count}")
+
+    tokens.destroy_all
+
+    logger.info("Tokens deleted.")
+    logger.info(
+      "Overdue OAuth refresh tokens for users with TRNs: " \
+      "#{OauthToken.overdue_refresh.joins(:user).where.not(user: { trn: nil }).count}",
+    )
+  end
+end

--- a/spec/jobs/teaching_record_system/allocate_trn_job_spec.rb
+++ b/spec/jobs/teaching_record_system/allocate_trn_job_spec.rb
@@ -53,6 +53,22 @@ RSpec.describe TeachingRecordSystem::AllocateTrnJob, type: :job do
         expect(TrnAllocatedMailer).not_to send_mail(:trn_allocated_mail, deliver_now: true)
         perform_job
       end
+
+      context "when the user's refresh token has already been removed" do
+        let(:user) do
+          create(:user,
+                 :with_teacher_auth,
+                 trn:,
+                 trn_verified: true,
+                 trn_auto_verified: true)
+        end
+
+        it "does not call the APIs" do
+          perform_job
+          expect(TeachingRecordSystem::RefreshTokens).not_to have_received(:refresh!)
+          expect(TeachingRecordSystem::ActivateTrnRequest).not_to have_received(:activate!)
+        end
+      end
     end
 
     context "with user without TRN" do

--- a/spec/services/teaching_record_system/webhooks/trn_request_completed_processor_spec.rb
+++ b/spec/services/teaching_record_system/webhooks/trn_request_completed_processor_spec.rb
@@ -28,6 +28,15 @@ RSpec.describe TeachingRecordSystem::Webhooks::TrnRequestCompletedProcessor do
       expect { subject }.to change(webhook_message, :status).from("pending").to("processed")
     end
 
+    context "when the user has a refresh token" do
+      let(:user) { create(:user, :with_teacher_auth, :with_refresh_token) }
+
+      it "destroys the user's refresh token" do
+        subject
+        expect(user.refresh_token).to be_nil
+      end
+    end
+
     context "when the user's TRN was initially nil" do
       let(:user) { create(:user, :with_teacher_auth, trn: nil) }
 

--- a/spec/services/teaching_record_system/webhooks/user_updated_processor_spec.rb
+++ b/spec/services/teaching_record_system/webhooks/user_updated_processor_spec.rb
@@ -35,6 +35,15 @@ RSpec.describe TeachingRecordSystem::Webhooks::UserUpdatedProcessor do
       expect { subject }.to change(webhook_message, :status).from("pending").to("processed")
     end
 
+    context "when the user has a refresh token" do
+      let(:user) { create(:user, :with_teacher_auth, :with_refresh_token) }
+
+      it "destroys the user's refresh token" do
+        subject
+        expect(user.refresh_token).to be_nil
+      end
+    end
+
     context "when there is no connected person" do
       let(:webhook_message) do
         create(
@@ -48,6 +57,15 @@ RSpec.describe TeachingRecordSystem::Webhooks::UserUpdatedProcessor do
       it "updates the user's email address" do
         subject
         expect(user.reload.email).to eq(new_email)
+      end
+
+      context "when the user has a refresh token" do
+        let(:user) { create(:user, :with_teacher_auth, :with_refresh_token) }
+
+        it "does not destroy the user's refresh token" do
+          subject
+          expect(user.refresh_token).not_to be_nil
+        end
       end
     end
 


### PR DESCRIPTION
### Context

Ticket: [NPQ-3904](https://dfedigital.atlassian.net/browse/NPQ-3904)

### Changes proposed in this pull request

1. update the webhooks to destory the refresh token if the user has a TRN
2. rake task to remove overdue refresh tokens for users that already have a TRN

[NPQ-3904]: https://dfedigital.atlassian.net/browse/NPQ-3904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ