### PR TITLE
NPQ-3918 Add eligibility column to workplaces admin page

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -141,3 +141,7 @@
     }
   }
 }
+
+.govuk-table td .govuk-list {
+  @include govuk-responsive-margin(0, "bottom");
+}

--- a/app/controllers/admin/schools_controller.rb
+++ b/app/controllers/admin/schools_controller.rb
@@ -7,7 +7,7 @@ class Admin::SchoolsController < AdminController
 private
 
   def scope
-    Workplace.includes(:source)
+    Workplace.includes(source: %i[urn_eligibility_entries ukprn_eligibility_entries])
              .order(:name, :source_id)
              .search(params[:q])
   end

--- a/app/models/eligibility_list/childminder.rb
+++ b/app/models/eligibility_list/childminder.rb
@@ -2,4 +2,5 @@ class EligibilityList::Childminder < EligibilityList::Entry
   IDENTIFIER_CSV_HEADERS = ["Childminder URN"].freeze
   IDENTIFIER_CSV_EXAMPLE = "CA000006\nEY248638\n225540".freeze
   IDENTIFIER_TYPE = :urn
+  SHORT_NAME = "Childminder".freeze
 end

--- a/app/models/eligibility_list/disadvantaged_early_years_school.rb
+++ b/app/models/eligibility_list/disadvantaged_early_years_school.rb
@@ -2,4 +2,5 @@ class EligibilityList::DisadvantagedEarlyYearsSchool < EligibilityList::Entry
   IDENTIFIER_CSV_HEADERS = ["Disadvantaged EY School URN", "Ofsted URN"].freeze
   IDENTIFIER_CSV_EXAMPLE = "150014,\n531156,EY555509".freeze
   IDENTIFIER_TYPE = :urn
+  SHORT_NAME = "Early years".freeze
 end

--- a/app/models/eligibility_list/entry.rb
+++ b/app/models/eligibility_list/entry.rb
@@ -11,6 +11,8 @@ class EligibilityList::Entry < ApplicationRecord
     last&.created_at
   end
 
+  def short_name = self.class::SHORT_NAME
+
 private
 
   def set_identifier_type

--- a/app/models/eligibility_list/local_authority_nursery.rb
+++ b/app/models/eligibility_list/local_authority_nursery.rb
@@ -2,4 +2,5 @@ class EligibilityList::LocalAuthorityNursery < EligibilityList::Entry
   IDENTIFIER_CSV_HEADERS = ["LA Nursery URN"].freeze
   IDENTIFIER_CSV_EXAMPLE = "123456\n112470".freeze
   IDENTIFIER_TYPE = :urn
+  SHORT_NAME = "LA Nursery".freeze
 end

--- a/app/models/eligibility_list/pp50_further_education.rb
+++ b/app/models/eligibility_list/pp50_further_education.rb
@@ -2,4 +2,5 @@ class EligibilityList::Pp50FurtherEducation < EligibilityList::Entry
   IDENTIFIER_CSV_HEADERS = ["FE UKPRN"].freeze
   IDENTIFIER_CSV_EXAMPLE = "10000599\n10004502".freeze
   IDENTIFIER_TYPE = :ukprn
+  SHORT_NAME = "PP50FE".freeze
 end

--- a/app/models/eligibility_list/pp50_school.rb
+++ b/app/models/eligibility_list/pp50_school.rb
@@ -2,4 +2,5 @@ class EligibilityList::Pp50School < EligibilityList::Entry
   IDENTIFIER_CSV_HEADERS = ["PP50 School URN"].freeze
   IDENTIFIER_CSV_EXAMPLE = "100000\n100006".freeze
   IDENTIFIER_TYPE = :urn
+  SHORT_NAME = "PP50".freeze
 end

--- a/app/models/eligibility_list/rise_school.rb
+++ b/app/models/eligibility_list/rise_school.rb
@@ -2,4 +2,5 @@ class EligibilityList::RiseSchool < EligibilityList::Entry
   IDENTIFIER_CSV_HEADERS = ["RISE School URN"].freeze
   IDENTIFIER_CSV_EXAMPLE = "112543\n112578".freeze
   IDENTIFIER_TYPE = :urn
+  SHORT_NAME = "RISE".freeze
 end

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -9,13 +9,13 @@ class LocalAuthority < ApplicationRecord
                       dictionary: "english",
                     },
                   }
-  def display_name
-    name
-  end
 
-  def urn
-    nil
-  end
+  def eligibility_lists = []
+  def display_name = name
+  def urn = nil
+  def identifier = "LocalAuthority-#{id}"
+  def in_england? = true
+  def la_name = name
 
   def address
     [address_1, address_2, address_3, town, county, postcode].reject(&:blank?)
@@ -27,17 +27,5 @@ class LocalAuthority < ApplicationRecord
 
   def name_with_address
     [display_name, address_string].join(" – ")
-  end
-
-  def identifier
-    "LocalAuthority-#{id}"
-  end
-
-  def in_england?
-    true
-  end
-
-  def la_name
-    name
   end
 end

--- a/app/models/private_childcare_provider.rb
+++ b/app/models/private_childcare_provider.rb
@@ -3,6 +3,11 @@ class PrivateChildcareProvider < ApplicationRecord
 
   REDACTED_DATA_STRING = "REDACTED".freeze
 
+  ELIGIBILITY_LISTS = [
+    EligibilityList::DisadvantagedEarlyYearsSchool,
+    EligibilityList::Childminder,
+  ].map(&:name).freeze
+
   include PgSearch::Model
 
   pg_search_scope :search_by_urn,
@@ -15,6 +20,14 @@ class PrivateChildcareProvider < ApplicationRecord
                   }
 
   validates :provider_urn, presence: true
+
+  has_many :urn_eligibility_entries,
+           -> { where(identifier_type: "urn", type: ELIGIBILITY_LISTS) },
+           class_name: "EligibilityList::Entry",
+           primary_key: :provider_urn,
+           foreign_key: :identifier
+
+  def eligibility_lists = urn_eligibility_entries
 
   def urn
     provider_urn

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -5,6 +5,14 @@ class School < ApplicationRecord
   PRIMARY_PHASE = "Primary".freeze
   MIDDLE_DEEMED_PRIMARY_PHASE = "Middle deemed primary".freeze
 
+  ELIGIBILITY_LISTS = [
+    EligibilityList::Pp50School,
+    EligibilityList::Pp50FurtherEducation,
+    EligibilityList::DisadvantagedEarlyYearsSchool,
+    EligibilityList::LocalAuthorityNursery,
+    EligibilityList::RiseSchool,
+  ].map(&:name).freeze
+
   ELIGIBLE_ESTABLISHMENT_TYPE_CODES = {
     "1" => "Community school",
     "2" => "Voluntary aided school",
@@ -59,6 +67,18 @@ class School < ApplicationRecord
 
   scope :open, -> { where(establishment_status_code: %w[1 3 4]) }
 
+  has_many :urn_eligibility_entries,
+           -> { where(identifier_type: "urn", type: ELIGIBILITY_LISTS) },
+           class_name: "EligibilityList::Entry",
+           primary_key: :urn,
+           foreign_key: :identifier
+
+  has_many :ukprn_eligibility_entries,
+           -> { where(identifier_type: "ukprn", type: ELIGIBILITY_LISTS) },
+           class_name: "EligibilityList::Entry",
+           primary_key: :ukprn,
+           foreign_key: :identifier
+
   ELIGIBLE_ESTABLISHMENT_TYPE_CODES.each do |code, name|
     define_method("#{name.parameterize.underscore}?") do
       establishment_type_code == code
@@ -69,6 +89,10 @@ class School < ApplicationRecord
     search_with_synonyms(name) do |name|
       search_by_fields(name).limit(NAME_SEARCH_LIMIT)
     end
+  end
+
+  def eligibility_lists
+    urn_eligibility_entries + ukprn_eligibility_entries
   end
 
   def display_name

--- a/app/views/admin/schools/index.html.erb
+++ b/app/views/admin/schools/index.html.erb
@@ -36,18 +36,25 @@
         row.with_cell(text: "UKPRN (UK provider reference number)")
         row.with_cell(text: "Local authority")
         row.with_cell(text: "Address")
+        row.with_cell(text: "Eligibility lists")
       end
     end
 
     table.with_body do |body|
       @schools.each do |school|
         body.with_row do |row|
-          row.with_cell(text: school.name)
-          row.with_cell(text: school.id)
-          row.with_cell(text: school.urn)
-          row.with_cell(text: school.ukprn)
-          row.with_cell(text: school.la_name)
-          row.with_cell(text: join_with_commas(school.town, school.county, school.postcode))
+          row.with_cell { school.name }
+          row.with_cell { school.id.to_s }
+          row.with_cell { school.urn }
+          row.with_cell { school.ukprn }
+          row.with_cell { school.la_name }
+          row.with_cell { join_with_commas(school.town, school.county, school.postcode) }
+
+          row.with_cell do
+            if school.eligibility_lists.any?
+              govuk_list school.eligibility_lists.map(&:short_name)
+            end
+          end
         end
       end
     end

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -30,18 +30,22 @@
         <%= render partial: "layouts/shared/messages" %>
 
         <div class="govuk-grid-row">
-          <div class="govuk-grid-column-one-quarter" id="side-navigation">
+          <% content_for :side_navigation do %>
             <%=
               render SubNavigationComponent.new(
                 request.path,
                 structure: admin_navigation_structure.sub_structure(request.path, default_to_first_section: true),
               )
             %>
+          <% end %>
 
+          <% if content_for? :side_navigation %>
+          <div class="govuk-grid-column-one-quarter" id="side-navigation">
             <%= yield :side_navigation %>
           </div>
+          <% end %>
 
-          <div class="govuk-grid-column-three-quarters">
+          <div class="govuk-grid-column-<%= content_for?(:side_navigation) ? "three-quarters" : "full" %>">
             <%= yield %>
           </div>
         </div>

--- a/spec/models/eligibility_list/childminder_spec.rb
+++ b/spec/models/eligibility_list/childminder_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe EligibilityList::Childminder, type: :model do
   let(:urn) { "100001" }
 
+  it { is_expected.to have_attributes short_name: "Childminder" }
+
   describe ".eligible?" do
     subject { described_class.eligible?(urn) }
 

--- a/spec/models/eligibility_list/disadvantaged_early_years_school_spec.rb
+++ b/spec/models/eligibility_list/disadvantaged_early_years_school_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe EligibilityList::DisadvantagedEarlyYearsSchool, type: :model do
   let(:urn) { "100001" }
 
+  it { is_expected.to have_attributes short_name: "Early years" }
+
   describe ".eligible?" do
     subject { described_class.eligible?(urn) }
 

--- a/spec/models/eligibility_list/entry_spec.rb
+++ b/spec/models/eligibility_list/entry_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe EligibilityList::Entry, type: :model do
   let(:identifier) { "123" }
 
+  it { expect { described_class.new.short_name }.to raise_exception NameError }
+
   describe "before_validation" do
     EligibilityList::Entry.descendants.each do |eligibility_list|
       context "with #{eligibility_list}" do

--- a/spec/models/eligibility_list/local_authority_nursery_spec.rb
+++ b/spec/models/eligibility_list/local_authority_nursery_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe EligibilityList::LocalAuthorityNursery, type: :model do
   let(:urn) { "100001" }
 
+  it { is_expected.to have_attributes short_name: "LA Nursery" }
+
   describe ".eligible?" do
     subject { described_class.eligible?(urn) }
 

--- a/spec/models/eligibility_list/pp50_further_education_spec.rb
+++ b/spec/models/eligibility_list/pp50_further_education_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe EligibilityList::Pp50FurtherEducation, type: :model do
   let(:ukprn) { "12345678" }
 
+  it { is_expected.to have_attributes short_name: "PP50FE" }
+
   describe ".eligible?" do
     subject { described_class.eligible?(ukprn) }
 

--- a/spec/models/eligibility_list/pp50_school_spec.rb
+++ b/spec/models/eligibility_list/pp50_school_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe EligibilityList::Pp50School, type: :model do
   let(:urn) { "100001" }
 
+  it { is_expected.to have_attributes short_name: "PP50" }
+
   describe ".eligible?" do
     subject { described_class.eligible?(urn) }
 

--- a/spec/models/eligibility_list/rise_school_spec.rb
+++ b/spec/models/eligibility_list/rise_school_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe EligibilityList::RiseSchool, type: :model do
   let(:urn) { "100001" }
 
+  it { is_expected.to have_attributes short_name: "RISE" }
+
   describe ".eligible?" do
     subject { described_class.eligible?(urn) }
 

--- a/spec/models/local_authority_spec.rb
+++ b/spec/models/local_authority_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe LocalAuthority do
+  describe "#eligibility_lists" do
+    subject { local_authority.eligibility_lists }
+
+    let(:entry) { create(:eligibility_list_entry, :pp50_further_education, identifier:) }
+    let(:identifier) { "12345678" }
+    let(:local_authority) { create :local_authority, ukprn: entry.identifier }
+
+    it { is_expected.to be_empty }
+  end
+end

--- a/spec/models/private_childcare_provider_spec.rb
+++ b/spec/models/private_childcare_provider_spec.rb
@@ -76,4 +76,21 @@ RSpec.describe PrivateChildcareProvider, type: :model do
       it { is_expected.to be false }
     end
   end
+
+  describe "#eligibility_lists" do
+    subject { provider.eligibility_lists.map(&:short_name) }
+
+    before { pp50 && childminder && early_years }
+
+    let(:identifier) { "1234567" }
+    let(:provider) { create(:private_childcare_provider, provider_urn: identifier) }
+    let(:childminder) { create(:eligibility_list_entry, :childminder, identifier:) }
+    let(:pp50) { create(:eligibility_list_entry, :pp50_school, identifier:) }
+
+    let :early_years do
+      create(:eligibility_list_entry, :disadvantaged_early_years_school, identifier:)
+    end
+
+    it { is_expected.to contain_exactly "Childminder", "Early years" }
+  end
 end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -359,4 +359,27 @@ RSpec.describe School do
       it { is_expected.to be false }
     end
   end
+
+  describe "#eligibility_lists" do
+    subject { school.eligibility_lists.map(&:short_name) }
+
+    before { entries }
+
+    let(:identifier) { "1234567" }
+    let(:ukprn) { "12345678" }
+    let(:school) { create(:school, urn: identifier, ukprn:) }
+
+    let :entries do
+      [
+        create(:eligibility_list_entry, :pp50_school, identifier:),
+        create(:eligibility_list_entry, :pp50_further_education, identifier: ukprn),
+        create(:eligibility_list_entry, :disadvantaged_early_years_school, identifier:),
+        create(:eligibility_list_entry, :local_authority_nursery, identifier:),
+        create(:eligibility_list_entry, :rise_school, identifier:),
+        create(:eligibility_list_entry, :childminder, identifier:),
+      ]
+    end
+
+    it { is_expected.to contain_exactly "PP50", "PP50FE", "Early years", "LA Nursery", "RISE" }
+  end
 end

--- a/spec/views/admin/schools/index.html.erb_spec.rb
+++ b/spec/views/admin/schools/index.html.erb_spec.rb
@@ -1,0 +1,88 @@
+require "rails_helper"
+
+RSpec.describe "admin/schools/index.html.erb", type: :view do
+  subject(:rendered) { Capybara.string(render) }
+
+  before do
+    assign(:schools, schools)
+
+    without_partial_double_verification do
+      allow(view).to receive(:current_admin).and_return admin
+    end
+  end
+
+  let(:admin) { build_stubbed(:admin) }
+  let(:local_authority) { create(:local_authority) }
+  let(:urn) { "123546" }
+  let(:ukprn) { "12354678" }
+
+  let :school do
+    create(:school, urn:, ukprn:).tap do
+      create(:eligibility_list_entry, :pp50_school, identifier: urn)
+      create(:eligibility_list_entry, :pp50_further_education, identifier: ukprn)
+    end
+  end
+
+  let :childcare do
+    create(:private_childcare_provider, provider_urn: urn) do
+      create(:eligibility_list_entry, :childminder, identifier: urn)
+    end
+  end
+
+  describe "Workplaces table" do
+    subject { rendered.find(".govuk-table tbody tr:first-of-type") }
+
+    context "with header row" do
+      subject { rendered.find(".govuk-table thead tr") }
+
+      let(:schools) { [] }
+
+      it { is_expected.to have_css "th", text: "Workplace name" }
+      it { is_expected.to have_css "th", text: "ID" }
+      it { is_expected.to have_css "th", text: "URN (unique reference number)" }
+      it { is_expected.to have_css "th", text: "UKPRN (UK provider reference number)" }
+      it { is_expected.to have_css "th", text: "Local authority" }
+      it { is_expected.to have_css "th", text: "Address" }
+      it { is_expected.to have_css "th", text: "Eligibility lists" }
+    end
+
+    context "with a school" do
+      let(:schools) { [school] }
+
+      it { is_expected.to have_css "td", text: school.name }
+      it { is_expected.to have_css "td", text: school.id }
+      it { is_expected.to have_css "td", text: school.urn }
+      it { is_expected.to have_css "td", text: school.ukprn }
+      it { is_expected.to have_css "td", text: school.la_name }
+      it { is_expected.to have_css "td", text: join_with_commas(school.address) }
+      it { is_expected.to have_css "td li", count: 2 }
+      it { is_expected.to have_css "td li", text: "PP50" }
+      it { is_expected.to have_css "td li", text: "PP50FE" }
+    end
+
+    context "with a local authority" do
+      let(:schools) { [local_authority] }
+
+      it { is_expected.to have_css "td", text: local_authority.name }
+      it { is_expected.to have_css "td", text: local_authority.id }
+      it { is_expected.to have_css "td", text: local_authority.urn }
+      it { is_expected.to have_css "td", text: local_authority.ukprn }
+      it { is_expected.to have_css "td", text: local_authority.la_name }
+      it { is_expected.to have_css "td", text: join_with_commas(local_authority.address) }
+      it { is_expected.to have_css "td span", count: 0 }
+    end
+
+    context "with a private childcare provider" do
+      let(:schools) { [childcare] }
+
+      it { is_expected.to have_css "td", text: childcare.name }
+      it { is_expected.to have_css "td", text: childcare.id }
+      it { is_expected.to have_css "td", text: childcare.urn }
+      it { is_expected.to have_css "td", text: childcare.ukprn }
+      it { is_expected.to have_css "td", text: childcare.la_name }
+      it { is_expected.to have_css "td", text: join_with_commas(childcare.town, childcare.county, childcare.postcode) }
+      it { is_expected.to have_css "td li", count: 1 }
+      it { is_expected.to have_css "td li", text: "Childminder" }
+    end
+  end
+end

--- a/spec/views/layouts/admin.html.erb_spec.rb
+++ b/spec/views/layouts/admin.html.erb_spec.rb
@@ -1,13 +1,11 @@
 require "rails_helper"
 
 RSpec.describe "layouts/admin.html.erb", type: :view do
-  subject { Capybara.string(render) }
+  subject(:rendered) { Capybara.string(render) }
 
   let(:admin) { build_stubbed(:admin) }
-  let(:expected_items) do
-    structure = Admin::NavigationStructures::AdminNavigationStructure.new(admin)
-    structure.primary_structure.map(&:name)
-  end
+  let(:nav) { Admin::NavigationStructures::AdminNavigationStructure.new(admin) }
+  let(:expected_items) { nav.primary_structure.map(&:name) }
 
   before do
     view.define_singleton_method(:current_admin, &method(:admin))
@@ -23,5 +21,27 @@ RSpec.describe "layouts/admin.html.erb", type: :view do
     end
 
     it { is_expected.to have_link("Sign out") }
+  end
+
+  describe "sidebar navigation" do
+    subject do
+      rendered.find(".govuk-width-container > .govuk-main-wrapper > .govuk-grid-row")
+    end
+
+    before { allow(view).to receive(:admin_navigation_structure).and_return(nav) }
+
+    context "when sidebar navigation content present" do
+      it { is_expected.to have_css "> .govuk-grid-column-one-quarter" }
+      it { is_expected.to have_css "> .govuk-grid-column-three-quarters" }
+      it { is_expected.not_to have_css "> .govuk-grid-column-full" }
+    end
+
+    context "when sidebar navigation content is blank" do
+      before { allow(nav).to receive(:sub_structure).and_return([]) }
+
+      it { is_expected.to have_css "> .govuk-grid-column-full" }
+      it { is_expected.not_to have_css "> .govuk-grid-column-one-quarter" }
+      it { is_expected.not_to have_css "> .govuk-grid-column-three-quarters" }
+    end
   end
 end


### PR DESCRIPTION
### Context

Ticket: [NPQ-3918](https://dfedigital.atlassian.net/browse/NPQ-3918)

There is a need to see if a workplace appears on any of the eligibility lists.

### Changes proposed in this pull request

1. Add a column to the Workplaces table showing which eligibility lists a workplace appears on
2. Only show the sidenav column if we do have a sidenav for the page - _a lot of the admin pages don't have a sidenav and always showing this restricts the available horizontal space for the wider tables_

### Notes

Optional section of anything unusual in the PR which requires further explanation


[NPQ-3918]: https://dfedigital.atlassian.net/browse/NPQ-3918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ