### PR TITLE
[BAU] Allow updates to other ruby packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,11 @@ updates:
   schedule:
     interval: daily
     time: "07:00"
-  allow:
+  ignore:
     - dependency-name: "rails"
       update-types:
-      - version-update:semver-patch
+      - version-update:semver-minor
+      - version-update:semver-major
   open-pull-requests-limit: 20
 - package-ecosystem: npm
   directory: "/"


### PR DESCRIPTION
### Context

Ticket: BAU

Change the dependabot config to include all ruby packages apart from major and minor rails updates

### Changes proposed in this pull request

1. change from allow list to ignore list

