### PR TITLE
2811 - Review app using Postgres v17 container

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     command: sleep infinity
     network_mode: service:postgres
   postgres:
-    image: postgres:14
+    image: postgres:17
     restart: unless-stopped
     volumes:
       - postgres-data:/var/lib/postgresql/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ x-app: &app
 
 services:
   db:
-    image: postgres:14-alpine
+    image: postgres:17-alpine
     restart: always
     volumes:
       - db-data:/var/lib/postgresql/data

--- a/terraform/application/config/review.tfvars.json
+++ b/terraform/application/config/review.tfvars.json
@@ -7,5 +7,6 @@
     "command": ["/bin/sh", "-c", "RAILS_ENV=review bundle exec rails db:environment:set db:migrate && bundle exec rails server -b 0.0.0.0"],
     "enable_logit": true,
     "enable_dfe_analytics_federated_auth": true,
-    "dataset_name": "npq_events_review"
+    "dataset_name": "npq_events_review",
+    "postgres_server_version": 17
 }

--- a/terraform/application/database.tf
+++ b/terraform/application/database.tf
@@ -35,7 +35,7 @@ module "postgres" {
   use_azure                      = var.deploy_azure_backing_services
   azure_enable_monitoring        = var.enable_monitoring
   azure_enable_backup_storage    = var.enable_postgres_backup_storage
-  server_version                 = "14"
+  server_version                 = var.postgres_server_version
   azure_extensions               = ["btree_gin", "citext", "fuzzystrmatch", "pg_trgm"]
   azure_enable_high_availability = var.postgres_enable_high_availability
   azure_sku_name                 = var.postgres_flexible_server_sku

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -111,6 +111,11 @@ variable "worker_replicas" {
   default = 1
 }
 
+variable "postgres_server_version" {
+  type = string
+  default = "14"
+}
+
 variable "postgres_flexible_server_sku" {
   type = string
   default = "B_Standard_B1ms"


### PR DESCRIPTION
### Context

https://trello.com/c/0Ux3mX0O/2811-upgrade-npq-postgres-version

We're looking to upgrade the Postgres version to 17.

### Changes proposed in this pull request

- This PR will create a review app to check application functionality with Postgres v17 containerised.
- A new variable, postgres_server_version will allow configuration between environments. The default is set to the current version 14.
- postgres_server_version set to 17 in review.tfvars.json
- Change the Docker container versions of Postgres to v17

### Guidance to review

- Run `make review terraform-plan PULL_REQUEST_NUMBER=3525 DOCKER_IMAGE=main` only the Kubernetes image should change.
- Check the npq-registration-review-3525-postgres deployment to ensure the image is ghcr.io/dfe-digital/teacher-services-cloud:postgres-17-alpine 
- Run `make staging terraform-plan DOCKER_IMAGE=main`  only the Kubernetes image should change.
- Test the [review app](https://npq-registration-review-3525-web.test.teacherservices.cloud/) crated by this PR.

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally