### PR TITLE
[NPQ-3873] move login

### DIFF
--- a/app/controllers/omniauth_controller.rb
+++ b/app/controllers/omniauth_controller.rb
@@ -144,12 +144,12 @@ private
       return new_email_update_path
     end
 
-    return account_path unless user_starting_registration?
+    return account_path unless user_continuing_registration?
 
-    start_questionnaire_path(user)
+    continue_questionnaire_path(user)
   end
 
-  def user_starting_registration?
+  def user_continuing_registration?
     request.env["omniauth.params"]&.fetch("start_now", nil) == "true"
   end
 
@@ -170,9 +170,18 @@ private
     end
   end
 
-  def start_questionnaire_path(user)
+  def continue_questionnaire_step
+    if Flipper.enabled?(Feature::CLOSED_REGISTRATION_ENABLED) &&
+        !Flipper.enabled?(Feature::REGISTRATION_OPEN)
+      :start
+    else
+      :login_callback
+    end
+  end
+
+  def continue_questionnaire_path(user)
     wizard = RegistrationWizard.new(
-      current_step: :login_callback,
+      current_step: continue_questionnaire_step,
       store: session["registration_store"],
       params: {},
       request:,

--- a/app/controllers/registration_wizard_controller.rb
+++ b/app/controllers/registration_wizard_controller.rb
@@ -4,7 +4,6 @@ class RegistrationWizardController < PublicPagesController
   before_action :set_form
   before_action :check_end_of_journey, only: %i[update]
   before_action :check_course_defined, only: %i[show]
-  before_action :check_teacher_auth_user
 
   rescue_from FundingEligibility::MissingMandatoryInstitution, with: :redirect_to_institution_picker
   rescue_from RegistrationWizard::RemovedStep, with: :redirect_to_course_start_date
@@ -108,13 +107,15 @@ private
   def check_end_of_journey
     if @form.valid? && @form.last_step?
       @wizard.save!
+      @wizard.store.clear
       redirect_to registration_complete_accounts_user_registration_path(current_user.applications.last)
     end
   end
 
   def check_course_defined
-    redirect_to_course_start_date if !FORMS_FOR_STEPS_BEFORE_COURSE_IS_CHOSEN.include?(@form.class) && defined?(@form.course) && !@form.course
-    redirect_to_course_start_date if @form.instance_of?(Questionnaires::CheckAnswers) && !@wizard.course
+    return if FORMS_FOR_STEPS_BEFORE_COURSE_IS_CHOSEN.include?(@form.class)
+
+    redirect_to_course_start_date if defined?(@form.course) && !@form.course
   end
 
   def registration_closed
@@ -137,18 +138,5 @@ private
     return {} if Feature.registration_closed?(current_user)
 
     params.fetch(:registration_wizard, {}).permit(RegistrationWizard.permitted_params_for_step(params[:step].underscore))
-  end
-
-  def check_teacher_auth_user
-    return unless Rails.configuration.x.teacher_auth.enabled
-    return if params[:step].to_s == "start"
-    return unless current_user&.get_an_identity_provider?
-
-    Sentry.capture_message("User attempted registration from GAI")
-
-    sign_out_all_scopes
-    flash[:error] = "Please restart your registration"
-
-    redirect_to(root_path)
   end
 end

--- a/app/controllers/registration_wizard_controller.rb
+++ b/app/controllers/registration_wizard_controller.rb
@@ -12,9 +12,14 @@ class RegistrationWizardController < PublicPagesController
   helper_method :first_questionnaire_step
 
   FORMS_FOR_STEPS_BEFORE_COURSE_IS_CHOSEN = [
+    Questionnaires::Start,
+    Questionnaires::CourseStartDate,
+    Questionnaires::CheckFunding,
+    Questionnaires::TeacherCatchment,
     Questionnaires::ChooseYourNpq,
     Questionnaires::FundingYourNpq,
     Questionnaires::IneligibleForFunding,
+    Questionnaires::Closed,
   ].freeze
 
   def show
@@ -114,8 +119,13 @@ private
 
   def check_course_defined
     return if FORMS_FOR_STEPS_BEFORE_COURSE_IS_CHOSEN.include?(@form.class)
+    return if @wizard.query_store.course
 
-    redirect_to_course_start_date if defined?(@form.course) && !@form.course
+    # redirect to course start date if the user has started the registration journey
+    return redirect_to_course_start_date if @wizard.query_store.has_answers?
+
+    # redirect to the start of the registration journey if the user has not started the registration journey
+    redirect_to "/"
   end
 
   def registration_closed

--- a/app/forms/questionnaires/base.rb
+++ b/app/forms/questionnaires/base.rb
@@ -90,20 +90,8 @@ module Questionnaires
     end
 
     def requirements_met?
-      # Redirect to new registration flow if a user wants to change the course or provider details
-      return true if return_to_new_registration_flow?
-
-      # Ensures the user is:
-      # a) logged in
-      # b) has answered at least one question
-      # Before allowing them to proceed into any questions.
-      # Certain questions, such as start and provider_check, override this
-      # as they are the first questions in the flow.
-      # Some questions add additional requirements, such as the confirmation page which requires
-      # a lead provider and a course to have been selected.
-      wizard.store.present? &&
-        query_store.current_user.present? &&
-        wizard.store.keys != %w[current_user]
+      # basic check to determine if user has completed a registration and is attempting to go directly to a step in the journey
+      query_store.has_answers?
     end
 
     def reset_store!

--- a/app/forms/questionnaires/check_answers.rb
+++ b/app/forms/questionnaires/check_answers.rb
@@ -1,16 +1,24 @@
 module Questionnaires
   class CheckAnswers < Base
+    def requirements_met?
+      wizard.query_store.has_answers?
+    end
+
     def previous_step
       :share_provider
     end
 
-    def next_step; end
+    def next_step
+      :continue_to_login unless user_logged_in?
+    end
 
     def last_step?
-      true
+      user_logged_in?
     end
 
     def after_save
+      return unless user_logged_in?
+
       wizard.store["email_template"] = email_template
 
       wizard.store["submitted"] = true
@@ -21,6 +29,12 @@ module Questionnaires
 
     def email_template
       @email_template ||= EmailTemplate.call(data: wizard.store)
+    end
+
+  private
+
+    def user_logged_in?
+      wizard.current_user
     end
   end
 end

--- a/app/forms/questionnaires/choose_school.rb
+++ b/app/forms/questionnaires/choose_school.rb
@@ -16,6 +16,10 @@ module Questionnaires
       ]
     end
 
+    def requirements_met?
+      query_store.work_setting
+    end
+
     # In the no js scenario we want the step to loop, showing a different screen
     # the second time but without showing an error - hence a negative response to
     # #valid? preventing saving but without appending errors

--- a/app/forms/questionnaires/choose_your_provider.rb
+++ b/app/forms/questionnaires/choose_your_provider.rb
@@ -72,7 +72,6 @@ module Questionnaires
         institution: query_store.institution,
         approved_itt_provider: approved_itt_provider?,
         inside_catchment: inside_catchment?,
-        user_ecf_id: query_store.user_ecf_id,
         query_store: wizard.query_store,
       )
     end

--- a/app/forms/questionnaires/continue_to_login.rb
+++ b/app/forms/questionnaires/continue_to_login.rb
@@ -1,0 +1,11 @@
+module Questionnaires
+  class ContinueToLogin < Base
+    def previous_step
+      :check_answers
+    end
+
+    def next_step
+      :check_answers
+    end
+  end
+end

--- a/app/forms/questionnaires/course_start_date.rb
+++ b/app/forms/questionnaires/course_start_date.rb
@@ -37,7 +37,7 @@ module Questionnaires
     end
 
     def requirements_met?
-      query_store.current_user
+      true
     end
 
     def next_step

--- a/app/forms/questionnaires/login_callback.rb
+++ b/app/forms/questionnaires/login_callback.rb
@@ -5,11 +5,11 @@ module Questionnaires
     end
 
     def next_step
-      first_questionnaire_step
+      :check_answers
     end
 
     def previous_step
-      :start
+      :continue_to_login
     end
   end
 end

--- a/app/forms/questionnaires/provider_check.rb
+++ b/app/forms/questionnaires/provider_check.rb
@@ -29,10 +29,6 @@ module Questionnaires
       ]
     end
 
-    def requirements_met?
-      query_store.current_user
-    end
-
     def next_step
       case chosen_provider
       when "yes"

--- a/app/forms/questionnaires/start.rb
+++ b/app/forms/questionnaires/start.rb
@@ -5,14 +5,7 @@ module Questionnaires
     end
 
     def next_step
-      if query_store.current_user
-        first_questionnaire_step
-      else
-        # This shouldn't really be reached, in this situation the user should have been
-        # presented the omniauth kickoff button on the start back. This is here as a fallback
-        # to send the user back to the start page where they'll be presented the oauth button again.
-        :start
-      end
+      first_questionnaire_step
     end
   end
 end

--- a/app/forms/questionnaires/work_setting.rb
+++ b/app/forms/questionnaires/work_setting.rb
@@ -67,10 +67,6 @@ module Questionnaires
       end
     end
 
-    def requirements_met?
-      true
-    end
-
     def return_to_regular_flow_on_change?
       true
     end

--- a/app/models/registration_wizard.rb
+++ b/app/models/registration_wizard.rb
@@ -65,6 +65,7 @@ class RegistrationWizard
     check_answers
     course_start_date
     cannot_register_yet
+    continue_to_login
   ].freeze
 
   REMOVED_REGISTRATION_STEPS = %i[
@@ -271,7 +272,7 @@ private
   end
 
   def load_current_user_into_store
-    store["current_user_id"] = current_user&.id
+    store["current_user_id"] = current_user.id if current_user
   end
 
   def institution_from_store

--- a/app/services/funding_eligibility.rb
+++ b/app/services/funding_eligibility.rb
@@ -58,7 +58,7 @@ class FundingEligibility
     def new_from_query_store(institution:,
                              course:,
                              inside_catchment:,
-                             user_ecf_id:,
+                             user_ecf_id: nil,
                              approved_itt_provider: false,
                              query_store: nil)
       cohort = Cohort.find_by(identifier: query_store.course_start_cohort)

--- a/app/services/registration_query_store.rb
+++ b/app/services/registration_query_store.rb
@@ -25,10 +25,6 @@ class RegistrationQueryStore
     store["trn_set_via_fallback_verification_question"]
   end
 
-  def trn
-    current_user.trn
-  end
-
   def inside_catchment?
     store["teacher_catchment"] == "england"
   end
@@ -215,5 +211,9 @@ class RegistrationQueryStore
 
   def declared_previous_funding?
     store["declared_previous_funding"] == "yes"
+  end
+
+  def has_answers?
+    store.excluding("current_user_id").any?
   end
 end

--- a/app/views/pages/closed_registration_exception.html.erb
+++ b/app/views/pages/closed_registration_exception.html.erb
@@ -4,9 +4,11 @@
 
     <% if Feature.registration_enabled? %>
       <%=
-        render(
-          "shared/teacher_auth/redirect_button",
-          button_text: "Start now"
+        govuk_start_button(
+          text: "Start now",
+          href: user_teacher_auth_omniauth_authorize_path(start_now: true),
+          as_button: true,
+          html_attributes: { data: { "prevent-double-click": true } }
         )
       %>
     <% end %>

--- a/app/views/registration_wizard/check_answers.html.erb
+++ b/app/views/registration_wizard/check_answers.html.erb
@@ -27,11 +27,18 @@
         end
   end %>
 
-  <h2 class="govuk-heading-m">Submit your registration</h2>
-
-  <p class="govuk-body">By submitting your registration to the DfE, you're confirming that all the information you entered is correct.</p>
-
-  <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
-    <%= f.govuk_submit "Submit" %>
+  <% if current_user %>
+    <h2 class="govuk-heading-m">Submit your registration</h2>
+    <p class="govuk-body">By submitting your registration to the DfE, you're confirming that all the information you entered is correct.</p>
+  <% else %>
+    <h2 class="govuk-heading-m">Continue to register</h2>
+    <p class="govuk-body">You can still check or change your answers later.</p>
   <% end %>
+
+  <%=
+    form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f|
+      button_text = current_user ? "Submit" : "Continue"
+      f.govuk_submit button_text
+    end
+  %>
 <% end %>

--- a/app/views/registration_wizard/continue_to_login.html.erb
+++ b/app/views/registration_wizard/continue_to_login.html.erb
@@ -1,0 +1,30 @@
+<% content_for :before_content do %>
+  <%= render GovukComponent::BackLinkComponent.new(
+    text: "Back",
+    href: registration_wizard_show_path(@wizard.previous_step_path)
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l"><%= t("helpers.title.registration_wizard.continue_to_login") %></h1>
+
+    <p class="govuk-body">
+      You need to create an account or sign in through GOV.UK One Login before you can submit your NPQ registration.
+    </p>
+
+    <p class="govuk-body">
+      This allows us to verify your identity before sending your registration to your NPQ provider.
+    </p>
+
+    <%=
+      render GovukComponent::ContinueButtonComponent.new(
+        text: "Continue",
+        href: user_teacher_auth_omniauth_authorize_path(start_now: true),
+        as_button: true,
+        html_attributes: { data: { "prevent-double-click": true } }
+      )
+    %>
+  </div>
+</div>

--- a/app/views/registration_wizard/start.html.erb
+++ b/app/views/registration_wizard/start.html.erb
@@ -14,9 +14,11 @@
       <% if Rails.configuration.x.teacher_auth.enabled %>
         <br>
         <%=
-          render(
-            "shared/teacher_auth/redirect_button",
-            button_text: "Start now"
+          govuk_start_button(
+            text: "Start now",
+            href: registration_wizard_show_path("course-start-date"),
+            as_button: true,
+            html_attributes: { method: :get, data: { "prevent-double-click": true } }
           )
         %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -995,6 +995,7 @@ en:
         senco_start_date: "When did you become a SENCO?"
         funding_eligibility_senco: "Funding"
         check_funding: "Check if you’re eligible for DfE scholarship funding"
+        continue_to_login: "Continue through GOV.UK One Login"
 
     legend:
       applications_change_training_status:

--- a/spec/features/account_spec.rb
+++ b/spec/features/account_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Account", :no_js, type: :feature do
     context "when logged in" do
       before do
         navigate_to_page(path: "/", submit_form: false, axe_check: false) do
-          page.click_button("Start now")
+          page.click_button("Sign in")
         end
       end
 
@@ -157,7 +157,7 @@ RSpec.feature "Account", :no_js, type: :feature do
   describe "breadcrumbs" do
     before do
       navigate_to_page(path: "/", submit_form: false, axe_check: false) do
-        page.click_button("Start now")
+        page.click_button("Sign in")
       end
     end
 

--- a/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
@@ -87,7 +87,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
       page.check("Yes, I agree to share my information", visible: :all)
     end
 
-    expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
+    check_answers_log_in_and_submit do
       expect_check_answers_page_to_have_answers(
         {
           "DfE scholarship funding" => "Eligible",
@@ -116,17 +116,9 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
         expect(application.eligible_for_funding).to be true
       end
     end
-    if User.last.applications.count == 1
-      navigate_to_page(path: "/accounts/user_registrations/#{User.last.applications.last.id}", axe_check: false, submit_form: false) do
-        expect(page).to have_text("Teach First")
-        expect(page).to have_text("Headship")
-      end
-    else
-      navigate_to_page(path: "/account", axe_check: false, submit_form: false) do
-        expect(page).to have_text("Teach First")
-        expect(page).to have_text("Headship")
-      end
-    end
+
+    expect(page).to have_text("Teach First")
+    expect(page).to have_text("Headship")
 
     visit "/registration/share-provider"
 

--- a/spec/features/journeys/happy_paths/course_start_date_spec.rb
+++ b/spec/features/journeys/happy_paths/course_start_date_spec.rb
@@ -9,8 +9,6 @@ RSpec.feature "Happy journeys", :no_js, type: :feature do
   include_context "with stubbed Teaching Record System person API"
 
   scenario "course start date" do
-    stub_participant_validation_request
-
     navigate_to_page(path: "/", submit_form: false, axe_check: false) do
       expect(page).to have_text("Before you start")
       page.click_button("Start now")

--- a/spec/features/journeys/happy_paths/funded_ehco_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/funded_ehco_registration_journey_spec.rb
@@ -79,7 +79,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
       page.check("Yes, I agree to share my information", visible: :all)
     end
 
-    expect_page_to_have(path: "/registration/check-answers", submit_form: true, submit_button_text: "Submit") do
+    check_answers_log_in_and_submit do
       expect_check_answers_page_to_have_answers(
         {
           "DfE scholarship funding" => "Eligible",

--- a/spec/features/journeys/happy_paths/international_teacher_npqh_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/international_teacher_npqh_journey_spec.rb
@@ -14,8 +14,6 @@ RSpec.feature "Happy journeys", :no_js, :with_cohorts, :with_default_schedules, 
   end
 
   def run_scenario(*)
-    stub_participant_validation_request
-
     navigate_to_page(path: "/", submit_form: false) do
       page.click_button("Start now")
     end
@@ -74,7 +72,7 @@ RSpec.feature "Happy journeys", :no_js, :with_cohorts, :with_default_schedules, 
       page.check("Yes, I agree to share my information", visible: :all)
     end
 
-    expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
+    check_answers_log_in_and_submit do
       expect_check_answers_page_to_have_answers(
         {
           "DfE scholarship funding" => "Not eligible",

--- a/spec/features/journeys/happy_paths/other_funded_ehco_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/other_funded_ehco_registration_journey_spec.rb
@@ -70,7 +70,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
       page.check("Yes, I agree to share my information", visible: :all)
     end
 
-    expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
+    check_answers_log_in_and_submit do
       expect_check_answers_page_to_have_answers(
         {
           "DfE scholarship funding" => "Not eligible",

--- a/spec/features/journeys/happy_paths/unfunded_cohort_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/unfunded_cohort_registration_journey_spec.rb
@@ -69,7 +69,7 @@ RSpec.feature "Happy journeys", :no_js, :with_cohorts, :with_default_schedules, 
       page.check("Yes, I agree to share my information", visible: :all)
     end
 
-    expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
+    check_answers_log_in_and_submit do
       expect_check_answers_page_to_have_answers(
         {
           "DfE scholarship funding" => "Not eligible",

--- a/spec/features/journeys/happy_paths/when_choose_lead_mentor_course_spec.rb
+++ b/spec/features/journeys/happy_paths/when_choose_lead_mentor_course_spec.rb
@@ -49,12 +49,10 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
       page.check("Yes, I agree to share my information", visible: :all)
     end
 
-    expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
+    check_answers_log_in_and_submit do
       expect_check_answers_page_to_have_answers(
         {
-
           "DfE scholarship funding" => "Eligible",
-
           "Cohort" => course_start_cohort_description,
           "Course" => "Leading teacher development",
           "Employment type" => "As a lead mentor for an accredited initial teacher training (ITT) provider",

--- a/spec/features/journeys/happy_paths/when_choose_maths_course_spec.rb
+++ b/spec/features/journeys/happy_paths/when_choose_maths_course_spec.rb
@@ -49,7 +49,7 @@ RSpec.feature "Happy journeys", :no_js, :with_cohorts, :with_default_schedules, 
       page.check("Yes, I agree to share my information", visible: :all)
     end
 
-    expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
+    check_answers_log_in_and_submit do
       expect_check_answers_page_to_have_answers(
         {
           "DfE scholarship funding" => "Eligible",

--- a/spec/features/journeys/happy_paths/when_outside_of_catchment_area_spec.rb
+++ b/spec/features/journeys/happy_paths/when_outside_of_catchment_area_spec.rb
@@ -77,7 +77,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
       page.check("Yes, I agree to share my information", visible: :all)
     end
 
-    expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
+    check_answers_log_in_and_submit do
       expect_check_answers_page_to_have_answers(
         {
           "DfE scholarship funding" => "Not eligible",

--- a/spec/features/journeys/happy_paths/when_previously_funded_spec.rb
+++ b/spec/features/journeys/happy_paths/when_previously_funded_spec.rb
@@ -6,11 +6,11 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_nursery, :wit
   include ApplicationHelper
 
   context "when JavaScript is enabled", :js do
-    scenario("registration journey when previously funded (with JS)") { run_scenario(js: true) }
+    scenario("registration journey when previously funded") { run_scenario(js: true) }
   end
 
   context "when JavaScript is disabled", :no_js do
-    scenario("registration journey when previously funded (without JS)") { run_scenario(js: false) }
+    scenario("registration journey when previously funded") { run_scenario(js: false) }
   end
 
   include_context "retrieve latest application data"

--- a/spec/features/journeys/happy_paths/when_referred_by_return_to_teaching_adviser_spec.rb
+++ b/spec/features/journeys/happy_paths/when_referred_by_return_to_teaching_adviser_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
       page.check("Yes, I agree to share my information", visible: :all)
     end
 
-    expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
+    check_answers_log_in_and_submit do
       expect_check_answers_page_to_have_answers(
         {
           "DfE scholarship funding" => "Not eligible",

--- a/spec/features/journeys/happy_paths/when_school_not_eligible_spec.rb
+++ b/spec/features/journeys/happy_paths/when_school_not_eligible_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, :with_de
       page.check("Yes, I agree to share my information", visible: :all)
     end
 
-    expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
+    check_answers_log_in_and_submit do
       expect_check_answers_page_to_have_answers(
         {
           "DfE scholarship funding" => "Not eligible",

--- a/spec/features/journeys/happy_paths/when_teacher_auth_returns_no_trn_spec.rb
+++ b/spec/features/journeys/happy_paths/when_teacher_auth_returns_no_trn_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature "Sad journeys", :no_js, :with_cohorts, :with_default_schedules, :w
         page.check("Yes, I agree to share my information", visible: :all)
       end
 
-      expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
+      check_answers_log_in_and_submit do
         expect_check_answers_page_to_have_answers(
           {
             "DfE scholarship funding" => "Not eligible",

--- a/spec/features/journeys/happy_paths/when_working_at_an_eligible_primary_school_spec.rb
+++ b/spec/features/journeys/happy_paths/when_working_at_an_eligible_primary_school_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
       page.check("Yes, I agree to share my information", visible: :all)
     end
 
-    expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
+    check_answers_log_in_and_submit do
       expect_check_answers_page_to_have_answers(
         {
           "DfE scholarship funding" => "Eligible",

--- a/spec/features/journeys/happy_paths/when_working_in_other_spec.rb
+++ b/spec/features/journeys/happy_paths/when_working_in_other_spec.rb
@@ -50,7 +50,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
       page.check("Yes, I agree to share my information", visible: :all)
     end
 
-    expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
+    check_answers_log_in_and_submit do
       expect_check_answers_page_to_have_answers(
         {
           "DfE scholarship funding" => "Not eligible",

--- a/spec/features/journeys/happy_paths/while_not_currently_working_at_school_spec.rb
+++ b/spec/features/journeys/happy_paths/while_not_currently_working_at_school_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature "Happy journeys", :no_js, :with_cohorts, :with_default_schedules, 
       page.check("Yes, I agree to share my information", visible: :all)
     end
 
-    expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
+    check_answers_log_in_and_submit do
       expect_check_answers_page_to_have_answers(
         {
           "DfE scholarship funding" => "Not eligible",

--- a/spec/features/journeys/happy_paths/while_working_in_neither_a_school_nor_childcare_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_in_neither_a_school_nor_childcare_spec.rb
@@ -50,7 +50,7 @@ RSpec.feature "Happy journeys", :no_js, :with_cohorts, :with_default_schedules, 
       page.check("Yes, I agree to share my information", visible: :all)
     end
 
-    expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
+    check_answers_log_in_and_submit do
       expect_check_answers_page_to_have_answers(
         {
           "DfE scholarship funding" => "Not eligible",

--- a/spec/features/journeys/post_mvp/when_already_logged_in_spec.rb
+++ b/spec/features/journeys/post_mvp/when_already_logged_in_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.feature "Happy journeys", :no_js, :with_cohorts, :with_default_schedules, :with_default_school, type: :feature do
+  include Helpers::JourneyAssertionHelper
+  include Helpers::JourneyStepHelper
+  include ApplicationHelper
+
+  include_context "with stubbed Teacher Auth OmniAuth responses"
+  include_context "with stubbed Teaching Record System person API"
+
+  scenario "When already logged in" do
+    navigate_to_page(path: "/", submit_form: false) do
+      page.click_button("Sign in")
+    end
+
+    complete_journey_as_far_as_choosing_a_work_setting(
+      course: "Headship",
+      work_setting: "Secondary school (11 to 16)",
+    )
+
+    choose_a_school(js: false, name: "open")
+
+    expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
+      page.click_link("Continue to register")
+    end
+
+    expect_page_to_have(path: "/registration/funding-your-npq", submit_form: true) do
+      expect(page).to have_text("How are you funding your course?")
+      page.choose "I am paying", visible: :all
+    end
+
+    expect_page_to_have(path: "/registration/choose-your-provider", submit_form: true) do
+      expect(page).to have_text("Select your provider")
+      page.choose("Teach First", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/share-provider", submit_form: true) do
+      expect(page).to have_text("Sharing your NPQ information")
+      page.check("Yes, I agree to share my information", visible: :all)
+    end
+
+    # check_back_journey_is_correct # FIXME: this currently fails
+
+    expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
+      expect_check_answers_page_to_have_answers(
+        {
+          "Course funding" => "I am paying",
+          "Cohort" => "Autumn 2026",
+          "Course" => "Headship",
+          "DfE scholarship funding" => "Not eligible",
+          "Provider" => "Teach First",
+          "Workplace" => "open manchester school – street 1, manchester",
+          "Work setting" => "Secondary school (11 to 16)",
+          "Working in England" => "Yes",
+        },
+      )
+    end
+
+    expect_applicant_reached_end_of_journey
+  end
+end

--- a/spec/features/journeys/post_mvp/when_not_logged_in_spec.rb
+++ b/spec/features/journeys/post_mvp/when_not_logged_in_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.feature "Happy journeys", :no_js, :with_cohorts, :with_default_schedules, :with_default_school, type: :feature do
+  include Helpers::JourneyAssertionHelper
+  include Helpers::JourneyStepHelper
+  include ApplicationHelper
+
+  scenario "When not logged in" do
+    navigate_to_page(path: "/", submit_form: false) do
+      page.click_button("Start now")
+    end
+
+    expect(page).to have_current_path("/registration/course-start-date")
+  end
+end

--- a/spec/features/journeys/post_mvp/work_setting_nested_radios_spec.rb
+++ b/spec/features/journeys/post_mvp/work_setting_nested_radios_spec.rb
@@ -7,19 +7,31 @@ RSpec.feature "Work setting nested radios", :with_cohorts, type: :feature do
   let(:school_types) { ["Primary school (5 to 11)", "Secondary school (11 to 16)", "Post-16 provider (16 to 19)"] }
   let(:group) { "#registration-wizard-work-setting-a-school-conditional" }
 
-  context "without JavaScript", :no_js do
-    # The step is only reached mid-journey, so seed a store with a course and
-    # catchment. Without it, submitting routes into the eligibility step, which
-    # reads the (missing) course and blows up - a test-only artifact of visiting
-    # the page directly.
-    let(:store) { build(:registration_wizard_store) }
-
-    before do
-      allow_any_instance_of(RegistrationWizardController)
-        .to receive(:session).and_return("registration_store" => store)
-      visit "/registration/work-setting"
+  before do
+    navigate_to_page(path: "/", submit_form: false) do
+      page.click_button("Start now")
     end
 
+    choose_course_start_date
+
+    expect_page_to_have(path: "/registration/check-funding", submit_form: true) do
+      click_button("Check funding")
+    end
+
+    expect_page_to_have(path: "/registration/teacher-catchment", submit_form: true) do
+      choose("Yes", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/choose-your-npq", submit_form: true) do
+      page.choose("Headship", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/funding-history", submit_form: true) do
+      page.choose("No", visible: :all)
+    end
+  end
+
+  context "without JavaScript", :no_js do
     scenario "renders the school types, so they do not rely on JavaScript" do
       school_types.each { |type| expect(page).to have_field(type) }
     end

--- a/spec/features/journeys/sad_paths/applying_for_ehco_but_not_new_headteacher_spec.rb
+++ b/spec/features/journeys/sad_paths/applying_for_ehco_but_not_new_headteacher_spec.rb
@@ -74,7 +74,7 @@ RSpec.feature "Sad journeys", :with_cohorts, :with_default_schedules, :with_defa
       page.check("Yes, I agree to share my information", visible: :all)
     end
 
-    expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
+    check_answers_log_in_and_submit do
       expect_check_answers_page_to_have_answers(
         {
           "DfE scholarship funding" => "Not eligible",

--- a/spec/features/journeys/sad_paths/applying_for_eyl_but_not_on_childminder_eligibility_list_spec.rb
+++ b/spec/features/journeys/sad_paths/applying_for_eyl_but_not_on_childminder_eligibility_list_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature "Happy journeys", :no_js, :with_cohorts, :with_default_nursery, :w
       page.check("Yes, I agree to share my information", visible: :all)
     end
 
-    expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
+    check_answers_log_in_and_submit do
       expect_check_answers_page_to_have_answers(
         {
           "DfE scholarship funding" => "Not eligible",

--- a/spec/features/journeys/sad_paths/childminder_applying_for_eyl_but_no_ofsted_urn_spec.rb
+++ b/spec/features/journeys/sad_paths/childminder_applying_for_eyl_but_no_ofsted_urn_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature "Happy journeys", :no_js, :with_cohorts, :with_default_schedules, 
       page.check("Yes, I agree to share my information", visible: :all)
     end
 
-    expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
+    check_answers_log_in_and_submit do
       expect_check_answers_page_to_have_answers(
         {
           "DfE scholarship funding" => "Not eligible",

--- a/spec/features/journeys/sad_paths/lead_mentor_journey_with_incorrect_course_spec.rb
+++ b/spec/features/journeys/sad_paths/lead_mentor_journey_with_incorrect_course_spec.rb
@@ -61,7 +61,7 @@ RSpec.feature "Sad journeys", :with_cohorts, :with_default_schedules, type: :fea
       page.check("Yes, I agree to share my information", visible: :all)
     end
 
-    expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
+    check_answers_log_in_and_submit do
       expect_check_answers_page_to_have_answers(
         {
           "DfE scholarship funding" => "Not eligible",

--- a/spec/features/journeys/sad_paths/navigating_directly_to_pages_spec.rb
+++ b/spec/features/journeys/sad_paths/navigating_directly_to_pages_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Sad journeys", :mvp, :no_js, :with_default_schedules, type: :feature do
+RSpec.feature "Sad journeys", :no_js, :with_cohorts, :with_default_schedules, type: :feature do
   include Helpers::JourneyAssertionHelper
   include Helpers::JourneyStepHelper
   include ApplicationHelper
@@ -14,41 +14,88 @@ RSpec.feature "Sad journeys", :mvp, :no_js, :with_default_schedules, type: :feat
     end
   end
 
-  # FIXME: ineligible-for-funding step currently does not need a course for 'not in england' user, but does for others
-  steps_that_require_course = %w[
-    check-answers
-    choose-your-provider
-    ehco-new-headteacher
-    ehco-possible-funding
-    funding-eligibility-maths
-    funding-eligibility-senco
-    ineligible-for-funding
-    login-callback
-    maths-eligibility-teaching-for-mastery
-    maths-understanding-of-approach
-    possible-funding
-    senco-in-role
-    senco-start-date
+  steps_that_do_not_need_the_journey_to_have_started = %i[
+    start
+    course_start_date
   ]
 
-  steps_that_require_closed_registration = %w[
-    closed
+  steps_that_do_not_require_course = %i[
+    check_funding
+    funding_your_npq
+    teacher_catchment
+    ineligible_for_funding
+    choose_your_npq
   ]
 
-  RegistrationWizard::VALID_REGISTRATION_STEPS
-    .excluding(:choose_your_npq)
-    .map { |step| step.to_s.dasherize }.each do |step|
-    scenario "Navigating directly to the #{step} page does not raise an error" do
-      if steps_that_require_closed_registration.include?(step)
-        Flipper.disable(Feature::REGISTRATION_OPEN)
+  context "with registration closed steps" do
+    before { Flipper.disable(Feature::REGISTRATION_OPEN) }
+
+    scenario "navigating directly to the closed registration page does not raise an error" do
+      visit "/registration/closed"
+      expect(page).to have_current_path("/registration/closed")
+    end
+  end
+
+  context "with steps that do not require the journey to have started" do
+    steps_that_do_not_need_the_journey_to_have_started
+      .map { |step| step.to_s.dasherize }
+      .each do |step|
+        scenario "navigating directly to the #{step} page shows the step" do
+          visit "/registration/#{step}"
+          expect(page).to have_current_path("/registration/#{step}")
+        end
+    end
+  end
+
+  context "with steps that are before the course is chosen" do
+    steps_that_do_not_require_course
+    .map { |step| step.to_s.dasherize }
+    .each do |step|
+      context "when the journey has not been started" do
+        scenario "navigating directly to the #{step} page redirects to the start page" do
+          visit "/registration/#{step}"
+          expect(page).to have_current_path("/")
+        end
       end
 
-      visit "/registration/#{step}"
+      context "when the journey has been started" do
+        before do
+          choose_course_start_date
+          expect_page_to_have(path: "/registration/check-funding", submit_form: false)
+        end
 
-      if steps_that_require_course.include?(step)
-        expect(page).to have_current_path("/registration/course-start-date")
-      else
-        expect(page).to have_current_path("/registration/#{step}")
+        scenario "navigating directly to the #{step} page shows the step" do
+          visit "/registration/#{step}"
+          expect(page).to have_current_path("/registration/#{step}")
+        end
+      end
+    end
+  end
+
+  context "with the other steps in the registration journey" do
+    RegistrationWizard::VALID_REGISTRATION_STEPS
+    .excluding(steps_that_do_not_need_the_journey_to_have_started)
+    .excluding(steps_that_do_not_require_course)
+    .excluding(:closed)
+    .map { |step| step.to_s.dasherize }
+    .each do |step|
+      context "when the journey has not been started" do
+        scenario "navigating directly to the #{step} page redirects to the start page" do
+          visit "/registration/#{step}"
+          expect(page).to have_current_path("/")
+        end
+      end
+
+      context "when the journey has been started" do
+        before do
+          choose_course_start_date
+          expect_page_to_have(path: "/registration/check-funding", submit_form: false)
+        end
+
+        scenario "navigating directly to the #{step} page redirects to the course start date page" do
+          visit "/registration/#{step}"
+          expect(page).to have_current_path("/registration/course-start-date")
+        end
       end
     end
   end

--- a/spec/features/journeys/sad_paths/school_not_in_england_spec.rb
+++ b/spec/features/journeys/sad_paths/school_not_in_england_spec.rb
@@ -14,16 +14,14 @@ RSpec.feature "Sad journeys", :with_cohorts, :with_default_schedules, type: :fea
   end
 
   context "when JavaScript is enabled", :js do
-    scenario("school not in England (with JS)") { run_scenario(js: true) }
+    scenario("school not in England") { run_scenario(js: true) }
   end
 
   context "when JavaScript is disabled", :no_js do
-    scenario("school not in England (without JS)") { run_scenario(js: false) }
+    scenario("school not in England") { run_scenario(js: false) }
   end
 
   def run_scenario(js:)
-    stub_participant_validation_request
-
     complete_journey_as_far_as_choosing_a_work_setting(
       course: "Headship",
       work_setting: "Primary school (5 to 11)",

--- a/spec/features/journeys/sad_paths/step_does_not_exist_spec.rb
+++ b/spec/features/journeys/sad_paths/step_does_not_exist_spec.rb
@@ -4,41 +4,30 @@ RSpec.feature "visiting steps that do not exist", type: :feature do
   include_context "with stubbed Teacher Auth OmniAuth responses"
   include_context "with stubbed Teaching Record System person API"
 
-  context "when not logged in" do
-    scenario "visiting steps that used to exist", :no_js do
-      visit "/registration/confirmation"
-      expect(page).to have_current_path "/"
+  scenario "visiting steps that used to exist", :no_js do
+    visit "/registration/confirmation"
+    expect(page).to have_current_path "/registration/course-start-date"
 
-      visit "/registration/about-npq"
-      expect(page).to have_current_path "/"
+    visit "/registration/about-npq"
+    expect(page).to have_current_path "/registration/course-start-date"
 
-      visit "/registration/choosen-start-date"
-      expect(page).to have_current_path "/"
-    end
-  end
+    visit "/registration/choosen-start-date"
+    expect(page).to have_current_path "/registration/course-start-date"
 
-  context "when logged in" do
-    before do
-      visit "/"
-      page.click_button("Start now")
-    end
+    visit "/registration/confirmation"
+    expect(page).to have_current_path "/registration/course-start-date"
 
-    scenario "visiting steps that used to exist", :no_js do
-      visit "/registration/confirmation"
-      expect(page).to have_current_path "/registration/course-start-date"
+    visit "/registration/about-npq"
+    expect(page).to have_current_path "/registration/course-start-date"
 
-      visit "/registration/about-npq"
-      expect(page).to have_current_path "/registration/course-start-date"
+    visit "/registration/choosen-start-date"
+    expect(page).to have_current_path "/registration/course-start-date"
 
-      visit "/registration/choosen-start-date"
-      expect(page).to have_current_path "/registration/course-start-date"
+    visit "/registration/find-school"
+    expect(page).to have_current_path "/registration/course-start-date"
 
-      visit "/registration/find-school"
-      expect(page).to have_current_path "/registration/course-start-date"
-
-      visit "/registration/find-childcare-provider"
-      expect(page).to have_current_path "/registration/course-start-date"
-    end
+    visit "/registration/find-childcare-provider"
+    expect(page).to have_current_path "/registration/course-start-date"
   end
 
   scenario "visiting steps that never existed", :no_js do

--- a/spec/features/journeys/sad_paths/works_in_childcare_but_not_in_england_spec.rb
+++ b/spec/features/journeys/sad_paths/works_in_childcare_but_not_in_england_spec.rb
@@ -77,7 +77,7 @@ RSpec.feature "Sad journeys", :with_cohorts, :with_default_schedules, :with_defa
       page.check("Yes, I agree to share my information", visible: :all)
     end
 
-    expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
+    check_answers_log_in_and_submit do
       expect_check_answers_page_to_have_answers(
         {
           "DfE scholarship funding" => "Not eligible",

--- a/spec/features/registration_complete_spec.rb
+++ b/spec/features/registration_complete_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Registration complete page", :no_js, type: :feature do
   context "when logged in" do
     before do
       navigate_to_page(path: "/", submit_form: false, axe_check: false) do
-        page.click_button("Start now")
+        page.click_button("Sign in")
       end
     end
 

--- a/spec/forms/questionnaires/choose_school_spec.rb
+++ b/spec/forms/questionnaires/choose_school_spec.rb
@@ -134,6 +134,20 @@ RSpec.describe Questionnaires::ChooseSchool, type: :model do
     end
   end
 
+  describe "#requirements_met?" do
+    subject { instance.requirements_met? }
+
+    context "when a work setting has been chosen" do
+      before { wizard.store["work_setting"] = "other" }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when a work setting has not been chosen" do
+      it { is_expected.to be_falsey }
+    end
+  end
+
   describe "#next_step" do
     subject { instance.next_step }
 

--- a/spec/forms/questionnaires/course_start_date_spec.rb
+++ b/spec/forms/questionnaires/course_start_date_spec.rb
@@ -42,6 +42,12 @@ RSpec.describe Questionnaires::CourseStartDate, type: :model do
     end
   end
 
+  describe "#requirements_met?" do
+    subject { instance.requirements_met? }
+
+    it { is_expected.to be true }
+  end
+
   describe "#next_step" do
     subject { instance.next_step }
 

--- a/spec/forms/questionnaires/start_spec.rb
+++ b/spec/forms/questionnaires/start_spec.rb
@@ -1,36 +1,21 @@
 require "rails_helper"
 
 RSpec.describe Questionnaires::Start do
+  subject(:instance) { described_class.new(wizard:) }
+
+  let(:wizard) { RegistrationWizard.new(store: {}, request: nil, current_step: :start, current_user: nil) }
+
   it { is_expected.to be_requirements_met }
+
+  describe "#requirements_met?" do
+    subject { instance.requirements_met? }
+
+    it { is_expected.to be true }
+  end
 
   describe "#next_step?" do
     subject { instance.next_step }
 
-    before { instance.wizard = wizard }
-
-    let(:instance) { described_class.new }
-    let(:wizard) { RegistrationWizard.new(store:, request:, current_step: :start, current_user:) }
-    let(:request) { nil }
-    let(:store) { {} }
-
-    context "when logged in" do
-      context "with TRN" do
-        let(:current_user) { create :user }
-
-        it { is_expected.to eq :course_start_date }
-      end
-
-      context "without TRN" do
-        let(:current_user) { create :user, trn: nil }
-
-        it { is_expected.to eq :course_start_date }
-      end
-    end
-
-    context "when not logged in" do
-      let(:current_user) { nil }
-
-      it { is_expected.to eq :start }
-    end
+    it { is_expected.to eq :course_start_date }
   end
 end

--- a/spec/models/registration_wizard_spec.rb
+++ b/spec/models/registration_wizard_spec.rb
@@ -12,6 +12,24 @@ RSpec.describe RegistrationWizard do
 
   before { create(:course, :additional_support_offer) }
 
+  context "when logged in" do
+    let(:user) { create(:user) }
+
+    it "stores the current user ID" do
+      subject
+      expect(store["current_user_id"]).to eq user.id
+    end
+  end
+
+  context "when not logged in" do
+    let(:user) { nil }
+
+    it "does not create a current_user_id entry" do
+      subject
+      expect(store.keys).not_to include("current_user_id")
+    end
+  end
+
   describe "#current_step" do
     subject { described_class.new(current_step:, store:, request:, current_user: user).current_step }
 

--- a/spec/services/registration_query_store_spec.rb
+++ b/spec/services/registration_query_store_spec.rb
@@ -70,4 +70,26 @@ RSpec.describe RegistrationQueryStore do
       it { is_expected.to be false }
     end
   end
+
+  describe "#has_answers?" do
+    subject { described_class.new(store:).has_answers? }
+
+    context "when the store is empty" do
+      let(:store) { {} }
+
+      it { is_expected.to be false }
+    end
+
+    context "when the store only has user id" do
+      let(:store) { { current_user_id: 123 }.stringify_keys }
+
+      it { is_expected.to be false }
+    end
+
+    context "when the store has at least one answer" do
+      let(:store) { { course_start_cohort: "2026b" }.stringify_keys }
+
+      it { is_expected.to be true }
+    end
+  end
 end

--- a/spec/support/helpers/journey_step_helper.rb
+++ b/spec/support/helpers/journey_step_helper.rb
@@ -164,5 +164,19 @@ module Helpers
       )
       form.options.map(&:value)
     end
+
+    def check_answers_log_in_and_submit(&block)
+      expect_page_to_have(path: "/registration/check-answers", submit_form: true) do
+        block.call if block_given?
+      end
+
+      expect_page_to_have(path: "/registration/continue-to-login", submit_form: true) do
+        expect(page).to have_text("Continue through GOV.UK One Login")
+      end
+
+      expect_page_to_have(path: "/registration/check-answers", submit_button_text: "Submit", submit_form: true) do
+        block.call if block_given?
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

Ticket: [NPQ-3873](https://dfedigital.atlassian.net/browse/NPQ-3873)

Move login to end of journey

### Changes proposed in this pull request

1. clicking 'Start now' on the start page does not redirect to a login, but continues to /course-start-date
2. after checking answers, the continue button redirects to a  login.
3. created a `check_answers_log_in_and_submit` helper for the journey specs, that checks the values on the check answers page, continues to the login page, and then confirms the check answers page again, before hitting the submit button.
4. clear the query store in the controller after completing a registration - this is so we can use the fact the store is empty to determine if they have completed a registration and are then attempting to access steps directly. 
5. allow closed registration exception users to still log in and complete the journey
6. re-enabled `spec/features/journeys/sad_paths/navigating_directly_to_pages_spec.rb`



[NPQ-3873]: https://dfedigital.atlassian.net/browse/NPQ-3873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ