### PR TITLE
[NPQ-3848] Update the check your answers page

### DIFF
--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -7,7 +7,15 @@ class RegistrationWizard
   class InvalidStep < StandardError; end
   class RemovedStep < StandardError; end
 
-  Answer = Struct.new(:key, :value, :change_step)
+  Answer = Struct.new(:key, :value, :change_step, :action_text, :action_href, :tag_colour) do
+    def action_text
+      self[:action_text] || "Change"
+    end
+
+    def action_href
+      self[:action_href] || "/registration/#{change_step.to_s.dasherize}/change"
+    end
+  end
 
   VALID_REGISTRATION_STEPS = %i[
     start
@@ -135,8 +143,9 @@ class RegistrationWizard
   def answers
     array = []
 
-    array << Answer.new("Course start", Questionnaires::CourseStartDate::OPTIONS[store["course_start_cohort"]][:cohort_description], :course_start_date)
-    array << Answer.new("Workplace in England", teacher_catchment_humanized, :teacher_catchment)
+    array << Answer.new("Cohort", Questionnaires::CourseStartDate::OPTIONS[store["course_start_cohort"]][:cohort_description], :course_start_date)
+    array << Answer.new("Working in England", teacher_catchment_humanized, :teacher_catchment)
+    array << Answer.new("Course", I18n.t(course.identifier, scope: "course.name"), :choose_your_npq)
 
     if store["referred_by_return_to_teaching_adviser"]
       array << Answer.new("Referred by return to teaching adviser", t("referred_by_return_to_teaching_adviser"), :referred_by_return_to_teaching_adviser)
@@ -175,8 +184,6 @@ class RegistrationWizard
       array << Answer.new("Employer", store["employer_name"], :your_employer) if employer_name_matters?
     end
 
-    array << Answer.new("Course", I18n.t(course.identifier, scope: "course.name"), :choose_your_npq)
-
     if course.ehco?
       array << Answer.new("Headship NPQ stage", t("npqh_status"), :npqh_status)
       array << Answer.new("Headteacher", t("ehco_headteacher"), :ehco_headteacher)
@@ -210,6 +217,16 @@ class RegistrationWizard
         array << Answer.new("Course funding", t("funding"), :funding_your_npq)
       end
     end
+
+    funded = funding_eligibility_calculator.funded?
+    array << Answer.new(
+      "DfE scholarship funding",
+      funded ? "Eligible" : "Not eligible",
+      :check_funding,
+      "View",
+      "/registration/check-funding",
+      funded ? "green" : "grey",
+    )
 
     array << Answer.new("Provider", lead_provider&.name, :choose_your_provider)
 

--- a/app/views/registration_wizard/check_answers.html.erb
+++ b/app/views/registration_wizard/check_answers.html.erb
@@ -5,23 +5,31 @@
     wizard: @wizard,
     ) do
 %>
-  <h1 class="govuk-heading-l">Check your answers and submit</h1>
+  <h1 class="govuk-heading-l">Check your answers</h1>
 
   <%= render GovukComponent::SummaryListComponent.new do |component|
         @wizard.answers.each do |answer|
           component.with_row do |row|
             row.with_key { answer.key }
-            row.with_value { answer.value }
+            row.with_value do
+              if answer.tag_colour
+                govuk_tag(text: answer.value, colour: answer.tag_colour)
+              else
+                answer.value
+              end
+            end
             row.with_action(
-              text: 'Change',
+              text: answer.action_text,
               visually_hidden_text: answer.key,
-              href: "/registration/#{answer.change_step.to_s.dasherize}/change",
+              href: answer.action_href,
             )
           end
         end
   end %>
 
-  <%= govuk_warning_text(text: "If you enter your information incorrectly, it may result in you not being offered a funded place on an NPQ course.") %>
+  <h2 class="govuk-heading-m">Submit your registration</h2>
+
+  <p class="govuk-body">By submitting your registration to the DfE, you're confirming that all the information you entered is correct.</p>
 
   <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
     <%= f.govuk_submit "Submit" %>

--- a/spec/features/journeys/happy_paths/able_to_receive_targeted_delivery_funding_spec.rb
+++ b/spec/features/journeys/happy_paths/able_to_receive_targeted_delivery_funding_spec.rb
@@ -80,8 +80,9 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, :w
     expect_page_to_have(path: "/registration/check-answers", submit_form: true, submit_button_text: "Submit") do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_cohort_description,
-          "Workplace in England" => "Yes",
+          "DfE scholarship funding" => "Eligible",
+          "Cohort" => course_start_cohort_description,
+          "Working in England" => "Yes",
           "Work setting" => "A school",
           "Course" => "Senior leadership",
           "Workplace" => "open manchester school – street 1, manchester",

--- a/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
@@ -78,13 +78,14 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, :w
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "Autumn 2026",
+          "DfE scholarship funding" => "Not eligible",
+          "Cohort" => "Autumn 2026",
           "Course" => "Headship",
           "Provider" => "Teach First",
           "Workplace" => "open manchester school – street 1, manchester",
           "Course funding" => "My trust is paying",
           "Work setting" => "A school",
-          "Workplace in England" => "Yes",
+          "Working in England" => "Yes",
         },
       )
     end

--- a/spec/features/journeys/happy_paths/changing_cohort_to_one_lead_provider_no_longer_supports_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_cohort_to_one_lead_provider_no_longer_supports_spec.rb
@@ -72,13 +72,14 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, :w
     expect_page_to_have(path: "/registration/check-answers", submit_form: false) do
       expect_check_answers_page_to_have_answers(
         {
+          "DfE scholarship funding" => "Not eligible",
           "Course funding" => "My workplace is covering the cost",
-          "Course start" => "Autumn 2026",
+          "Cohort" => "Autumn 2026",
           "Course" => "Headship",
           "Provider" => "Teach First",
           "Workplace" => "open manchester school – street 1, manchester",
           "Work setting" => "A school",
-          "Workplace in England" => "Yes",
+          "Working in England" => "Yes",
         },
       )
       page.click_link("Change", href: "/registration/course-start-date/change")
@@ -137,13 +138,14 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, :w
     expect_page_to_have(path: "/registration/check-answers", submit_form: false) do
       expect_check_answers_page_to_have_answers(
         {
+          "DfE scholarship funding" => "Not eligible",
           "Course funding" => "My workplace is covering the cost",
-          "Course start" => "Spring 2026",
+          "Cohort" => "Spring 2026",
           "Course" => "Headship",
           "Provider" => "Best Practice Network",
           "Workplace" => "open manchester school – street 1, manchester",
           "Work setting" => "A school",
-          "Workplace in England" => "Yes",
+          "Working in England" => "Yes",
         },
       )
     end

--- a/spec/features/journeys/happy_paths/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
@@ -82,14 +82,15 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, ty
     expect_page_to_have(path: "/registration/check-answers", submit_form: false) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_cohort_description,
+          "DfE scholarship funding" => "Not eligible",
+          "Cohort" => course_start_cohort_description,
           "Course" => "Leading teaching",
           "Course funding" => "I am paying",
           "Employment type" => "In an independent hospital education organisation",
           "Employer" => "Big company",
           "Provider" => "Teach First",
           "Work setting" => "Another setting",
-          "Workplace in England" => "Yes",
+          "Working in England" => "Yes",
         },
       )
 
@@ -133,13 +134,14 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, ty
     expect_page_to_have(path: "/registration/check-answers", submit_form: true, submit_button_text: "Submit") do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_cohort_description,
+          "DfE scholarship funding" => "Not eligible",
+          "Cohort" => course_start_cohort_description,
           "Course" => "Leading teaching",
           "Course funding" => "My workplace is covering the cost",
           "Work setting" => "A school",
           "Workplace" => "open manchester school – street 1, manchester",
           "Provider" => "Teach First",
-          "Workplace in England" => "Yes",
+          "Working in England" => "Yes",
         },
       )
     end

--- a/spec/features/journeys/happy_paths/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
@@ -86,13 +86,14 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, ty
     expect_page_to_have(path: "/registration/check-answers", submit_form: false) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_cohort_description,
+          "DfE scholarship funding" => "Not eligible",
+          "Cohort" => course_start_cohort_description,
           "Course" => "Leading teaching",
           "Course funding" => "My workplace is covering the cost",
           "Work setting" => "Early years or childcare",
           "Provider" => "Teach First",
           "Workplace" => "open manchester school – street 1, manchester",
-          "Workplace in England" => "Yes",
+          "Working in England" => "Yes",
           "Early years setting" => public_kind_of_nursery,
         },
       )
@@ -141,14 +142,15 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, ty
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_cohort_description,
+          "DfE scholarship funding" => "Not eligible",
+          "Cohort" => course_start_cohort_description,
           "Course" => "Leading teaching",
           "Course funding" => "I am paying",
           "Employment type" => "In an independent hospital education organisation",
           "Employer" => "Big company",
           "Work setting" => "Another setting",
           "Provider" => "Teach First",
-          "Workplace in England" => "Yes",
+          "Working in England" => "Yes",
         },
       )
     end

--- a/spec/features/journeys/happy_paths/changing_from_outside_of_catchment_area_to_inside_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_from_outside_of_catchment_area_to_inside_spec.rb
@@ -74,12 +74,13 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, ty
     expect_page_to_have(path: "/registration/check-answers", submit_form: false) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_cohort_description,
+          "DfE scholarship funding" => "Not eligible",
+          "Cohort" => course_start_cohort_description,
           "Course" => "Senior leadership",
           "Course funding" => "I am paying",
           "Work setting" => "A school",
           "Provider" => "Teach First",
-          "Workplace in England" => "No",
+          "Working in England" => "No",
         },
       )
 
@@ -128,13 +129,14 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, ty
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_cohort_description,
+          "DfE scholarship funding" => "Not eligible",
+          "Cohort" => course_start_cohort_description,
           "Course" => "Senior leadership",
           "Workplace" => "open manchester school – street 1, manchester",
           "Course funding" => "My workplace is covering the cost",
           "Work setting" => "A school",
           "Provider" => "Teach First",
-          "Workplace in England" => "Yes",
+          "Working in England" => "Yes",
         },
       )
     end

--- a/spec/features/journeys/happy_paths/changing_npq_to_one_that_is_not_eligible_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_npq_to_one_that_is_not_eligible_spec.rb
@@ -95,13 +95,14 @@ RSpec.feature "Happy journeys", :mvp, :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_form: false) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_cohort_description,
+          "DfE scholarship funding" => "Eligible",
+          "Cohort" => course_start_cohort_description,
           "Course" => "Senior leadership",
           "Provider" => "Best Practice Network",
           "Work setting" => "Early years or childcare",
           "Workplace" => "open manchester school – street 1, manchester",
           "Early years setting" => public_kind_of_nursery,
-          "Workplace in England" => "Yes",
+          "Working in England" => "Yes",
         },
       )
 
@@ -140,14 +141,15 @@ RSpec.feature "Happy journeys", :mvp, :with_default_schedules, type: :feature do
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_cohort_description,
+          "DfE scholarship funding" => "Not eligible",
+          "Cohort" => course_start_cohort_description,
           "Course" => "Executive leadership",
           "Course funding" => "My workplace is covering the cost",
           "Provider" => "National Institute of Teaching",
           "Work setting" => "Early years or childcare",
           "Workplace" => "open manchester school – street 1, manchester",
           "Early years setting" => public_kind_of_nursery,
-          "Workplace in England" => "Yes",
+          "Working in England" => "Yes",
         },
       )
     end

--- a/spec/features/journeys/happy_paths/funded_ehco_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/funded_ehco_registration_journey_spec.rb
@@ -95,8 +95,9 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, ty
     expect_page_to_have(path: "/registration/check-answers", submit_form: true, submit_button_text: "Submit") do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_cohort_description,
-          "Workplace in England" => "Yes",
+          "DfE scholarship funding" => "Eligible",
+          "Cohort" => course_start_cohort_description,
+          "Working in England" => "Yes",
           "Work setting" => "A school",
           "Course" => "Early headship coaching offer",
           "Provider" => "Teach First",

--- a/spec/features/journeys/happy_paths/international_teacher_npqh_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/international_teacher_npqh_journey_spec.rb
@@ -70,8 +70,9 @@ RSpec.feature "Happy journeys", :mvp, :no_js, :with_cohorts, :with_default_sched
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_cohort_description,
-          "Workplace in England" => "No",
+          "DfE scholarship funding" => "Not eligible",
+          "Cohort" => course_start_cohort_description,
+          "Working in England" => "No",
           "Work setting" => "A school",
           "Course" => "Headship",
           "Provider" => "Teach First",

--- a/spec/features/journeys/happy_paths/other_funded_ehco_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/other_funded_ehco_registration_journey_spec.rb
@@ -93,8 +93,9 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, ty
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_cohort_description,
-          "Workplace in England" => "Yes",
+          "DfE scholarship funding" => "Not eligible",
+          "Cohort" => course_start_cohort_description,
+          "Working in England" => "Yes",
           "Work setting" => "A school",
           "Course" => "Early headship coaching offer",
           "Provider" => "Teach First",

--- a/spec/features/journeys/happy_paths/previously_received_targeted_delivery_funding_spec.rb
+++ b/spec/features/journeys/happy_paths/previously_received_targeted_delivery_funding_spec.rb
@@ -79,8 +79,9 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, :w
     expect_page_to_have(path: "/registration/check-answers", submit_form: true, submit_button_text: "Submit") do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_cohort_description,
-          "Workplace in England" => "Yes",
+          "DfE scholarship funding" => "Eligible",
+          "Cohort" => course_start_cohort_description,
+          "Working in England" => "Yes",
           "Work setting" => "A school",
           "Course" => "Senior leadership",
           "Workplace" => "open manchester school – street 1, manchester",

--- a/spec/features/journeys/happy_paths/teacher_auth_login_spec.rb
+++ b/spec/features/journeys/happy_paths/teacher_auth_login_spec.rb
@@ -54,13 +54,14 @@ RSpec.feature "Happy journeys", :mvp, :no_js, :with_cohorts, :with_default_sched
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_cohort_description,
+          "DfE scholarship funding" => "Not eligible",
+          "Cohort" => course_start_cohort_description,
           "Course" => "Headship",
           "Provider" => "Teach First",
           "Workplace" => "open manchester school – street 1, manchester",
           "Course funding" => "My trust is paying",
           "Work setting" => "A school",
-          "Workplace in England" => "Yes",
+          "Working in England" => "Yes",
         },
       )
     end

--- a/spec/features/journeys/happy_paths/unfunded_cohort_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/unfunded_cohort_registration_journey_spec.rb
@@ -62,13 +62,14 @@ RSpec.feature "Happy journeys", :mvp, :no_js, :with_cohorts, :with_default_sched
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => "Spring 2026",
+          "DfE scholarship funding" => "Not eligible",
+          "Cohort" => "Spring 2026",
           "Course" => "Headship",
           "Provider" => "LLSE",
           "Workplace" => "open manchester school – street 1, manchester",
           "Course funding" => "My trust is paying",
           "Work setting" => "A school",
-          "Workplace in England" => "Yes",
+          "Working in England" => "Yes",
         },
       )
     end

--- a/spec/features/journeys/happy_paths/via_using_old_name_and_not_headship_spec.rb
+++ b/spec/features/journeys/happy_paths/via_using_old_name_and_not_headship_spec.rb
@@ -76,13 +76,14 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, :w
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_cohort_description,
+          "DfE scholarship funding" => "Not eligible",
+          "Cohort" => course_start_cohort_description,
           "Course" => "Senior leadership",
           "Workplace" => "open manchester school – street 1, manchester",
           "Course funding" => "My workplace is covering the cost",
           "Work setting" => "A school",
           "Provider" => "Teach First",
-          "Workplace in England" => "Yes",
+          "Working in England" => "Yes",
         },
       )
     end

--- a/spec/features/journeys/happy_paths/when_choose_lead_mentor_course_spec.rb
+++ b/spec/features/journeys/happy_paths/when_choose_lead_mentor_course_spec.rb
@@ -75,13 +75,15 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, ty
       expect_check_answers_page_to_have_answers(
         {
 
-          "Course start" => course_start_cohort_description,
+          "DfE scholarship funding" => "Eligible",
+
+          "Cohort" => course_start_cohort_description,
           "Course" => "Leading teacher development",
           "Employment type" => "As a lead mentor for an accredited initial teacher training (ITT) provider",
           "ITT provider" => approved_itt_provider_legal_name,
           "Provider" => "Church of England",
           "Work setting" => "Another setting",
-          "Workplace in England" => "Yes",
+          "Working in England" => "Yes",
         },
       )
     end

--- a/spec/features/journeys/happy_paths/when_choose_maths_course_spec.rb
+++ b/spec/features/journeys/happy_paths/when_choose_maths_course_spec.rb
@@ -91,8 +91,9 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, :w
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_cohort_description,
-          "Workplace in England" => "Yes",
+          "DfE scholarship funding" => "Eligible",
+          "Cohort" => course_start_cohort_description,
+          "Working in England" => "Yes",
           "Work setting" => "A school",
           "Workplace" => "open manchester school – street 1, manchester",
           "Course" => "Leading primary mathematics",

--- a/spec/features/journeys/happy_paths/when_outside_of_catchment_area_crown_dependencies_spec.rb
+++ b/spec/features/journeys/happy_paths/when_outside_of_catchment_area_crown_dependencies_spec.rb
@@ -76,12 +76,13 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, ty
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_cohort_description,
+          "DfE scholarship funding" => "Not eligible",
+          "Cohort" => course_start_cohort_description,
           "Course" => "Senior leadership",
           "Course funding" => "I am paying",
           "Work setting" => "A school",
           "Provider" => "Teach First",
-          "Workplace in England" => "No",
+          "Working in England" => "No",
         },
       )
     end

--- a/spec/features/journeys/happy_paths/when_outside_of_catchment_area_spec.rb
+++ b/spec/features/journeys/happy_paths/when_outside_of_catchment_area_spec.rb
@@ -73,12 +73,13 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, ty
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_cohort_description,
+          "DfE scholarship funding" => "Not eligible",
+          "Cohort" => course_start_cohort_description,
           "Course" => "Senior leadership",
           "Course funding" => "I am paying",
           "Work setting" => "A school",
           "Provider" => "Teach First",
-          "Workplace in England" => "No",
+          "Working in England" => "No",
         },
       )
     end

--- a/spec/features/journeys/happy_paths/when_previously_funded_spec.rb
+++ b/spec/features/journeys/happy_paths/when_previously_funded_spec.rb
@@ -116,7 +116,8 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_nursery, :wit
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_cohort_description,
+          "DfE scholarship funding" => "Not eligible",
+          "Cohort" => course_start_cohort_description,
           "Course" => "Early headship coaching offer",
           "Course funding" => "I am paying",
           "Headship NPQ stage" => "I’ve completed it",
@@ -126,7 +127,7 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_nursery, :wit
           "Provider" => "Teach First",
           "Ofsted unique reference number (URN)" => "EY487263 – searchable childcare provider – street 1, manchester",
           "Early years setting" => "Private nursery",
-          "Workplace in England" => "Yes",
+          "Working in England" => "Yes",
         },
       )
     end

--- a/spec/features/journeys/happy_paths/when_referred_by_return_to_teaching_adviser_spec.rb
+++ b/spec/features/journeys/happy_paths/when_referred_by_return_to_teaching_adviser_spec.rb
@@ -68,12 +68,13 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, ty
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_cohort_description,
+          "DfE scholarship funding" => "Not eligible",
+          "Cohort" => course_start_cohort_description,
           "Course" => "Senior leadership",
           "Work setting" => "Other",
           "Referred by return to teaching adviser" => "Yes",
           "Provider" => "Teach First",
-          "Workplace in England" => "Yes",
+          "Working in England" => "Yes",
         },
       )
     end

--- a/spec/features/journeys/happy_paths/when_teacher_auth_returns_no_trn_spec.rb
+++ b/spec/features/journeys/happy_paths/when_teacher_auth_returns_no_trn_spec.rb
@@ -59,13 +59,14 @@ RSpec.feature "Sad journeys", :mvp, :no_js, :with_cohorts, :with_default_schedul
       expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
         expect_check_answers_page_to_have_answers(
           {
-            "Course start" => course_start_cohort_description,
+            "DfE scholarship funding" => "Not eligible",
+            "Cohort" => course_start_cohort_description,
             "Course" => "Headship",
             "Provider" => "Teach First",
             "Workplace" => "open manchester school – street 1, manchester",
             "Course funding" => "My trust is paying",
             "Work setting" => "A school",
-            "Workplace in England" => "Yes",
+            "Working in England" => "Yes",
           },
         )
       end

--- a/spec/features/journeys/happy_paths/when_working_at_an_eligible_primary_school_spec.rb
+++ b/spec/features/journeys/happy_paths/when_working_at_an_eligible_primary_school_spec.rb
@@ -75,12 +75,13 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, ty
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_cohort_description,
+          "DfE scholarship funding" => "Eligible",
+          "Cohort" => course_start_cohort_description,
           "Course" => "Headship",
           "Provider" => "Teach First",
           "Workplace" => "open manchester school – street 1, manchester",
           "Work setting" => "A school",
-          "Workplace in England" => "Yes",
+          "Working in England" => "Yes",
         },
       )
     end

--- a/spec/features/journeys/happy_paths/when_working_in_other_spec.rb
+++ b/spec/features/journeys/happy_paths/when_working_in_other_spec.rb
@@ -76,13 +76,14 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, ty
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
+          "DfE scholarship funding" => "Not eligible",
           "Course funding" => "My workplace is covering the cost",
-          "Course start" => course_start_cohort_description,
+          "Cohort" => course_start_cohort_description,
           "Course" => "Senior leadership",
           "Work setting" => "Other",
           "Referred by return to teaching adviser" => "No",
           "Provider" => "Teach First",
-          "Workplace in England" => "Yes",
+          "Working in England" => "Yes",
         },
       )
     end

--- a/spec/features/journeys/happy_paths/while_not_currently_working_at_school_spec.rb
+++ b/spec/features/journeys/happy_paths/while_not_currently_working_at_school_spec.rb
@@ -82,14 +82,15 @@ RSpec.feature "Happy journeys", :mvp, :no_js, :with_cohorts, :with_default_sched
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_cohort_description,
+          "DfE scholarship funding" => "Not eligible",
+          "Cohort" => course_start_cohort_description,
           "Course" => "Executive leadership",
           "Course funding" => "I am paying",
           "Work setting" => "Another setting",
           "Employment type" => "In an independent hospital education organisation",
           "Employer" => "Big company",
           "Provider" => "Teach First",
-          "Workplace in England" => "Yes",
+          "Working in England" => "Yes",
         },
       )
     end

--- a/spec/features/journeys/happy_paths/while_working_at_private_childcare_provider_but_not_a_nursery_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_at_private_childcare_provider_but_not_a_nursery_spec.rb
@@ -104,12 +104,13 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_nursery, :wit
     expect_page_to_have(path: "/registration/check-answers", submit_form: true, submit_button_text: "Submit") do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_cohort_description,
+          "DfE scholarship funding" => "Eligible",
+          "Cohort" => course_start_cohort_description,
           "Course" => "Early years leadership",
           "Work setting" => "Early years or childcare",
           "Provider" => "Teach First",
           "Ofsted unique reference number (URN)" => "EY487263 – searchable childcare provider – street 1, manchester",
-          "Workplace in England" => "Yes",
+          "Working in England" => "Yes",
           "Early years setting" => "Private nursery",
         },
       )

--- a/spec/features/journeys/happy_paths/while_working_at_private_nursery_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_at_private_nursery_spec.rb
@@ -106,13 +106,14 @@ RSpec.feature "Happy journeys", :mvp, :with_default_nursery, :with_default_sched
     expect_page_to_have(path: "/registration/check-answers", submit_form: true, submit_button_text: "Submit") do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_cohort_description,
+          "DfE scholarship funding" => "Eligible",
+          "Cohort" => course_start_cohort_description,
           "Course" => "Early years leadership",
           "Work setting" => "Early years or childcare",
           "Provider" => "Teach First",
           "Ofsted unique reference number (URN)" => "EY487263 – searchable childcare provider – street 1, manchester",
           "Early years setting" => "Private nursery",
-          "Workplace in England" => "Yes",
+          "Working in England" => "Yes",
         },
       )
     end

--- a/spec/features/journeys/happy_paths/while_working_at_public_nursery_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_at_public_nursery_spec.rb
@@ -87,14 +87,15 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, ty
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_cohort_description,
+          "DfE scholarship funding" => "Not eligible",
+          "Cohort" => course_start_cohort_description,
           "Course" => "Senior leadership",
           "Course funding" => "My workplace is covering the cost",
           "Work setting" => "Early years or childcare",
           "Provider" => "Teach First",
           "Workplace" => "open manchester school – street 1, manchester",
           "Early years setting" => public_kind_of_nursery,
-          "Workplace in England" => "Yes",
+          "Working in England" => "Yes",
         },
       )
     end

--- a/spec/features/journeys/happy_paths/while_working_in_neither_a_school_nor_childcare_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_in_neither_a_school_nor_childcare_spec.rb
@@ -78,14 +78,15 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, ty
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
+          "DfE scholarship funding" => "Not eligible",
           "Course funding" => "I am paying",
-          "Course start" => course_start_cohort_description,
+          "Cohort" => course_start_cohort_description,
           "Course" => "Early years leadership",
           "Employment type" => "In an independent hospital education organisation",
           "Employer" => "Big company",
           "Work setting" => "Another setting",
           "Provider" => "Teach First",
-          "Workplace in England" => "Yes",
+          "Working in England" => "Yes",
         },
       )
     end

--- a/spec/features/journeys/sad_paths/applying_for_ehco_but_not_new_headteacher_spec.rb
+++ b/spec/features/journeys/sad_paths/applying_for_ehco_but_not_new_headteacher_spec.rb
@@ -101,8 +101,9 @@ RSpec.feature "Sad journeys", :mvp, :with_cohorts, :with_default_schedules, :wit
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_cohort_description,
-          "Workplace in England" => "Yes",
+          "DfE scholarship funding" => "Not eligible",
+          "Cohort" => course_start_cohort_description,
+          "Working in England" => "Yes",
           "Work setting" => "A school",
           "Course" => "Early headship coaching offer",
           "Provider" => "Teach First",

--- a/spec/features/journeys/sad_paths/applying_for_eyl_but_not_on_childminder_eligibility_list_spec.rb
+++ b/spec/features/journeys/sad_paths/applying_for_eyl_but_not_on_childminder_eligibility_list_spec.rb
@@ -70,14 +70,15 @@ RSpec.feature "Happy journeys", :mvp, :no_js, :with_cohorts, :with_default_nurse
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
+          "DfE scholarship funding" => "Not eligible",
           "Course funding" => "I am paying",
-          "Course start" => course_start_cohort_description,
+          "Cohort" => course_start_cohort_description,
           "Course" => "Early years leadership",
           "Early years setting" => "As a childminder",
           "Ofsted unique reference number (URN)" => "EY487263 – searchable childcare provider – street 1, manchester",
           "Provider" => "Teach First",
           "Work setting" => "Early years or childcare",
-          "Workplace in England" => "Yes",
+          "Working in England" => "Yes",
         },
       )
     end

--- a/spec/features/journeys/sad_paths/childminder_applying_for_eyl_but_no_ofsted_urn_spec.rb
+++ b/spec/features/journeys/sad_paths/childminder_applying_for_eyl_but_no_ofsted_urn_spec.rb
@@ -67,14 +67,15 @@ RSpec.feature "Happy journeys", :mvp, :no_js, :with_cohorts, :with_default_sched
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
+          "DfE scholarship funding" => "Not eligible",
           "Course funding" => "I am paying",
-          "Course start" => course_start_cohort_description,
+          "Cohort" => course_start_cohort_description,
           "Course" => "Early years leadership",
           "Early years setting" => "As a childminder",
           "Ofsted unique reference number (URN)" => "Not applicable",
           "Provider" => "Teach First",
           "Work setting" => "Early years or childcare",
-          "Workplace in England" => "Yes",
+          "Working in England" => "Yes",
         },
       )
     end

--- a/spec/features/journeys/sad_paths/lead_mentor_journey_with_incorrect_course_spec.rb
+++ b/spec/features/journeys/sad_paths/lead_mentor_journey_with_incorrect_course_spec.rb
@@ -86,13 +86,14 @@ RSpec.feature "Sad journeys", :mvp, :with_cohorts, :with_default_schedules, type
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_cohort_description,
+          "DfE scholarship funding" => "Not eligible",
+          "Cohort" => course_start_cohort_description,
           "Course" => "Senior leadership",
           "Employment type" => "As a lead mentor for an accredited initial teacher training (ITT) provider",
           "ITT provider" => approved_itt_provider_legal_name,
           "Provider" => "Church of England",
           "Work setting" => "Another setting",
-          "Workplace in England" => "Yes",
+          "Working in England" => "Yes",
           "Course funding" => "I am paying",
         },
       )

--- a/spec/features/journeys/sad_paths/works_in_childcare_but_not_in_england_spec.rb
+++ b/spec/features/journeys/sad_paths/works_in_childcare_but_not_in_england_spec.rb
@@ -75,12 +75,13 @@ RSpec.feature "Sad journeys", :mvp, :with_cohorts, :with_default_schedules, type
     expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "Course start" => course_start_cohort_description,
+          "DfE scholarship funding" => "Not eligible",
+          "Cohort" => course_start_cohort_description,
           "Course" => "Senior leadership",
           "Course funding" => "My workplace is covering the cost",
           "Work setting" => "Early years or childcare",
           "Provider" => "Teach First",
-          "Workplace in England" => "No",
+          "Working in England" => "No",
         },
       )
     end

--- a/spec/models/registration_wizard_spec.rb
+++ b/spec/models/registration_wizard_spec.rb
@@ -72,6 +72,29 @@ RSpec.describe RegistrationWizard do
       it "does not show Ofsted registration details" do
         expect(subject.answers.map(&:key)).not_to include("Ofsted registration details")
       end
+
+      describe "the check your answers layout" do
+        let(:keys) { subject.answers.map(&:key) }
+
+        it "uses the Cohort and Working in England labels" do
+          expect(keys).to include("Cohort", "Working in England")
+          expect(keys).not_to include("Course start", "Workplace in England")
+        end
+
+        it "shows the Course row right after Working in England" do
+          expect(keys.index("Course")).to eq(keys.index("Working in England") + 1)
+        end
+
+        it "adds a DfE scholarship funding row with a View link and a status tag" do
+          row = subject.answers.find { |answer| answer.key == "DfE scholarship funding" }
+
+          expect(row).to be_present
+          expect(row.action_text).to eq("View")
+          expect(row.action_href).to eq("/registration/check-funding")
+          expect(row.value).to be_in(["Eligible", "Not eligible"])
+          expect(row.tag_colour).to be_in(%w[green grey])
+        end
+      end
     end
 
     context "when working in private nursery" do


### PR DESCRIPTION
### Context

Ticket: [NPQ-3848](https://dfedigital.atlassian.net/browse/NPQ-3848)

This updates the "Check your answers" page shown before a registration is submitted. 

### Changes proposed in this pull request

1. Change the page heading to "Check your answers".
2. Rename "Course start" to "Cohort" and "Workplace in England" to "Working in England".
3. Move the Course row up, just after "Working in England".
4. Add a new "DfE scholarship funding" row. It shows the funding status as a tag and a "View" link to the check funding page.
5. Remove the funding warning text below the summary list.
6. Add a "Submit your registration" section with a short text and the Submit button.
7. Update the journey specs and add unit tests for the new answers.

### Notes

- The "View" link points to the check funding page (`/registration/check-funding`). The link will only work once the PRs on eligibility tickets are merged.
- The funding status is shown as a simple "Eligible" or "Not eligible" tag based on the current funding check.


[NPQ-3848]: https://dfedigital.atlassian.net/browse/NPQ-3848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ