### PR TITLE
[NPQ-3850] Update the Your NPQ registrations page

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,8 +1,16 @@
 class AccountsController < LoggedInController
   def show
-    return unless current_user.applications.count == 1
+    applications = current_user.applications
 
-    application = current_user.applications.first
-    redirect_to accounts_user_registration_path(application)
+    if applications.count == 1
+      redirect_to accounts_user_registration_path(applications.first)
+    else
+      @active_applications = applications.active_applications
+                                         .includes(:course, :lead_provider)
+                                         .order(created_at: :desc, id: :desc)
+      @expired_applications = applications.expired_applications
+                                          .includes(:course, :lead_provider)
+                                          .order(created_at: :desc, id: :desc)
+    end
   end
 end

--- a/app/views/accounts/_active_application_table.html.erb
+++ b/app/views/accounts/_active_application_table.html.erb
@@ -6,9 +6,11 @@
         <%= application.lead_provider.name %>
       </p>
     </div>
-    <span class="govuk-summary-card__action govuk-!-margin-top-1">
-      <%= govuk_link_to("View details", accounts_user_registration_path(application)) %>
-    </span>
+    <ul class="govuk-summary-card__actions">
+      <li class="govuk-summary-card__action">
+        <%= govuk_link_to("View details", accounts_user_registration_path(application)) %>
+      </li>
+    </ul>
   </div>
   <div class="govuk-summary-card__content">
     <dl class="govuk-summary-list">

--- a/app/views/accounts/_active_application_table.html.erb
+++ b/app/views/accounts/_active_application_table.html.erb
@@ -23,12 +23,19 @@
 
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-          Provider application
+          Application status
         </dt>
         <dd class="govuk-summary-list__value">
           <% if application.lead_provider_approval_status.blank? || pending?(application) %>
-            <%= govuk_tag(text: "Apply with provider", colour: "yellow") %>
-            <%= render 'provider_pending_status' %>
+            <%= govuk_tag(text: "Awaiting provider", colour: "yellow") %>
+
+            <p class="govuk-body govuk-!-margin-top-2">
+              Your provider will contact you with instructions on how to apply for the course.
+            </p>
+
+            <p class="govuk-body govuk-!-margin-bottom-0">
+              You do not need to do anything until they contact you.
+            </p>
           <% elsif accepted?(application) %>
             <%= govuk_tag(text: "Successful", colour: "green") %>
           <% elsif rejected?(application) %>

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -1,34 +1,20 @@
-<% application_count = current_user.applications.count %>
-
 <% content_for :title, "Your NPQ registrations" %>
-<% if application_count > 0%>
-  <% if application_count == 1 %>
-    <h1 class="govuk-heading-l"><%= title ||= t(".title") %></h1>
-  <% else %>
-    <h1 class="govuk-heading-l"><%= title ||= t(".pural_title") %></h1>
-  <% end %>
+
+<h1 class="govuk-heading-l">Your NPQ registrations</h1>
+
+<%= govuk_inset_text do %>
+  You can change your personal details on <%= govuk_link_to "GOV.UK One Login (opens in a new tab)", Rails.configuration.x.teacher_auth.onelogin_home_uri, target: "_blank", rel: "noopener noreferrer" %>.
 <% end %>
 
-<% if Time.zone.now > Time.zone.local(2024, 4, 2) %>
-  <% active_applications = current_user.applications.active_applications.includes(:course, :lead_provider).order(created_at: :desc, id: :desc) %>
-  <% expired_applications = current_user.applications.expired_applications.includes(:course, :lead_provider).order(created_at: :desc, id: :desc) %>
+<% @active_applications.each do |application| %>
+  <%= render "active_application_table", application: application %>
+<% end %>
 
-  <% active_applications.each do |application| %>
-    <%= render "active_application_table", application: application %>
-  <% end %>
+<% if @expired_applications.any? %>
+  <h3 class="govuk-heading-l">Expired registrations</h3>
 
-  <% if expired_applications.count > 0 %>
-    <h3 class="govuk-heading-l">Expired registrations</h3>
-
-    <% expired_applications.each do |application| %>
-      <%= render "expired_application_table", application: application %>
-    <% end %>
-  <% end %>
-<% else %>
-  <% active_applications = current_user.applications.order(created_at: :desc, id: :desc) %>
-
-  <% active_applications.each do |application| %>
-    <%= render "active_application_table", application: application %>
+  <% @expired_applications.each do |application| %>
+    <%= render "expired_application_table", application: application %>
   <% end %>
 <% end %>
 

--- a/spec/features/account_spec.rb
+++ b/spec/features/account_spec.rb
@@ -33,6 +33,34 @@ RSpec.feature "Account", :no_js, type: :feature do
         expect(page).to have_current_path("/accounts/user_registrations/#{application.id}")
       end
 
+      context "when the user has more than one registration" do
+        let(:second_application) { create(:application, user:, cohort:) }
+        let :expired_application do
+          create(:application,
+                 user:,
+                 lead_provider_approval_status: :rejected,
+                 created_at: Application.cut_off_date_for_expired_applications - 1.day)
+        end
+
+        before do
+          second_application
+          expired_application
+        end
+
+        scenario "it shows the registrations overview page with active and expired registrations" do
+          visit "/account"
+
+          expect(page).to have_current_path("/account")
+          expect(page).to have_css("h1", text: "Your NPQ registrations")
+          expect(page).to have_link("GOV.UK One Login (opens in a new tab)")
+          expect(page).to have_content("Awaiting provider")
+          expect(page).to have_content("Expired registrations")
+          expect(page).to have_link("View details", href: accounts_user_registration_path(application))
+          expect(page).to have_link("View details", href: accounts_user_registration_path(second_application))
+          expect(page).not_to have_link("View details", href: accounts_user_registration_path(expired_application))
+        end
+      end
+
       scenario "it shows the course start cohort" do
         visit "/account"
         expect(page).to have_summary_item("Course start", "2025")

--- a/spec/views/accounts/show.html.erb_spec.rb
+++ b/spec/views/accounts/show.html.erb_spec.rb
@@ -4,20 +4,33 @@ RSpec.describe "accounts/show.html.erb", type: :view do
   subject { render }
 
   before do
-    applications
+    assign(:active_applications, active_applications)
+    assign(:expired_applications, expired_applications)
     allow(view).to receive(:current_user).and_return(user)
   end
 
   let(:user) { create(:user, :with_teacher_auth) }
-  let(:applications) { create_list :application, 2, user: }
+  let(:active_applications) { create_list :application, 2, user: }
+  let(:expired_applications) { [] }
 
+  it { is_expected.to have_css "h1", text: "Your NPQ registrations" }
   it { is_expected.to have_content "Register for another NPQ" }
   it { is_expected.to have_css ".govuk-summary-card", count: 2 }
-  it { is_expected.to have_link "View details", href: accounts_user_registration_path(applications[0]) }
-  it { is_expected.to have_link "View details", href: accounts_user_registration_path(applications[1]) }
+  it { is_expected.to have_link "View details", href: accounts_user_registration_path(active_applications[0]) }
+  it { is_expected.to have_link "View details", href: accounts_user_registration_path(active_applications[1]) }
+
+  it "shows a link to update personal details on GOV.UK One Login" do
+    expect(render).to have_link "GOV.UK One Login (opens in a new tab)", href: Rails.configuration.x.teacher_auth.onelogin_home_uri
+  end
+
+  it "shows the awaiting provider application status" do
+    expect(render).to have_content "Awaiting provider"
+    expect(render).to have_content "Your provider will contact you with instructions on how to apply for the course."
+  end
 
   context "with expired applications" do
-    let(:applications) { [active, expired] }
+    let(:active_applications) { [active] }
+    let(:expired_applications) { [expired] }
     let(:active) { create :application, user: }
 
     let :expired do
@@ -28,6 +41,7 @@ RSpec.describe "accounts/show.html.erb", type: :view do
     end
 
     it { is_expected.to have_content "Register for another NPQ" }
+    it { is_expected.to have_content "Expired registrations" }
     it { is_expected.to have_css ".govuk-summary-card", count: 2 }
     it { is_expected.to have_link "View details", href: accounts_user_registration_path(active) }
     it { is_expected.not_to have_link "View details", href: accounts_user_registration_path(expired) }


### PR DESCRIPTION
### Context

Ticket: [NPQ-3850](https://dfedigital.atlassian.net/browse/NPQ-3850)

This updates the "Your NPQ registrations" page. This is the overview page users see when they have more than one registration. The new design shows a simpler summary for each registration and aligns the status with the individual registration page.

### Changes proposed in this pull request

1. Show a fixed "Your NPQ registrations" heading.
2. Add a personal details panel with a link to GOV.UK One Login.
3. Simplify each registration card. It now shows the application status "Awaiting provider" with a short note that the provider will contact the user.
4. Keep the course outcome row on the card.
5. Move the active and expired applications logic from the view into the accounts controller.
6. Update the view spec and add a feature test for the page with active and expired registrations.


[NPQ-3850]: https://dfedigital.atlassian.net/browse/NPQ-3850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ