### PR TITLE
[NPQ-3945] Only offer NPQs with a provider in the chosen cohort

### DIFF
--- a/app/forms/questionnaires/choose_your_npq.rb
+++ b/app/forms/questionnaires/choose_your_npq.rb
@@ -28,6 +28,10 @@ module Questionnaires
       [QUESTION_NAME]
     end
 
+    def requirements_met?
+      super && cohort.present?
+    end
+
     def questions
       [
         QuestionTypes::RadioButtonGroup.new(
@@ -127,12 +131,15 @@ module Questionnaires
     end
 
     def valid_providers
-      cohort = Cohort.find_by!(identifier: wizard.query_store.course_start_cohort)
       LeadProvider.for(course:, cohort:)
     end
 
+    def cohort
+      @cohort ||= Cohort.find_by(identifier: wizard.query_store.course_start_cohort)
+    end
+
     def courses
-      Course.where(display: true).order(:position)
+      Course.offered_in(cohort).where(display: true).order(:position)
     end
 
     def previous_course

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -16,6 +16,13 @@ class Course < ApplicationRecord
   validates :identifier, presence: true, uniqueness: true
   validates :ecf_id, uniqueness: { case_sensitive: false }, allow_nil: true
 
+  # Only courses at least one lead provider delivers in the given cohort
+  scope :offered_in, lambda { |cohort|
+    joins(course_cohorts: :course_cohort_providers)
+      .where(course_cohorts: { cohort: })
+      .distinct
+  }
+
   # npq-additional-support-offer is replaced by npq-early-headship-coaching-offer
   IDENTIFIERS = %w[
     npq-senior-leadership

--- a/spec/features/journeys/happy_paths/choose_a_childcare_provider_spec.rb
+++ b/spec/features/journeys/happy_paths/choose_a_childcare_provider_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Choose a childcare provider page", :with_default_schedules, type: :feature do
+RSpec.feature "Choose a childcare provider page", :with_cohorts, :with_default_schedules, type: :feature do
   include Helpers::JourneyAssertionHelper
   include Helpers::JourneyStepHelper
   include ApplicationHelper

--- a/spec/features/journeys/happy_paths/choose_a_school_spec.rb
+++ b/spec/features/journeys/happy_paths/choose_a_school_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Choose a school page", :with_default_schedules, type: :feature do
+RSpec.feature "Choose a school page", :with_cohorts, :with_default_schedules, type: :feature do
   include Helpers::JourneyAssertionHelper
   include Helpers::JourneyStepHelper
   include ApplicationHelper

--- a/spec/features/journeys/happy_paths/unfunded_cohort_registration_journey_spec.rb
+++ b/spec/features/journeys/happy_paths/unfunded_cohort_registration_journey_spec.rb
@@ -13,6 +13,38 @@ RSpec.feature "Happy journeys", :no_js, :with_cohorts, :with_default_schedules, 
     create(:course_cohort_provider, course_cohort:, lead_provider: LeadProvider.find_by(name: "LLSE"))
   end
 
+  scenario "does not offer courses no lead provider delivers in the chosen cohort" do
+    stub_participant_validation_request
+
+    navigate_to_page(path: "/", submit_form: false, axe_check: false) do
+      page.click_button("Start now")
+    end
+
+    expect_page_to_have(path: "/registration/course-start-date", submit_form: true) do
+      page.choose("No, I already started in Spring", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/provider-check", submit_form: true) do
+      page.choose("Yes", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/teacher-catchment", axe_check: false, submit_form: true) do
+      page.choose("Yes", visible: :all)
+    end
+
+    expect_page_to_have(path: "/registration/work-setting", submit_form: true) do
+      page.choose("A school", visible: :all)
+    end
+
+    choose_a_school(js: false, name: "open")
+
+    # Only Headship has a lead provider in the Spring cohort
+    expect(page).to have_current_path("/registration/choose-your-npq")
+    expect(page).to have_text("Headship")
+    expect(page).not_to have_text("Early years leadership")
+    expect(page).not_to have_text("Leading literacy")
+  end
+
   scenario "unfunded cohort registration journey" do
     stub_participant_validation_request
 

--- a/spec/features/journeys/happy_paths/while_working_at_private_childcare_provider_but_not_a_nursery_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_at_private_childcare_provider_but_not_a_nursery_spec.rb
@@ -61,7 +61,7 @@ RSpec.feature "Happy journeys", :with_cohorts, :with_default_nursery, :with_defa
     ehco_course = ["Early headship coaching offer"]
     npqlpm_course = ["Leading primary mathematics"]
 
-    ineligible_courses_list = Questionnaires::ChooseYourNpq.new.options.map(&:value)
+    ineligible_courses_list = course_identifiers_offered_in_chosen_cohort
 
     ineligible_courses = ineligible_courses_list.map { |name|
       I18n.t("course.name.#{name}")

--- a/spec/features/journeys/happy_paths/while_working_at_private_nursery_spec.rb
+++ b/spec/features/journeys/happy_paths/while_working_at_private_nursery_spec.rb
@@ -65,7 +65,7 @@ RSpec.feature "Happy journeys", :with_default_nursery, :with_default_schedules, 
     ehco_course = ["Early headship coaching offer"]
     npqlpm_course = ["Leading primary mathematics"]
 
-    ineligible_courses_list = Questionnaires::ChooseYourNpq.new.options.map(&:value)
+    ineligible_courses_list = course_identifiers_offered_in_chosen_cohort
 
     ineligible_courses = ineligible_courses_list.map { |name|
       I18n.t("course.name.#{name}")

--- a/spec/forms/questionnaires/choose_your_npq_spec.rb
+++ b/spec/forms/questionnaires/choose_your_npq_spec.rb
@@ -7,14 +7,25 @@ RSpec.describe Questionnaires::ChooseYourNpq, type: :model do
   let(:leading_behaviour_culture_course) { Course.find_by(identifier: "npq-leading-behaviour-culture") }
   let(:leading_primary_mathematics_course) { Course.find_by(identifier: "npq-leading-primary-mathematics") }
   let(:leading_teaching_course) { Course.find_by(identifier: "npq-leading-teaching") }
+  let(:leading_literacy_course) { Course.find_by(identifier: "npq-leading-literacy") }
   let(:senco_course) { Course.find_by(identifier: "npq-senco") }
 
   describe "validations" do
     let(:valid_course_identifier) { ehco_course.identifier }
+    let(:cohort) { create(:cohort, :next, :with_all_courses_for_provider, suffix: "b") }
+
+    before do
+      subject.wizard = RegistrationWizard.new(
+        current_step: :choose_your_npq,
+        store: { "course_start_cohort" => cohort.identifier },
+        request: nil,
+        current_user: create(:user),
+      )
+    end
 
     it { is_expected.to validate_presence_of(:course_identifier) }
 
-    it "course for course_id must be available to applicant" do
+    it "the course must be available to the applicant" do
       subject.course_identifier = create(:course, :additional_support_offer).identifier
       subject.valid?
       expect(subject.errors[:course_identifier]).to be_present
@@ -22,6 +33,41 @@ RSpec.describe Questionnaires::ChooseYourNpq, type: :model do
       subject.course_identifier = valid_course_identifier
       subject.valid?
       expect(subject.errors[:course_identifier]).to be_blank
+    end
+
+    it "the course must be offered in the chosen cohort" do
+      cohort.course_cohorts.find_by(course: leading_literacy_course).destroy!
+
+      subject.course_identifier = leading_literacy_course.identifier
+      subject.valid?
+      expect(subject.errors[:course_identifier]).to be_present
+    end
+  end
+
+  describe "#options" do
+    let(:cohort) { create(:cohort, :next, :with_all_courses_for_provider, suffix: "b") }
+
+    before do
+      subject.wizard = RegistrationWizard.new(
+        current_step: :choose_your_npq,
+        store: { "course_start_cohort" => cohort.identifier },
+        request: nil,
+        current_user: create(:user),
+      )
+    end
+
+    it "only offer courses a lead provider delivers in the chosen cohort" do
+      expect(subject.options.map(&:value)).to include(leading_literacy_course.identifier)
+
+      cohort.course_cohorts.find_by(course: leading_literacy_course).destroy!
+
+      expect(subject.options.map(&:value)).not_to include(leading_literacy_course.identifier)
+    end
+
+    it "does not offer a course whose only lead provider was removed from the cohort" do
+      cohort.course_cohorts.find_by(course: senco_course).course_cohort_providers.destroy_all
+
+      expect(subject.options.map(&:value)).not_to include(senco_course.identifier)
     end
   end
 
@@ -31,7 +77,7 @@ RSpec.describe Questionnaires::ChooseYourNpq, type: :model do
     let(:instance) { described_class.new(course_identifier: course.identifier) }
     let(:course) { leading_behaviour_culture_course }
     let(:lead_provider) { create(:lead_provider) }
-    let(:cohort) { create(:cohort, :next, suffix: "b") }
+    let(:cohort) { create(:cohort, :next, :with_all_courses_for_provider, suffix: "b") }
 
     let(:store) do
       {

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -16,6 +16,32 @@ RSpec.describe Course do
     it { is_expected.to have_many(:lead_providers).through(:course_cohort_providers) }
   end
 
+  describe ".offered_in" do
+    let(:cohort) { create(:cohort) }
+    let(:another_cohort) { create(:cohort, suffix: "b") }
+    let(:course) { described_class.npqeyl }
+
+    it "returns the courses a lead provider delivers in the cohort" do
+      create(:course_cohort, :with_provider, course:, cohort:)
+
+      expect(described_class.offered_in(cohort)).to contain_exactly(course)
+      expect(described_class.offered_in(another_cohort)).to be_empty
+    end
+
+    it "excludes a course in the cohort that no lead provider delivers" do
+      create(:course_cohort, course:, cohort:)
+
+      expect(described_class.offered_in(cohort)).to be_empty
+    end
+
+    it "returns a course once when several lead providers deliver it" do
+      course_cohort = create(:course_cohort, :with_provider, course:, cohort:)
+      create(:course_cohort_provider, course_cohort:, lead_provider: create(:lead_provider))
+
+      expect(described_class.offered_in(cohort)).to contain_exactly(course)
+    end
+  end
+
   describe ".ehco" do
     it { expect(described_class.ehco).to eq(described_class.find_by(identifier: "npq-early-headship-coaching-offer")) }
   end

--- a/spec/support/helpers/journey_step_helper.rb
+++ b/spec/support/helpers/journey_step_helper.rb
@@ -122,5 +122,16 @@ module Helpers
         page.choose(course_start_cohort_label, visible: :all)
       end
     end
+
+    def course_identifiers_offered_in_chosen_cohort
+      form = Questionnaires::ChooseYourNpq.new
+      form.wizard = RegistrationWizard.new(
+        current_step: :choose_your_npq,
+        store: { "course_start_cohort" => course_start_cohort_value },
+        request: nil,
+        current_user: nil,
+      )
+      form.options.map(&:value)
+    end
   end
 end


### PR DESCRIPTION
### Context

Ticket: [NPQ-3945](https://dfedigital.atlassian.net/browse/NPQ-3945)

Users who chose the Spring cohort could get stuck. They picked an NPQ, answered all the questions, and then the provider page showed an empty list, with no way to go on and submit. It happened both when choosing Spring from the start and when changing the course start date from Autumn to Spring on the check answers page.

The cause is that the choose your NPQ step listed every course and never looked at the cohort. Some courses have no lead provider in Spring, so the provider list came back empty.

### Changes proposed in this pull request

1. New `Course.offered_in(cohort)` scope: the courses that at least one lead provider delivers in that cohort.
2. The choose your NPQ step now only lists those courses. The validation uses the same rule, so a user who changes the start date from Autumn to Spring cannot keep a course with no Spring provider.
3. Added `requirements_met?` to the step, so a session with no course start date is sent back instead of failing.
4. Tests for the new scope, for the step, and a full journey test that a Spring user is not offered courses with no Spring provider.
5. Fixed some journey specs. Some of them never really answered the course start date step because they had no cohorts, so they now use `:with_cohorts`. Others built the form with no wizard to list the courses, which needs a cohort now.


[NPQ-3945]: https://dfedigital.atlassian.net/browse/NPQ-3945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ