### PR TITLE
[NPQ-3831] add nested school types to the work setting page

### DIFF
--- a/app/forms/question_types/radio_option.rb
+++ b/app/forms/question_types/radio_option.rb
@@ -1,5 +1,5 @@
 module QuestionTypes
-  RadioOption = Struct.new(:value, :link_errors, :divider, :revealed_question, :label, :hint, keyword_init: true)
+  RadioOption = Struct.new(:value, :link_errors, :divider, :revealed_question, :nested_options, :label, :hint, keyword_init: true)
 
   class RadioOption
     def to_options
@@ -8,6 +8,10 @@ module QuestionTypes
         label: normalize_text_for(label),
         hint: normalize_text_for(hint),
       }.compact
+    end
+
+    def nested?
+      nested_options.present?
     end
 
   private

--- a/app/forms/questionnaires/base.rb
+++ b/app/forms/questionnaires/base.rb
@@ -114,7 +114,7 @@ module Questionnaires
       wizard.query_store
     end
 
-    def build_option_struct(value:, label: nil, hint: nil, link_errors: false, divider: false, revealed_question: nil)
+    def build_option_struct(value:, label: nil, hint: nil, link_errors: false, divider: false, revealed_question: nil, nested_options: nil)
       QuestionTypes::RadioOption.new(
         value:,
         label:,
@@ -122,6 +122,7 @@ module Questionnaires
         link_errors:,
         divider:,
         revealed_question:,
+        nested_options:,
       )
     end
 

--- a/app/forms/questionnaires/work_setting.rb
+++ b/app/forms/questionnaires/work_setting.rb
@@ -3,11 +3,19 @@ module Questionnaires
     A_SCHOOL = "a_school".freeze
     AN_ACADEMY_TRUST = "an_academy_trust".freeze
     A_16_TO_19_EDUCATIONAL_SETTING = "a_16_to_19_educational_setting".freeze
+    PRIMARY_SCHOOL = "primary_school".freeze
+    SECONDARY_SCHOOL = "secondary_school".freeze
+
+    NESTED_SCHOOL_SETTINGS = [
+      PRIMARY_SCHOOL,
+      SECONDARY_SCHOOL,
+      A_16_TO_19_EDUCATIONAL_SETTING,
+    ].freeze
 
     SCHOOL_SETTINGS = [
       A_SCHOOL,
       AN_ACADEMY_TRUST,
-      A_16_TO_19_EDUCATIONAL_SETTING,
+      *NESTED_SCHOOL_SETTINGS,
     ].freeze
 
     CHILDCARE_SETTINGS = %w[
@@ -26,7 +34,9 @@ module Questionnaires
 
     attribute :work_setting
 
-    validates :work_setting, presence: true, inclusion: { in: ALL_SETTINGS }
+    validates :work_setting, presence: true
+    validates :work_setting, inclusion: { in: ALL_SETTINGS }, allow_blank: true
+    validate :school_type_chosen
 
     def self.permitted_params
       %i[work_setting]
@@ -101,15 +111,26 @@ module Questionnaires
     def options
       [
         build_option_struct(value: "early_years_or_childcare", link_errors: true),
-        build_option_struct(value: "a_school"),
-        build_option_struct(value: "an_academy_trust"),
-        build_option_struct(value: "a_16_to_19_educational_setting"),
+        build_option_struct(value: A_SCHOOL, nested_options: school_type_options),
+        build_option_struct(value: AN_ACADEMY_TRUST),
         build_option_struct(value: "another_setting"),
         build_option_struct(value: "other", divider: true),
       ]
     end
 
   private
+
+    def school_type_options
+      NESTED_SCHOOL_SETTINGS.map { |value| build_option_struct(value:) }
+    end
+
+    def school_parent_selected?
+      work_setting == A_SCHOOL
+    end
+
+    def school_type_chosen
+      errors.add(:work_setting, :school_type_blank) if school_parent_selected?
+    end
 
     def build_option_struct(**kwargs)
       super(**kwargs.deep_merge(label: { size: "s" }))

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -6,6 +6,7 @@ import accessibleAutocomplete from 'accessible-autocomplete';
 import { initCrossServiceHeader } from '@govuk-one-login/service-header/dist/scripts/service-header';
 
 import institutionPicker from "./institution-picker";
+import "./nested-radios";
 // These modules run on import for their side effects and export nothing.
 import "./itt-provider-picker.js";
 import "./cookie-banner";

--- a/app/javascript/nested-radios.js
+++ b/app/javascript/nested-radios.js
@@ -1,0 +1,22 @@
+// Nested radio options.
+//
+// GOV.UK decides whether a conditional reveal is open purely from the state of
+// the radio that controls it. Our nested school types share the parent's input
+// name, so picking one unchecks the parent and the reveal would close the option
+// the user just chose. This keeps it open instead.
+//
+import { Radios } from 'govuk-frontend';
+
+const syncWithInputState = Radios.prototype.syncConditionalRevealWithInputState;
+
+Radios.prototype.syncConditionalRevealWithInputState = function ($input) {
+  const $target = document.getElementById($input.getAttribute('aria-controls'));
+
+  if ($target?.querySelector('input[type="radio"]:checked')) {
+    $input.setAttribute('aria-expanded', 'true');
+    $target.classList.remove('govuk-radios__conditional--hidden');
+    return;
+  }
+
+  syncWithInputState.call(this, $input);
+};

--- a/app/views/registration_wizard/shared/questions/_radio_option.html.erb
+++ b/app/views/registration_wizard/shared/questions/_radio_option.html.erb
@@ -12,4 +12,16 @@
       )
     %>
   <% end %>
+
+  <% if radio_option.nested? %>
+    <div class="govuk-radios govuk-radios--small">
+      <%=
+        render(
+          partial: "registration_wizard/shared/questions/radio_option",
+          locals: { form: form, question: question },
+          collection: radio_option.nested_options
+        )
+      %>
+    </div>
+  <% end %>
 <% end  %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -538,6 +538,7 @@ en:
           attributes:
             work_setting:
               blank: Select the setting that you work in
+              school_type_blank: Select the type of school that you work in
         email_updates:
           attributes:
             email_updates_status:
@@ -1090,8 +1091,10 @@ en:
         work_setting_options:
           early_years_or_childcare: "Early years or childcare"
           a_school: "A school"
+          primary_school: "Primary school (5 to 11)"
+          secondary_school: "Secondary school (11 to 16)"
+          a_16_to_19_educational_setting: "Post-16 provider (16 to 19)"
           an_academy_trust: "An academy trust"
-          a_16_to_19_educational_setting: "A 16 to 19 educational setting"
           another_setting: "Another setting"
           other: "Other"
 

--- a/spec/features/journeys/happy_paths/able_to_receive_targeted_delivery_funding_spec.rb
+++ b/spec/features/journeys/happy_paths/able_to_receive_targeted_delivery_funding_spec.rb
@@ -41,6 +41,7 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, :w
 
     expect_page_to_have(path: "/registration/work-setting", submit_form: true) do
       page.choose("A school", visible: :all)
+      page.choose("Primary school (5 to 11)", visible: :all)
     end
 
     School.create!(
@@ -83,7 +84,7 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, :w
           "DfE scholarship funding" => "Eligible",
           "Cohort" => course_start_cohort_description,
           "Working in England" => "Yes",
-          "Work setting" => "A school",
+          "Work setting" => "Primary school (5 to 11)",
           "Course" => "Senior leadership",
           "Workplace" => "open manchester school – street 1, manchester",
           "Provider" => "Teach First",
@@ -135,7 +136,7 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, :w
       "works_in_childcare" => false,
       "works_in_nursery" => nil,
       "works_in_school" => true,
-      "work_setting" => "a_school",
+      "work_setting" => "primary_school",
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
@@ -153,7 +154,7 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, :w
         "submitted" => true,
         "teacher_catchment" => "england",
         "teacher_catchment_country" => nil,
-        "work_setting" => "a_school",
+        "work_setting" => "primary_school",
         "works_in_childcare" => "no",
         "works_in_school" => "yes",
       },

--- a/spec/features/journeys/happy_paths/changing_cohort_to_one_lead_provider_no_longer_supports_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_cohort_to_one_lead_provider_no_longer_supports_spec.rb
@@ -44,6 +44,7 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, :w
 
     expect_page_to_have(path: "/registration/work-setting", submit_form: true) do
       page.choose("A school", visible: :all)
+      page.choose("Primary school (5 to 11)", visible: :all)
     end
 
     choose_a_school(js:, name: "open")
@@ -78,7 +79,7 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, :w
           "Course" => "Headship",
           "Provider" => "Teach First",
           "Workplace" => "open manchester school – street 1, manchester",
-          "Work setting" => "A school",
+          "Work setting" => "Primary school (5 to 11)",
           "Working in England" => "Yes",
         },
       )
@@ -101,6 +102,7 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, :w
 
     expect_page_to_have(path: "/registration/work-setting", submit_form: true) do
       page.choose("A school", visible: :all)
+      page.choose("Primary school (5 to 11)", visible: :all)
     end
 
     choose_a_school(js:, name: "open", already_searched_for_workplace: true)
@@ -144,7 +146,7 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, :w
           "Course" => "Headship",
           "Provider" => "Best Practice Network",
           "Workplace" => "open manchester school – street 1, manchester",
-          "Work setting" => "A school",
+          "Work setting" => "Primary school (5 to 11)",
           "Working in England" => "Yes",
         },
       )

--- a/spec/features/journeys/happy_paths/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
@@ -99,6 +99,7 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, ty
 
     expect_page_to_have(path: "/registration/work-setting/change", submit_form: true) do
       page.choose("A school", visible: :all)
+      page.choose("Primary school (5 to 11)", visible: :all)
     end
 
     choose_a_school(js:, name: "open")
@@ -138,7 +139,7 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, ty
           "Cohort" => course_start_cohort_description,
           "Course" => "Leading teaching",
           "Course funding" => "My workplace is covering the cost",
-          "Work setting" => "A school",
+          "Work setting" => "Primary school (5 to 11)",
           "Workplace" => "open manchester school – street 1, manchester",
           "Provider" => "Teach First",
           "Working in England" => "Yes",
@@ -189,7 +190,7 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, ty
       "works_in_childcare" => false,
       "works_in_nursery" => nil,
       "works_in_school" => true,
-      "work_setting" => "a_school",
+      "work_setting" => "primary_school",
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
@@ -210,7 +211,7 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, ty
         "submitted" => true,
         "teacher_catchment" => "england",
         "teacher_catchment_country" => nil,
-        "work_setting" => "a_school",
+        "work_setting" => "primary_school",
         "works_in_childcare" => "no",
         "works_in_school" => "yes",
       },

--- a/spec/features/journeys/happy_paths/choose_a_school_spec.rb
+++ b/spec/features/journeys/happy_paths/choose_a_school_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Choose a school page", :with_cohorts, :with_default_schedules, ty
 
     complete_journey_as_far_as_choosing_a_work_setting(
       course: "Senior leadership",
-      work_setting: "A school",
+      work_setting: "Primary school (5 to 11)",
     )
   end
 

--- a/spec/features/journeys/happy_paths/funded_ehco_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/funded_ehco_registration_journey_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
 
     complete_journey_as_far_as_choosing_a_work_setting(
       course: "Early headship coaching offer",
-      work_setting: "A school",
+      work_setting: "Primary school (5 to 11)",
     )
 
     choose_a_school(js:, name: "open")
@@ -85,7 +85,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
           "DfE scholarship funding" => "Eligible",
           "Cohort" => course_start_cohort_description,
           "Working in England" => "Yes",
-          "Work setting" => "A school",
+          "Work setting" => "Primary school (5 to 11)",
           "Course" => "Early headship coaching offer",
           "Provider" => "Teach First",
           "Workplace" => "open manchester school – street 1, manchester",
@@ -154,7 +154,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
       "works_in_childcare" => false,
       "works_in_nursery" => nil,
       "works_in_school" => true,
-      "work_setting" => "a_school",
+      "work_setting" => "primary_school",
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
@@ -178,7 +178,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
         "teacher_catchment_country" => nil,
         "works_in_school" => "yes",
         "works_in_childcare" => "no",
-        "work_setting" => "a_school",
+        "work_setting" => "primary_school",
       },
     )
   end

--- a/spec/features/journeys/happy_paths/international_teacher_npqh_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/international_teacher_npqh_journey_spec.rb
@@ -47,6 +47,7 @@ RSpec.feature "Happy journeys", :no_js, :with_cohorts, :with_default_schedules, 
 
     expect_page_to_have(path: "/registration/work-setting", submit_form: true) do
       page.choose("A school", visible: :all)
+      page.choose("Primary school (5 to 11)", visible: :all)
     end
 
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
@@ -79,7 +80,7 @@ RSpec.feature "Happy journeys", :no_js, :with_cohorts, :with_default_schedules, 
           "DfE scholarship funding" => "Not eligible",
           "Cohort" => course_start_cohort_description,
           "Working in England" => "No",
-          "Work setting" => "A school",
+          "Work setting" => "Primary school (5 to 11)",
           "Course" => "Headship",
           "Provider" => "Teach First",
           "Course funding" => "My workplace is covering the cost",
@@ -145,7 +146,7 @@ RSpec.feature "Happy journeys", :no_js, :with_cohorts, :with_default_schedules, 
       "works_in_childcare" => false,
       "works_in_nursery" => nil,
       "works_in_school" => true,
-      "work_setting" => "a_school",
+      "work_setting" => "primary_school",
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
@@ -156,7 +157,7 @@ RSpec.feature "Happy journeys", :no_js, :with_cohorts, :with_default_schedules, 
         "submitted" => true,
         "works_in_school" => "yes",
         "works_in_childcare" => "no",
-        "work_setting" => "a_school",
+        "work_setting" => "primary_school",
         "can_share_choices" => "1",
         "check_funding" => "yes",
         "course_start_cohort" => course_start_cohort_value,

--- a/spec/features/journeys/happy_paths/other_funded_ehco_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/other_funded_ehco_registration_journey_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
 
     complete_journey_as_far_as_choosing_a_work_setting(
       course: "Early headship coaching offer",
-      work_setting: "A school",
+      work_setting: "Primary school (5 to 11)",
     )
 
     choose_a_school(js:, name: "open")
@@ -76,7 +76,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
           "DfE scholarship funding" => "Not eligible",
           "Cohort" => course_start_cohort_description,
           "Working in England" => "Yes",
-          "Work setting" => "A school",
+          "Work setting" => "Primary school (5 to 11)",
           "Course" => "Early headship coaching offer",
           "Provider" => "Teach First",
           "Workplace" => "open manchester school – street 1, manchester",
@@ -145,7 +145,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
       "works_in_childcare" => false,
       "works_in_nursery" => nil,
       "works_in_school" => true,
-      "work_setting" => "a_school",
+      "work_setting" => "primary_school",
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
@@ -168,7 +168,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
         "teacher_catchment" => "england",
         "teacher_catchment_country" => nil,
         "works_in_school" => "yes",
-        "work_setting" => "a_school",
+        "work_setting" => "primary_school",
         "works_in_childcare" => "no",
       },
     )

--- a/spec/features/journeys/happy_paths/previously_received_targeted_delivery_funding_spec.rb
+++ b/spec/features/journeys/happy_paths/previously_received_targeted_delivery_funding_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :feature do
+RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, :with_eligibility_list_entries, type: :feature do
   include Helpers::JourneyAssertionHelper
   include Helpers::JourneyStepHelper
   include ApplicationHelper
@@ -9,28 +9,16 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
   include_context "with stubbed Teacher Auth OmniAuth responses"
   include_context "with stubbed Teaching Record System person API"
 
-  before do
-    # create an eligible school
-    School.create!(
-      urn: 100_000,
-      name: "open manchester school",
-      address_1: "street 1",
-      town: "manchester",
-      establishment_status_code: "1",
-      establishment_type_code: "1",
-    )
-  end
-
   context "when JavaScript is enabled", :js do
-    scenario("registration journey") { run_scenario(js: true) }
+    scenario("registration journey that is blocked from targeted delivery funding because they were previously funded (with JS)") { run_scenario(js: true) }
   end
 
   context "when JavaScript is disabled", :no_js do
-    scenario("registration journey") { run_scenario(js: false) }
+    scenario("registration journey that is blocked from targeted delivery funding because they were previously funded (without JS)") { run_scenario(js: false) }
   end
 
   def run_scenario(js:)
-    stub_participant_validation_request
+    stub_participant_validation_request(trn: "12345", response: { trn: "12345" })
 
     navigate_to_page(path: "/", submit_form: false, axe_check: false) do
       expect(page).to have_text("Before you start")
@@ -41,24 +29,13 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
 
     choose_course_start_date
 
-    expect_page_to_have(path: "/registration/check-funding", submit_form: true) do
-      expect(page).to have_text("Check if you’re eligible for DfE scholarship funding")
-      click_button("Check funding")
+    expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
+      expect(page).to have_text("Have you chosen an NPQ and provider?")
+      page.choose("Yes", visible: :all)
     end
 
-    expect_page_to_have(path: "/registration/teacher-catchment", submit_form: true) do
-      expect(page).to have_text("Do you work in England?")
-      choose("Yes", visible: :all)
-    end
-
-    expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do
-      expect(page).to have_text("Which NPQ do you want to do?")
-      page.choose("Headship", visible: :all)
-    end
-
-    expect_page_to_have(path: "/registration/funding-history", submit_form: true) do
-      expect(page).to have_text("Have you received DfE funding for this course before?")
-      page.choose("No", visible: :all)
+    expect_page_to_have(path: "/registration/teacher-catchment", axe_check: false, submit_form: true) do
+      page.choose("Yes", visible: :all)
     end
 
     expect_page_to_have(path: "/registration/work-setting", submit_form: true) do
@@ -66,11 +43,26 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
       page.choose("Primary school (5 to 11)", visible: :all)
     end
 
+    School.create!(
+      urn: 100_000,
+      name: "open manchester school",
+      address_1: "street 1",
+      town: "manchester",
+      establishment_status_code: "1",
+      establishment_type_code: "1",
+      high_pupil_premium: true,
+      number_of_pupils: 100,
+    )
+
     choose_a_school(js:, name: "open")
 
+    expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do
+      expect(page).to have_text("Which NPQ do you want to do?")
+      page.choose("Senior leadership", visible: :all)
+    end
+
     expect_page_to_have(path: "/registration/possible-funding", submit_form: false) do
-      expect(page).to have_text("DfE scholarship funding")
-      expect(page).to have_text("You’re eligible for scholarship funding for the Headship NPQ")
+      expect(page).to have_text("Funding")
 
       page.click_button("Continue")
     end
@@ -80,66 +72,33 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
       page.choose("Teach First", visible: :all)
     end
 
-    check_back_journey_is_correct
-
     expect_page_to_have(path: "/registration/share-provider", submit_form: true) do
       expect(page).to have_text("Sharing your NPQ information")
       page.check("Yes, I agree to share my information", visible: :all)
     end
 
-    expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
+    expect_page_to_have(path: "/registration/check-answers", submit_form: true, submit_button_text: "Submit") do
       expect_check_answers_page_to_have_answers(
         {
-          "DfE scholarship funding" => "Eligible",
-          "Cohort" => "Autumn 2026",
-          "Course" => "Headship",
-          "Provider" => "Teach First",
-          "Workplace" => "open manchester school – street 1, manchester",
+          "Course start" => course_start_cohort_description,
+          "Workplace in England" => "Yes",
           "Work setting" => "Primary school (5 to 11)",
-          "Working in England" => "Yes",
+          "Course" => "Senior leadership",
+          "Workplace" => "open manchester school – street 1, manchester",
+          "Provider" => "Teach First",
         },
       )
     end
 
-    expect_applicant_reached_end_of_journey
-
-    User.last.tap do |user|
-      expect(user.email).to eql("user@example.com")
-      expect(user.full_name).to eql("John Doe")
-      expect(user.trn).to eql("1234567")
-      expect(user.trn_verified).to be true
-      expect(user.trn_auto_verified).to be true
-      expect(user.national_insurance_number).to be_nil
-      expect(user.applications.count).to be(1)
-
-      user.applications.first.tap do |application|
-        expect(application.eligible_for_funding).to be true
-      end
-    end
-    if User.last.applications.count == 1
-      navigate_to_page(path: "/accounts/user_registrations/#{User.last.applications.last.id}", axe_check: false, submit_form: false) do
-        expect(page).to have_text("Teach First")
-        expect(page).to have_text("Headship")
-      end
-    else
-      navigate_to_page(path: "/account", axe_check: false, submit_form: false) do
-        expect(page).to have_text("Teach First")
-        expect(page).to have_text("Headship")
-      end
-    end
-
-    visit "/registration/share-provider"
-
-    expect_page_to_have(path: "/", axe_check: false, submit_form: false) do
-      expect(page).to have_content("Before you start")
-    end
+    expect(User.count).to be(1)
+    expect(Application.count).to be(1)
 
     expect(retrieve_latest_application_user_data).to match(user_attributes_from_stubbed_callback_response)
 
     deep_compare_application_data(
       "accepted_at" => nil,
       "cohort_id" => Cohort.current.id,
-      "course_id" => Course.find_by(identifier: "npq-headship").id,
+      "course_id" => Course.find_by(identifier: "npq-senior-leadership").id,
       "schedule_id" => nil,
       "ecf_id" => latest_application.ecf_id,
       "eligible_for_funding" => true,
@@ -149,8 +108,8 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
       "funded_place" => nil,
       "funding_choice" => nil,
       "funding_eligiblity_status_code" => "funded",
-      "kind_of_nursery" => nil,
       "headteacher_status" => nil,
+      "kind_of_nursery" => nil,
       "itt_provider_id" => nil,
       "lead_mentor" => false,
       "lead_provider_approval_status" => "pending",
@@ -169,7 +128,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
       "training_status" => nil,
       "ukprn" => nil,
       "primary_establishment" => false,
-      "number_of_pupils" => nil,
+      "number_of_pupils" => 100,
       "tsf_primary_eligibility" => false,
       "tsf_primary_plus_eligibility" => false,
       "works_in_childcare" => false,
@@ -182,10 +141,9 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
       "review_status" => nil,
       "raw_application_data" => {
         "can_share_choices" => "1",
-        "check_funding" => "yes",
-        "course_start_cohort" => "2026b",
-        "course_identifier" => "npq-headship",
-        "declared_previous_funding" => "no",
+        "chosen_provider" => "yes",
+        "course_start_cohort" => course_start_cohort_value,
+        "course_identifier" => "npq-senior-leadership",
         "email_template" => "eligible_scholarship_funding_not_tsf",
         "funding_eligiblity_status_code" => "funded",
         "institution_identifier" => "School-100000",

--- a/spec/features/journeys/happy_paths/teacher_auth_login_spec.rb
+++ b/spec/features/journeys/happy_paths/teacher_auth_login_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+RSpec.feature "Happy journeys", :mvp, :no_js, :with_cohorts, :with_default_schedules, :with_default_school, type: :feature do
+  include Helpers::JourneyAssertionHelper
+  include Helpers::JourneyStepHelper
+  include ApplicationHelper
+
+  include_context "with stubbed Teacher Auth OmniAuth responses"
+  include_context "with stubbed Teaching Record System person API"
+
+  scenario "the registration journey starts" do
+    navigate_to_page(path: "/", submit_form: false, axe_check: false) do
+      expect(page).to have_text("Before you start")
+      page.click_button("Start now")
+    end
+
+    choose_course_start_date
+    expect(User.last.attributes).to include(minimal_user_attributes_from_stubbed_callback_response)
+
+    expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
+      page.choose("Yes", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/teacher-catchment", axe_check: false, submit_form: true) do
+      page.choose("Yes", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/work-setting", submit_form: true) do
+      page.choose("A school", visible: :all)
+      page.choose("Primary school (5 to 11)", visible: :all)
+    end
+
+    choose_a_school(js: false, name: "open")
+
+    expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do
+      page.choose("Headship", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
+      page.click_link("Continue")
+    end
+
+    expect_page_to_have(path: "/registration/funding-your-npq", submit_form: true) do
+      page.choose "My trust is paying", visible: :all
+    end
+
+    expect_page_to_have(path: "/registration/choose-your-provider", submit_form: true) do
+      page.choose("Teach First", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/share-provider", submit_form: true) do
+      page.check("Yes, I agree to share my information", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
+      expect_check_answers_page_to_have_answers(
+        {
+          "Course start" => course_start_cohort_description,
+          "Course" => "Headship",
+          "Provider" => "Teach First",
+          "Workplace" => "open manchester school – street 1, manchester",
+          "Course funding" => "My trust is paying",
+          "Work setting" => "Primary school (5 to 11)",
+          "Workplace in England" => "Yes",
+        },
+      )
+    end
+
+    expect_applicant_reached_end_of_journey
+
+    expect(retrieve_latest_application_user_data).to include(user_attributes_from_stubbed_callback_response)
+  end
+end

--- a/spec/features/journeys/happy_paths/unfunded_cohort_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/unfunded_cohort_registration_journey_spec.rb
@@ -34,6 +34,7 @@ RSpec.feature "Happy journeys", :no_js, :with_cohorts, :with_default_schedules, 
 
     expect_page_to_have(path: "/registration/work-setting", submit_form: true) do
       page.choose("A school", visible: :all)
+      page.choose("Primary school (5 to 11)", visible: :all)
     end
 
     choose_a_school(js: false, name: "open")
@@ -63,7 +64,7 @@ RSpec.feature "Happy journeys", :no_js, :with_cohorts, :with_default_schedules, 
           "Course" => "Headship",
           "Provider" => "LLSE",
           "Course funding" => "I am paying",
-          "Work setting" => "A school",
+          "Work setting" => "Primary school (5 to 11)",
           "Working in England" => "",
         },
       )

--- a/spec/features/journeys/happy_paths/when_choose_maths_course_spec.rb
+++ b/spec/features/journeys/happy_paths/when_choose_maths_course_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Happy journeys", :no_js, :with_cohorts, :with_default_schedules, 
 
     complete_journey_as_far_as_choosing_a_work_setting(
       course: "Leading primary mathematics",
-      work_setting: "A school",
+      work_setting: "Primary school (5 to 11)",
     )
 
     choose_a_school(js: false, name: "open")
@@ -55,7 +55,7 @@ RSpec.feature "Happy journeys", :no_js, :with_cohorts, :with_default_schedules, 
           "DfE scholarship funding" => "Eligible",
           "Cohort" => course_start_cohort_description,
           "Working in England" => "Yes",
-          "Work setting" => "A school",
+          "Work setting" => "Primary school (5 to 11)",
           "Workplace" => "open manchester school – street 1, manchester",
           "Course" => "Leading primary mathematics",
           "Completed one year of the primary maths Teaching for Mastery programme" => "Yes",
@@ -139,7 +139,7 @@ RSpec.feature "Happy journeys", :no_js, :with_cohorts, :with_default_schedules, 
       "works_in_childcare" => false,
       "works_in_nursery" => nil,
       "works_in_school" => true,
-      "work_setting" => "a_school",
+      "work_setting" => "primary_school",
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
@@ -162,7 +162,7 @@ RSpec.feature "Happy journeys", :no_js, :with_cohorts, :with_default_schedules, 
         "teacher_catchment_country" => nil,
         "works_in_school" => "yes",
         "works_in_childcare" => "no",
-        "work_setting" => "a_school",
+        "work_setting" => "primary_school",
       },
     )
   end

--- a/spec/features/journeys/happy_paths/when_outside_of_catchment_area_crown_dependencies_spec.rb
+++ b/spec/features/journeys/happy_paths/when_outside_of_catchment_area_crown_dependencies_spec.rb
@@ -10,14 +10,14 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, ty
   include_context "with stubbed Teaching Record System person API"
 
   context "when JavaScript is enabled", :js do
-    scenario("registration journey changing from outside of catchment area to inside (with JS)") { run_scenario(js: true) }
+    scenario("registration journey when outside of catchment area - crown dependencies (with JS)") { run_scenario(js: true) }
   end
 
   context "when JavaScript is disabled", :no_js do
-    scenario("registration journey changing from outside of catchment area to inside (without JS)") { run_scenario(js: false) }
+    scenario("registration journey when outside of catchment area - crown dependencies (without JS)") { run_scenario(js: false) }
   end
 
-  def run_scenario(js:)
+  def run_scenario(js:) # rubocop:disable Lint/UnusedMethodArgument
     stub_participant_validation_request(nino: "")
 
     navigate_to_page(path: "/", submit_form: false, axe_check: false) do
@@ -34,10 +34,12 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, ty
       page.choose("Yes", visible: :all)
     end
 
-    choose_teacher_catchment(js:, region: "No")
-
     # TODO: aria-expanded
-    expect_page_to_have(path: "/registration/work-setting", axe_check: false, submit_form: true) do
+    expect_page_to_have(path: "/registration/teacher-catchment", axe_check: false, submit_form: true) do
+      page.choose("No", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/work-setting", submit_form: true) do
       page.choose("A school", visible: :all)
       page.choose("Primary school (5 to 11)", visible: :all)
     end
@@ -50,11 +52,11 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, ty
     end
 
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
-      expect(page).to have_text("DfE scholarship funding")
+      expect(page).to have_text("Funding")
       expect(page).to have_text("you do not work in England")
       expect(page).to have_text("This means that you would need to pay for the course another way")
 
-      page.click_link("Continue to register")
+      page.click_link("Continue")
     end
 
     expect_page_to_have(path: "/registration/funding-your-npq", submit_form: true) do
@@ -72,73 +74,15 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, ty
       page.check("Yes, I agree to share my information", visible: :all)
     end
 
-    expect_page_to_have(path: "/registration/check-answers", submit_form: false) do
+    expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
       expect_check_answers_page_to_have_answers(
         {
-          "DfE scholarship funding" => "Not eligible",
-          "Cohort" => course_start_cohort_description,
+          "Course start" => course_start_cohort_description,
           "Course" => "Senior leadership",
           "Course funding" => "I am paying",
           "Work setting" => "Primary school (5 to 11)",
           "Provider" => "Teach First",
-          "Working in England" => "No",
-        },
-      )
-
-      page.click_link("Change", href: "/registration/teacher-catchment/change")
-    end
-
-    # TODO: aria-expanded
-    expect_page_to_have(path: "/registration/teacher-catchment/change", axe_check: false, submit_form: true) do
-      page.choose("Yes", visible: :all)
-    end
-
-    expect_page_to_have(path: "/registration/work-setting", submit_form: true) do
-      page.choose("A school", visible: :all)
-      page.choose("Primary school (5 to 11)", visible: :all)
-    end
-
-    choose_a_school(js:, name: "open")
-
-    expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do
-      expect(page).to have_text("Which NPQ do you want to do?")
-      page.choose("Senior leadership", visible: :all)
-    end
-
-    expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
-      expect(page).to have_text("DfE scholarship funding")
-      expect(page).to have_text("such as state-funded schools")
-      expect(page).to have_text("You’re not eligible for scholarship funding")
-
-      page.click_link("Continue to register")
-    end
-
-    expect_page_to_have(path: "/registration/funding-your-npq", submit_form: true) do
-      expect(page).to have_text("How are you funding your course?")
-      page.choose "My workplace is covering the cost", visible: :all
-    end
-
-    expect_page_to_have(path: "/registration/choose-your-provider", submit_form: true) do
-      expect(page).to have_text("Select your provider")
-      page.choose("Teach First", visible: :all)
-    end
-
-    expect_page_to_have(path: "/registration/share-provider", submit_form: true) do
-      expect(page).to have_text("Sharing your NPQ information")
-      page.check("Yes, I agree to share my information", visible: :all)
-    end
-
-    expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
-      expect_check_answers_page_to_have_answers(
-        {
-          "DfE scholarship funding" => "Not eligible",
-          "Cohort" => course_start_cohort_description,
-          "Course" => "Senior leadership",
-          "Workplace" => "open manchester school – street 1, manchester",
-          "Course funding" => "My workplace is covering the cost",
-          "Work setting" => "Primary school (5 to 11)",
-          "Provider" => "Teach First",
-          "Working in England" => "Yes",
+          "Workplace in England" => "No",
         },
       )
     end
@@ -158,33 +102,33 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, ty
       "employment_type" => nil,
       "employment_role" => nil,
       "funded_place" => nil,
-      "funding_choice" => "school",
-      "funding_eligiblity_status_code" => "ineligible_establishment_type",
+      "funding_choice" => "self",
+      "funding_eligiblity_status_code" => "not_in_england",
+      "kind_of_nursery" => nil,
+      "headteacher_status" => nil,
+      "lead_provider_id" => LeadProvider.find_by(name: "Teach First").id,
+      "notes" => nil,
+      "private_childcare_provider_id" => nil,
+      "school_id" => nil,
       "itt_provider_id" => nil,
       "lead_mentor" => false,
       "lead_provider_approval_status" => "pending",
       "participant_outcome_state" => nil,
-      "headteacher_status" => nil,
-      "kind_of_nursery" => nil,
-      "lead_provider_id" => LeadProvider.find_by(name: "Teach First").id,
-      "notes" => nil,
-      "private_childcare_provider_id" => nil,
       "referred_by_return_to_teaching_adviser" => nil,
-      "school_id" => School.find_by(urn: "100000").id,
       "targeted_delivery_funding_eligibility" => false,
       "targeted_support_funding_eligibility" => false,
-      "teacher_catchment" => "england",
-      "teacher_catchment_country" => "United Kingdom of Great Britain and Northern Ireland",
-      "teacher_catchment_iso_country_code" => "GBR",
+      "teacher_catchment" => "another",
+      "teacher_catchment_country" => nil,
+      "teacher_catchment_iso_country_code" => nil,
       "teacher_catchment_synced_to_ecf" => false,
       "training_status" => nil,
       "ukprn" => nil,
       "primary_establishment" => false,
-      "number_of_pupils" => nil,
+      "number_of_pupils" => 0,
       "tsf_primary_eligibility" => false,
       "tsf_primary_plus_eligibility" => false,
-      "works_in_childcare" => false,
       "works_in_nursery" => nil,
+      "works_in_childcare" => false,
       "works_in_school" => true,
       "work_setting" => "primary_school",
       "senco_in_role" => nil,
@@ -196,18 +140,16 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, ty
         "chosen_provider" => "yes",
         "course_start_cohort" => course_start_cohort_value,
         "course_identifier" => "npq-senior-leadership",
-        "email_template" => "not_eligible_scholarship_funding_not_tsf",
-        "funding" => "school",
-        "funding_eligiblity_status_code" => "ineligible_establishment_type",
-        "institution_identifier" => "School-100000",
-        "institution_name" => js ? "" : "open",
+        "email_template" => "not_england_wrong_catchment",
+        "funding" => "self",
+        "funding_eligiblity_status_code" => "not_in_england",
         "lead_provider_id" => LeadProvider.find_by(name: "Teach First").id.to_s,
         "submitted" => true,
-        "teacher_catchment" => "england",
+        "teacher_catchment" => "another",
         "teacher_catchment_country" => nil,
-        "works_in_school" => "yes",
-        "works_in_childcare" => "no",
         "work_setting" => "primary_school",
+        "works_in_childcare" => "no",
+        "works_in_school" => "yes",
       },
     )
   end

--- a/spec/features/journeys/happy_paths/when_outside_of_catchment_area_spec.rb
+++ b/spec/features/journeys/happy_paths/when_outside_of_catchment_area_spec.rb
@@ -51,6 +51,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
 
     expect_page_to_have(path: "/registration/work-setting", submit_form: true) do
       page.choose("A school", visible: :all)
+      page.choose("Primary school (5 to 11)", visible: :all)
     end
 
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
@@ -83,7 +84,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
           "Cohort" => course_start_cohort_description,
           "Course" => "Senior leadership",
           "Course funding" => "I am paying",
-          "Work setting" => "A school",
+          "Work setting" => "Primary school (5 to 11)",
           "Provider" => "Teach First",
           "Working in England" => "No",
         },
@@ -131,7 +132,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
       "works_in_childcare" => false,
       "works_in_nursery" => nil,
       "works_in_school" => true,
-      "work_setting" => "a_school",
+      "work_setting" => "primary_school",
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
@@ -149,7 +150,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
         "submitted" => true,
         "teacher_catchment" => "another",
         "teacher_catchment_country" => nil,
-        "work_setting" => "a_school",
+        "work_setting" => "primary_school",
         "works_in_school" => "yes",
         "works_in_childcare" => "no",
       },

--- a/spec/features/journeys/happy_paths/when_school_not_eligible_spec.rb
+++ b/spec/features/journeys/happy_paths/when_school_not_eligible_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, :with_de
 
     complete_journey_as_far_as_choosing_a_work_setting(
       course: "Headship",
-      work_setting: "A school",
+      work_setting: "Primary school (5 to 11)",
     )
 
     choose_a_school(js:, name: "open")
@@ -60,7 +60,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, :with_de
           "Course" => "Headship",
           "Provider" => "Teach First",
           "Workplace" => "open manchester school – street 1, manchester",
-          "Work setting" => "A school",
+          "Work setting" => "Primary school (5 to 11)",
           "Working in England" => "Yes",
         },
       )
@@ -140,7 +140,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, :with_de
       "works_in_childcare" => false,
       "works_in_nursery" => nil,
       "works_in_school" => true,
-      "work_setting" => "a_school",
+      "work_setting" => "primary_school",
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
@@ -160,7 +160,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, :with_de
         "submitted" => true,
         "teacher_catchment" => "england",
         "teacher_catchment_country" => nil,
-        "work_setting" => "a_school",
+        "work_setting" => "primary_school",
         "works_in_childcare" => "no",
         "works_in_school" => "yes",
       },

--- a/spec/features/journeys/happy_paths/when_teacher_auth_returns_no_trn_spec.rb
+++ b/spec/features/journeys/happy_paths/when_teacher_auth_returns_no_trn_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Sad journeys", :no_js, :with_cohorts, :with_default_schedules, :w
     scenario "the registration journey starts" do
       complete_journey_as_far_as_choosing_a_work_setting(
         course: "Headship",
-        work_setting: "A school",
+        work_setting: "Primary school (5 to 11)",
       )
 
       choose_a_school(js: false, name: "open")
@@ -44,7 +44,7 @@ RSpec.feature "Sad journeys", :no_js, :with_cohorts, :with_default_schedules, :w
             "Provider" => "Teach First",
             "Workplace" => "open manchester school – street 1, manchester",
             "Course funding" => "My trust is paying",
-            "Work setting" => "A school",
+            "Work setting" => "Primary school (5 to 11)",
             "Working in England" => "Yes",
           },
         )

--- a/spec/features/journeys/happy_paths/when_working_at_an_eligible_primary_school_spec.rb
+++ b/spec/features/journeys/happy_paths/when_working_at_an_eligible_primary_school_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
 
     complete_journey_as_far_as_choosing_a_work_setting(
       course: "Headship",
-      work_setting: "A school",
+      work_setting: "Primary school (5 to 11)",
     )
 
     choose_a_school(js:, name: "open")
@@ -59,7 +59,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
           "Course" => "Headship",
           "Provider" => "Teach First",
           "Workplace" => "open manchester school – street 1, manchester",
-          "Work setting" => "A school",
+          "Work setting" => "Primary school (5 to 11)",
           "Working in England" => "Yes",
         },
       )
@@ -140,7 +140,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
       "works_in_childcare" => false,
       "works_in_nursery" => nil,
       "works_in_school" => true,
-      "work_setting" => "a_school",
+      "work_setting" => "primary_school",
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
@@ -161,7 +161,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
         "teacher_catchment_country" => nil,
         "works_in_school" => "yes",
         "works_in_childcare" => "no",
-        "work_setting" => "a_school",
+        "work_setting" => "primary_school",
       },
     )
   end

--- a/spec/features/journeys/post_mvp/work_setting_nested_radios_spec.rb
+++ b/spec/features/journeys/post_mvp/work_setting_nested_radios_spec.rb
@@ -1,0 +1,79 @@
+require "rails_helper"
+
+RSpec.feature "Work setting nested radios", :with_cohorts, type: :feature do
+  include Helpers::JourneyAssertionHelper
+  include Helpers::JourneyStepHelper
+
+  let(:school_types) { ["Primary school (5 to 11)", "Secondary school (11 to 16)", "Post-16 provider (16 to 19)"] }
+  let(:group) { "#registration-wizard-work-setting-a-school-conditional" }
+
+  context "without JavaScript", :no_js do
+    # The step is only reached mid-journey, so seed a store with a course and
+    # catchment. Without it, submitting routes into the eligibility step, which
+    # reads the (missing) course and blows up - a test-only artifact of visiting
+    # the page directly.
+    let(:store) { build(:registration_wizard_store) }
+
+    before do
+      allow_any_instance_of(RegistrationWizardController)
+        .to receive(:session).and_return("registration_store" => store)
+      visit "/registration/work-setting"
+    end
+
+    scenario "renders the school types, so they do not rely on JavaScript" do
+      school_types.each { |type| expect(page).to have_field(type) }
+    end
+
+    scenario "asks for a school type when only 'A school' is picked" do
+      choose("A school")
+      click_button("Continue")
+
+      expect(page).to have_current_path("/registration/work-setting")
+      within(".govuk-error-summary") do
+        expect(page).to have_link("Select the type of school that you work in")
+      end
+      expect(page).to have_css(".govuk-error-message", text: "Select the type of school that you work in")
+    end
+
+    scenario "moves on once a school type is picked" do
+      choose("Primary school (5 to 11)")
+      click_button("Continue")
+
+      expect(page).not_to have_current_path("/registration/work-setting")
+    end
+  end
+
+  context "with JavaScript", :js do
+    let(:collapsed_group) { "#{group}.govuk-radios__conditional--hidden" }
+
+    before { visit "/registration/work-setting" }
+
+    scenario "keeps the school types collapsed until 'A school' is picked" do
+      expect(page).to have_css(collapsed_group, visible: :all)
+
+      choose("A school", visible: :all)
+
+      expect(page).to have_no_css(collapsed_group, visible: :all)
+    end
+
+    scenario "keeps the school types open after one of them is picked" do
+      expect(page).to have_css(collapsed_group, visible: :all)
+
+      choose("A school", visible: :all)
+      choose("Primary school (5 to 11)", visible: :all)
+
+      expect(page).to have_no_css(collapsed_group, visible: :all)
+      expect(page).to have_no_checked_field("A school", visible: :all)
+      expect(page).to have_checked_field("Primary school (5 to 11)", visible: :all)
+    end
+
+    scenario "collapses the school types again when another setting is picked" do
+      choose("A school", visible: :all)
+      choose("Primary school (5 to 11)", visible: :all)
+      choose("Other", visible: :all)
+
+      expect(page).to have_css(collapsed_group, visible: :all)
+      expect(page).to have_no_checked_field("Primary school (5 to 11)", visible: :all)
+    end
+  end
+end

--- a/spec/features/journeys/sad_paths/applying_for_ehco_but_not_new_headteacher_spec.rb
+++ b/spec/features/journeys/sad_paths/applying_for_ehco_but_not_new_headteacher_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "Sad journeys", :with_cohorts, :with_default_schedules, :with_defa
 
     complete_journey_as_far_as_choosing_a_work_setting(
       course: "Early headship coaching offer",
-      work_setting: "A school",
+      work_setting: "Primary school (5 to 11)",
     )
 
     choose_a_school(js:, name: "open")
@@ -80,7 +80,7 @@ RSpec.feature "Sad journeys", :with_cohorts, :with_default_schedules, :with_defa
           "DfE scholarship funding" => "Not eligible",
           "Cohort" => course_start_cohort_description,
           "Working in England" => "Yes",
-          "Work setting" => "A school",
+          "Work setting" => "Primary school (5 to 11)",
           "Course" => "Early headship coaching offer",
           "Provider" => "Teach First",
           "Course funding" => "I am paying",
@@ -135,7 +135,7 @@ RSpec.feature "Sad journeys", :with_cohorts, :with_default_schedules, :with_defa
       "works_in_nursery" => nil,
       "works_in_childcare" => false,
       "works_in_school" => true,
-      "work_setting" => "a_school",
+      "work_setting" => "primary_school",
       "senco_in_role" => nil,
       "senco_start_date" => nil,
       "on_submission_trn" => nil,
@@ -160,7 +160,7 @@ RSpec.feature "Sad journeys", :with_cohorts, :with_default_schedules, :with_defa
         "teacher_catchment_country" => nil,
         "works_in_school" => "yes",
         "works_in_childcare" => "no",
-        "work_setting" => "a_school",
+        "work_setting" => "primary_school",
       },
     )
   end

--- a/spec/features/journeys/sad_paths/going_back_to_choose_school_step_spec.rb
+++ b/spec/features/journeys/sad_paths/going_back_to_choose_school_step_spec.rb
@@ -39,6 +39,7 @@ RSpec.feature "Sad journeys", :mvp, :with_cohorts, :with_default_schedules, :wit
 
     navigate_to_page(path: "/registration/work-setting", submit_form: true) do
       page.choose("A school", visible: :all)
+      page.choose("Primary school (5 to 11)", visible: :all)
     end
 
     choose_a_school(js:, name: school_name)

--- a/spec/features/journeys/sad_paths/missing_mandatory_institution_spec.rb
+++ b/spec/features/journeys/sad_paths/missing_mandatory_institution_spec.rb
@@ -34,6 +34,7 @@ RSpec.feature "Sad journeys", :no_js, :with_cohorts, :with_default_schedules, ty
     # choose a setting that does require an institution, but don't set it
     navigate_to_page(path: "/registration/work-setting", submit_form: true) do
       page.choose("A school", visible: :all)
+      page.choose("Primary school (5 to 11)", visible: :all)
     end
 
     expect_page_to_have(path: "/registration/choose-school", submit_form: false)

--- a/spec/features/journeys/sad_paths/school_not_in_england_spec.rb
+++ b/spec/features/journeys/sad_paths/school_not_in_england_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature "Sad journeys", :with_cohorts, :with_default_schedules, type: :fea
 
     complete_journey_as_far_as_choosing_a_work_setting(
       course: "Headship",
-      work_setting: "A school",
+      work_setting: "Primary school (5 to 11)",
     )
 
     choose_a_school(js:, name: "open wrexham school")

--- a/spec/forms/questionnaires/work_setting_spec.rb
+++ b/spec/forms/questionnaires/work_setting_spec.rb
@@ -20,11 +20,47 @@ RSpec.describe Questionnaires::WorkSetting, type: :model do
   describe "validations" do
     it { is_expected.to validate_presence_of(:work_setting) }
     it { is_expected.to validate_inclusion_of(:work_setting).in_array(described_class::ALL_SETTINGS) }
+
+    it "rejects the 'a_school' value" do
+      form = described_class.new(work_setting: described_class::A_SCHOOL)
+
+      expect(form).to be_invalid
+      expect(form).to have_error(:work_setting, :school_type_blank, "Select the type of school that you work in")
+    end
+
+    described_class::NESTED_SCHOOL_SETTINGS.each do |setting|
+      it "accepts the nested school type '#{setting}'" do
+        expect(described_class.new(work_setting: setting)).to be_valid
+      end
+    end
+  end
+
+  describe "#options" do
+    subject(:school_option) { described_class.new.options.find { |option| option.value == described_class::A_SCHOOL } }
+
+    it "nests the school types under 'a_school'" do
+      expect(school_option).to be_nested
+      expect(school_option.nested_options.map(&:value)).to eq(described_class::NESTED_SCHOOL_SETTINGS)
+    end
+
+    it "does not show the school types at the top level" do
+      top_level = described_class.new.options.map(&:value)
+
+      expect(top_level).not_to include(*described_class::NESTED_SCHOOL_SETTINGS)
+    end
   end
 
   describe "#after_save" do
     {
       "a_school" => {
+        "works_in_school" => "yes",
+        "works_in_childcare" => "no",
+      },
+      "primary_school" => {
+        "works_in_school" => "yes",
+        "works_in_childcare" => "no",
+      },
+      "secondary_school" => {
         "works_in_school" => "yes",
         "works_in_childcare" => "no",
       },

--- a/spec/support/helpers/journey_step_helper.rb
+++ b/spec/support/helpers/journey_step_helper.rb
@@ -149,6 +149,7 @@ module Helpers
       end
 
       expect_page_to_have(path: "/registration/work-setting", submit_form: true) do
+        page.choose("A school", visible: :all)
         page.choose(work_setting, visible: :all)
       end
     end


### PR DESCRIPTION
### Context

Ticket: [NPQ-3831](https://dfedigital.atlassian.net/browse/NPQ-3831)

The "What setting do you work in?" step in the registration journey needs school types nested under the "A school" option, so people can say what kind of school they work in.

### Changes proposed in this pull request

1. "A school" now shows three school types under it: primary school (5 to 11), secondary school (11 to 16) and post-16 provider (16 to 19).

2. "A school" is now only a parent and cannot be submitted.

3. Patched the GOV.UK Radios `syncConditionalRevealWithInputState` so the reveal stays open when a nested option is selected. Without this it closes as soon as you pick a school type, because that unselects "A school".

4. New specs for the form and for the page, covering JavaScript and no JavaScript.

5. Updated the old MVP journey specs to pick "Primary school (5 to 11)" instead of "A school".


[NPQ-3831]: https://dfedigital.atlassian.net/browse/NPQ-3831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ