### PR TITLE
[NPQ-3940] page to show archived users with blank emails and applications

### DIFF
--- a/app/controllers/admin/users/duplicates_controller.rb
+++ b/app/controllers/admin/users/duplicates_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Admin::Users
+  class DuplicatesController < AdminController
+    def index
+      scope = User
+        .where(email: nil)
+        .joins(:applications)
+        .where.not(applications: { lead_provider_approval_status: "rejected" })
+        .distinct
+        .order(created_at: :desc)
+
+      @pagy, @users = pagy(scope)
+      @potential_matches = User.where(email: @users.map(&:archived_email)).group_by(&:email)
+    end
+  end
+end

--- a/app/jobs/seeding_job.rb
+++ b/app/jobs/seeding_job.rb
@@ -1,6 +1,7 @@
 class SeedingJob < ApplicationJob
   load(Rails.root.join("db/seeds/base/add_applications.rb"))
   load(Rails.root.join("db/seeds/base/add_declarations.rb"))
+  load(Rails.root.join("db/seeds/base/add_users.rb"))
 
   queue_as :default
 
@@ -14,6 +15,7 @@ class SeedingJob < ApplicationJob
     ApplicationRecord.transaction do
       SeedAddApplications.new.load(multiplier:)
       SeedAddDeclarations.new.load(multiplier:)
+      SeedAddUsers.new.load if times == 1
     end
 
     SeedingJob.perform_later(times: times - 1) if times > 1

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -169,6 +169,10 @@ class User < ApplicationRecord
     trn_lookup_status == "Found"
   end
 
+  def verified_trn
+    trn if trn_verified?
+  end
+
 private
 
   def touch_significantly_updated_at

--- a/app/serializers/api/application_serializer.rb
+++ b/app/serializers/api/application_serializer.rb
@@ -17,7 +17,7 @@ module API
       field(:ineligible_for_funding_reason)
       field(:participant_id) { |a| a.user.ecf_id }
       field(:private_childcare_provider_urn) { |a| a.private_childcare_provider_including_disabled&.provider_urn }
-      field(:teacher_reference_number) { |a| a.user.trn if a.user.trn_verified }
+      field(:teacher_reference_number) { |a| a.user.verified_trn }
       field(:teacher_reference_number_validated) { |a| a.user.trn_verified }
       field(:school_urn) { |a| a.school&.urn }
       field(:ukprn, name: :school_ukprn)

--- a/app/services/applications/accept.rb
+++ b/app/services/applications/accept.rb
@@ -110,7 +110,7 @@ module Applications
     end
 
     def trn
-      @trn ||= user.trn_verified? ? user.trn : nil
+      @trn ||= user.verified_trn
     end
 
     def same_trn_users

--- a/app/services/users/archiver.rb
+++ b/app/services/users/archiver.rb
@@ -7,7 +7,7 @@ module Users
 
     attribute :user
 
-    def archive!(blank_email: false)
+    def archive!(blank_email: false, enable_sentry: true)
       raise ArgumentError, "User already archived" if user.archived?
 
       user.archived_email = user.email
@@ -20,7 +20,7 @@ module Users
       # If we're archiving a user who still has applications then we want to
       # know about it otherwise its a user account for expression of interest,
       # or from a past incomplete registration
-      send_sentry_capture_message if blank_email && user.applications.any?
+      send_sentry_capture_message if enable_sentry && blank_email && user.applications.any?
     end
 
     def set_uid_to_nil!

--- a/app/views/admin/users/_users_side_navigation.html.erb
+++ b/app/views/admin/users/_users_side_navigation.html.erb
@@ -1,0 +1,20 @@
+<% content_for :side_navigation do %>
+  <%=
+    render SubNavigationComponent.new(
+      request.path,
+      structure:
+        [
+          NavigationStructure::Node.new(
+            name: "All users",
+            href: admin_users_path,
+            prefix: /\/admin\/users(?!\/duplicates)$/,
+            ),
+          NavigationStructure::Node.new(
+            name: "Archived duplicate users",
+            href: admin_duplicate_users_path,
+            prefix: /\/admin\/users\/duplicates$/,
+            ),
+        ]
+    )
+  %>
+<% end %>

--- a/app/views/admin/users/duplicates/index.html.erb
+++ b/app/views/admin/users/duplicates/index.html.erb
@@ -1,0 +1,40 @@
+<%= render "admin/users/users_side_navigation" %>
+
+<h1 class="govuk-heading-l">Archived duplicate users</h1>
+
+<p class="govuk-body">
+These are archived users with blank emails that have at least one application that is not rejected,
+that had the same email as other users before they were archived and had their email blanked.
+</p>
+
+<%=
+  govuk_table do |table|
+    table.with_head do |header|
+      header.with_row do |row|
+        row.with_cell(text: "Name")
+        row.with_cell(text: "Archived email")
+        row.with_cell(text: "Verified TRN")
+        row.with_cell(text: "Date added")
+        row.with_cell(text: "Potential matches")
+      end
+    end
+
+    table.with_body do |body|
+      @users.each do |user|
+        body.with_row do |row|
+          row.with_cell(text: govuk_link_to(user.full_name, admin_user_path(user)))
+          row.with_cell(text: user.archived_email)
+          row.with_cell(text: user.verified_trn)
+          row.with_cell(text: user.created_at.to_date.to_formatted_s(:govuk))
+          row.with_cell do
+            @potential_matches[user.archived_email].to_a.map do |potential_match|
+              trn_text = " (#{potential_match.trn})" if potential_match.trn_verified?
+              concat tag.div(govuk_link_to((potential_match.full_name + trn_text.to_s), admin_user_path(potential_match)))
+            end
+          end
+        end
+      end
+    end
+  end
+%>
+<%= govuk_pagination(pagy: @pagy) %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,3 +1,5 @@
+<%= render "users_side_navigation" %>
+
 <h1 class="govuk-heading-l">Users</h1>
 
 <div class="admin-search-box">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -210,6 +210,9 @@ Rails.application.routes.draw do
 
     resources :courses, only: %i[index show]
     resources :users, only: %i[index show] do
+      collection do
+        resources :duplicates, controller: "users/duplicates", as: "duplicate_users", only: :index
+      end
       member do
         namespace :users, path: nil do
           resource :change_trn, controller: "change_trn", only: %i[show create]

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -35,6 +35,14 @@ def load_csv(file, model_class)
   end
 end
 
+def load_using_seed_class(description, file, seed_class_name)
+  ApplicationRecord.transaction do
+    Rails.logger.info("Seeding #{description}")
+    load_base_file(file)
+    seed_class_name.constantize.new.load
+  end
+end
+
 Rails.logger.info("Seeding database")
 
 # Due to migrations modifying the tables, we need to reset column informations before running seeds
@@ -53,7 +61,7 @@ ApplicationRecord.descendants.each(&:reset_column_information)
   "add_schedules.rb",
   "add_lead_providers.rb",
   "add_itt_providers.rb",
-  "add_users.rb",
+  "add_admin_users.rb",
   "add_statements.rb",
   "add_contracts.rb",
   "add_api_tokens.rb",
@@ -68,18 +76,11 @@ ApplicationRecord.descendants.each(&:reset_column_information)
   end
 end
 
-# add_applications.rb and add_declarations.rb are dealt with separately
+# add_applications.rb, add_declarations.rb and add_users.rb are dealt with separately
 if Rails.env.local?
-  ApplicationRecord.transaction do
-    Rails.logger.info("seeding applications")
-    load_base_file("add_applications.rb")
-    SeedAddApplications.new.load
-  end
-  ApplicationRecord.transaction do
-    Rails.logger.info("seeding declaration")
-    load_base_file("add_declarations.rb")
-    SeedAddDeclarations.new.load
-  end
+  load_using_seed_class("applications", "add_applications.rb", "SeedAddApplications")
+  load_using_seed_class("declarations", "add_declarations.rb", "SeedAddDeclarations")
+  load_using_seed_class("users", "add_users.rb", "SeedAddUsers")
 else
   # use background job to speed up review app deployment
   Rails.logger.info("seeding applications and declarations in background")

--- a/db/seeds/base/add_admin_users.rb
+++ b/db/seeds/base/add_admin_users.rb
@@ -1,0 +1,19 @@
+otp_testing_code = "00000"
+
+# Create admin user
+Admin.find_or_create_by!(
+  email: "admin@example.com",
+  full_name: "example admin",
+  otp_hash: otp_testing_code,
+  otp_expires_at: "3000-01-01 00:00:00.000000000 +0000",
+  super_admin: false,
+)
+
+# Create admin user
+Admin.find_or_create_by!(
+  email: "superadmin@example.com",
+  full_name: "example super admin",
+  otp_hash: otp_testing_code,
+  otp_expires_at: "3000-01-01 00:00:00.000000000 +0000",
+  super_admin: true,
+)

--- a/db/seeds/base/add_users.rb
+++ b/db/seeds/base/add_users.rb
@@ -1,19 +1,33 @@
-otp_testing_code = "00000"
+# frozen_string_literal: true
 
-# Create admin user
-Admin.find_or_create_by!(
-  email: "admin@example.com",
-  full_name: "example admin",
-  otp_hash: otp_testing_code,
-  otp_expires_at: "3000-01-01 00:00:00.000000000 +0000",
-  super_admin: false,
-)
+class SeedAddUsers
+  def load
+    # create some users that have been archived with blanked emails
 
-# Create admin user
-Admin.find_or_create_by!(
-  email: "superadmin@example.com",
-  full_name: "example super admin",
-  otp_hash: otp_testing_code,
-  otp_expires_at: "3000-01-01 00:00:00.000000000 +0000",
-  super_admin: true,
-)
+    cohorts_with_teacher_auth_users = Cohort.where(start_year: 2025..)
+
+    User
+      .joins(applications: :cohort)
+      .with_get_an_identity_id
+      .where(cohort: { start_year: ..2025 })
+      .where.not(email: nil)
+      .order(id: :desc)
+      .limit(40).each do |user|
+      # archive the user and blank the email
+      email = user.email
+      full_name = user.full_name
+      trn = user.trn
+      Users::Archiver.new(user:).archive!(blank_email: true, enable_sentry: false)
+
+      # create a new user with the same name, email address and an application
+      FactoryBot.create(
+        :application,
+        :with_random_user,
+        :with_random_work_setting,
+        user: FactoryBot.create(:user, :with_random_name, :with_teacher_auth, :with_verified_trn, full_name:, email:, trn:),
+        lead_provider_approval_status: "pending",
+        cohort: cohorts_with_teacher_auth_users.sample,
+      )
+    end
+  end
+end

--- a/spec/factories/applications.rb
+++ b/spec/factories/applications.rb
@@ -115,7 +115,13 @@ FactoryBot.define do
     end
 
     trait :with_random_user do
-      user { build(:user, :with_random_name) }
+      user do
+        if cohort.start_year > 2025
+          build(:user, :with_teacher_auth, :with_random_name)
+        else
+          create(:user, :with_get_an_identity_id, :with_random_name, :with_verified_trn)
+        end
+      end
     end
 
     trait :with_participant_id_change do

--- a/spec/features/admin/duplicate_users_page_spec.rb
+++ b/spec/features/admin/duplicate_users_page_spec.rb
@@ -1,0 +1,78 @@
+require "rails_helper"
+
+RSpec.feature "Admin Duplicate Users page", :no_js, type: :feature do
+  include Helpers::AdminLogin
+
+  let(:admin) { create(:admin) }
+
+  let(:archived_user_with_no_matched_user) { create(:user, :archived, email: nil) }
+
+  let(:archived_user_with_matched_user_and_trn_but_no_applications) { create(:user, :archived, :with_verified_trn, email: nil) }
+  let(:matched_user_with_trn) { create(:user, :with_verified_trn, email: archived_user_with_matched_user_and_trn_but_no_applications.archived_email) }
+
+  let(:archived_user_with_matched_user_and_trn) { create(:user, :archived, :with_verified_trn, email: nil) }
+  let(:matched_user_with_trn_2) { create(:user, :with_verified_trn, email: archived_user_with_matched_user_and_trn.archived_email) }
+
+  let(:archived_user_with_matched_user_and_unverified_trn) { create(:user, :archived, email: nil) }
+  let(:matched_user_with_unverifed_trn) { create(:user, email: archived_user_with_matched_user_and_unverified_trn.archived_email) }
+
+  let(:archived_user_with_matched_user_and_no_trn) { create(:user, :archived, email: nil, trn: nil) }
+  let(:matched_user_with_no_trn) { create(:user, trn: nil, email: archived_user_with_matched_user_and_no_trn.archived_email) }
+
+  let(:archived_user_with_matched_user_and_rejected_application) { create(:user, :archived, email: nil) }
+  let(:matched_user_with_trn_3) { create(:user, :with_verified_trn, email: archived_user_with_matched_user_and_rejected_application.archived_email) }
+
+  before do
+    create(:application, user: archived_user_with_no_matched_user)
+    create(:application, user: archived_user_with_matched_user_and_trn)
+    create(:application, user: archived_user_with_matched_user_and_unverified_trn)
+    create(:application, user: archived_user_with_matched_user_and_no_trn)
+    create(:application, :rejected, user: archived_user_with_matched_user_and_rejected_application)
+    matched_user_with_trn
+    matched_user_with_trn_2
+    matched_user_with_trn_3
+    matched_user_with_unverifed_trn
+    matched_user_with_no_trn
+  end
+
+  context "when not logged in" do
+    scenario "duplicate users page is inaccessible" do
+      visit admin_duplicate_users_path
+      expect(page).to have_current_path(sign_in_path)
+    end
+  end
+
+  context "when logged in as admin" do
+    before { sign_in_as_admin }
+
+    scenario "it displays the duplicate users page" do
+      page.click_link "Users"
+      page.click_link "Archived duplicate users"
+
+      expect(page).to have_content("Archived duplicate users")
+
+      expect(page).to have_content(archived_user_with_no_matched_user.full_name)
+      expect(page).to have_content(archived_user_with_no_matched_user.archived_email)
+
+      expect(page).not_to have_content(archived_user_with_matched_user_and_trn_but_no_applications.full_name)
+
+      expect(page).not_to have_content(archived_user_with_matched_user_and_rejected_application.full_name)
+
+      expect(page).to have_content(archived_user_with_matched_user_and_trn.full_name)
+      expect(page).to have_content(archived_user_with_matched_user_and_trn.archived_email)
+      expect(page).to have_content(archived_user_with_matched_user_and_trn.trn)
+      expect(page).to have_link("#{matched_user_with_trn_2.full_name} (#{matched_user_with_trn_2.trn})", href: admin_user_path(matched_user_with_trn_2))
+
+      expect(page).to have_content(archived_user_with_matched_user_and_unverified_trn.full_name)
+      expect(page).to have_content(archived_user_with_matched_user_and_unverified_trn.archived_email)
+      expect(page).not_to have_content(archived_user_with_matched_user_and_unverified_trn.trn)
+      expect(page).to have_link(matched_user_with_unverifed_trn.full_name, href: admin_user_path(matched_user_with_unverifed_trn))
+      expect(page).not_to have_content(matched_user_with_unverifed_trn.trn)
+
+      expect(page).to have_content(archived_user_with_matched_user_and_no_trn.full_name)
+      expect(page).to have_content(archived_user_with_matched_user_and_no_trn.archived_email)
+      expect(page).to have_link(matched_user_with_no_trn.full_name, href: admin_user_path(matched_user_with_no_trn))
+      expect(page).not_to have_content("()")
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -788,4 +788,31 @@ RSpec.describe User do
       end
     end
   end
+
+  describe "#verified_trn" do
+    subject { user.verified_trn }
+
+    let(:user) { build(:user, trn:, trn_verified:) }
+
+    context "when trn is present and verified" do
+      let(:trn) { "1234567" }
+      let(:trn_verified) { true }
+
+      it { is_expected.to eq trn }
+    end
+
+    context "when trn is present but not verified" do
+      let(:trn) { "1234567" }
+      let(:trn_verified) { false }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when trn is nil" do
+      let(:trn) { nil }
+      let(:trn_verified) { false }
+
+      it { is_expected.to be_nil }
+    end
+  end
 end


### PR DESCRIPTION
### Context

Ticket: [NPQ-3940](https://dfedigital.atlassian.net/browse/NPQ-3940)

New admin page called "Archived duplicate users"

### Changes proposed in this pull request

1. new admin page, under the "Users" tab
2. updated the seeds to create some archived users, with blank emails, that have an application that is not rejected
3. added a new method to `User`: `verified_trn` - which returns the TRN only if it is verified - we seemed to use this logic in a few places


[NPQ-3940]: https://dfedigital.atlassian.net/browse/NPQ-3940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ