### PR TITLE
[NPQ-3919] Allow outcomes for transferred applications

### DIFF
--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -37,9 +37,14 @@ class Declaration < ApplicationRecord
   scope :latest_first, -> { order(created_at: :desc, id: :desc) }
   scope :not_voided, -> { where.not(state: :voided) }
 
+  scope :with_lead_provider_or_application_lead_provider, lambda { |lead_provider|
+    relation = joins(:application)
+    relation.where(lead_provider:).or(relation.where(application: { lead_provider: }))
+  }
+
   scope :eligible_for_outcomes, lambda { |lead_provider, course_identifier|
     completed
-    .with_lead_provider(lead_provider)
+    .with_lead_provider_or_application_lead_provider(lead_provider)
     .with_course_identifier(course_identifier)
     .billable_or_voidable
     .latest_first

--- a/spec/models/declaration_spec.rb
+++ b/spec/models/declaration_spec.rb
@@ -664,17 +664,21 @@ RSpec.describe Declaration, type: :model do
       let(:course_identifier) { completed_declaration.course_identifier }
       let(:completed_declaration) { create(:declaration, :completed, :payable) }
       let(:course) { completed_declaration.course }
+      let(:other_lead_provider) { LeadProvider.where.not(id: lead_provider.id).first }
       let(:older_completed_declaration) { travel_to(1.hour.ago) { create(:declaration, :completed, :payable, course:, lead_provider:) } }
 
       before do
         # Not a completed declaration.
         create(:declaration, :payable, lead_provider:, course:, declaration_type: "retained-1")
 
-        # Declaration on another provider.
-        create(:declaration, :completed, :payable, lead_provider: LeadProvider.where.not(id: lead_provider.id).first, course:)
+        # Declaration and application on another provider.
+        other_lead_provider_application = create(:application, :accepted, course:, lead_provider: other_lead_provider)
+        create(:declaration, :completed, :payable, lead_provider: other_lead_provider, course:, application: other_lead_provider_application)
 
         # Declaration with different course.
-        create(:declaration, :completed, :payable, lead_provider:, course:, application: create(:application, course: create(:course, identifier: "other-course")))
+        other_course = create(:course, identifier: "other-course")
+        other_course_application = create(:application, course: other_course)
+        create(:declaration, :completed, :payable, lead_provider:, course:, application: other_course_application)
 
         # Declarations that are not billable or voidable.
         Declaration.states.keys.excluding(Declaration::BILLABLE_STATES + Declaration::VOIDABLE_STATES).each do |state|
@@ -683,6 +687,30 @@ RSpec.describe Declaration, type: :model do
       end
 
       it { is_expected.to eq([completed_declaration, older_completed_declaration]) }
+
+      context "when the application was transferred to the lead provider" do
+        let!(:transferred_declaration) do
+          travel_to(2.hours.ago) do
+            create(:declaration, :completed, :payable, lead_provider: other_lead_provider, course:, application: create(:application, :accepted, course:, lead_provider:))
+          end
+        end
+
+        it "includes the declaration submitted by the previous provider" do
+          expect(subject).to eq([completed_declaration, older_completed_declaration, transferred_declaration])
+        end
+      end
+
+      context "when the application was transferred from the lead provider" do
+        let!(:transferred_declaration) do
+          travel_to(2.hours.ago) do
+            create(:declaration, :completed, :payable, lead_provider:, course:, application: create(:application, :accepted, course:, lead_provider: other_lead_provider))
+          end
+        end
+
+        it "includes the declaration submitted by the lead provider" do
+          expect(subject).to eq([completed_declaration, older_completed_declaration, transferred_declaration])
+        end
+      end
 
       context "when there are no declarations" do
         before { Declaration.destroy_all }

--- a/spec/services/participant_outcomes/create_spec.rb
+++ b/spec/services/participant_outcomes/create_spec.rb
@@ -53,6 +53,21 @@ RSpec.describe ParticipantOutcomes::Create, type: :model do
         it { is_expected.to have_error(:base, :no_completed_declarations, "The participant has not had a 'completed' declaration submitted for them. Therefore you cannot update their outcome.") }
       end
 
+      context "when the application was transferred to the lead provider" do
+        let(:previous_lead_provider) { create(:lead_provider) }
+        let(:lead_provider) { create(:lead_provider) }
+        let(:application) { create(:application, :accepted, course:, lead_provider:) }
+        let!(:completed_declaration) do
+          travel_to(2.days.ago) do
+            create(:declaration, :completed, :payable, course:, application:, lead_provider: previous_lead_provider)
+          end
+        end
+
+        it "allows the outcome to be submitted by the application's lead provider" do
+          expect(instance).to be_valid
+        end
+      end
+
       context "when the participant has completed declarations with a different course identifier" do
         let(:other_course) { Course.find_by(identifier: described_class::PERMITTED_COURSES.excluding(course_identifier).first) }
 


### PR DESCRIPTION
### Context

Ticket: [NPQ-3919](https://dfedigital.atlassian.net/browse/NPQ-3919)

Some applications were moved from SLN to NIOT during the SLN wind down. These applications still have all their declarations owned by SLN, but the application now belongs to NIOT. NIOT can already view these declarations, but they cannot submit new outcomes for them, because the code only checked the lead provider that owns the completed declaration, not the one that owns the application.

### Changes proposed in this pull request

1. Expand `Declaration.eligible_for_outcomes` to match on the application's lead provider as well as the declaration's.
2. Add specs for the new behaviour on both the scope and the `ParticipantOutcomes::Create` service.


[NPQ-3919]: https://dfedigital.atlassian.net/browse/NPQ-3919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ