### PR TITLE
[NPQ-3920] merge other users with same TRN

### DIFF
--- a/app/services/teaching_record_system/webhooks/trn_request_completed_processor.rb
+++ b/app/services/teaching_record_system/webhooks/trn_request_completed_processor.rb
@@ -6,6 +6,7 @@ module TeachingRecordSystem
       def process!
         User.transaction do
           user.update!(trn: new_trn, trn_verified: true, trn_auto_verified: true)
+          merge_and_archive_other_users_with_same_trn
           user.refresh_token&.destroy!
         end
 
@@ -22,6 +23,12 @@ module TeachingRecordSystem
 
       def new_trn
         webhook_message.message["trnRequest"]["trn"]
+      end
+
+      def merge_and_archive_other_users_with_same_trn
+        User.not_archived.with_trn(new_trn).where.not(id: user.id).find_each do |other_user|
+          Users::MergeAndArchive.new(user_to_merge: other_user, user_to_keep: user).call(dry_run: false)
+        end
       end
 
       def correct_format?

--- a/app/services/teaching_record_system/webhooks/user_updated_processor.rb
+++ b/app/services/teaching_record_system/webhooks/user_updated_processor.rb
@@ -17,7 +17,7 @@ module TeachingRecordSystem
 
       def params_to_update
         { email: user_email }.tap do |params|
-          if new_trn.present? && new_trn != user.trn
+          if new_trn.present?
             params[:trn] = new_trn
             params[:trn_verified] = true
             params[:trn_auto_verified] = true
@@ -40,6 +40,7 @@ module TeachingRecordSystem
       def merge_and_archive_other_users_with_same_trn
         users_with_same_trn = User.not_archived.with_trn(new_trn).order(created_at: :desc).to_a
         user_to_keep = users_with_same_trn[0]
+
         users_with_same_trn[1..].each do |user_to_merge|
           Users::MergeAndArchive.new(user_to_merge:, user_to_keep:).call(dry_run: false)
         end

--- a/app/services/teaching_record_system/webhooks/user_updated_processor.rb
+++ b/app/services/teaching_record_system/webhooks/user_updated_processor.rb
@@ -6,7 +6,10 @@ module TeachingRecordSystem
       def process!
         User.transaction do
           user.update!(params_to_update)
-          user.refresh_token&.destroy! if new_trn.present?
+          if new_trn.present?
+            merge_and_archive_other_users_with_same_trn
+            user.refresh_token&.destroy!
+          end
         end
       end
 
@@ -32,6 +35,14 @@ module TeachingRecordSystem
 
       def new_trn
         webhook_message.message["connectedPerson"]["trn"] if webhook_message.message["connectedPerson"]
+      end
+
+      def merge_and_archive_other_users_with_same_trn
+        users_with_same_trn = User.not_archived.with_trn(new_trn).order(created_at: :desc).to_a
+        user_to_keep = users_with_same_trn[0]
+        users_with_same_trn[1..].each do |user_to_merge|
+          Users::MergeAndArchive.new(user_to_merge:, user_to_keep:).call(dry_run: false)
+        end
       end
 
       def correct_format?

--- a/spec/services/teaching_record_system/webhooks/trn_request_completed_processor_spec.rb
+++ b/spec/services/teaching_record_system/webhooks/trn_request_completed_processor_spec.rb
@@ -58,6 +58,23 @@ RSpec.describe TeachingRecordSystem::Webhooks::TrnRequestCompletedProcessor do
       end
     end
 
+    context "when there are other users with the same verified TRN" do
+      let(:other_user) { create(:user, :with_get_an_identity_id, :with_verified_trn, trn: new_trn) }
+      let(:application) { create(:application, :accepted, user: other_user) }
+
+      before do
+        application
+        create(:user, :archived, :with_get_an_identity_id, :with_verified_trn, trn: new_trn)
+      end
+
+      it "merges the other users into this user" do
+        subject
+        expect(other_user.reload).to be_archived
+        expect(application.reload.user).to eq user
+        expect(user.participant_id_changes.first).to have_attributes(from_participant_id: other_user.ecf_id, to_participant_id: user.ecf_id)
+      end
+    end
+
     context "when the message format is incorrect" do
       let(:webhook_message) { create(:trs_trn_request_completed_webhook_message, user_uid: user.uid, user_trn: new_trn, message:) }
 

--- a/spec/services/teaching_record_system/webhooks/user_updated_processor_spec.rb
+++ b/spec/services/teaching_record_system/webhooks/user_updated_processor_spec.rb
@@ -44,6 +44,31 @@ RSpec.describe TeachingRecordSystem::Webhooks::UserUpdatedProcessor do
       end
     end
 
+    context "when the TRN is blank" do
+      let(:trn) { "1234567" }
+      let(:user) { create(:user, :with_teacher_auth, :with_verified_trn, trn:) }
+      let(:new_trn) { nil }
+
+      it "does not blank the user's TRN" do
+        subject
+        expect(user.reload.trn).to eq(trn)
+      end
+    end
+
+    context "when the new TRN is the same as the existing TRN" do
+      let(:trn) { "1234567" }
+      let(:user) { create(:user, :with_teacher_auth, trn:) }
+      let(:new_trn) { "1234567" }
+
+      it "updates the verified_trn fields" do
+        subject
+        expect(user.reload).to have_attributes(
+          trn_verified: true,
+          trn_auto_verified: true,
+        )
+      end
+    end
+
     context "when there are other users with the same verified TRN" do
       let(:other_user) { create(:user, :with_get_an_identity_id, :with_verified_trn, trn: new_trn, created_at: 1.day.ago) }
       let(:more_recent_other_user) { create(:user, :with_teacher_auth, :with_verified_trn, trn: new_trn) }

--- a/spec/services/teaching_record_system/webhooks/user_updated_processor_spec.rb
+++ b/spec/services/teaching_record_system/webhooks/user_updated_processor_spec.rb
@@ -44,6 +44,31 @@ RSpec.describe TeachingRecordSystem::Webhooks::UserUpdatedProcessor do
       end
     end
 
+    context "when there are other users with the same verified TRN" do
+      let(:other_user) { create(:user, :with_get_an_identity_id, :with_verified_trn, trn: new_trn, created_at: 1.day.ago) }
+      let(:more_recent_other_user) { create(:user, :with_teacher_auth, :with_verified_trn, trn: new_trn) }
+      let(:application) { create(:application, :accepted, user: user) }
+      let(:application_for_other_user) { create(:application, :accepted, user: other_user) }
+      let(:application_for_more_recent_other_user) { create(:application, :accepted, user: more_recent_other_user) }
+
+      before do
+        application
+        application_for_other_user
+        application_for_more_recent_other_user
+        create(:user, :archived, :with_get_an_identity_id, :with_verified_trn, trn: new_trn)
+      end
+
+      it "merges the other users into the most created user" do
+        subject
+        expect(user.reload).to be_archived
+        expect(other_user.reload).to be_archived
+        expect(application.reload.user).to eq more_recent_other_user
+        expect(application_for_other_user.reload.user).to eq more_recent_other_user
+        expect(more_recent_other_user.participant_id_changes.first).to have_attributes(from_participant_id: other_user.ecf_id, to_participant_id: more_recent_other_user.ecf_id)
+        expect(more_recent_other_user.participant_id_changes.last).to have_attributes(from_participant_id: user.ecf_id, to_participant_id: more_recent_other_user.ecf_id)
+      end
+    end
+
     context "when there is no connected person" do
       let(:webhook_message) do
         create(


### PR DESCRIPTION
### Context

Ticket: [NPQ-3920](https://dfedigital.atlassian.net/browse/NPQ-3920)

Merge and archive other users with same TRN in the webhooks

### Changes proposed in this pull request

1. for the`trn_request.completed` webhook, merge and archive other users with the same TRN
2. for the `one_login_user.updated` webhook, merge users with the same TRN into the most recenlty created user

[NPQ-3920]: https://dfedigital.atlassian.net/browse/NPQ-3920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ