### PR TITLE
[NPQ-3832] add breadcrumbs to post-registration pages

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,8 +1,9 @@
 class AccountsController < LoggedInController
   def show
     applications = current_user.applications
+    @application_count = applications.count
 
-    if applications.count == 1
+    if @application_count == 1
       redirect_to accounts_user_registration_path(applications.first)
     else
       @active_applications = applications.active_applications

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -1,9 +1,13 @@
 <% content_for :title, "Your NPQ registrations" %>
 
-<h1 class="govuk-heading-l">Your NPQ registrations</h1>
+<% content_for :before_content do %>
+  <%= render GovukComponent::BreadcrumbsComponent.new(
+    breadcrumbs: { t(".plural_title") => nil }
+  ) %>
+<% end %>
 
-<%= govuk_inset_text do %>
-  You can change your personal details on <%= govuk_link_to "GOV.UK One Login (opens in a new tab)", Rails.configuration.x.teacher_auth.onelogin_home_uri, target: "_blank", rel: "noopener noreferrer" %>.
+<% if application_count > 0 %>
+  <h1 class="govuk-heading-l"><%= t(application_count == 1 ? ".title" : ".plural_title") %></h1>
 <% end %>
 
 <% @active_applications.each do |application| %>

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -2,12 +2,16 @@
 
 <% content_for :before_content do %>
   <%= render GovukComponent::BreadcrumbsComponent.new(
-    breadcrumbs: { t(".plural_title") => nil }
+    breadcrumbs: { t(".title.other") => nil }
   ) %>
 <% end %>
 
 <% if application_count > 0 %>
-  <h1 class="govuk-heading-l"><%= t(application_count == 1 ? ".title" : ".plural_title") %></h1>
+  <h1 class="govuk-heading-l"><%= t(".title", count: application_count) %></h1>
+<% end %>
+
+<%= govuk_inset_text do %>
+  You can change your personal details on <%= govuk_link_to "GOV.UK One Login (opens in a new tab)", Rails.configuration.x.teacher_auth.onelogin_home_uri, target: "_blank", rel: "noopener noreferrer" %>.
 <% end %>
 
 <% @active_applications.each do |application| %>

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -6,8 +6,8 @@
   ) %>
 <% end %>
 
-<% if application_count > 0 %>
-  <h1 class="govuk-heading-l"><%= t(".title", count: application_count) %></h1>
+<% if @application_count > 0 %>
+  <h1 class="govuk-heading-l"><%= t(".title", count: @application_count) %></h1>
 <% end %>
 
 <%= govuk_inset_text do %>

--- a/app/views/accounts/user_registrations/show.html.erb
+++ b/app/views/accounts/user_registrations/show.html.erb
@@ -3,15 +3,14 @@
 <% content_for :title, page_heading %>
 
 <% content_for :before_content do %>
-  <% breadcrumbs = current_user.applications.count > 1 ? { I18n.t("accounts.show.plural_title") => account_path } : {} %>
+  <% breadcrumbs = current_user.applications.count > 1 ? { I18n.t("accounts.show.title.other") => account_path } : {} %>
   <%= render GovukComponent::BreadcrumbsComponent.new(
-    breadcrumbs: breadcrumbs.merge(I18n.t("accounts.show.title") => nil)
+    breadcrumbs: breadcrumbs.merge(I18n.t("accounts.show.title.one") => nil)
   ) %>
 <% end %>
 
 <span class="govuk-caption-m">Submitted <%= @application.created_at.to_date.to_fs(:govuk) %></span>
 <h1 class="govuk-heading-l"><%= page_heading %></h1>
-
 <p class="govuk-body"><strong>Registration ID:</strong> <%= @application.ecf_id %></p>
 
 <%= render "course_details", application: @application %>

--- a/app/views/accounts/user_registrations/show.html.erb
+++ b/app/views/accounts/user_registrations/show.html.erb
@@ -1,12 +1,12 @@
 <% page_heading = "Your #{localise_course_name(@application.course)} registration" %>
+
 <% content_for :title, page_heading %>
+
 <% content_for :before_content do %>
-  <% if current_user.applications.count > 1 %>
-    <%= render GovukComponent::BackLinkComponent.new(
-      text: "Back to your registrations",
-      href: account_path
-    ) %>
-  <% end %>
+  <% breadcrumbs = current_user.applications.count > 1 ? { I18n.t("accounts.show.plural_title") => account_path } : {} %>
+  <%= render GovukComponent::BreadcrumbsComponent.new(
+    breadcrumbs: breadcrumbs.merge(I18n.t("accounts.show.title") => nil)
+  ) %>
 <% end %>
 
 <span class="govuk-caption-m">Submitted <%= @application.created_at.to_date.to_fs(:govuk) %></span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -752,8 +752,9 @@ en:
 
   accounts:
     show:
-      title: "Your NPQ registration"
-      plural_title: "Your NPQ registrations"
+      title:
+        one: "Your NPQ registration"
+        other: "Your NPQ registrations"
 
   admin:
     layout:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -753,7 +753,7 @@ en:
   accounts:
     show:
       title: "Your NPQ registration"
-      pural_title: "Your NPQ registrations"
+      plural_title: "Your NPQ registrations"
 
   admin:
     layout:

--- a/spec/features/account_spec.rb
+++ b/spec/features/account_spec.rb
@@ -153,4 +153,48 @@ RSpec.feature "Account", :no_js, type: :feature do
       expect(page).to have_current_path("/")
     end
   end
+
+  describe "breadcrumbs" do
+    before do
+      navigate_to_page(path: "/", submit_form: false, axe_check: false) do
+        page.click_button("Start now")
+      end
+    end
+
+    context "with a single application" do
+      scenario "the registration page shows only the page, no back link and no breadcrum to registration list" do
+        visit accounts_user_registration_path(application)
+
+        expect(page).to have_current_breadcrumb("Your NPQ registration")
+        expect(page).not_to have_breadcrumb_link("Your NPQ registrations")
+        expect(page).not_to have_css(".govuk-back-link")
+      end
+    end
+
+    context "with multiple applications" do
+      before { create(:application, user:, cohort:) }
+
+      scenario "the registrations page shows the page only with a current breadcrumb" do
+        visit "/account"
+
+        expect(page).to have_current_breadcrumb("Your NPQ registrations")
+      end
+
+      scenario "the registration page links back to the registrations page" do
+        visit accounts_user_registration_path(application)
+
+        expect(page).to have_breadcrumb_link("Your NPQ registrations", href: account_path)
+        expect(page).to have_current_breadcrumb("Your NPQ registration")
+        expect(page).not_to have_css(".govuk-back-link")
+      end
+
+      scenario "selecting the registrations breadcrumb goes to the registrations page" do
+        visit accounts_user_registration_path(application)
+
+        within(".govuk-breadcrumbs") { click_link "Your NPQ registrations" }
+
+        expect(page).to have_current_path("/account")
+      end
+    end
+  end
 end

--- a/spec/support/matchers/breadcrumb_matcher.rb
+++ b/spec/support/matchers/breadcrumb_matcher.rb
@@ -1,0 +1,19 @@
+RSpec::Matchers.define :have_current_breadcrumb do |expected_text|
+  match do |page|
+    page.has_css?(".govuk-breadcrumbs__list-item[aria-current='page']", exact_text: expected_text)
+  end
+
+  match_when_negated do |page|
+    page.has_no_css?(".govuk-breadcrumbs__list-item[aria-current='page']", exact_text: expected_text)
+  end
+end
+
+RSpec::Matchers.define :have_breadcrumb_link do |expected_text, href: nil|
+  match do |page|
+    page.has_link?(expected_text, class: "govuk-breadcrumbs__link", href:, exact_text: true)
+  end
+
+  match_when_negated do |page|
+    page.has_no_link?(expected_text, class: "govuk-breadcrumbs__link", href:, exact_text: true)
+  end
+end

--- a/spec/views/accounts/show.html.erb_spec.rb
+++ b/spec/views/accounts/show.html.erb_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe "accounts/show.html.erb", type: :view do
   subject { render }
 
   before do
+    assign(:application_count, application_count)
     assign(:active_applications, active_applications)
     assign(:expired_applications, expired_applications)
     allow(view).to receive(:current_user).and_return(user)
@@ -12,6 +13,7 @@ RSpec.describe "accounts/show.html.erb", type: :view do
   let(:user) { create(:user, :with_teacher_auth) }
   let(:active_applications) { create_list :application, 2, user: }
   let(:expired_applications) { [] }
+  let(:application_count) { active_applications.count + expired_applications.count }
 
   it { is_expected.to have_css "h1", text: "Your NPQ registrations" }
   it { is_expected.to have_content "Register for another NPQ" }


### PR DESCRIPTION
### Context

Ticket: [NPQ-3832](https://dfedigital.atlassian.net/browse/NPQ-3832)
This ticket adds breadcrumbs to post-registration pages and removes the old back link, so users always know where they are and can move back to the list.
### Changes proposed in this pull request
1. Add a breadcrumb to the "Your NPQ registrations" page.
2. Add a breadcrumb to the "Your NPQ registration" page.
3. Remove the old "Back to your registrations".
4. Fix a typo in the locale key: `pural_title` is now `plural_title`.
5. Add feature specs for both pages.


[NPQ-3832]: https://dfedigital.atlassian.net/browse/NPQ-3832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ