### PR TITLE
[NPQ-3828] eligibility outcome pages

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,7 +36,7 @@ module ApplicationHelper
     govuk_tag(text: eligibility.to_s.humanize, colour: tag_colour)
   end
 
-  def funding_title(eligibility, title: "Funding")
+  def funding_title(eligibility, title: "DfE scholarship funding")
     tag.div(class: "eligibility-page-header") do
       tag.h1(class: "govuk-heading-l govuk-!-margin-0") { title } + eligibility_tag(eligibility)
     end

--- a/app/views/registration_wizard/possible_funding.html.erb
+++ b/app/views/registration_wizard/possible_funding.html.erb
@@ -1,6 +1,6 @@
 <%=
   render(
-    'registration_wizard/shared/copy_page',
+    "registration_wizard/shared/copy_page",
     form: @form,
     wizard: @wizard,
     ) do
@@ -8,7 +8,7 @@
 
   <%= render "registration_wizard/possible_funding/#{@form.message_template}", course: @form.course %>
 
-  <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: 'registration_wizard', method: :patch do |f| %>
-    <%= f.govuk_submit %>
+  <%= form_with model: @form, url: registration_wizard_form_url(@form), scope: "registration_wizard", method: :patch do |f| %>
+    <%= f.govuk_submit "Continue to register" %>
   <% end %>
 <% end %>

--- a/spec/features/journeys/happy_paths/able_to_receive_targeted_delivery_funding_spec.rb
+++ b/spec/features/journeys/happy_paths/able_to_receive_targeted_delivery_funding_spec.rb
@@ -62,9 +62,9 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, :w
     end
 
     expect_page_to_have(path: "/registration/possible-funding", submit_form: false) do
-      expect(page).to have_text("Funding")
+      expect(page).to have_text("DfE scholarship funding")
 
-      page.click_button("Continue")
+      page.click_button("Continue to register")
     end
 
     expect_page_to_have(path: "/registration/choose-your-provider", submit_form: true) do

--- a/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/basic_registration_journey_spec.rb
@@ -68,7 +68,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
     choose_a_school(js:, name: "open")
 
     expect_page_to_have(path: "/registration/possible-funding", submit_form: false) do
-      expect(page).to have_text("Funding")
+      expect(page).to have_text("DfE scholarship funding")
       expect(page).to have_text("You’re eligible for scholarship funding for the Headship NPQ")
 
       page.click_button("Continue")

--- a/spec/features/journeys/happy_paths/changing_cohort_to_one_lead_provider_no_longer_supports_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_cohort_to_one_lead_provider_no_longer_supports_spec.rb
@@ -53,7 +53,7 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, :w
     end
 
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
-      page.click_link("Continue")
+      page.click_link("Continue to register")
     end
 
     expect_page_to_have(path: "/registration/funding-your-npq", submit_form: true) do
@@ -110,7 +110,7 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, :w
     end
 
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
-      page.click_link("Continue")
+      page.click_link("Continue to register")
     end
 
     expect_page_to_have(path: "/registration/funding-your-npq", submit_form: true) do

--- a/spec/features/journeys/happy_paths/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_do_you_work_in_a_school_from_no_to_yes_spec.rb
@@ -60,8 +60,8 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, ty
     end
 
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
-      expect(page).to have_text("Funding")
-      page.click_on("Continue")
+      expect(page).to have_text("DfE scholarship funding")
+      page.click_on("Continue to register")
     end
 
     expect_page_to_have(path: "/registration/funding-your-npq", submit_form: true) do
@@ -109,11 +109,11 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, ty
     end
 
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
-      expect(page).to have_text("Funding")
+      expect(page).to have_text("DfE scholarship funding")
       expect(page).to have_text("such as state-funded schools")
       expect(page).to have_text("You’re not eligible for scholarship funding")
 
-      page.click_link("Continue")
+      page.click_link("Continue to register")
     end
 
     expect_page_to_have(path: "/registration/funding-your-npq", submit_form: true) do

--- a/spec/features/journeys/happy_paths/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_do_you_work_in_childcare_from_yes_to_no_spec.rb
@@ -61,11 +61,11 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, ty
     end
 
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
-      expect(page).to have_text("Funding")
+      expect(page).to have_text("DfE scholarship funding")
       expect(page).to have_text("such as state-funded schools")
       expect(page).to have_text("This means that you would need to pay for the course another way")
 
-      page.click_link("Continue")
+      page.click_link("Continue to register")
     end
 
     expect_page_to_have(path: "/registration/funding-your-npq", submit_form: true) do
@@ -120,8 +120,8 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, ty
     end
 
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
-      expect(page).to have_text("Funding")
-      page.click_on("Continue")
+      expect(page).to have_text("DfE scholarship funding")
+      page.click_on("Continue to register")
     end
 
     expect_page_to_have(path: "/registration/funding-your-npq", submit_form: true) do

--- a/spec/features/journeys/happy_paths/changing_from_outside_of_catchment_area_to_inside_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_from_outside_of_catchment_area_to_inside_spec.rb
@@ -49,11 +49,11 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, ty
     end
 
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
-      expect(page).to have_text("Funding")
+      expect(page).to have_text("DfE scholarship funding")
       expect(page).to have_text("you do not work in England")
       expect(page).to have_text("This means that you would need to pay for the course another way")
 
-      page.click_link("Continue")
+      page.click_link("Continue to register")
     end
 
     expect_page_to_have(path: "/registration/funding-your-npq", submit_form: true) do
@@ -104,11 +104,11 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, ty
     end
 
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
-      expect(page).to have_text("Funding")
+      expect(page).to have_text("DfE scholarship funding")
       expect(page).to have_text("such as state-funded schools")
       expect(page).to have_text("You’re not eligible for scholarship funding")
 
-      page.click_link("Continue")
+      page.click_link("Continue to register")
     end
 
     expect_page_to_have(path: "/registration/funding-your-npq", submit_form: true) do

--- a/spec/features/journeys/happy_paths/changing_npq_to_one_that_is_not_eligible_spec.rb
+++ b/spec/features/journeys/happy_paths/changing_npq_to_one_that_is_not_eligible_spec.rb
@@ -78,7 +78,7 @@ RSpec.feature "Happy journeys", :mvp, :with_default_schedules, type: :feature do
     end
 
     expect_page_to_have(path: "/registration/possible-funding", submit_form: true) do
-      expect(page).to have_text("Funding")
+      expect(page).to have_text("DfE scholarship funding")
       expect(page).to have_text("You’re eligible for scholarship funding for the Senior leadership NPQ")
     end
 
@@ -115,11 +115,11 @@ RSpec.feature "Happy journeys", :mvp, :with_default_schedules, type: :feature do
     end
 
     expect_page_to_have(path: "/registration/ineligible-for-funding/change", submit_form: false) do
-      expect(page).to have_text("Funding")
+      expect(page).to have_text("DfE scholarship funding")
       expect(page).to have_text("You’re not eligible for scholarship funding for the Executive leadership NPQ course")
       expect(page).to have_text("This means that you would need to pay for the course another way")
 
-      page.click_link("Continue")
+      page.click_link("Continue to register")
     end
 
     expect_page_to_have(path: "/registration/funding-your-npq", submit_form: true) do

--- a/spec/features/journeys/happy_paths/international_teacher_npqh_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/international_teacher_npqh_journey_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "Happy journeys", :no_js, :with_cohorts, :with_default_schedules, 
     end
 
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
-      expect(page).to have_text("Funding")
+      expect(page).to have_text("DfE scholarship funding")
       expect(page).to have_text("You’re not eligible for DfE scholarship funding because you do not work in England.")
 
       page.click_link("Continue to register")
@@ -50,10 +50,10 @@ RSpec.feature "Happy journeys", :no_js, :with_cohorts, :with_default_schedules, 
     end
 
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
-      expect(page).to have_text("Funding")
+      expect(page).to have_text("DfE scholarship funding")
       expect(page).to have_text("You’re not eligible for DfE scholarship funding because you do not work in England.")
 
-      page.click_link("Continue")
+      page.click_link("Continue to register")
     end
 
     expect_page_to_have(path: "/registration/funding-your-npq", submit_form: true) do

--- a/spec/features/journeys/happy_paths/unfunded_cohort_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/unfunded_cohort_registration_journey_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature "Happy journeys", :no_js, :with_cohorts, :with_default_schedules, 
 
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
       expect(page).to have_content("You’re not eligible for scholarship funding for the Headship NPQ course as you have selected the Spring 2026 cohort.")
-      page.click_link("Continue")
+      page.click_link("Continue to register")
     end
 
     expect_page_to_have(path: "/registration/funding-your-npq", submit_form: true) do

--- a/spec/features/journeys/happy_paths/when_choose_lead_mentor_course_spec.rb
+++ b/spec/features/journeys/happy_paths/when_choose_lead_mentor_course_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
     choose_an_itt_provider(js:, name: approved_itt_provider_legal_name)
 
     expect_page_to_have(path: "/registration/possible-funding", submit_form: true) do
-      expect(page).to have_text("Funding")
+      expect(page).to have_text("DfE scholarship funding")
       expect(page).to have_text("You’re eligible for scholarship funding for the")
     end
 

--- a/spec/features/journeys/happy_paths/when_choose_maths_course_spec.rb
+++ b/spec/features/journeys/happy_paths/when_choose_maths_course_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature "Happy journeys", :no_js, :with_cohorts, :with_default_schedules, 
     end
 
     expect_page_to_have(path: "/registration/funding-eligibility-maths", submit_form: true) do
-      expect(page).to have_text("Funding")
+      expect(page).to have_text("DfE scholarship funding")
       expect(page).to have_text("You’re eligible for scholarship funding for the Leading primary mathematics NPQ, but this does not guarantee a funded place is available.")
     end
 

--- a/spec/features/journeys/happy_paths/when_outside_of_catchment_area_spec.rb
+++ b/spec/features/journeys/happy_paths/when_outside_of_catchment_area_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
     end
 
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
-      expect(page).to have_text("Funding")
+      expect(page).to have_text("DfE scholarship funding")
       expect(page).to have_text("You’re not eligible for DfE scholarship funding because you do not work in England.")
 
       page.click_link("Continue to register")
@@ -54,10 +54,10 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
     end
 
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
-      expect(page).to have_text("Funding")
+      expect(page).to have_text("DfE scholarship funding")
       expect(page).to have_text("You’re not eligible for DfE scholarship funding because you do not work in England.")
 
-      page.click_link("Continue")
+      page.click_link("Continue to register")
     end
 
     expect_page_to_have(path: "/registration/funding-your-npq", submit_form: true) do

--- a/spec/features/journeys/happy_paths/when_previously_funded_spec.rb
+++ b/spec/features/journeys/happy_paths/when_previously_funded_spec.rb
@@ -66,7 +66,7 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_nursery, :wit
     end
 
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
-      expect(page).to have_text("Funding")
+      expect(page).to have_text("DfE scholarship funding")
       expect(page).to have_text("already been allocated scholarship funding for")
 
       page.click_link("Back")
@@ -92,7 +92,7 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_nursery, :wit
     end
 
     expect_page_to_have(path: "/registration/ehco-previously-funded", submit_form: false) do
-      expect(page).to have_text("Funding")
+      expect(page).to have_text("DfE scholarship funding")
       expect(page).to have_text("You would need to pay for the EHCO if you were previously funded but you withdrew")
 
       page.click_link("Continue")

--- a/spec/features/journeys/happy_paths/when_referred_by_return_to_teaching_adviser_spec.rb
+++ b/spec/features/journeys/happy_paths/when_referred_by_return_to_teaching_adviser_spec.rb
@@ -26,8 +26,8 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
     end
 
     expect_page_to_have(path: "/registration/possible-funding", submit_form: false) do
-      expect(page).to have_text("Funding")
-      page.click_button("Continue")
+      expect(page).to have_text("DfE scholarship funding")
+      page.click_button("Continue to register")
     end
 
     expect_page_to_have(path: "/registration/choose-your-provider", submit_form: true) do

--- a/spec/features/journeys/happy_paths/when_school_not_eligible_spec.rb
+++ b/spec/features/journeys/happy_paths/when_school_not_eligible_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, :with_de
     choose_a_school(js:, name: "open")
 
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
-      expect(page).to have_text("Funding")
+      expect(page).to have_text("DfE scholarship funding")
       expect(page).to have_text("You’re not eligible for scholarship funding for the Headship NPQ course")
 
       page.click_link "Continue to register"

--- a/spec/features/journeys/happy_paths/when_teacher_auth_returns_no_trn_spec.rb
+++ b/spec/features/journeys/happy_paths/when_teacher_auth_returns_no_trn_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Sad journeys", :no_js, :with_cohorts, :with_default_schedules, :w
       choose_a_school(js: false, name: "open")
 
       expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
-        page.click_link("Continue")
+        page.click_link("Continue to register")
       end
 
       expect_page_to_have(path: "/registration/funding-your-npq", submit_form: true) do

--- a/spec/features/journeys/happy_paths/when_working_at_an_eligible_primary_school_spec.rb
+++ b/spec/features/journeys/happy_paths/when_working_at_an_eligible_primary_school_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
     choose_a_school(js:, name: "open")
 
     expect_page_to_have(path: "/registration/possible-funding", submit_form: true) do
-      expect(page).to have_text("Funding")
+      expect(page).to have_text("DfE scholarship funding")
     end
 
     expect_page_to_have(path: "/registration/choose-your-provider", submit_form: true) do

--- a/spec/features/journeys/happy_paths/when_working_in_other_spec.rb
+++ b/spec/features/journeys/happy_paths/when_working_in_other_spec.rb
@@ -26,11 +26,11 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_schedules, type: :f
     end
 
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
-      expect(page).to have_text("Funding")
+      expect(page).to have_text("DfE scholarship funding")
       expect(page).to have_text("such as state-funded schools")
       expect(page).to have_text("You’re not eligible for scholarship funding")
 
-      page.click_link("Continue")
+      page.click_link("Continue to register")
     end
 
     expect_page_to_have(path: "/registration/funding-your-npq", submit_form: true) do

--- a/spec/features/journeys/happy_paths/while_not_currently_working_at_school_spec.rb
+++ b/spec/features/journeys/happy_paths/while_not_currently_working_at_school_spec.rb
@@ -37,8 +37,8 @@ RSpec.feature "Happy journeys", :no_js, :with_cohorts, :with_default_schedules, 
     end
 
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
-      expect(page).to have_text("Funding")
-      page.click_on("Continue")
+      expect(page).to have_text("DfE scholarship funding")
+      page.click_on("Continue to register")
     end
 
     expect_page_to_have(path: "/registration/funding-your-npq", submit_form: true) do

--- a/spec/features/journeys/happy_paths/while_working_at_private_childcare_provider_but_not_a_nursery_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_at_private_childcare_provider_but_not_a_nursery_spec.rb
@@ -87,7 +87,7 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_nursery, :wit
     end
 
     expect_page_to_have(path: "/registration/possible-funding", submit_form: true) do
-      expect(page).to have_text("Funding")
+      expect(page).to have_text("DfE scholarship funding")
       expect(page).to have_text("eligible for scholarship funding for the Early years leadership NPQ")
     end
 

--- a/spec/features/journeys/happy_paths/while_working_at_private_nursery_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_at_private_nursery_spec.rb
@@ -89,7 +89,7 @@ RSpec.feature "Happy journeys", :mvp, :with_default_nursery, :with_default_sched
     end
 
     expect_page_to_have(path: "/registration/possible-funding", submit_form: true) do
-      expect(page).to have_text("Funding")
+      expect(page).to have_text("DfE scholarship funding")
       expect(page).to have_text("eligible for scholarship funding")
     end
 

--- a/spec/features/journeys/happy_paths/while_working_at_public_nursery_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_at_public_nursery_spec.rb
@@ -61,12 +61,12 @@ RSpec.feature "Happy journeys", :mvp, :with_cohorts, :with_default_schedules, ty
     end
 
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
-      expect(page).to have_text("Funding")
+      expect(page).to have_text("DfE scholarship funding")
       expect(page).to have_text("You’re not eligible for scholarship funding")
       expect(page).to have_text("such as state-funded schools")
       expect(page).to have_text("This means that you would need to pay for the course another way")
 
-      page.click_link("Continue")
+      page.click_link("Continue to register")
     end
 
     expect_page_to_have(path: "/registration/funding-your-npq", submit_form: true) do

--- a/spec/features/journeys/happy_paths/while_working_in_neither_a_school_nor_childcare_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_in_neither_a_school_nor_childcare_spec.rb
@@ -31,8 +31,8 @@ RSpec.feature "Happy journeys", :no_js, :with_cohorts, :with_default_schedules, 
     end
 
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
-      expect(page).to have_text("Funding")
-      page.click_on("Continue")
+      expect(page).to have_text("DfE scholarship funding")
+      page.click_on("Continue to register")
     end
 
     expect_page_to_have(path: "/registration/funding-your-npq", submit_form: true) do

--- a/spec/features/journeys/sad_paths/applying_for_eyl_but_not_on_childminder_eligibility_list_spec.rb
+++ b/spec/features/journeys/sad_paths/applying_for_eyl_but_not_on_childminder_eligibility_list_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature "Happy journeys", :no_js, :with_cohorts, :with_default_nursery, :w
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
       expect(page).to have_text("You’re not eligible for scholarship funding for the Early years leadership NPQ")
       expect(page).to have_text("as your workplace is not in the list of EY settings that are eligible for funding")
-      page.click_on("Continue")
+      page.click_on("Continue to register")
     end
 
     expect_page_to_have(path: "/registration/funding-your-npq", submit_form: true) do

--- a/spec/features/journeys/sad_paths/childminder_applying_for_eyl_but_no_ofsted_urn_spec.rb
+++ b/spec/features/journeys/sad_paths/childminder_applying_for_eyl_but_no_ofsted_urn_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Happy journeys", :no_js, :with_cohorts, :with_default_schedules, 
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
       expect(page).to have_text("You’re not eligible for scholarship funding for the Early years leadership NPQ")
       expect(page).to have_text("as your workplace is not in the list of EY settings that are eligible for funding")
-      page.click_on("Continue")
+      page.click_on("Continue to register")
     end
 
     expect_page_to_have(path: "/registration/funding-your-npq", submit_form: true) do

--- a/spec/features/journeys/sad_paths/going_back_and_changing_referred_by_return_to_teaching_adviser_spec.rb
+++ b/spec/features/journeys/sad_paths/going_back_and_changing_referred_by_return_to_teaching_adviser_spec.rb
@@ -55,7 +55,7 @@ RSpec.feature "Sad journey", :mvp, :with_cohorts, :with_default_schedules, type:
     end
 
     click_button "Continue"
-    click_button "Continue"
+    click_button "Continue to register"
 
     click_link "Back"
     click_link "Back"

--- a/spec/features/journeys/sad_paths/going_back_to_choose_childcare_provider_step_spec.rb
+++ b/spec/features/journeys/sad_paths/going_back_to_choose_childcare_provider_step_spec.rb
@@ -63,7 +63,7 @@ RSpec.feature "Sad journeys", :mvp, :with_cohorts, :with_default_schedules, :wit
     end
 
     navigate_to_page(path: "/registration/possible-funding", submit_form: false) do
-      page.click_button("Continue")
+      page.click_button("Continue to register")
     end
 
     navigate_to_page(path: "/registration/choose-your-provider", submit_form: true) do

--- a/spec/features/journeys/sad_paths/going_back_to_choose_private_childcare_provider_step_spec.rb
+++ b/spec/features/journeys/sad_paths/going_back_to_choose_private_childcare_provider_step_spec.rb
@@ -68,7 +68,7 @@ RSpec.feature "Sad journeys", :mvp, :with_cohorts, :with_default_nursery, :with_
     end
 
     navigate_to_page(path: "/registration/possible-funding", submit_form: false) do
-      page.click_button("Continue")
+      page.click_button("Continue to register")
     end
 
     navigate_to_page(path: "/registration/choose-your-provider", submit_form: true) do

--- a/spec/features/journeys/sad_paths/going_back_to_choose_school_step_spec.rb
+++ b/spec/features/journeys/sad_paths/going_back_to_choose_school_step_spec.rb
@@ -59,7 +59,7 @@ RSpec.feature "Sad journeys", :mvp, :with_cohorts, :with_default_schedules, :wit
     end
 
     navigate_to_page(path: "/registration/ineligible-for-funding", submit_form: false) do
-      page.click_link("Continue")
+      page.click_link("Continue to register")
     end
 
     navigate_to_page(path: "/registration/funding-your-npq", submit_form: true) do

--- a/spec/features/journeys/sad_paths/lead_mentor_journey_with_incorrect_course_spec.rb
+++ b/spec/features/journeys/sad_paths/lead_mentor_journey_with_incorrect_course_spec.rb
@@ -39,11 +39,11 @@ RSpec.feature "Sad journeys", :with_cohorts, :with_default_schedules, type: :fea
     choose_an_itt_provider(js:, name: approved_itt_provider_legal_name)
 
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
-      expect(page).to have_text("Funding")
+      expect(page).to have_text("DfE scholarship funding")
       expect(page).to have_text("such as state-funded schools")
       expect(page).to have_text("This means that you would need to pay for the course another way")
 
-      page.click_link("Continue")
+      page.click_link("Continue to register")
     end
 
     expect_page_to_have(path: "/registration/funding-your-npq", submit_form: true) do

--- a/spec/features/journeys/sad_paths/works_in_childcare_but_not_in_england_spec.rb
+++ b/spec/features/journeys/sad_paths/works_in_childcare_but_not_in_england_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature "Sad journeys", :with_cohorts, :with_default_schedules, :with_defa
     end
 
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
-      expect(page).to have_text("Funding")
+      expect(page).to have_text("DfE scholarship funding")
       expect(page).to have_text("You’re not eligible for DfE scholarship funding because you do not work in England.")
 
       page.click_link("Continue to register")
@@ -54,10 +54,10 @@ RSpec.feature "Sad journeys", :with_cohorts, :with_default_schedules, :with_defa
     end
 
     expect_page_to_have(path: "/registration/ineligible-for-funding", submit_form: false) do
-      expect(page).to have_text("Funding")
+      expect(page).to have_text("DfE scholarship funding")
       expect(page).to have_text("You’re not eligible for DfE scholarship funding because you do not work in England.")
 
-      page.click_link("Continue")
+      page.click_link("Continue to register")
     end
 
     expect_page_to_have(path: "/registration/funding-your-npq", submit_form: true) do


### PR DESCRIPTION
### Context

Ticket: [NPQ-3828](https://dfedigital.atlassian.net/browse/NPQ-3828)

Eligibility outcomes pages - header and button change

### Changes proposed in this pull request

1. header now says "DfE scholarship funding"
2. button now says "Continue to register"


[NPQ-3828]: https://dfedigital.atlassian.net/browse/NPQ-3828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ